### PR TITLE
feat(lang): add deterministic immutable maps

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -25,8 +25,9 @@ The habits that break first, in one place. Each is expanded below.
   There is no `<>` (inequality is `!=` only), no `%` (`Math.mod`), no `^`
   (`Math.pow`), and no string-concatenation operator (use `$"…"`).
 - **No loops** — iterate with `List.map` / `List.filter` / `List.fold`.
-- **All numbers are `float`** (f64); type names are lowercase (`float`,
-  `string`, `bool`, `List<…>`).
+- **All numbers are `float`** (f64); primitive type names are lowercase
+  (`float`, `string`, `bool`), while generic containers are `List<…>` and
+  `Map<…, …>`.
 - **Every `match` arm and every variant alternative needs a leading `|`**,
   the first one included. Arm bodies are full expressions, so a nested
   `match` must be parenthesized.
@@ -262,7 +263,7 @@ let grab = (s) =>
   that creates no cycle.
 - **Protected namespaces**: a file whose module name collides with a
   builtin/prelude or bundled-core namespace (Net, Key, Mouse, Random, Option, Result,
-  List, Text, Math, Debug, Scene,
+  List, Map, Text, Math, Debug, Scene,
   Sprite, Anim, Asset, Camera, Camera2D, Frame, Light, Fog, Color, Vec3, Skybox,
   Angle, Texture, Time, Input, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr,
   Style, AudioSource, AudioScene) is a
@@ -623,6 +624,24 @@ tuple slot, and it truncates to the shorter side) ·
 end is the whole list / `[]`, and a negative count acts as 0) ·
 `List.sum(list)` (Floats; empty is `0.0`) ·
 `List.concatMap(fn, list)` (map then flatten one level; `fn` returns a list) ·
+`Map.empty()` → `Map<'key, 'value>` ·
+`Map.get(key, map)` → `Option.t<'value>` ·
+`Map.insert(key, value, map)` / `Map.remove(key, map)` → a new map ·
+`Map.member(key, map)` → `bool` ·
+`Map.values(map)` → `List<'value>` ·
+`Map.toList(map)` → `List<('key, 'value)>` ·
+`Map.fromList(entries)` → `Map<'key, 'value>` (the LAST tuple for a duplicate
+key wins). Maps are immutable plain data. Keys are bounded to `bool`, FINITE
+`float`, or `string`; inference keeps a map homogeneous in ordinary code,
+while a generic/`unknown` seam is checked again at runtime. `-0.0` and `0.0`
+are the SAME key; NaN and infinities are refused. Every map is stored in
+canonical key order: bool < float < string, then false < true / ascending
+numeric / lexicographic Unicode scalar-value string order (not locale-aware).
+Therefore `values`/`toList`,
+structural equality, display (`Map.fromList([…])`), native, and wasm all agree
+byte-for-byte. `get`/`member` are logarithmic; immutable `insert`/`remove`
+copy the ordered vector and are linear; `values`/`toList` are linear and
+`fromList` is O(n log n) ·
 `Text.concat(a, b)` · `Text.fromFloat(n)` ·
 `Text.fixed(n, decimals)` (fixed-decimal; `Text.fixed(42.0, 0.0)` = `"42"`, the
 `%d` shape) · `Text.toBullets(list)` · `Text.split(sep, s)` (→ `List<string>`;
@@ -698,7 +717,7 @@ every frame (~60/s), so prefer an event path (`input`/`update`), or remove it
 when done.
 
 **The list above is the WHOLE registry, and it is CLOSED.** A builtin
-namespace (`List`, `Text`, `Math`, `Random`, `Debug`) owns exactly these
+namespace (`List`, `Map`, `Text`, `Math`, `Random`, `Debug`) owns exactly these
 members in every embedding, so anything else is a **check-time error** —
 `functor-lang check` (and `functor build`) reject `List.tail` /
 `Text.padLeft` with `` `List` has no builtin `tail` `` plus the nearest name
@@ -1097,7 +1116,9 @@ Effect.sendMsg(connId, msg)                                // send a plain-data 
                                                            //   shared-module ADT variant); the
                                                            //   other end receives it decoded as
                                                            //   Net.Data(id, value) — no string
-                                                           //   codec. Functions/host values in
+                                                           //   codec. Lists, Maps, tuples,
+                                                           //   records, and variants cross
+                                                           //   structurally; functions/host values in
                                                            //   the payload are teaching errors
 Effect.none() / Effect.batch([fx, …])                      //   random: [0,1); now: epoch secs
 Effect.httpGet(url, tagger)                                // HTTP one-shots; the tagger
@@ -1705,8 +1726,12 @@ values do support structural display/equality, snapshots, and hot reload.
 
 `functor-lang check` runs REAL INFERENCE (B7): unannotated code gets full types via
 unification with let-polymorphism — generic functions instantiate fresh at
-every use, element types flow through `List.map`/`filter`/`fold`, and
-apostrophe-prefixed annotation names are type variables (`(xs: List<'a>, seed: 'b): List<'b>`). Inference has teeth: unannotated bad calls, mixed-element
+every use, element types flow through `List.map`/`filter`/`fold`, key/value
+types flow through every `Map` operation, and apostrophe-prefixed annotation
+names are type variables (`(xs: List<'a>, seed: 'b): List<'b>`). Map keys are
+limited to `bool`, finite `float`, and `string`; concrete violations diagnose
+during checking, while polymorphic/`unknown` seams repeat that validation at
+runtime. Inference has teeth: unannotated bad calls, mixed-element
 lists, and contradictory `mut` use are errors now. `Unknown` remains ONLY
 at genuinely-dynamic seams (host values, and the `unknown` annotation you
 write on purpose — an UNRECOGNIZED type name is an error, not a seam)
@@ -1727,7 +1752,8 @@ variant type; a foreign literal arm is a can-never-match error);
 exhaustiveness checks all ctors / `true`+`false` / catch-all; arm results
 must agree.
 
-**Type names are lowercase**: `float`, `string`, `bool`, `List<…>`. A
+**Primitive type names are lowercase**: `float`, `string`, `bool`; the
+built-in generic containers are `List<…>` and `Map<key, value>`. A
 miscased or misspelled name is a **check error** with a did-you-mean, so
 you find out immediately:
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -108,13 +108,15 @@ full depth, construction order — but opaque text; don't parse it. Before
 protocol v4, `model` carried that text and there was no structured view — gate
 on `GET /`'s `protocol_version` before reading `model` as data.)
 Plain data maps structurally
-(records as objects, lists as arrays, numbers/strings/bools as themselves);
+(records as objects, lists as arrays, immutable Maps as a `$map` entry list,
+numbers/strings/bools as themselves);
 everything else becomes a sigil-keyed object no source-authored record field
 can collide with (`$` is not a Functor Lang identifier character — though a record
 key that arrived off the network in a typed message can carry one, so treat
 the sigils as a strong convention rather than a proof):
 
 ```jsonc
+{"$map": [["a", 1.0], ["b", 2.0]]}      // Maps, in canonical key order
 {"$tuple": [1.0, 2.0]}                 // tuples, kept distinct from lists
 {"$ctor": "Playing", "args": [7.0]}    // variants: constructor + positional args
 {"$fn": "<fn(dt)>"}                    // closures/callables (their Display form)

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -259,6 +259,24 @@ snapshots — no GPU, fully agent-verifiable.
       state/replay invariants survive untouched. Typechecked: slot types fix
       at the initializer; updates check against declared record types.
       *Verify:* 18 semantics/error/diagnostic tests + example goldens. (done)
+- [x] **Deterministic immutable `Map`** (2026-07-27; #543). A language-owned
+      `Map<'key, 'value>` value and closed `Map.*` builtin namespace:
+      `empty` / `get` / `insert` / `remove` / `member` / `values` /
+      `toList` / `fromList`. Keys are deliberately bounded to bool, finite
+      float, and string; `-0.0` canonicalizes to `0.0`, and NaN/infinities are
+      rejected. Storage is one immutable vector sorted by an explicit
+      cross-target order (bool < float < string; false < true; ascending
+      numeric/text order), with unique keys and last-write-wins
+      `fromList`. That representation makes iteration, structural equality,
+      display (`Map.fromList([…])`), native/wasm behavior, and typed-message
+      wire order deterministic. HM inference carries both key and value
+      types; direct concrete invalid keys diagnose at check time and the
+      runtime repeats the boundary check for generic/`unknown` seams.
+      Map values walk through closure rebinding, reload-safety classification,
+      debug JSON (`$map`), and `EffectValue`, so a plain map remains model
+      data for hot reload, time travel, and networking. Every scan/search/copy
+      is charged under bounded expect evaluation. `groupBy` and
+      `List.updateAt` remain separately scoped follow-ups.
 - [x] **Units, tier 1: branded `Angle` values** (2026-07-03; design:
       `~/notes/ideas/functor-lang/units.md`). `Angle.degrees(n)` /
       `Angle.radians(n)` opaque host values; rotations and camera angles

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -116,7 +116,9 @@ each side. The host converts the payload to the broker's serializable
 error), frames it as a control-prefixed JSON text on the existing transport,
 and the receiving end decodes it back and delivers `Net.Data(id, value)`
 through the connection's tagger — the game matches `value` directly against the
-shared ADT's constructors. Plain-text `Effect.send` traffic shares the
+shared ADT's constructors. Lists, immutable Maps, tuples, records, and variants
+all cross this seam structurally; Map entries retain their canonical key order.
+Plain-text `Effect.send` traffic shares the
 connection untouched (interop with non-Functor peers); a frame that fails to
 decode (version skew, corruption) arrives as `Net.Error`. Typed sends land in
 the structured effect log as data (`net.sendMsg` records), so they replay and

--- a/functor-lang/benches/README.md
+++ b/functor-lang/benches/README.md
@@ -119,6 +119,8 @@ when the currying spike lands.
 | `pattern_match.fun` | nested bool-literal `match` dispatch over 200k |
 | `adt.fun` | ADT construct + variant-pattern match over 100k |
 | `record_update.fun` | `{ r with … }` record update threaded through a 100k fold |
+| `map_from_list.fun` | canonical `Map.fromList` over reversed input plus 20k binary-search lookups |
+| `map_updates.fun` | 1.5k persistent inserts followed by removals (search + ordered-vector copies) |
 
 ## Micro-suite vs the frame bench (which to use when)
 

--- a/functor-lang/benches/corpus/map_from_list.fun
+++ b/functor-lang/benches/corpus/map_from_list.fun
@@ -1,0 +1,22 @@
+// BENCH: deterministic Map bulk construction + lookup -- builds a 20k-entry
+// map from reversed input, then performs 20k binary-search reads. Exercises
+// canonical sorting, tuple/list materialization, Option construction, and the
+// lookup hot path together.
+//
+// Convention: `main` is the timed unit of work. Also:
+// `functor-lang run map_from_list.fun`.
+let main = () =>
+  let entries =
+    List.range(20000)
+      |> List.reverse
+      |> List.map((key) => (key, key * 2.0))
+  in
+  let map = Map.fromList(entries) in
+  List.range(20000)
+    |> List.fold(
+      (sum, key) =>
+        match map |> Map.get(key) with
+        | Option.Some(value) => sum + value
+        | Option.None => sum,
+      0.0
+    )

--- a/functor-lang/benches/corpus/map_updates.fun
+++ b/functor-lang/benches/corpus/map_updates.fun
@@ -1,0 +1,12 @@
+// BENCH: persistent Map updates -- inserts 1.5k ascending keys into an
+// immutable map, then removes every key. Measures binary search plus the
+// linear ordered-vector copies that dominate persistent updates.
+//
+// Convention: `main` is the timed unit of work. Also:
+// `functor-lang run map_updates.fun`.
+let main = () =>
+  let keys = List.range(1500) in
+  let populated =
+    keys |> List.fold((map, key) => map |> Map.insert(key, key), Map.empty())
+  in
+  keys |> List.fold((map, key) => map |> Map.remove(key), populated)

--- a/functor-lang/src/codelens.rs
+++ b/functor-lang/src/codelens.rs
@@ -72,6 +72,10 @@ mod tests {
     fn infers_an_unannotated_signature() {
         // The whole signature is recovered with no annotations written.
         assert_eq!(sigs("let f = (x) => x + 1.0"), vec!["f : (float) => float"]);
+        assert_eq!(
+            sigs("let cells = Map.empty() |> Map.insert(\"origin\", 0.0)"),
+            vec!["cells : Map<string, float>"]
+        );
     }
 
     #[test]

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -872,6 +872,16 @@ mod tests {
             Some("List.map : (('a) => 'b, List<'a>) => List<'b>")
         );
         assert_eq!(find(&items, "map").kind, CompletionKind::Function);
+
+        let maps = game(STUB, &[], "let m = Map.");
+        assert_eq!(
+            labels(&maps),
+            vec!["empty", "fromList", "get", "insert", "member", "remove", "toList", "values"]
+        );
+        assert_eq!(
+            find(&maps, "insert").detail.as_deref(),
+            Some("Map.insert : ('a, 'b, Map<'a, 'b>) => Map<'a, 'b>")
+        );
     }
 
     // Bundled stdlib modules complete from their ordinary inferred `.fun`
@@ -1033,6 +1043,7 @@ mod tests {
         assert_eq!(find(&items, "Utils").kind, CompletionKind::Module);
         assert_eq!(find(&items, "Scene").kind, CompletionKind::Module);
         assert_eq!(find(&items, "List").kind, CompletionKind::Module);
+        assert_eq!(find(&items, "Map").kind, CompletionKind::Module);
         assert!(!has(&items, "Utils.clamp"), "qualified label leaked");
         assert!(!has(&items, "Game"), "entry name offered as a module");
     }

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -19,8 +19,8 @@
 //!
 //! [`ExprKind::External`] names resolve against the builtin registry at
 //! evaluation time ([`builtin`]): `List.map`/`filter`/`fold`/`maximum`,
-//! `Text.concat`/`fromFloat`/`toBullets`, `Math.clamp01`. An unregistered
-//! external is a spanned runtime error.
+//! `Map.get`/`insert`/`fromList`, `Text.concat`/`fromFloat`/`toBullets`,
+//! `Math.clamp01`. An unregistered external is a spanned runtime error.
 //!
 //! ## Tracing
 //!
@@ -34,8 +34,9 @@ use crate::ir::{
     BindingId, Def, ExpectDef, Expr, ExprKind, Module, Pattern, PatternKind, StringPart,
 };
 use crate::span::Span;
-use crate::value::{Closure, Env, Value};
+use crate::value::{canonicalize_map_entries, Closure, Env, MapKey, Value};
 use crate::RunError;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::rc::Rc;
@@ -465,8 +466,8 @@ pub fn run_expects(
 /// so one runaway is blamed precisely and cannot starve the rest). Exceeding
 /// it is a spanned [`ExpectOutcome::Error`] (or the returned `Err` when the
 /// def load itself exceeds it). A step is one function call, or one
-/// element/byte a bulk list/text builtin materializes or scans (see
-/// [`Fuel`] — growth builtins charge their OUTPUT, closing the
+/// element/byte/entry a bulk list/text/map builtin materializes, scans, or
+/// compares (see [`Fuel`] — growth builtins charge their OUTPUT, closing the
 /// doubling-amplifier hole) — the honest runaway proxy for a loop-free
 /// language, chosen over per-eval-node charging to keep the frame loop's
 /// hot path branch-free. Total interpreter work is O(budget), so the budget
@@ -691,7 +692,8 @@ impl Session {
 /// arithmetic), or one element/byte a bulk builtin materializes or scans
 /// (`List.range`'s count; `List.append`/`flatten` output elements;
 /// `Text.concat`/`join`/`toBullets` output bytes; `reverse`/`maximum`/
-/// `split` input size). Charging GROWTH builtins by output is what makes
+/// `split` input size; Map key comparisons, copied entries, and materialized
+/// iteration output). Charging GROWTH builtins by output is what makes
 /// the budget honest — `(x) => List.append(x, x)` doubles per call, so a
 /// per-call-only charge would allow exponential work under a linear budget.
 /// The general per-node eval path is deliberately uncharged so the frame
@@ -867,6 +869,43 @@ impl Interp<'_> {
             }
         }
         Ok(())
+    }
+
+    /// Refuse work whose conservative upper bound cannot fit, without
+    /// consuming that bound. The operation charges its actual work afterward,
+    /// so successful realistic inputs are not double-charged.
+    fn preflight_charge(&self, units: u64, span: Span) -> Result<(), RunError> {
+        if let Some(fuel) = self.fuel {
+            if fuel.remaining < units {
+                return Err(step_budget_error(fuel.limit, span));
+            }
+        }
+        Ok(())
+    }
+
+    /// Binary-search a canonical Map vector, charging before each key
+    /// comparison. Precharging matters for strings: their shared prefix can
+    /// be arbitrarily long, so charging only after `str::cmp` would let the
+    /// comparison itself escape the evaluator's bound.
+    fn map_search(
+        &mut self,
+        entries: &[(MapKey, Value)],
+        key: &MapKey,
+        span: Span,
+    ) -> Result<Result<usize, usize>, RunError> {
+        let mut left = 0usize;
+        let mut right = entries.len();
+        while left < right {
+            let mid = left + (right - left) / 2;
+            let candidate = &entries[mid].0;
+            self.charge(candidate.comparison_units(key), span)?;
+            match candidate.compare(key) {
+                Ordering::Less => left = mid + 1,
+                Ordering::Greater => right = mid,
+                Ordering::Equal => return Ok(Ok(mid)),
+            }
+        }
+        Ok(Err(left))
     }
 
     fn eval(&mut self, expr: &Expr, env: &Env) -> Result<Value, RunError> {
@@ -2118,6 +2157,145 @@ most 1000000 cells"
                 }
                 _ => err("List.concatMap(fn, list) expects a function and a list".to_string()),
             },
+            Builtin::MapEmpty => match args.as_slice() {
+                [] => Ok(Value::Map(Rc::new(Vec::new()))),
+                _ => unreachable!("builtin arity checked before dispatch"),
+            },
+            // Maps are immutable sorted vectors. Lookup is binary search;
+            // updates copy one canonical vector and preserve key order.
+            // Subject-LAST throughout, so `map |> Map.get(key)` works.
+            Builtin::MapGet => match args.as_slice() {
+                [key, Value::Map(entries)] => {
+                    let key = map_key_from_value(key, builtin_name(b))
+                        .map_err(|message| RunError { message, span })?;
+                    let found = self.map_search(entries, &key, span)?;
+                    Ok(option_value(
+                        found.ok().map(|index| entries[index].1.clone()),
+                    ))
+                }
+                _ => err("Map.get(key, map) expects a key and a map".to_string()),
+            },
+            Builtin::MapInsert => match args.as_slice() {
+                [key, value, Value::Map(entries)] => {
+                    let key = map_key_from_value(key, builtin_name(b))
+                        .map_err(|message| RunError { message, span })?;
+                    let found = self.map_search(entries, &key, span)?;
+                    let out_len = if found.is_ok() {
+                        entries.len()
+                    } else {
+                        entries.len().saturating_add(1)
+                    };
+                    // Pre-charge the immutable copy so a low-budget tool
+                    // cannot allocate it before discovering it is over fuel.
+                    self.charge(out_len as u64, span)?;
+                    let mut out = entries.as_ref().clone();
+                    match found {
+                        Ok(index) => out[index].1 = value.clone(),
+                        Err(index) => out.insert(index, (key, value.clone())),
+                    }
+                    Ok(Value::Map(Rc::new(out)))
+                }
+                _ => {
+                    err("Map.insert(key, value, map) expects a key, a value, and a map".to_string())
+                }
+            },
+            Builtin::MapRemove => match args.as_slice() {
+                [key, Value::Map(entries)] => {
+                    let key = map_key_from_value(key, builtin_name(b))
+                        .map_err(|message| RunError { message, span })?;
+                    let found = self.map_search(entries, &key, span)?;
+                    let Ok(index) = found else {
+                        return Ok(Value::Map(entries.clone()));
+                    };
+                    self.charge(entries.len().saturating_sub(1) as u64, span)?;
+                    let mut out = entries.as_ref().clone();
+                    out.remove(index);
+                    Ok(Value::Map(Rc::new(out)))
+                }
+                _ => err("Map.remove(key, map) expects a key and a map".to_string()),
+            },
+            Builtin::MapMember => match args.as_slice() {
+                [key, Value::Map(entries)] => {
+                    let key = map_key_from_value(key, builtin_name(b))
+                        .map_err(|message| RunError { message, span })?;
+                    let found = self.map_search(entries, &key, span)?;
+                    Ok(Value::Bool(found.is_ok()))
+                }
+                _ => err("Map.member(key, map) expects a key and a map".to_string()),
+            },
+            Builtin::MapValues => match args.as_slice() {
+                [Value::Map(entries)] => {
+                    self.charge(entries.len() as u64, span)?;
+                    Ok(Value::List(Rc::new(
+                        entries.iter().map(|(_, value)| value.clone()).collect(),
+                    )))
+                }
+                _ => err("Map.values(map) expects one map".to_string()),
+            },
+            Builtin::MapToList => match args.as_slice() {
+                [Value::Map(entries)] => {
+                    // Each entry materializes a two-cell tuple.
+                    self.charge((entries.len() as u64).saturating_mul(2), span)?;
+                    Ok(Value::List(Rc::new(
+                        entries
+                            .iter()
+                            .map(|(key, value)| {
+                                Value::Tuple(Rc::new(vec![key.to_value(), value.clone()]))
+                            })
+                            .collect(),
+                    )))
+                }
+                _ => err("Map.toList(map) expects one map".to_string()),
+            },
+            Builtin::MapFromList => match args.as_slice() {
+                [Value::List(items)] => {
+                    // Charge entry cloning up front. After validating the
+                    // keys, refuse an over-budget sort before its first
+                    // comparison. The preflight is conservative; actual
+                    // comparison work is charged afterward.
+                    self.charge(items.len() as u64, span)?;
+                    let mut sorted = Vec::with_capacity(items.len());
+                    let mut max_comparison_units = 1u64;
+                    for (index, item) in items.iter().enumerate() {
+                        let Value::Tuple(pair) = item else {
+                            return err(format!(
+                                "Map.fromList(entries) expects (key, value) tuples; entry {index} is {}",
+                                item.kind_name()
+                            ));
+                        };
+                        let [key, value] = pair.as_slice() else {
+                            return err(format!(
+                                "Map.fromList(entries) expects 2-tuples; entry {index} has {} items",
+                                pair.len()
+                            ));
+                        };
+                        let key = map_key_from_value(key, builtin_name(b)).map_err(|message| {
+                            RunError {
+                                message: format!("{message} at entry {index}"),
+                                span,
+                            }
+                        })?;
+                        max_comparison_units =
+                            max_comparison_units.max(key.comparison_unit_ceiling());
+                        sorted.push((key, value.clone()));
+                    }
+                    let comparison_count_ceiling = stable_sort_comparison_ceiling(items.len())
+                        .saturating_add(
+                            u64::try_from(items.len().saturating_sub(1))
+                                .unwrap_or(u64::MAX),
+                        );
+                    let comparison_work_ceiling =
+                        comparison_count_ceiling.saturating_mul(max_comparison_units);
+                    self.preflight_charge(comparison_work_ceiling, span)?;
+                    let (out, comparison_work) = canonicalize_map_entries(sorted);
+                    debug_assert!(comparison_work <= comparison_work_ceiling);
+                    self.charge(comparison_work, span)?;
+                    Ok(Value::Map(Rc::new(out)))
+                }
+                _ => {
+                    err("Map.fromList(entries) expects one list of (key, value) tuples".to_string())
+                }
+            },
             Builtin::TextConcat => match args.as_slice() {
                 [Value::String(a), Value::String(b)] => {
                     // Growth builtin: charge output BYTES (the List.append
@@ -2675,12 +2853,20 @@ fn value_eq(
     /// still fires first, exactly like the old interleaved walk).
     enum Work<'a> {
         Pair(&'a Value, &'a Value),
+        Key(&'a MapKey, &'a MapKey),
         MissingField,
     }
     let mut work: Vec<Work> = vec![Work::Pair(a, b)];
     while let Some(item) = work.pop() {
         let (a, b) = match item {
             Work::Pair(a, b) => (a, b),
+            Work::Key(a, b) => {
+                *compared += 1;
+                if a != b {
+                    return Ok(false);
+                }
+                continue;
+            }
             Work::MissingField => return Ok(false),
         };
         *compared += 1;
@@ -2706,6 +2892,15 @@ fn value_eq(
                     return Ok(false);
                 }
                 work.extend(xs.iter().zip(ys.iter()).rev().map(|(x, y)| Work::Pair(x, y)));
+            }
+            (Value::Map(xs), Value::Map(ys)) => {
+                if xs.len() != ys.len() {
+                    return Ok(false);
+                }
+                for ((xk, xv), (yk, yv)) in xs.iter().zip(ys.iter()).rev() {
+                    work.push(Work::Pair(xv, yv));
+                    work.push(Work::Key(xk, yk));
+                }
             }
             (Value::Record(xs), Value::Record(ys)) => {
                 if xs.len() != ys.len() {
@@ -2809,6 +3004,40 @@ fn sort_key_cmp(a: f64, b: f64) -> std::cmp::Ordering {
     }
 }
 
+/// Validate and canonicalize one public Map key. `-0.0` becomes `0.0` so
+/// language equality, lookup, and ordering all agree; non-finite floats are
+/// refused because NaN has no equality-compatible ordering and cannot cross
+/// the plain-data wire.
+fn map_key_from_value(value: &Value, operation: &str) -> Result<MapKey, String> {
+    match value {
+        Value::Bool(value) => Ok(MapKey::Bool(*value)),
+        Value::Number(value) if value.is_finite() => Ok(MapKey::Number(*value + 0.0)),
+        Value::Number(value) => Err(format!(
+            "{operation} keys must be finite; got {value} (NaN/Infinity cannot be map keys)"
+        )),
+        Value::String(value) => Ok(MapKey::String(value.clone())),
+        other => Err(format!(
+            "{operation} keys must be bools, finite floats, or strings; got {}",
+            other.kind_name()
+        )),
+    }
+}
+
+/// Conservative comparison ceiling for Rust's stable O(n log n) slice sort.
+///
+/// `Map.fromList` uses this only as a non-consuming preflight; it charges the
+/// actual comparison work afterward. The factor of two leaves headroom for
+/// run detection/merge bookkeeping while keeping realistic editor budgets
+/// proportional to the work they permit.
+fn stable_sort_comparison_ceiling(len: usize) -> u64 {
+    let n = u64::try_from(len).unwrap_or(u64::MAX);
+    if n < 2 {
+        return 0;
+    }
+    let levels = u64::from(u64::BITS - (n - 1).leading_zeros());
+    n.saturating_mul(levels).saturating_mul(2)
+}
+
 /// Wrap a "maybe absent" result as the language's `Option.t` — the shared
 /// answer of every PARTIAL builtin (`List.nth`/`head`/`last`/`find`).
 ///
@@ -2872,7 +3101,8 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::ListGrid
         | Builtin::RandomRange
         | Builtin::TextReplace
-        | Builtin::MathClamp => 3,
+        | Builtin::MathClamp
+        | Builtin::MapInsert => 3,
         Builtin::ListMap
         | Builtin::ListFilter
         | Builtin::ListAppend
@@ -2897,7 +3127,10 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::MathMax
         | Builtin::MathPow
         | Builtin::RandomFork
-        | Builtin::DebugLog => 2,
+        | Builtin::DebugLog
+        | Builtin::MapGet
+        | Builtin::MapRemove
+        | Builtin::MapMember => 2,
         Builtin::ListRange
         | Builtin::ListMaximum
         | Builtin::ListLength
@@ -2929,10 +3162,13 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::MathCeil
         | Builtin::MathLog
         | Builtin::MathExp
-        | Builtin::MathSign => 1,
+        | Builtin::MathSign
+        | Builtin::MapValues
+        | Builtin::MapToList
+        | Builtin::MapFromList => 1,
         // `Math.pi` resolves straight to a number in `eval` (it's a constant,
         // never a callable value), so this arity is never consulted.
-        Builtin::MathPi => 0,
+        Builtin::MathPi | Builtin::MapEmpty => 0,
         Builtin::RandomSeed | Builtin::RandomStep => 1,
     }
 }
@@ -2974,6 +3210,14 @@ pub enum Builtin {
     ListDrop,
     ListSum,
     ListConcatMap,
+    MapEmpty,
+    MapGet,
+    MapInsert,
+    MapRemove,
+    MapMember,
+    MapValues,
+    MapToList,
+    MapFromList,
     TextConcat,
     TextFromFloat,
     TextFixed,
@@ -3101,7 +3345,7 @@ fn unknown_external_error(path: &[String], joined: String, span: Span) -> RunErr
 /// these is a typo (a plain error), never a host-provided external — the
 /// distinction the unknown-external error message (and through it the
 /// expect gutter's `unrunnable` classification) rests on.
-pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Text", "Math", "Random", "Debug"];
+pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Map", "Text", "Math", "Random", "Debug"];
 
 /// The complete builtin registry as a list. Hand-listed because [`Builtin`] is
 /// not iterable — keep in sync with the enum (`builtins_list_is_exhaustive`
@@ -3110,7 +3354,7 @@ pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Text", "Math", "Random", "Deb
 /// [`builtin`] so the members the CHECKER knows about (for its
 /// unknown-member diagnostic and its suggestions) and the ones the
 /// interpreter DISPATCHES come from one place.
-pub const ALL_BUILTINS: [Builtin; 65] = [
+pub const ALL_BUILTINS: [Builtin; 73] = [
     Builtin::ListMap,
     Builtin::ListFilter,
     Builtin::ListFold,
@@ -3135,6 +3379,14 @@ pub const ALL_BUILTINS: [Builtin; 65] = [
     Builtin::ListDrop,
     Builtin::ListSum,
     Builtin::ListConcatMap,
+    Builtin::MapEmpty,
+    Builtin::MapGet,
+    Builtin::MapInsert,
+    Builtin::MapRemove,
+    Builtin::MapMember,
+    Builtin::MapValues,
+    Builtin::MapToList,
+    Builtin::MapFromList,
     Builtin::MathSin,
     Builtin::MathCos,
     Builtin::MathSqrt,
@@ -3217,6 +3469,14 @@ pub fn builtin(path: &[String]) -> Option<Builtin> {
         "List.drop" => Builtin::ListDrop,
         "List.sum" => Builtin::ListSum,
         "List.concatMap" => Builtin::ListConcatMap,
+        "Map.empty" => Builtin::MapEmpty,
+        "Map.get" => Builtin::MapGet,
+        "Map.insert" => Builtin::MapInsert,
+        "Map.remove" => Builtin::MapRemove,
+        "Map.member" => Builtin::MapMember,
+        "Map.values" => Builtin::MapValues,
+        "Map.toList" => Builtin::MapToList,
+        "Map.fromList" => Builtin::MapFromList,
         "Text.concat" => Builtin::TextConcat,
         "Text.fromFloat" => Builtin::TextFromFloat,
         "Text.fixed" => Builtin::TextFixed,
@@ -3289,6 +3549,14 @@ pub fn builtin_name(b: Builtin) -> &'static str {
         Builtin::ListDrop => "List.drop",
         Builtin::ListSum => "List.sum",
         Builtin::ListConcatMap => "List.concatMap",
+        Builtin::MapEmpty => "Map.empty",
+        Builtin::MapGet => "Map.get",
+        Builtin::MapInsert => "Map.insert",
+        Builtin::MapRemove => "Map.remove",
+        Builtin::MapMember => "Map.member",
+        Builtin::MapValues => "Map.values",
+        Builtin::MapToList => "Map.toList",
+        Builtin::MapFromList => "Map.fromList",
         Builtin::TextConcat => "Text.concat",
         Builtin::TextFromFloat => "Text.fromFloat",
         Builtin::TextFixed => "Text.fixed",
@@ -3367,7 +3635,7 @@ pub fn render_trace(events: &[TraceEvent]) -> String {
 
 #[cfg(test)]
 mod sort_key_tests {
-    use super::sort_key_cmp;
+    use super::{sort_key_cmp, stable_sort_comparison_ceiling};
     use std::cmp::Ordering;
 
     /// THE CROSS-PLATFORM LOCK. `List.sortBy`'s order must not depend on a
@@ -3423,6 +3691,15 @@ mod sort_key_tests {
         assert_eq!(sort_key_cmp(2.0, 1.0), Ordering::Greater);
         assert_eq!(sort_key_cmp(2.0, 2.0), Ordering::Equal);
         assert_eq!(sort_key_cmp(f64::NEG_INFINITY, f64::INFINITY), Ordering::Less);
+    }
+
+    #[test]
+    fn map_sort_preflight_is_zero_for_trivial_inputs_and_n_log_n_afterward() {
+        assert_eq!(stable_sort_comparison_ceiling(0), 0);
+        assert_eq!(stable_sort_comparison_ceiling(1), 0);
+        assert_eq!(stable_sort_comparison_ceiling(2), 4);
+        assert_eq!(stable_sort_comparison_ceiling(8), 48);
+        assert_eq!(stable_sort_comparison_ceiling(1000), 20_000);
     }
 }
 
@@ -3486,6 +3763,14 @@ mod builtin_registry_tests {
                 | Builtin::ListDrop
                 | Builtin::ListSum
                 | Builtin::ListConcatMap
+                | Builtin::MapEmpty
+                | Builtin::MapGet
+                | Builtin::MapInsert
+                | Builtin::MapRemove
+                | Builtin::MapMember
+                | Builtin::MapValues
+                | Builtin::MapToList
+                | Builtin::MapFromList
                 | Builtin::MathSin
                 | Builtin::MathCos
                 | Builtin::MathSqrt
@@ -3529,7 +3814,7 @@ mod builtin_registry_tests {
                 | Builtin::DebugLog => {}
             }
         }
-        assert_eq!(ALL_BUILTINS.len(), 65, "ALL_BUILTINS must list every Builtin");
+        assert_eq!(ALL_BUILTINS.len(), 73, "ALL_BUILTINS must list every Builtin");
 
         // The length check alone would accept a DUPLICATE entry standing in
         // for a missing one.

--- a/functor-lang/src/hover.rs
+++ b/functor-lang/src/hover.rs
@@ -228,6 +228,9 @@ mod tests {
     fn hover_on_a_builtin_shows_its_signature() {
         let text = hover_at("let f = (xs) => xs |> List.maximum", "List.maximum").unwrap();
         assert_eq!(text, "List.maximum : (List<float>) => float");
+
+        let text = hover_at("let f = (xs) => xs |> Map.fromList", "Map.fromList").unwrap();
+        assert_eq!(text, "Map.fromList : (List<('a, 'b)>) => Map<'a, 'b>");
     }
 
     #[test]

--- a/functor-lang/src/inlay.rs
+++ b/functor-lang/src/inlay.rs
@@ -139,4 +139,11 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].1, ": List<float>");
     }
+
+    #[test]
+    fn infers_a_map_param() {
+        let got = hints("let f = (map) => map |> Map.get(\"origin\")");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].1, ": Map<string, 'a>");
+    }
 }

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -214,7 +214,7 @@ fn lower_module(
                 // types), yielding nonsense like "expected float, got float".
                 if matches!(
                     decl.name.as_str(),
-                    "float" | "bool" | "string" | "unknown" | "List"
+                    "float" | "bool" | "string" | "unknown" | "List" | "Map"
                 ) {
                     return Err(LowerError {
                         message: format!("cannot redeclare builtin type `{}`", decl.name),

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -46,6 +46,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Net",
     "Key",
     "List",
+    "Map",
     "Text",
     "Math",
     "Random",

--- a/functor-lang/src/rebind.rs
+++ b/functor-lang/src/rebind.rs
@@ -122,6 +122,12 @@ fn walk(value: &Value, old: &ModuleIndex, new: &ModuleIndex, report: &mut Rebind
         Value::List(items) => Value::List(Rc::new(
             items.iter().map(|v| walk(v, old, new, report)).collect(),
         )),
+        Value::Map(entries) => Value::Map(Rc::new(
+            entries
+                .iter()
+                .map(|(key, value)| (key.clone(), walk(value, old, new, report)))
+                .collect(),
+        )),
         Value::Tuple(items) => Value::Tuple(Rc::new(
             items.iter().map(|v| walk(v, old, new, report)).collect(),
         )),

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -31,7 +31,7 @@
 //!   nominal, by name.
 //! - Declared variant types (`type Shape = | Circle(radius: float) | Point`)
 //!   — nominal, by name, like records.
-//! - `List<T>`.
+//! - `List<T>` and `Map<K, V>`.
 //! - Function types, from lambda annotations
 //!   (`(a: float, b: float): float => …`); an unannotated return type is the
 //!   body's type when that is known (inferred in a single quiet enrichment
@@ -103,6 +103,10 @@ pub enum Type {
     String,
     Bool,
     List(Box<Type>),
+    /// An immutable keyed collection. Runtime keys are bounded to bool,
+    /// finite float, and string; inference keeps a map's key type
+    /// homogeneous in ordinary (non-`unknown`) code.
+    Map(Box<Type>, Box<Type>),
     /// A product type: `Float * Float` in annotations. Structural, like the
     /// runtime.
     Tuple(Vec<Type>),
@@ -128,6 +132,7 @@ impl fmt::Display for Type {
             Type::String => write!(f, "string"),
             Type::Bool => write!(f, "bool"),
             Type::List(elem) => write!(f, "List<{elem}>"),
+            Type::Map(key, value) => write!(f, "Map<{key}, {value}>"),
             Type::Tuple(elems) => {
                 write!(f, "(")?;
                 for (i, elem) in elems.iter().enumerate() {
@@ -199,6 +204,7 @@ pub fn compatible(a: &Type, b: &Type) -> bool {
             true
         }
         (Type::List(x), Type::List(y)) => compatible(x, y),
+        (Type::Map(xk, xv), Type::Map(yk, yv)) => compatible(xk, yk) && compatible(xv, yv),
         (Type::Tuple(xs), Type::Tuple(ys)) => {
             xs.len() == ys.len() && xs.iter().zip(ys).all(|(x, y)| compatible(x, y))
         }
@@ -221,6 +227,7 @@ pub fn compatible(a: &Type, b: &Type) -> bool {
 fn contains_fn(ty: &Type) -> bool {
     match ty {
         Type::Fn(..) => true,
+        Type::Map(key, value) => contains_fn(key) || contains_fn(value),
         Type::Tuple(elems) => elems.iter().any(contains_fn),
         // A generic nominal can carry a function in its ARGUMENTS
         // (`Box<(Float) => Float>`) even when the declaration's own fields
@@ -280,6 +287,10 @@ fn subst_params(ty: &Type, args: &[Type]) -> Type {
             .cloned()
             .unwrap_or_else(|| Type::Var(*v)),
         Type::List(e) => Type::List(Box::new(subst_params(e, args))),
+        Type::Map(key, value) => Type::Map(
+            Box::new(subst_params(key, args)),
+            Box::new(subst_params(value, args)),
+        ),
         Type::Tuple(es) => Type::Tuple(es.iter().map(|e| subst_params(e, args)).collect()),
         Type::Fn(ps, r) => Type::Fn(
             ps.iter().map(|p| subst_params(p, args)).collect(),
@@ -303,6 +314,10 @@ fn renumber_with(ty: &Type, order: &[u32]) -> Type {
             Type::Var(idx)
         }
         Type::List(e) => Type::List(Box::new(renumber_with(e, order))),
+        Type::Map(key, value) => Type::Map(
+            Box::new(renumber_with(key, order)),
+            Box::new(renumber_with(value, order)),
+        ),
         Type::Tuple(es) => Type::Tuple(es.iter().map(|e| renumber_with(e, order)).collect()),
         Type::Fn(ps, r) => Type::Fn(
             ps.iter().map(|p| renumber_with(p, order)).collect(),
@@ -329,6 +344,10 @@ fn free_vars_of(ty: &Type, out: &mut Vec<u32>) {
             }
         }
         Type::List(elem) => free_vars_of(elem, out),
+        Type::Map(key, value) => {
+            free_vars_of(key, out);
+            free_vars_of(value, out);
+        }
         Type::Tuple(elems) => {
             for elem in elems {
                 free_vars_of(elem, out);
@@ -556,6 +575,43 @@ pub fn builtin_signature(b: Builtin) -> Type {
                 List(Box::new(Var(0))),
             ],
             List(Box::new(Var(1))),
+        ),
+        // Map keys infer normally but are dynamically bounded to bool,
+        // finite float, and string (the HM type language has no type-class
+        // constraint syntax). Every operation preserves one K/V pair.
+        // Map.empty : () => Map<'key, 'value>
+        Builtin::MapEmpty => func(vec![], Map(Box::new(Var(0)), Box::new(Var(1)))),
+        // Subject-LAST. Map.get : ('key, Map<'key, 'value>) => Option.t<'value>
+        Builtin::MapGet => func(
+            vec![Var(0), Map(Box::new(Var(0)), Box::new(Var(1)))],
+            option(Var(1)),
+        ),
+        // Subject-LAST. Map.insert : ('key, 'value, Map<'key, 'value>) => Map<'key, 'value>
+        Builtin::MapInsert => func(
+            vec![Var(0), Var(1), Map(Box::new(Var(0)), Box::new(Var(1)))],
+            Map(Box::new(Var(0)), Box::new(Var(1))),
+        ),
+        // Subject-LAST. Map.remove : ('key, Map<'key, 'value>) => Map<'key, 'value>
+        Builtin::MapRemove => func(
+            vec![Var(0), Map(Box::new(Var(0)), Box::new(Var(1)))],
+            Map(Box::new(Var(0)), Box::new(Var(1))),
+        ),
+        // Subject-LAST. Map.member : ('key, Map<'key, 'value>) => bool
+        Builtin::MapMember => func(vec![Var(0), Map(Box::new(Var(0)), Box::new(Var(1)))], Bool),
+        // Map.values : (Map<'key, 'value>) => List<'value>
+        Builtin::MapValues => func(
+            vec![Map(Box::new(Var(0)), Box::new(Var(1)))],
+            List(Box::new(Var(1))),
+        ),
+        // Map.toList : (Map<'key, 'value>) => List<('key, 'value)>
+        Builtin::MapToList => func(
+            vec![Map(Box::new(Var(0)), Box::new(Var(1)))],
+            List(Box::new(Tuple(vec![Var(0), Var(1)]))),
+        ),
+        // Map.fromList : (List<('key, 'value)>) => Map<'key, 'value>
+        Builtin::MapFromList => func(
+            vec![List(Box::new(Tuple(vec![Var(0), Var(1)])))],
+            Map(Box::new(Var(0)), Box::new(Var(1))),
         ),
         // Text.concat : (String, String) => String
         Builtin::TextConcat => func(vec![String, String], String),
@@ -1128,6 +1184,9 @@ impl Checker<'_> {
                 None => Type::Var(*v),
             },
             Type::List(elem) => Type::List(Box::new(self.zonk(elem))),
+            Type::Map(key, value) => {
+                Type::Map(Box::new(self.zonk(key)), Box::new(self.zonk(value)))
+            }
             Type::Tuple(elems) => Type::Tuple(elems.iter().map(|e| self.zonk(e)).collect()),
             Type::Fn(params, ret) => Type::Fn(
                 params.iter().map(|p| self.zonk(p)).collect(),
@@ -1182,6 +1241,9 @@ impl Checker<'_> {
                 ok
             }
             (Type::List(x), Type::List(y)) => self.unify_rec(x, y, span, what),
+            (Type::Map(xk, xv), Type::Map(yk, yv)) => {
+                self.unify_rec(xk, yk, span, what) & self.unify_rec(xv, yv, span, what)
+            }
             (Type::Tuple(xs), Type::Tuple(ys)) if xs.len() == ys.len() => {
                 let mut ok = true;
                 for (x, y) in xs.clone().iter().zip(ys.clone().iter()) {
@@ -1232,6 +1294,45 @@ impl Checker<'_> {
         self.diag(span, format!("{what}: expected {expected}, got {got}"));
     }
 
+    /// Enforce Map's deliberately bounded key domain when a direct builtin
+    /// call has made the key type concrete. Unsolved variables and `unknown`
+    /// remain valid gradual/generic seams; the evaluator repeats the check on
+    /// every operation, so an invalid value can never enter a Map even when a
+    /// polymorphic helper delayed the concrete type beyond this call site.
+    fn check_map_key_domain(&mut self, callee: &Expr, args: &[Expr], params: &[Type]) {
+        let ExprKind::External(path) = &callee.kind else {
+            return;
+        };
+        let Some(builtin) = builtin(path) else {
+            return;
+        };
+        let (key_ty, span) = match builtin {
+            Builtin::MapGet | Builtin::MapInsert | Builtin::MapRemove | Builtin::MapMember => {
+                match (params.first(), args.first()) {
+                    (Some(key), Some(arg)) => (self.zonk(key), arg.span),
+                    _ => return,
+                }
+            }
+            Builtin::MapFromList => match (params.first(), args.first()) {
+                (Some(Type::List(entries)), Some(arg)) => match entries.as_ref() {
+                    Type::Tuple(pair) if pair.len() == 2 => (self.zonk(&pair[0]), arg.span),
+                    _ => return,
+                },
+                _ => return,
+            },
+            _ => return,
+        };
+        if !matches!(
+            key_ty,
+            Type::Bool | Type::Float | Type::String | Type::Unknown | Type::Var(_)
+        ) {
+            self.diag(
+                span,
+                format!("Map keys must be bool, finite float, or string; got {key_ty}"),
+            );
+        }
+    }
+
     /// Instantiate a scheme: quantified variables become fresh ones.
     fn instantiate(&mut self, scheme: &Scheme) -> Type {
         if scheme.vars.is_empty() {
@@ -1242,6 +1343,9 @@ impl Checker<'_> {
             match ty {
                 Type::Var(v) => mapping.get(v).cloned().unwrap_or(Type::Var(*v)),
                 Type::List(e) => Type::List(Box::new(walk(e, mapping))),
+                Type::Map(key, value) => {
+                    Type::Map(Box::new(walk(key, mapping)), Box::new(walk(value, mapping)))
+                }
                 Type::Tuple(es) => Type::Tuple(es.iter().map(|e| walk(e, mapping)).collect()),
                 Type::Fn(ps, r) => Type::Fn(
                     ps.iter().map(|p| walk(p, mapping)).collect(),
@@ -1335,6 +1439,27 @@ impl Checker<'_> {
                     return arity_error(self, 1);
                 }
                 Type::List(Box::new(self.resolve_type(&ty.args[0], report)))
+            }
+            "Map" => {
+                if ty.args.len() != 2 {
+                    return arity_error(self, 2);
+                }
+                let key = self.resolve_type(&ty.args[0], report);
+                if report
+                    && !matches!(
+                        key,
+                        Type::Bool | Type::Float | Type::String | Type::Unknown | Type::Var(_)
+                    )
+                {
+                    self.diag(
+                        ty.args[0].span,
+                        format!("Map keys must be bool, finite float, or string; got {key}"),
+                    );
+                }
+                Type::Map(
+                    Box::new(key),
+                    Box::new(self.resolve_type(&ty.args[1], report)),
+                )
             }
             // The parser encodes a tuple annotation (`(Float, Float)`) as the
             // reserved name `*` with the elements as args.
@@ -1479,7 +1604,7 @@ the type: `type Name<{name}> = …`"
         // three-edit one that spends its budget on the capital F. Budget: 2
         // for a name long enough that two edits still leave it recognizable,
         // 1 for short names where 2 edits could reach anything.
-        let mut candidates: Vec<&str> = vec!["float", "string", "bool", "unknown", "List"];
+        let mut candidates: Vec<&str> = vec!["float", "string", "bool", "unknown", "List", "Map"];
         candidates.extend(declared);
         let budget = if name.chars().count() >= 4 { 2 } else { 1 };
         let near = candidates
@@ -2064,6 +2189,7 @@ missing {missing}. Did you forget an argument?"
                             let what = format!("argument {} of `{}`", i + 1, callee_label(callee));
                             self.expect(arg, param_ty, &what);
                         }
+                        self.check_map_key_domain(callee, args, &params);
                         match args.len().cmp(&params.len()) {
                             std::cmp::Ordering::Equal => *ret,
                             // Under-applied: the value is a function of the

--- a/functor-lang/src/value.rs
+++ b/functor-lang/src/value.rs
@@ -4,13 +4,134 @@
 //! The `Display` impl is the canonical textual form used by `functor-lang run`/`trace`
 //! output (and the committed `.run`/`.trace` goldens): numbers via Rust's
 //! `f64` `Display`, strings in double quotes with `Debug` escaping, records
-//! and lists structurally, closures as `<fn(param, …)>` (their environment is
-//! not printed).
+//! and collections structurally (Maps in canonical key order), closures as
+//! `<fn(param, …)>` (their environment is not printed).
 
 use crate::eval::builtin_name;
 use crate::ir::{BindingId, Expr, Param};
+use std::cmp::Ordering;
 use std::fmt;
 use std::rc::Rc;
+
+/// One key in an immutable [`Value::Map`].
+///
+/// The language deliberately bounds map keys to scalar plain data: bools,
+/// finite floats, and strings. The explicit cross-kind order keeps maps that
+/// arrive through an `unknown` seam canonical too; normally HM inference makes
+/// a map homogeneous.
+#[derive(Clone)]
+pub enum MapKey {
+    Bool(bool),
+    Number(f64),
+    String(Rc<str>),
+}
+
+impl MapKey {
+    /// The canonical target-independent key order:
+    /// bool < float < string, then false < true / numeric / lexicographic
+    /// Unicode scalar-value text (Rust UTF-8 `str` order).
+    pub fn compare(&self, other: &MapKey) -> Ordering {
+        let rank = |key: &MapKey| match key {
+            MapKey::Bool(_) => 0,
+            MapKey::Number(_) => 1,
+            MapKey::String(_) => 2,
+        };
+        match rank(self).cmp(&rank(other)) {
+            Ordering::Equal => match (self, other) {
+                (MapKey::Bool(a), MapKey::Bool(b)) => a.cmp(b),
+                // Construction rejects non-finite values and normalizes -0,
+                // so partial_cmp is total and agrees with language equality.
+                (MapKey::Number(a), MapKey::Number(b)) => {
+                    a.partial_cmp(b).expect("map keys are finite")
+                }
+                (MapKey::String(a), MapKey::String(b)) => a.as_ref().cmp(b.as_ref()),
+                _ => unreachable!("equal key ranks have equal variants"),
+            },
+            order => order,
+        }
+    }
+
+    /// Conservative fuel units for comparing two keys. String ordering may
+    /// inspect every byte of their common extent, while kind/bool/number
+    /// comparisons are constant work.
+    pub fn comparison_units(&self, other: &MapKey) -> u64 {
+        match (self, other) {
+            (MapKey::String(a), MapKey::String(b)) => u64::try_from(a.len().min(b.len()))
+                .unwrap_or(u64::MAX)
+                .saturating_add(1),
+            _ => 1,
+        }
+    }
+
+    /// Worst-case units for comparing this key with another map key.
+    pub fn comparison_unit_ceiling(&self) -> u64 {
+        match self {
+            MapKey::String(value) => u64::try_from(value.len())
+                .unwrap_or(u64::MAX)
+                .saturating_add(1),
+            MapKey::Bool(_) | MapKey::Number(_) => 1,
+        }
+    }
+
+    pub fn to_value(&self) -> Value {
+        match self {
+            MapKey::Bool(value) => Value::Bool(*value),
+            MapKey::Number(value) => Value::Number(*value),
+            MapKey::String(value) => Value::String(value.clone()),
+        }
+    }
+}
+
+impl PartialEq for MapKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.compare(other) == Ordering::Equal
+    }
+}
+
+impl Eq for MapKey {}
+
+impl fmt::Display for MapKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MapKey::Bool(value) => write!(f, "{value}"),
+            MapKey::Number(value) => write!(f, "{value}"),
+            MapKey::String(value) => write!(f, "{value:?}"),
+        }
+    }
+}
+
+/// Sort validated map entries into the language's canonical order and fold
+/// duplicate keys with the public last-write-wins rule. Returns conservative
+/// comparison work units (string bytes, or one for constant-time keys) so
+/// bounded evaluators can charge the real sort/dedup work.
+///
+/// The stable sort is load-bearing: equal keys retain input order before the
+/// final value replaces earlier ones.
+pub fn canonicalize_map_entries(mut entries: Vec<(MapKey, Value)>) -> (Vec<(MapKey, Value)>, u64) {
+    let mut comparison_units = 0u64;
+    entries.sort_by(|(a, _), (b, _)| {
+        comparison_units = comparison_units.saturating_add(a.comparison_units(b));
+        a.compare(b)
+    });
+    // Compact in place: after the stable sort, equal keys remain in input
+    // order. `dedup_by` passes the later entry first; moving its value into the
+    // retained earlier slot therefore implements last-write-wins without a
+    // second input-sized vector.
+    entries.dedup_by(|later, earlier| {
+        comparison_units =
+            comparison_units.saturating_add(later.0.comparison_units(&earlier.0));
+        if later.0 == earlier.0 {
+            std::mem::swap(&mut later.1, &mut earlier.1);
+            true
+        } else {
+            false
+        }
+    });
+    // A duplicate-heavy external/replay payload must not leave a tiny map
+    // retaining capacity for its full untrusted input.
+    entries.shrink_to_fit();
+    (entries, comparison_units)
+}
 
 #[derive(Clone)]
 pub enum Value {
@@ -18,6 +139,9 @@ pub enum Value {
     String(Rc<str>),
     Bool(bool),
     List(Rc<Vec<Value>>),
+    /// Immutable keyed data in canonical key order. Language and host
+    /// construction seams validate keys and keep entries unique.
+    Map(Rc<Vec<(MapKey, Value)>>),
     /// At least two elements; structural equality, `(1, 2)` display.
     Tuple(Rc<Vec<Value>>),
     /// Field order is the construction order (deterministic output).
@@ -142,7 +266,7 @@ impl Value {
     /// depth-limited [`Value::preview`] inline and the full `Display` on
     /// hover. Callables and host data count as primitive: their `Display` is
     /// already a short opaque tag (`<fn(x)>`, `<ctor Circle>`). Empty
-    /// collections are primitive too (`[]` is complete).
+    /// collections are primitive too (`[]` / `Map.fromList([])` are complete).
     pub fn is_primitive(&self) -> bool {
         match self {
             Value::Number(_) | Value::Bool(_) => true,
@@ -150,6 +274,7 @@ impl Value {
             Value::String(s) => s.chars().take(MAX_PREVIEW_STRING + 1).count() <= MAX_PREVIEW_STRING,
             Value::Variant { args, .. } => args.is_empty(),
             Value::List(items) => items.is_empty(),
+            Value::Map(entries) => entries.is_empty(),
             Value::Record(fields) => fields.is_empty(),
             Value::Tuple(_) => false, // never empty (two elements minimum)
             Value::Ctor { .. }
@@ -200,6 +325,25 @@ impl Value {
                 let tail = if items.len() > MAX_PREVIEW_ITEMS { ", …" } else { "" };
                 format!("[{}{tail}]", shown.join(", "))
             }
+            Value::Map(entries) => {
+                let shown: Vec<String> = entries
+                    .iter()
+                    .take(MAX_PREVIEW_ITEMS)
+                    .map(|(key, value)| {
+                        format!(
+                            "({}, {})",
+                            key.to_value().preview_at(depth + 1),
+                            value.preview_at(depth + 1)
+                        )
+                    })
+                    .collect();
+                let tail = if entries.len() > MAX_PREVIEW_ITEMS {
+                    ", …"
+                } else {
+                    ""
+                };
+                format!("Map.fromList([{}{tail}])", shown.join(", "))
+            }
             Value::Tuple(items) => {
                 let shown: Vec<String> = items
                     .iter()
@@ -233,6 +377,48 @@ impl Value {
     }
 }
 
+#[cfg(test)]
+mod map_tests {
+    use super::{canonicalize_map_entries, MapKey, Value};
+    use std::rc::Rc;
+
+    #[test]
+    fn comparison_units_cover_string_bytes_and_scalar_constant_work() {
+        let short = MapKey::String(Rc::from("abc"));
+        let long = MapKey::String(Rc::from("abcdef"));
+
+        assert_eq!(MapKey::Bool(false).comparison_units(&MapKey::Bool(true)), 1);
+        assert_eq!(
+            MapKey::Number(1.0).comparison_units(&MapKey::Number(2.0)),
+            1
+        );
+        assert_eq!(short.comparison_units(&MapKey::Bool(false)), 1);
+        assert_eq!(short.comparison_units(&long), 4);
+        assert_eq!(short.comparison_unit_ceiling(), 4);
+        assert_eq!(long.comparison_unit_ceiling(), 7);
+    }
+
+    #[test]
+    fn duplicate_heavy_canonicalization_compacts_and_keeps_the_last_value() {
+        let entries = (0..1024)
+            .map(|value| {
+                (
+                    MapKey::String(Rc::from("same")),
+                    Value::Number(value as f64),
+                )
+            })
+            .collect();
+        let (canonical, _) = canonicalize_map_entries(entries);
+
+        assert_eq!(canonical.len(), 1);
+        assert!(
+            canonical.capacity() < 1024,
+            "a one-entry map retained the untrusted input capacity"
+        );
+        assert!(matches!(canonical[0].1, Value::Number(value) if value == 1023.0));
+    }
+}
+
 // NOTE on deep values and the native stack: `Value` deliberately has NO
 // manual `Drop` — an iterative-teardown Drop was built and measured at ~2x
 // frame_bench wall-clock (every dying container paid worklist/TLS churn that
@@ -257,6 +443,7 @@ impl fmt::Display for Value {
         /// closers, field names — all borrowed from `self` or 'static).
         enum Tok<'a> {
             Val(&'a Value),
+            Key(&'a MapKey),
             Text(&'a str),
         }
         let mut stack: Vec<Tok> = vec![Tok::Val(self)];
@@ -264,6 +451,10 @@ impl fmt::Display for Value {
             let value = match tok {
                 Tok::Text(s) => {
                     f.write_str(s)?;
+                    continue;
+                }
+                Tok::Key(key) => {
+                    write!(f, "{key}")?;
                     continue;
                 }
                 Tok::Val(value) => value,
@@ -289,6 +480,20 @@ impl fmt::Display for Value {
                     stack.push(Tok::Text("]"));
                     for (i, item) in items.iter().enumerate().rev() {
                         stack.push(Tok::Val(item));
+                        if i > 0 {
+                            stack.push(Tok::Text(", "));
+                        }
+                    }
+                }
+                Value::Map(entries) => {
+                    f.write_str("Map.fromList([")?;
+                    stack.push(Tok::Text("])"));
+                    for (i, (key, value)) in entries.iter().enumerate().rev() {
+                        stack.push(Tok::Text(")"));
+                        stack.push(Tok::Val(value));
+                        stack.push(Tok::Text(", "));
+                        stack.push(Tok::Key(key));
+                        stack.push(Tok::Text("("));
                         if i > 0 {
                             stack.push(Tok::Text(", "));
                         }
@@ -364,6 +569,9 @@ impl Value {
             Value::List(items) | Value::Tuple(items) => {
                 items.iter().all(Value::is_reload_safe_snapshot)
             }
+            Value::Map(entries) => entries
+                .iter()
+                .all(|(_, value)| value.is_reload_safe_snapshot()),
             Value::Record(fields) => fields
                 .iter()
                 .all(|(_, value)| value.is_reload_safe_snapshot()),
@@ -386,6 +594,7 @@ impl Value {
             Value::String(_) => "a string",
             Value::Bool(_) => "a bool",
             Value::List(_) => "a list",
+            Value::Map(_) => "a map",
             Value::Tuple(_) => "a tuple",
             Value::Record(_) => "a record",
             Value::Variant { .. } => "a variant",

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -31,6 +31,77 @@ fn assert_clean(src: &str) {
     assert!(diags.is_empty(), "expected no diagnostics, got {diags:?}");
 }
 
+// ------------------------------------------------------------- immutable Map
+
+#[test]
+fn map_operations_infer_key_and_value_types_through_pipelines() {
+    assert_clean(
+        r#"
+let build = (pairs: List<(string, float)>): Map<string, float> =>
+  Map.fromList(pairs) |> Map.insert("bonus", 4.0)
+let read = (map: Map<string, float>) => map |> Map.get("bonus")
+let entries = (map: Map<string, float>): List<(string, float)> => Map.toList(map)
+"#,
+    );
+}
+
+#[test]
+fn map_operations_reject_inconsistent_key_and_value_types() {
+    let diags = check_src(
+        r#"
+let map = Map.empty() |> Map.insert("a", 1.0)
+let badKey = map |> Map.get(2.0)
+let badValue = map |> Map.insert("b", true)
+"#,
+    );
+    let messages: Vec<&str> = diags
+        .iter()
+        .map(|(message, _, _)| message.as_str())
+        .collect();
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("expected Map<float, float>, got Map<string, float>")),
+        "missing key mismatch: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("expected Map<string, bool>, got Map<string, float>")),
+        "missing value mismatch: {messages:?}"
+    );
+}
+
+#[test]
+fn map_key_domain_is_checked_for_concrete_calls_and_annotations() {
+    let (message, _, _) = single_diag("let bad = () => Map.empty() |> Map.insert([1.0], \"x\")");
+    assert_eq!(
+        message,
+        "Map keys must be bool, finite float, or string; got List<float>"
+    );
+
+    let (message, _, _) = single_diag("let bad = (map: Map<List<float>, string>) => map");
+    assert_eq!(
+        message,
+        "Map keys must be bool, finite float, or string; got List<float>"
+    );
+}
+
+#[test]
+fn map_type_arity_is_checked() {
+    let (message, _, _) = single_diag("let bad = (map: Map<string>) => map");
+    assert_eq!(message, "`Map` takes 2 type argument(s), got 1");
+}
+
+#[test]
+fn map_builtin_namespace_is_closed() {
+    let (message, _, _) = single_diag("let bad = Map.lookup");
+    assert!(
+        message.starts_with("`Map` has no builtin `lookup`"),
+        "{message}"
+    );
+}
+
 #[test]
 fn interpolation_is_string_and_checks_every_hole() {
     assert_clean(

--- a/functor-lang/tests/expects.rs
+++ b/functor-lang/tests/expects.rs
@@ -246,6 +246,105 @@ fn append_doubling_cannot_amplify_past_the_budget() {
 }
 
 #[test]
+fn immutable_map_updates_charge_the_copied_output() {
+    // Four inserts materialize vectors of lengths 1+2+3+4. Together with
+    // their logarithmic searches this must exceed a budget that a
+    // per-builtin-call-only implementation would fit.
+    let src = "expect Map.member(4.0,\n\
+               Map.insert(4.0, 4.0,\n\
+               Map.insert(3.0, 3.0,\n\
+               Map.insert(2.0, 2.0,\n\
+               Map.insert(1.0, 1.0, Map.empty())))))\n";
+    let out = budgeted(src, 15);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Error(_)));
+
+    // A realistic budget still completes the same operation.
+    let out = budgeted(src, 100);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn map_bulk_construction_and_iteration_charge_their_entries() {
+    // The three top-level lists cost 19 container-construction steps and fit
+    // the 20-step load budget. The expect then gets a fresh budget: a
+    // per-call-only implementation would fit its three Map calls, but
+    // fromList's input/sort and values/toList's materialized entries cannot.
+    let src = "let pairs = [(8.0, 8.0), (7.0, 7.0), (6.0, 6.0), (5.0, 5.0), \
+                           (4.0, 4.0), (3.0, 3.0), (2.0, 2.0), (1.0, 1.0)]\n\
+               let expected = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), \
+                               (5.0, 5.0), (6.0, 6.0), (7.0, 7.0), (8.0, 8.0)]\n\
+               let values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]\n\
+               expect (\n\
+                 let map = Map.fromList(pairs) in\n\
+                 (Map.values(map), Map.toList(map)) == (values, expected)\n\
+               )\n";
+    let out = budgeted(src, 20);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Error(_)));
+
+    let out = budgeted(src, 200);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn map_searches_charge_key_comparisons() {
+    // Build without fromList so its sort preflight is not what this test
+    // measures. Repeated binary searches would fit under call-only
+    // accounting, but their key comparisons must exhaust the fresh expect
+    // budget.
+    let src = "let map = Map.empty()\n\
+                 |> Map.insert(1.0, true) |> Map.insert(2.0, true)\n\
+                 |> Map.insert(3.0, true) |> Map.insert(4.0, true)\n\
+                 |> Map.insert(5.0, true) |> Map.insert(6.0, true)\n\
+                 |> Map.insert(7.0, true) |> Map.insert(8.0, true)\n\
+               expect List.all((_) => Map.member(8.0, map), List.range(32.0))\n";
+    let out = budgeted(src, 100);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Error(_)));
+
+    let out = budgeted(src, 500);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn map_string_searches_charge_compared_bytes() {
+    // The map is built during def loading without comparing keys. The
+    // expect's lookup compares two strings whose common prefix is long:
+    // charging merely one step per comparison would let this fit.
+    let prefix = "a".repeat(4096);
+    let src = format!(
+        "let map = Map.insert(\"{prefix}x\", true, Map.empty())\n\
+         expect Map.member(\"{prefix}y\", map) == false\n"
+    );
+    let out = budgeted(&src, 100);
+    let ExpectOutcome::Error(err) = &out[0].outcome else {
+        panic!("expected the long string-key comparison to exceed the budget");
+    };
+    assert!(err.message.contains("step budget"), "unexpected: {err:?}");
+
+    let out = budgeted(&src, 10_000);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
+fn map_from_list_preflights_string_comparison_bytes() {
+    // Sorting and duplicate folding both compare keys. Preflight their
+    // conservative byte-work bound before the first potentially long
+    // comparison, then charge the actual work only once on success.
+    let prefix = "a".repeat(4096);
+    let src = format!(
+        "expect Map.values(Map.fromList(\
+         [(\"{prefix}y\", 2.0), (\"{prefix}x\", 1.0)])) == [1.0, 2.0]\n"
+    );
+    let out = budgeted(&src, 100);
+    let ExpectOutcome::Error(err) = &out[0].outcome else {
+        panic!("expected Map.fromList preflight to exceed the budget");
+    };
+    assert!(err.message.contains("step budget"), "unexpected: {err:?}");
+
+    let out = budgeted(&src, 30_000);
+    assert!(matches!(out[0].outcome, ExpectOutcome::Pass));
+}
+
+#[test]
 fn text_join_doubling_cannot_amplify_past_the_budget() {
     // The string flavor of the same amplifier: join("", [s, s]) doubles s.
     let src = "let d = (s) => Text.join(\"\", [s, s])\n\

--- a/functor-lang/tests/ir.rs
+++ b/functor-lang/tests/ir.rs
@@ -113,6 +113,8 @@ fn error_redeclare_builtin_type() {
     assert_eq!(message, "cannot redeclare builtin type `float`");
     let (message, _, _) = lower_err("type List = { head: float }");
     assert_eq!(message, "cannot redeclare builtin type `List`");
+    let (message, _, _) = lower_err("type Map = { value: float }");
+    assert_eq!(message, "cannot redeclare builtin type `Map`");
     // `unknown` is reserved for the same reason: `resolve_type` answers it
     // before consulting declared types, so a user's `type unknown` could
     // never be reached from an annotation.

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -430,6 +430,22 @@ namespace `Scene` — rename the file"
     );
 }
 
+#[test]
+fn map_namespace_module_name_is_refused() {
+    let err = load_err(
+        "protected-map",
+        &[
+            ("game.fun", "let main = () => 0.0\n"),
+            ("map.fun", "let empty = 1.0\n"),
+        ],
+    );
+    assert_eq!(
+        err,
+        "map.fun:1:1: module name `Map` (from map.fun) collides with the builtin/prelude \
+namespace `Map` — rename the file"
+    );
+}
+
 /// `Debug` is protected (the `Debug.log` builtin's namespace), so a sibling
 /// `debug.fun` can't shadow it — a load error names the collision.
 #[test]

--- a/functor-lang/tests/rebind.rs
+++ b/functor-lang/tests/rebind.rs
@@ -199,6 +199,43 @@ fn plain_data_is_preserved() {
 }
 
 #[test]
+fn map_plain_data_is_reload_safe_and_preserves_canonical_order() {
+    let a = module("let main = () => Map.fromList([(\"b\", [2.0]), (\"a\", [1.0])])");
+    let b = module("let main = () => Map.empty()");
+    let stored = main_value(&a);
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 0);
+    assert!(report.warnings.is_empty());
+    assert_eq!(
+        rebound.to_string(),
+        "Map.fromList([(\"a\", [1]), (\"b\", [2])])"
+    );
+    assert!(stored.is_reload_safe_snapshot());
+}
+
+#[test]
+fn closures_nested_in_maps_rebind_and_keep_snapshots_unsafe() {
+    let a = module(&format!(
+        "{APPLY}let behavior = (x) => x + 1.0\n\
+         let main = () => Map.empty() |> Map.insert(\"behavior\", behavior)"
+    ));
+    let b = module(&format!(
+        "{APPLY}let behavior = (x) => x + 10.0\n\
+         let main = () => Map.empty() |> Map.insert(\"behavior\", behavior)"
+    ));
+    let stored = main_value(&a);
+    assert!(!stored.is_reload_safe_snapshot());
+    let (rebound, report) = rebind_value(&stored, &a, &b);
+    assert_eq!(report.rebound, 1);
+    assert!(report.warnings.is_empty());
+    let Value::Map(entries) = rebound else {
+        panic!("expected map");
+    };
+    assert_eq!(entries.len(), 1);
+    assert_eq!(num(&apply(&b, entries[0].1.clone(), 2.0)), 12.0);
+}
+
+#[test]
 fn stored_closures_make_a_snapshot_reload_unsafe() {
     let module = module(&format!(
         "{APPLY}let mul = (k) => (x) => x * k\nlet main = () => {{ nested: [mul(3.0)] }}"

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -44,6 +44,141 @@ fn main_result(src: &str) -> String {
     }
 }
 
+// ------------------------------------------------------------- immutable Map
+
+#[test]
+fn map_core_operations_are_immutable_and_subject_last() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  let original = Map.empty() |> Map.insert("b", 2.0) |> Map.insert("a", 1.0) in
+  let changed = original |> Map.insert("b", 20.0) |> Map.remove("a") in
+  (Map.get("b", original), Map.member("a", original),
+   Map.get("b", changed), Map.member("a", changed))
+"#
+        ),
+        "(Option.Some(2), true, Option.Some(20), false)"
+    );
+}
+
+#[test]
+fn map_iteration_and_display_are_in_canonical_key_order() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  Map.fromList([("z", 3.0), ("a", 1.0), ("m", 2.0)])
+"#
+        ),
+        r#"Map.fromList([("a", 1), ("m", 2), ("z", 3)])"#
+    );
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  Map.fromList([("z", 3.0), ("a", 1.0), ("m", 2.0)]) |> Map.values
+"#
+        ),
+        "[1, 2, 3]"
+    );
+    // String order is Unicode scalar-value lexicographic, never locale
+    // collation: decomposed `e + acute` sorts by its leading `e`, before z,
+    // while precomposed `é` sorts after z.
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  Map.fromList([("é", 3.0), ("z", 2.0), ("é", 1.0)]) |> Map.values
+"#
+        ),
+        "[1, 2, 3]"
+    );
+}
+
+#[test]
+fn map_from_list_is_last_write_wins_and_to_list_is_canonical() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  Map.fromList([(2.0, "old"), (1.0, "one"), (2.0, "new")])
+  |> Map.toList
+"#
+        ),
+        r#"[(1, "one"), (2, "new")]"#
+    );
+}
+
+#[test]
+fn map_key_order_is_explicit_even_through_a_gradual_seam() {
+    // `run` does not typecheck first, so this deliberately exercises the
+    // runtime order used when an `unknown` host payload mixes supported key
+    // kinds: bool < finite float < string.
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  Map.fromList([("a", 3.0), (1.0, 2.0), (true, 1.0), (false, 0.0)])
+  |> Map.toList
+"#
+        ),
+        r#"[(false, 0), (true, 1), (1, 2), ("a", 3)]"#
+    );
+}
+
+#[test]
+fn map_normalizes_signed_zero_as_one_key() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () => Map.fromList([(0.0 - 0.0, "first"), (-0.0, "last")])
+"#
+        ),
+        r#"Map.fromList([(0, "last")])"#
+    );
+}
+
+#[test]
+fn maps_compare_structurally_independent_of_insertion_order() {
+    assert_eq!(
+        main_result(
+            r#"
+let main = () =>
+  Map.fromList([("b", [2.0]), ("a", [1.0])])
+  == (Map.empty() |> Map.insert("a", [1.0]) |> Map.insert("b", [2.0]))
+"#
+        ),
+        "true"
+    );
+}
+
+#[test]
+fn map_rejects_non_finite_and_non_scalar_keys() {
+    for (src, needle) in [
+        (
+            "let main = () => Map.empty() |> Map.insert(0.0 / 0.0, 1.0)",
+            "NaN/Infinity cannot be map keys",
+        ),
+        (
+            "let main = () => Map.empty() |> Map.insert([1.0], 1.0)",
+            "keys must be bools, finite floats, or strings",
+        ),
+    ] {
+        let (message, _, _) = run_err(src);
+        assert!(message.contains(needle), "unexpected message: {message}");
+    }
+}
+
+#[test]
+fn map_from_list_rejects_malformed_entries() {
+    let (message, _, _) = run_err("let main = () => Map.fromList([[\"a\", 1.0]])");
+    assert!(
+        message.contains("expects (key, value) tuples; entry 0 is a list"),
+        "unexpected message: {message}"
+    );
+}
+
 #[test]
 fn string_interpolation_renders_values_and_literal_braces() {
     assert_eq!(

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -401,6 +401,35 @@ fn active_world_raycast(origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> Effec
 /// INSIDE the drain, so the bound holds even mid-frame.
 pub const EFFECT_LOG_CAP: usize = 256;
 
+/// A serializable key for an [`EffectValue::Map`]. It mirrors Functor Lang's
+/// deliberately bounded scalar key domain.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum EffectMapKey {
+    Bool(bool),
+    Number(f64),
+    Text(String),
+}
+
+impl EffectMapKey {
+    fn to_functor_lang(&self) -> Result<functor_lang::value::MapKey, String> {
+        match self {
+            EffectMapKey::Bool(value) => Ok(functor_lang::value::MapKey::Bool(*value)),
+            // JSON refuses NaN/infinity, but fake/replay values are also
+            // publicly constructible in memory. Validate that external seam
+            // instead of letting MapKey::compare panic or admitting infinity.
+            EffectMapKey::Number(value) if value.is_finite() => Ok(
+                functor_lang::value::MapKey::Number(if *value == 0.0 { 0.0 } else { *value }),
+            ),
+            EffectMapKey::Number(value) => Err(format!(
+                "effect map keys must be finite; got {value} (NaN/Infinity cannot be map keys)"
+            )),
+            EffectMapKey::Text(value) => Ok(functor_lang::value::MapKey::String(Rc::from(
+                value.as_str(),
+            ))),
+        }
+    }
+}
+
 /// A performed effect's structured result: the serializable plain-data
 /// subset of [`Value`] — no closures, no host data — which is what makes
 /// results loggable, replayable, and fakeable. `now`/`random` results are
@@ -411,6 +440,8 @@ pub enum EffectValue {
     Bool(bool),
     Text(String),
     List(Vec<EffectValue>),
+    /// Canonically key-sorted immutable map data.
+    Map(Vec<(EffectMapKey, EffectValue)>),
     /// Structural tuple (at least two elements), mirroring [`Value::Tuple`] —
     /// so an `Effect.sendMsg` payload carrying a tuple field roundtrips as a
     /// tuple, not a list.
@@ -424,29 +455,52 @@ pub enum EffectValue {
 }
 
 impl EffectValue {
-    /// The Functor Lang value handed to the effect's tagger.
-    pub fn to_functor_lang(&self) -> Value {
-        match self {
+    /// The Functor Lang value handed to the effect's tagger. External
+    /// fake/replay map keys are validated here; malformed structured data is
+    /// an error rather than a host panic.
+    pub fn to_functor_lang(&self) -> Result<Value, String> {
+        Ok(match self {
             EffectValue::Number(n) => Value::Number(*n),
             EffectValue::Bool(b) => Value::Bool(*b),
             EffectValue::Text(s) => Value::String(Rc::from(s.as_str())),
-            EffectValue::List(items) => {
-                Value::List(Rc::new(items.iter().map(EffectValue::to_functor_lang).collect()))
+            EffectValue::List(items) => Value::List(Rc::new(
+                items
+                    .iter()
+                    .map(EffectValue::to_functor_lang)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            EffectValue::Map(entries) => {
+                let sorted = entries
+                    .iter()
+                    .map(|(key, value)| Ok((key.to_functor_lang()?, value.to_functor_lang()?)))
+                    .collect::<Result<Vec<_>, String>>()?;
+                // Replay/network data is an external seam, so restore the
+                // same canonical order and last-write-wins rule as
+                // Map.fromList instead of trusting serialized entry order.
+                let (canonical, _) = functor_lang::value::canonicalize_map_entries(sorted);
+                Value::Map(Rc::new(canonical))
             }
-            EffectValue::Tuple(items) => {
-                Value::Tuple(Rc::new(items.iter().map(EffectValue::to_functor_lang).collect()))
-            }
+            EffectValue::Tuple(items) => Value::Tuple(Rc::new(
+                items
+                    .iter()
+                    .map(EffectValue::to_functor_lang)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
             EffectValue::Record(fields) => Value::Record(Rc::new(
                 fields
                     .iter()
-                    .map(|(k, v)| (k.clone(), v.to_functor_lang()))
-                    .collect(),
+                    .map(|(k, v)| Ok((k.clone(), v.to_functor_lang()?)))
+                    .collect::<Result<Vec<_>, String>>()?,
             )),
             EffectValue::Variant(ctor, args) => Value::Variant {
                 ctor: Rc::from(ctor.as_str()),
-                args: Rc::new(args.iter().map(EffectValue::to_functor_lang).collect()),
+                args: Rc::new(
+                    args.iter()
+                        .map(EffectValue::to_functor_lang)
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
             },
-        }
+        })
     }
 }
 
@@ -469,13 +523,15 @@ const VALUE_JSON_MAX_DEPTH: usize = 120;
 /// A total, LOSSY JSON view of a [`Value`], for observation surfaces (the
 /// debug server's `GET /state` `model`, protocol v4). Unlike
 /// [`effect_value_from_value`] it never fails: plain data maps structurally
-/// (numbers, strings, bools; lists as arrays; records as objects — field
-/// order is the serde_json map's, not construction order), and everything
+/// (numbers, strings, bools; lists as arrays; maps as `$map` entry arrays;
+/// records as objects — field order is the serde_json map's, not construction
+/// order), and everything
 /// else becomes a sigil-keyed object no source-authored record field can
 /// collide with (`$` is not a Functor Lang identifier character; a record key
 /// arriving off the network via a typed message CAN carry `$`, so treat
 /// sigils as a strong convention, not a proof):
 ///
+/// - maps: `{"$map": [[key, value], ...]}` (canonical key order)
 /// - tuples: `{"$tuple": [...]}` (so they stay distinct from lists)
 /// - variants: `{"$ctor": "Some", "args": [...]}`
 /// - callables: `{"$fn": "<fn(dt)>"}` — the `Display` form
@@ -511,6 +567,17 @@ fn value_to_json_at(value: &Value, depth: usize) -> serde_json::Value {
         Value::String(s) => json!(s.as_ref()),
         Value::Bool(b) => json!(b),
         Value::List(items) => Json::Array(items_json(items, 1)),
+        Value::Map(entries) => json!({
+            "$map": entries
+                .iter()
+                .map(|(key, value)| {
+                    Json::Array(vec![
+                        value_to_json_at(&key.to_value(), depth + 3),
+                        value_to_json_at(value, depth + 3),
+                    ])
+                })
+                .collect::<Vec<_>>()
+        }),
         Value::Tuple(items) => json!({ "$tuple": items_json(items, 2) }),
         Value::Record(fields) => Json::Object(
             fields
@@ -549,6 +616,21 @@ pub fn effect_value_from_value(value: &Value) -> Result<EffectValue, String> {
         Value::List(items) => Ok(EffectValue::List(
             items.iter().map(effect_value_from_value).collect::<Result<_, _>>()?,
         )),
+        Value::Map(entries) => Ok(EffectValue::Map(
+            entries
+                .iter()
+                .map(|(key, value)| {
+                    let key = match key {
+                        functor_lang::value::MapKey::Bool(value) => EffectMapKey::Bool(*value),
+                        functor_lang::value::MapKey::Number(value) => EffectMapKey::Number(*value),
+                        functor_lang::value::MapKey::String(value) => {
+                            EffectMapKey::Text(value.to_string())
+                        }
+                    };
+                    Ok((key, effect_value_from_value(value)?))
+                })
+                .collect::<Result<_, String>>()?,
+        )),
         Value::Tuple(items) => Ok(EffectValue::Tuple(
             items.iter().map(effect_value_from_value).collect::<Result<_, _>>()?,
         )),
@@ -564,7 +646,7 @@ pub fn effect_value_from_value(value: &Value) -> Result<EffectValue, String> {
         )),
         other => Err(format!(
             "not plain data: {} — a message must be numbers, strings, bools, \
-lists, tuples, records, and variants of those (no functions, no host values)",
+lists, maps, tuples, records, and variants of those (no functions, no host values)",
             value_kind(other)
         )),
     }
@@ -577,6 +659,7 @@ fn value_kind(value: &Value) -> &'static str {
         Value::String(_) => "a string",
         Value::Bool(_) => "a bool",
         Value::List(_) => "a list",
+        Value::Map(_) => "a map",
         Value::Tuple(_) => "a tuple",
         Value::Record(_) => "a record",
         Value::Variant { .. } => "a variant",
@@ -4006,7 +4089,9 @@ pub fn http_response_value(result: &crate::net::HttpResult) -> Value {
     } else {
         EffectValue::Variant("Net.Failure".into(), vec![EffectValue::Text(result.error_text())])
     };
-    variant.to_functor_lang()
+    variant
+        .to_functor_lang()
+        .expect("host-built HTTP responses have no map keys")
 }
 
 thread_local! {
@@ -4417,6 +4502,7 @@ pub fn contains_effect(value: &Value) -> bool {
     match value {
         Value::HostData(data) => data.as_any().downcast_ref::<FunctorLangEffect>().is_some(),
         Value::Tuple(items) | Value::List(items) => items.iter().any(contains_effect),
+        Value::Map(entries) => entries.iter().any(|(_, value)| contains_effect(value)),
         Value::Record(fields) => fields.iter().any(|(_, v)| contains_effect(v)),
         Value::Variant { args, .. } => args.iter().any(contains_effect),
         _ => false,
@@ -4785,7 +4871,15 @@ dropping the rest"
             EffectTree::Random { tagger } => ("random", runner.random().into(), tagger),
         };
         let value: EffectValue = value;
-        let functor_lang_value = value.to_functor_lang();
+        let functor_lang_value = match value.to_functor_lang() {
+            Ok(value) => value,
+            Err(error) => {
+                report(format!(
+                    "[functor-lang] Effect.{kind} produced invalid structured data: {error}"
+                ));
+                continue;
+            }
+        };
         log.push(EffectRecord { kind, value });
         if log.len() > EFFECT_LOG_CAP {
             log.remove(0);
@@ -5108,7 +5202,7 @@ fn sync_cast(
         w.raycast_excluding([ox, oy, oz], [dx, dy, dz], max_dist, exclude)
     })
     .flatten();
-    Ok(ray_result_value(hit).to_functor_lang())
+    ray_result_value(hit).to_functor_lang()
 }
 
 fn no_body(tag: &str) -> String {
@@ -8494,19 +8588,75 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             ("hit".to_string(), EffectValue::Bool(true)),
             ("distance".to_string(), EffectValue::Number(4.25)),
             ("tag".to_string(), EffectValue::Text("crate-1".to_string())),
+            (
+                "scores".to_string(),
+                EffectValue::Map(vec![
+                    (
+                        EffectMapKey::Number(1.0),
+                        EffectValue::Text("one".to_string()),
+                    ),
+                    (
+                        EffectMapKey::Text("two".to_string()),
+                        EffectValue::Number(2.0),
+                    ),
+                ]),
+            ),
         ]);
-        let functor_lang = value.to_functor_lang();
+        let functor_lang = value.to_functor_lang().unwrap();
         let Value::Record(fields) = &functor_lang else {
             panic!("expected a record, got {}", functor_lang.kind_name());
         };
-        assert_eq!(fields.len(), 3);
+        assert_eq!(fields.len(), 4);
         assert_eq!(fields[0].0, "hit");
         assert!(matches!(fields[0].1, Value::Bool(true)));
         assert!(matches!(fields[1].1, Value::Number(n) if n == 4.25));
+        assert!(matches!(&fields[3].1, Value::Map(entries) if entries.len() == 2));
 
         let json = serde_json::to_string(&value).expect("serialize");
         let back: EffectValue = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, value);
+        assert_eq!(effect_value_from_value(&functor_lang).unwrap(), value);
+    }
+
+    #[test]
+    fn effect_map_values_restore_canonical_order_at_the_replay_seam() {
+        let value = EffectValue::Map(vec![
+            (
+                EffectMapKey::Text("z".to_string()),
+                EffectValue::Number(1.0),
+            ),
+            (
+                EffectMapKey::Number(-0.0),
+                EffectValue::Text("old".to_string()),
+            ),
+            (EffectMapKey::Bool(false), EffectValue::Number(2.0)),
+            (
+                EffectMapKey::Number(0.0),
+                EffectValue::Text("new".to_string()),
+            ),
+        ])
+        .to_functor_lang()
+        .unwrap();
+
+        assert_eq!(
+            value.to_string(),
+            r#"Map.fromList([(false, 2), (0, "new"), ("z", 1)])"#
+        );
+    }
+
+    #[test]
+    fn effect_map_values_reject_non_finite_keys_at_the_replay_seam() {
+        for key in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let value = EffectValue::List(vec![EffectValue::Map(vec![(
+                EffectMapKey::Number(key),
+                EffectValue::Bool(true),
+            )])]);
+            let error = value
+                .to_functor_lang()
+                .err()
+                .expect("a non-finite map key must be rejected");
+            assert!(error.contains("effect map keys must be finite"), "{error}");
+        }
     }
 
     /// The lossy model-JSON walker (`GET /state` `model`, v4): plain data
@@ -8532,6 +8682,19 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
                 Value::List(Rc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
             ),
             (
+                "scores".to_string(),
+                Value::Map(Rc::new(vec![
+                    (
+                        functor_lang::value::MapKey::String(Rc::from("a")),
+                        Value::Number(1.0),
+                    ),
+                    (
+                        functor_lang::value::MapKey::String(Rc::from("b")),
+                        Value::Number(2.0),
+                    ),
+                ])),
+            ),
+            (
                 "pos".to_string(),
                 Value::Tuple(Rc::new(vec![Value::Number(1.0), Value::Number(2.0)])),
             ),
@@ -8555,6 +8718,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
                 "name": "hello",
                 "alive": true,
                 "items": [1.0, 2.0],
+                "scores": { "$map": [["a", 1.0], ["b", 2.0]] },
                 "pos": { "$tuple": [1.0, 2.0] },
                 "state": { "$ctor": "Playing", "args": [7.0] },
                 "spawn": { "$fn": "<host Scene.cube>" },
@@ -8719,6 +8883,11 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
             ))])),
         )]));
         assert!(contains_effect(&nested));
+        let in_map = Value::Map(std::rc::Rc::new(vec![(
+            functor_lang::value::MapKey::String(std::rc::Rc::from("command")),
+            nested,
+        )]));
+        assert!(contains_effect(&in_map));
         assert!(!contains_effect(&Value::Number(1.0)));
     }
 
@@ -9335,7 +9504,9 @@ the game dir"
     /// binds them.
     #[test]
     fn net_event_value_matches_the_net_module() {
-        let ev = net_event_value(NetEventKind::Message, 3, "yo").to_functor_lang();
+        let ev = net_event_value(NetEventKind::Message, 3, "yo")
+            .to_functor_lang()
+            .unwrap();
         match ev {
             Value::Variant { ctor, args } => {
                 assert_eq!(ctor.as_ref(), "Net.Message");
@@ -9369,7 +9540,7 @@ the game dir"
         assert!(wire.starts_with(TYPED_MSG_PREFIX));
         assert_eq!(decode_typed_msg(&wire).unwrap().unwrap(), payload);
         assert_eq!(
-            effect_value_from_value(&payload.to_functor_lang()).unwrap(),
+            effect_value_from_value(&payload.to_functor_lang().unwrap()).unwrap(),
             payload
         );
 
@@ -10066,8 +10237,9 @@ a number",
                 .collect();
             (m, sends)
         }
-        let event =
-            |kind, id: u64, text: &str| net_event_value(kind, id, text).to_functor_lang();
+        let event = |kind, id: u64, text: &str| {
+            net_event_value(kind, id, text).to_functor_lang().unwrap()
+        };
 
         // The listener is declared on the arena address.
         let subs = call(&session, "subscriptions", vec![session.global("init").unwrap()]);
@@ -10174,7 +10346,9 @@ a number",
                 })
                 .collect()
         }
-        let event = |kind, id: u64, text: &str| net_event_value(kind, id, text).to_functor_lang();
+        let event = |kind, id: u64, text: &str| {
+            net_event_value(kind, id, text).to_functor_lang().unwrap()
+        };
         // Keys are the built-in `Key` module's variants (`Key.W`), as the
         // producers deliver them.
         let key = |k: &str| Value::Variant {

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1064,7 +1064,9 @@ to receive their messages; dropping them"
         let Some(sub) = conns.into_iter().find(|c| c.key == key) else {
             return; // an event for a no-longer-declared connection: drop it
         };
-        let value = net_event_value(kind, conn as u64, &text).to_functor_lang();
+        let value = net_event_value(kind, conn as u64, &text)
+            .to_functor_lang()
+            .expect("decoded network events contain only JSON-finite map keys");
         let msg = match self
             .session
             .apply(sub.tagger, vec![value], "net event", &mut FunctorHost)

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -580,9 +580,9 @@ let pos = model.pos |> Vec3.add(step)</pre>
             These modules are part of the <em>language</em>, not the engine — unlike the prelude
             above, they resolve everywhere Functor Lang runs, including the bare
             <code>functor-lang</code> interpreter. The collection and container functions
-            (<code>List</code>, <code>Option</code>, <code>Result</code>) take their subject
-            <strong>last</strong>, so they pipe. The numeric and formatting helpers instead read
-            as ordinary notation — <code>Text.fixed(n, decimals)</code> and the two-argument
+            (<code>List</code>, <code>Map</code>, <code>Option</code>, <code>Result</code>) take
+            their subject <strong>last</strong>, so they pipe. The numeric and formatting helpers
+            instead read as ordinary notation — <code>Text.fixed(n, decimals)</code> and the two-argument
             <code>Math</code> functions (<code>pow</code>, <code>atan2</code>, <code>mod</code>,
             <code>min</code>, <code>max</code>) take their number <em>first</em>, so a pipeline
             would feed the wrong slot: write <code>Text.fixed(hp, 0.0)</code>, not
@@ -653,6 +653,45 @@ let pos = model.pos |> Vec3.add(step)</pre>
 match enemies |> List.find((e) =&gt; e.hp &lt;= 0.0) with
 | Option.Some(dead) =&gt; respawn(dead)
 | Option.None =&gt; model</code></pre>
+
+          <h3 id="stdlib-map">Map</h3>
+          <p>
+            Deterministic immutable keyed data. A <code>Map&lt;key, value&gt;</code> accepts
+            <code>bool</code>, finite <code>float</code>, or <code>string</code> keys;
+            ordinary inference keeps one key type per map. Every iteration surface uses canonical
+            key order on native and wasm: bools before floats before strings, then
+            <code>false</code> before <code>true</code>, ascending numbers, and ascending Unicode
+            scalar-value strings (lexicographic, not locale-aware). <code>-0.0</code> is the same
+            key as <code>0.0</code>; NaN and infinities are rejected.
+          </p>
+          <pre class="functor-lang">let occupied =
+  Map.empty()
+  |> Map.insert("4,7", Player)
+  |> Map.insert("8,2", Wall)
+
+match occupied |> Map.get("4,7") with
+| Option.Some(cell) =&gt; drawCell(cell)
+| Option.None =&gt; Scene.group([])</pre>
+          <table>
+            <tbody>
+              <tr><td><code>Map.empty()</code></td><td>an empty <code>Map&lt;'key, 'value&gt;</code>; later operations infer both types</td></tr>
+              <tr><td><code>Map.get(key, map)</code></td><td><code>Option.Some(value)</code>, or <code>Option.None</code></td></tr>
+              <tr><td><code>Map.insert(key, value, map)</code></td><td>return a new map; replacing an existing key leaves the original map untouched</td></tr>
+              <tr><td><code>Map.remove(key, map)</code></td><td>return a new map without the key; removing an absent key is a no-op</td></tr>
+              <tr><td><code>Map.member(key, map)</code></td><td>whether the key exists</td></tr>
+              <tr><td><code>Map.values(map)</code></td><td>values in canonical key order</td></tr>
+              <tr><td><code>Map.toList(map)</code></td><td>canonical <code>List&lt;(key, value)&gt;</code></td></tr>
+              <tr><td><code>Map.fromList(entries)</code></td><td>build from <code>(key, value)</code> tuples; the last value for a duplicate key wins</td></tr>
+            </tbody>
+          </table>
+          <p>
+            Lookup and membership are logarithmic. Because the collection is immutable,
+            insertion and removal copy the ordered entry vector and are linear. Maps compare
+            structurally, display as <code>Map.fromList([…])</code>, and remain plain model data.
+            <code>values</code> and <code>toList</code> are linear;
+            <code>fromList</code> is <em>O(n log n)</em>. Plain maps survive hot reload and work
+            with time travel, debug state, and typed messages.
+          </p>
 
           <h3 id="stdlib-text">Text</h3>
           <table>

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -76,8 +76,10 @@ export interface RuntimeView {
 }
 
 /** A structured JSON view of a Functor Lang value: plain data maps structurally
- * (records as objects, lists as arrays), and everything else is a sigil-keyed
- * object no record field can collide with — `{"$tuple": [...]}`,
+ * (records as objects, lists as arrays, maps as canonical entry arrays), and
+ * everything else is a sigil-keyed object no record field can collide with —
+ * `{"$map": [[key, value], ...]}`,
+ * `{"$tuple": [...]}`,
  * `{"$ctor": "Some", "args": [...]}`, `{"$fn": "<fn(dt)>"}`,
  * `{"$host": "SceneNode"}`, `{"$number": "NaN"}`, and
  * `{"$truncated": "max depth"}` past the nesting bound. */


### PR DESCRIPTION
## Summary

- add first-class immutable `Map<K, V>` values to Functor Lang, backed by a canonical sorted persistent vector
- constrain keys to bools, finite floats, or strings; normalize `-0.0` to `0.0` and reject NaN/infinity at language and replay/network seams
- define target-independent ordering as bool < float < string, then `false < true`, numeric order, and lexicographic UTF-8/string order
- add subject-last `Map.empty`, `get`, `insert`, `remove`, `member`, `values`, `toList`, and `fromList`; duplicate `fromList` keys use stable last-write-wins semantics
- integrate `Map<K, V>` through HM inference, diagnostics, display/preview, structural equality, hot reload/rebind, effect serialization/replay, debug/network JSON, editor intelligence, SDK types, docs, and corpus benchmarks

Closes #543

## Visual evidence

![Deterministic Map manual before/after](https://gist.githubusercontent.com/tommy-xr/b771d0f46cb3e6db5d363d17ce75b5a7/raw/map-manual-before-after.gif)

<sub>Exact PR base `05564a1c` flows directly from `List` into `Text`; branch `1424402` inserts the deterministic `Map` API and guide at `/manual/#stdlib-map`. Captured headlessly at 1440×1400 from freshly built exact-base and branch site artifacts.</sub>

### Before → after

![Exact-base and branch Map manual comparison](https://gist.githubusercontent.com/tommy-xr/b771d0f46cb3e6db5d363d17ce75b5a7/raw/map-manual-before-after.png)

<sub>Desktop evidence only: this change adds manual content but does not alter CSS or responsive layout.</sub>

## Validation

Post-review validation:

- final exact-head `npm run build` under native Node 22.20.0: release web runtime wasm, release CLI, Functor Lang wasm, and site all built successfully; the source worktree remained clean
- focused string-comparison fuel, sort-preflight, duplicate-compaction, and nested non-finite replay-key regressions: all passed
- `cargo test -p functor-lang`: full unit and integration suite passed (including 121 unit, 163 checker, 33 budgeted-expect, and 130 runtime tests)
- `cargo test -p functor_runtime_common`: 562 unit + 10 prelude integration tests passed; 1 documentation test intentionally ignored
- `cargo test -p functor-lang-wasm`: 22/22 passed
- `cargo check -p functor-lang --target wasm32-unknown-unknown`: passed
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown`: passed
- `npm run check:docs`: Markdown and JSON generation checks passed
- `git diff --check` and conflict-marker scan: clean

Additional end-to-end checks completed before the review-only hardening fixes:

- release wasm packages built successfully
- Node 22 exercised the actual wasm Map expects: 0 diagnostics, 2/2 passed
- `npm run check:site` and `npm run site:build` passed; site source did not change after that build

## Review disposition

Two independent xreview engines reviewed the change, followed by a focused follow-up:

- **Non-finite public `EffectMapKey::Number` could panic or admit infinity:** accepted. Effect conversion is now recursively fallible, rejects NaN/infinity, normalizes zero, and reports/drops malformed fake/replay structured data. A nested seam regression covers NaN and both infinities.
- **`Map.fromList` performed sort work before enforcing the evaluator budget:** accepted. It charges entry cloning, conservatively preflights sort + dedup work, then charges successful actual work once.
- **Duplicate-heavy canonicalization retained an input-sized allocation:** accepted. Stable sorting now compacts last-write-wins duplicates in place and shrinks retained capacity.
- **Long common-prefix string keys were charged as one comparison:** accepted from the follow-up. Search precharges conservative compared bytes before every comparison; `fromList` preflights a saturating comparison-count × key-byte ceiling. Low/high-budget regressions cover both paths.
- **Insert might allocate before charging:** dismissed after inspection; immutable copy size was already precharged.
- **Last-write-wins needed old/new duplicate coverage:** already covered by canonical-order and replay seam tests.
- **Finite-key `partial_cmp(...).expect(...)` should be weakened:** dismissed; the loud invariant is intentional after every public seam validates finite keys.

The follow-up agreed the first three fixes were resolved; Claude reported no remaining Medium+ finding at that checkpoint.

Final media xreview:

- **[AGREED] No visual findings:** Claude Opus and Codex independently verified the exact-base still has no `Map` section and the branch still cleanly inserts the complete eight-operation guide before `Text`, with readable constraints, example, complexity/persistence guidance, and no clipping, overlap, or broken layout.
- A final Opus code pass returned a clean-to-ship verdict. Its two unagreed optimization suggestions were dismissed after inspection: charging long string comparisons before `cmp` is required so expensive comparison work cannot escape the evaluator budget, and `shrink_to_fit` is load-bearing for duplicate-heavy untrusted payloads while already being a no-op when capacity is fitted.
- **Synthesized verdict:** ship as-is; 0 agreed Critical/High findings.

Duplication review:

- prevention index covered 2,535 API items and found no existing Map helper to reuse
- semantic `dupfinder review` was timeboxed at 10 minutes and reached 1,008/5,352 embeddings without a finding before the timebox
- token-clone fallback was unavailable because the installed wrapper rejected its `--gitignore` flag; the two xreview engines independently found no meaningful implementation duplication

## Performance

`frame_bench` was rebuilt from exact base `5525e792` and from this change, with both `functor-lang` and `functor_runtime_common` visibly recompiled. Three release runs per side used distinct verified binaries (base `0d13c7cd…`, change `ae7f0fd1…`).

| Cells | Base min range (µs/frame) | Change min range (µs/frame) | Best-min delta | Allocs/frame | Bytes/frame |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 400 (20×20) | 514.1–543.6 | 549.3–555.7 | +6.8% | 13,877 | 843,379 |
| 1,600 (40×40) | 2,161.9–2,389.1 | 2,163.8–2,182.2 | +0.1% | 54,717 | 3,307,219 |
| 3,136 (56×56) | 4,210.0–4,784.4 | 4,233.5–4,257.1 | +0.6% | 106,973 | 6,460,243 |

Allocation and byte counts are exactly identical at every size. Wall-clock results are noise-sensitive: the small 20×20 workload shows a +6.8% best-min signal while the base runs themselves spread 5.7%; the larger workloads are +0.1% and +0.6%. This is recorded as a small-workload signal, not a blanket no-regression claim.

## Draft checklist

- [x] capture and embed before/after manual screenshots / PR media
- [x] implementation, review fixes, post-review verification, and benchmark comparison complete

Final verification, media, and review are complete.


