### PR TITLE
feat(2d): make pointer-led Sprite games resize-correct

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -306,8 +306,14 @@ let grab = (s) =>
 - **`Input` is the engine's continuously sampled input module.**
   `Input.snapshot` contains keyboard levels and fixed-step transitions:
   `heldKeys`, `pressedKeys`, and `releasedKeys` (all `List<Key.t>`). Its
-  pixel-space `mouse` record has `x`, `y`, and three `{left,right,middle}`
-  sets: `buttons` for held levels plus `pressed` / `released` for transitions.
+  top-left-origin logical `mouse` record has `x`, `y`, `surfaceWidth`,
+  `surfaceHeight`, and three `{left,right,middle}` sets: `buttons` for held
+  levels plus `pressed` / `released` for transitions. Position and surface
+  extent share one coordinate space — GLFW window points natively, CSS pixels
+  on web — so they are stable across Retina/device-pixel-ratio changes.
+  `Camera2D.toWorld` treats the ideal half-open fit in that logical space as
+  authoritative; only the renderer rounds its corresponding viewport to
+  physical framebuffer pixels.
   A quick tap can appear in both edge sets while the held set carries the final
   level. The snapshot also contains
   `xr: Option.t<Input.xr>`. XR head/grip/aim poses are rig-local
@@ -944,6 +950,13 @@ Camera2D.create(width, height)                             // center-origin, +X 
                                                            //   aspect-fits without stretching
 camera2d |> Camera2D.at(x, y)                              // pan the world-space view
 camera2d |> Camera2D.zoom(k)                               // positive zoom; larger = closer
+Camera2D.toWorld(mouse, camera2d)                          // Option.t<Input.point2>; maps the
+                                                           //   sampled logical mouse through
+                                                           //   aspect fit + pan/zoom; None in
+                                                           //   letterbox/pillarbox bars. The
+                                                           //   ideal half-open logical fit is
+                                                           //   DPR-invariant; raster rounding
+                                                           //   is renderer-only
 Sprite.blank()
 Sprite.rectangle(color, width, height) / Sprite.square(color, size)
 Sprite.circle(color, radius)                               // FILLED circle, centered like
@@ -1567,14 +1580,15 @@ let input = (model, key, isDown) => model'  // OPTIONAL; key: Key.t — match
 let sampledInput = (model, snapshot: Input.snapshot) => model'
                                             // OPTIONAL; called once immediately
                                             // before every simulation tick
-let mouseMove = (model, x, y) => model'     // OPTIONAL; window pixels
+let mouseMove = (model, x, y) => model'     // OPTIONAL; logical window/CSS coordinates
 let mouseWheel = (model, delta) => model'   // OPTIONAL
 let mouseButton = (model, button, isDown) => model'
                                             // OPTIONAL; button: Mouse.t — match
                                             // | Mouse.Left / Mouse.Right /
-                                            // Mouse.Middle. Delivered while the
-                                            // cursor is captured, so click-to-
-                                            // shoot works under free-look
+                                            // Mouse.Middle. Captured projects
+                                            // receive it under free-look;
+                                            // visible projects receive absolute
+                                            // pointer clicks
 let update = (model, msg) => model'         // OPTIONAL; msgs are ADT variants
                                             // ANY entry point may instead return
                                             // (model', effect) — a 2-tuple whose
@@ -1694,8 +1708,11 @@ click-to-capture and the web mouse-look button, routing captured
 `mouseMove`/`mouseWheel`/`mouseButton` input into the ordinary game hooks.
 On native, a non-UI click captures; Escape or focus loss releases. Absent (or
 explicit `"none"`) keeps the pointer free and hides the button, which is the
-default for 2D, UI, and fixed-camera projects. `orbit`/`fps` detached
-shell-owned modes are not implemented spellings yet.
+default for UI and fixed-camera projects. Absolute pointer-led games instead add
+`"cursor":"visible"`; native keeps the system cursor free and web routes its
+absolute CSS-pixel movement/buttons without Pointer Lock. Visible pointer input
+and `viewer.camera.control = "game"` are mutually exclusive. `orbit`/`fps`
+detached shell-owned modes are not implemented spellings yet.
 
 `examples/hello/game.fun` is the reference
 (`examples/physics/game.fun` for the physics hook, including the

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1608,12 +1608,13 @@ let soundScape = (model) => AudioScene.create([source, …])  // OPTIONAL; conti
                                             // frame (needs no `update`)
 ```
 
-The three mouse hooks receive live shell input only while the cursor is
-captured. Opt the project in with
-`"viewer": { "camera": { "control": "game" } }` in `functor.json`; without it
-the runtime warns once and leaves the hooks inert. Native capture starts on a
-non-UI click and Escape releases it. Manifest-less site IDE/inline sessions use
-`?camera=game` on the page URL.
+The three mouse hooks receive live shell input only when the project claims a
+pointer mode. Captured free-look opts in with
+`"viewer": { "camera": { "control": "game" } }`; absolute pointer-led games use
+`"cursor":"visible"` instead. Without either setting the runtime warns once and
+leaves the hooks inert. Native capture starts on a non-UI click and Escape
+releases it. Manifest-less site IDE/inline sessions use `?camera=game` or
+`?cursor=visible` on the page URL.
 
 Subscription timers are **stateless**: `Sub.every` fires when an integer
 multiple of its period lies in `(prevTts, tts]` — the global time grid, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,14 +71,14 @@ name (contract in the `functor-lang` skill; reference: `examples/hello/game.fun`
 - `init` — the initial model, a plain Functor Lang value
 - `input = (model, key, isDown) => model'` — OPTIONAL; keyboard events, keys as the built-in
   `Key` module's variants (`Key.W`, `Key.Up`, `Key.Space`, `Key.Num0`..`Key.Num9`).
-  `mouseMove`/`mouseWheel`/`mouseButton` are the analogous optional entry points. They receive
-  live shell input only while the cursor is captured, so projects defining them opt in with
-  `"viewer": { "camera": { "control": "game" } }` in `functor.json`; otherwise the runtime
-  warns once and keeps the hooks inert.
+  `mouseMove`/`mouseWheel`/`mouseButton` are the analogous optional entry points. Captured
+  free-look opts in with `"viewer": { "camera": { "control": "game" } }`; absolute
+  pointer-led games use `"cursor": "visible"` instead. Without either setting, the runtime
+  warns once and keeps pointer hooks inert.
 - `mouseButton = (model, button, isDown) => model'` — OPTIONAL; mouse-button edges, buttons as
   the built-in `Mouse` module's variants (`Mouse.Left`, `Mouse.Right`, `Mouse.Middle`).
-  Delivered **while the cursor is captured** (the rule `mouseMove`/`mouseWheel` already follow),
-  so click-to-shoot works under free-look; a held button is swept released on focus loss
+  Captured delivery enables click-to-shoot under free-look; visible delivery supports absolute
+  2D picking. A held button is swept released on focus loss
 - `sampledInput = (model, snapshot: Input.snapshot) => model'` — OPTIONAL; per-fixed-step
   held/device state plus deterministic keyboard/mouse transitions.
   `pressedKeys`/`releasedKeys` and `mouse.pressed`/`.released` are de-duplicated edges consumed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,13 @@ name (contract in the `functor-lang` skill; reference: `examples/hello/game.fun`
   warns once and keeps the hooks inert.
 - `mouseButton = (model, button, isDown) => model'` — OPTIONAL; mouse-button edges, buttons as
   the built-in `Mouse` module's variants (`Mouse.Left`, `Mouse.Right`, `Mouse.Middle`).
-  Delivered **while the cursor is captured** (the rule `mouseMove`/`mouseWheel` already follow),
-  so click-to-shoot works under free-look; a held button is swept released on focus loss
+  With the default `"cursor":"captured"` project policy these are delivered while the cursor is
+  captured, so click-to-shoot works under free-look. A `"cursor":"visible"` project instead gets
+  absolute pointer motion and buttons without capture; a held button is swept released on focus loss
 - `sampledInput = (model, snapshot: Input.snapshot) => model'` — OPTIONAL; per-fixed-step
   held/device state plus deterministic keyboard/mouse transitions.
+  `mouse.x`/`.y` and `mouse.surfaceWidth`/`.surfaceHeight` share logical
+  top-left-origin coordinates.
   `pressedKeys`/`releasedKeys` and `mouse.pressed`/`.released` are de-duplicated edges consumed
   by the next fixed step; `heldKeys` and `mouse.buttons` are levels for continuous behavior.
   Typed device domains (`xr` first; gamepad and mobile touch extend it as siblings) sit beside them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,13 +77,10 @@ name (contract in the `functor-lang` skill; reference: `examples/hello/game.fun`
   warns once and keeps the hooks inert.
 - `mouseButton = (model, button, isDown) => model'` — OPTIONAL; mouse-button edges, buttons as
   the built-in `Mouse` module's variants (`Mouse.Left`, `Mouse.Right`, `Mouse.Middle`).
-  With the default `"cursor":"captured"` project policy these are delivered while the cursor is
-  captured, so click-to-shoot works under free-look. A `"cursor":"visible"` project instead gets
-  absolute pointer motion and buttons without capture; a held button is swept released on focus loss
+  Delivered **while the cursor is captured** (the rule `mouseMove`/`mouseWheel` already follow),
+  so click-to-shoot works under free-look; a held button is swept released on focus loss
 - `sampledInput = (model, snapshot: Input.snapshot) => model'` — OPTIONAL; per-fixed-step
   held/device state plus deterministic keyboard/mouse transitions.
-  `mouse.x`/`.y` and `mouse.surfaceWidth`/`.surfaceHeight` share logical
-  top-left-origin coordinates.
   `pressedKeys`/`releasedKeys` and `mouse.pressed`/`.released` are de-duplicated edges consumed
   by the next fixed step; `heldKeys` and `mouse.buttons` are levels for continuous behavior.
   Typed device domains (`xr` first; gamepad and mobile touch extend it as siblings) sit beside them.

--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ npm run fetch:assets
 
 The CLI operates on a directory containing a `functor.json`
 (`{"language": "functor-lang", "entry": "game.fun"}`). Point it at the example with `-d`.
-Pointer-led games add `"cursor":"visible"`; the default `"captured"` policy is
-for relative free-look.
 The `run` command interprets the game's `.fun` and launches it — no build step:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ npm run fetch:assets
 
 The CLI operates on a directory containing a `functor.json`
 (`{"language": "functor-lang", "entry": "game.fun"}`). Point it at the example with `-d`.
+Pointer-led games add `"cursor":"visible"`; the default `"captured"` policy is
+for relative free-look.
 The `run` command interprets the game's `.fun` and launches it — no build step:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ That enables click-to-capture camera input on native and the web player’s
 mouse-look button, routing captured motion/buttons to the game’s
 `mouseMove`/`mouseButton` hooks. On native, a non-UI click enters capture;
 Escape or focus loss releases it.
-Projects without the setting—including 2D games—show no camera control and
-never capture an ordinary click.
+Pointer-led 2D games use `"cursor": "visible"` instead to receive absolute
+motion/buttons without capture. Projects without either setting show no camera
+control and leave ordinary clicks with UI.
 
 XR games can use the Quest-isomorphic desktop adapter with
 `... run native --emulate-xr`; see [the VR guide](docs/vr.md#desktop-xr-emulation)

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -152,11 +152,18 @@ impl FunctorLangConfig {
     /// `--entry <name>`; a `Named` project with no request defaults to
     /// `client`, or the sole entry.
     pub fn select(&self, requested: Option<&str>) -> Result<FunctorLangProject, Error> {
-        let camera_control = *self
+        let mut camera_control = *self
             .camera_control
             .as_ref()
             .map_err(|message| Error::other(message.clone()))?;
         let cursor = self.cursor_policy()?;
+        // `viewer.camera.control` is the canonical captured-input setting on
+        // current main. Keep the branch's explicit `"cursor":"captured"`
+        // spelling as a compatibility alias, while an absent `cursor` retains
+        // main's safe free-pointer default.
+        if self.cursor.is_some() && cursor == CursorPolicy::Captured {
+            camera_control = CameraControl::Game;
+        }
         if camera_control == CameraControl::Game && cursor == CursorPolicy::Visible {
             return Err(Error::other(
                 "functor.json cannot combine `cursor: \"visible\"` with \
@@ -1573,6 +1580,16 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("visible"));
+
+        let captured = FunctorLangConfig {
+            entries: FunctorLangEntries::Single("game.fun".to_string()),
+            camera_control: Ok(CameraControl::None),
+            cursor: Some(serde_json::Value::from("captured")),
+        };
+        assert_eq!(
+            captured.select(None).unwrap().camera_control,
+            CameraControl::Game
+        );
     }
 
     #[test]

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -36,6 +36,9 @@ pub struct FunctorLangProject {
     pub entry: String,
     /// Main-viewport input ownership selected by `viewer.camera.control`.
     pub camera_control: CameraControl,
+    /// Whether the shell exposes an absolute pointer or uses the captured
+    /// camera-control path.
+    pub cursor: CursorPolicy,
 }
 
 #[derive(Default, serde::Deserialize)]
@@ -50,6 +53,25 @@ struct ViewerSettings {
 struct ViewerCameraSettings {
     #[serde(default)]
     control: CameraControl,
+}
+
+/// Shell pointer behavior declared by `functor.json`'s `cursor` field.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorPolicy {
+    /// Use the captured camera-control path when the project opts into it.
+    #[default]
+    Captured,
+    /// Keep the system cursor visible and deliver absolute pointer input.
+    Visible,
+}
+
+impl CursorPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Captured => "captured",
+            Self::Visible => "visible",
+        }
+    }
 }
 
 /// The entry layout `functor.json` declares: the classic single `entry`, or a
@@ -70,6 +92,7 @@ enum FunctorLangEntries {
 pub struct FunctorLangConfig {
     entries: FunctorLangEntries,
     camera_control: Result<CameraControl, String>,
+    cursor: Option<serde_json::Value>,
 }
 
 fn manifest_camera_control(json: &serde_json::Value) -> Result<CameraControl, String> {
@@ -109,10 +132,22 @@ pub fn detect(working_directory: &str) -> Option<FunctorLangConfig> {
     Some(FunctorLangConfig {
         entries,
         camera_control: manifest_camera_control(&json),
+        cursor: json.get("cursor").cloned(),
     })
 }
 
 impl FunctorLangConfig {
+    fn cursor_policy(&self) -> Result<CursorPolicy, Error> {
+        match self.cursor.as_ref() {
+            None => Ok(CursorPolicy::Captured),
+            Some(value) if value.as_str() == Some("captured") => Ok(CursorPolicy::Captured),
+            Some(value) if value.as_str() == Some("visible") => Ok(CursorPolicy::Visible),
+            Some(_) => Err(Error::other(
+                "functor.json `cursor` must be \"captured\" or \"visible\"",
+            )),
+        }
+    }
+
     /// Resolve which entry this invocation runs. `requested` is the CLI's
     /// `--entry <name>`; a `Named` project with no request defaults to
     /// `client`, or the sole entry.
@@ -121,9 +156,17 @@ impl FunctorLangConfig {
             .camera_control
             .as_ref()
             .map_err(|message| Error::other(message.clone()))?;
+        let cursor = self.cursor_policy()?;
+        if camera_control == CameraControl::Game && cursor == CursorPolicy::Visible {
+            return Err(Error::other(
+                "functor.json cannot combine `cursor: \"visible\"` with \
+`viewer.camera.control: \"game\"` — choose absolute pointer input or captured mouse look",
+            ));
+        }
         let project = |entry: String| FunctorLangProject {
             entry,
             camera_control,
+            cursor,
         };
         match &self.entries {
             FunctorLangEntries::Conflicting => Err(Error::other(
@@ -448,6 +491,8 @@ impl FunctorLangProject {
             self.entry.clone(),
             "--camera-control".to_string(),
             self.camera_control.to_string(),
+            "--cursor".to_string(),
+            self.cursor.as_str().to_string(),
         ];
         let (runner_args, debug_warning) = resolve_debug_args(develop, runner_args);
         if let Some(message) = debug_warning {
@@ -733,6 +778,7 @@ relative path inside it (got {})",
                 working_directory,
                 &self.entry,
                 self.camera_control,
+                self.cursor.as_str(),
             )?;
             for name in &export.shadowed {
                 emit(Event::Warning {
@@ -829,6 +875,7 @@ relative path inside it (got {})",
                 working_directory,
                 &self.entry,
                 self.camera_control,
+                self.cursor.as_str(),
             );
             if no_open {
                 emit(Event::Info {
@@ -1342,7 +1389,7 @@ mod tests {
     use super::entry_escapes_project;
     use super::{
         manifest_camera_control, nth_line, project_asset_files, resolve_debug_args, CameraControl,
-        FunctorLangConfig, FunctorLangEntries,
+        CursorPolicy, FunctorLangConfig, FunctorLangEntries,
     };
 
     fn resolve(develop: bool, args: &[&str]) -> (Vec<String>, Option<String>) {
@@ -1430,6 +1477,7 @@ mod tests {
         FunctorLangConfig {
             entries: FunctorLangEntries::Single(entry.to_string()),
             camera_control: Ok(CameraControl::None),
+            cursor: None,
         }
     }
 
@@ -1442,6 +1490,7 @@ mod tests {
                     .collect(),
             ),
             camera_control: Ok(CameraControl::None),
+            cursor: None,
         }
     }
 
@@ -1488,9 +1537,42 @@ mod tests {
 
     #[test]
     fn single_entry_selects_by_default_and_rejects_the_flag() {
-        assert_eq!(single("game.fun").select(None).unwrap().entry, "game.fun");
+        let project = single("game.fun").select(None).unwrap();
+        assert_eq!(project.entry, "game.fun");
+        assert_eq!(project.camera_control, CameraControl::None);
+        assert_eq!(project.cursor, CursorPolicy::Captured);
         let err = single("game.fun").select(Some("server")).unwrap_err();
         assert!(err.to_string().contains("single `entry`"), "{err}");
+    }
+
+    #[test]
+    fn cursor_policy_is_explicit_and_validated() {
+        let visible = FunctorLangConfig {
+            entries: FunctorLangEntries::Single("game.fun".to_string()),
+            camera_control: Ok(CameraControl::None),
+            cursor: Some(serde_json::Value::from("visible")),
+        };
+        assert_eq!(visible.select(None).unwrap().cursor, CursorPolicy::Visible);
+
+        let invalid = FunctorLangConfig {
+            entries: FunctorLangEntries::Single("game.fun".to_string()),
+            camera_control: Ok(CameraControl::None),
+            cursor: Some(serde_json::Value::from("free")),
+        };
+        let err = invalid.select(None).unwrap_err();
+        assert!(err.to_string().contains("captured"), "{err}");
+        assert!(err.to_string().contains("visible"), "{err}");
+
+        let non_string = FunctorLangConfig {
+            entries: FunctorLangEntries::Single("game.fun".to_string()),
+            camera_control: Ok(CameraControl::None),
+            cursor: Some(serde_json::Value::Bool(true)),
+        };
+        assert!(non_string
+            .select(None)
+            .unwrap_err()
+            .to_string()
+            .contains("visible"));
     }
 
     #[test]
@@ -1498,6 +1580,17 @@ mod tests {
         let config = named(&[("client", "client.fun"), ("server", "server.fun")]);
         assert_eq!(config.select(Some("server")).unwrap().entry, "server.fun");
         assert_eq!(config.select(Some("client")).unwrap().entry, "client.fun");
+    }
+
+    #[test]
+    fn visible_pointer_and_captured_camera_control_are_mutually_exclusive() {
+        let config = FunctorLangConfig {
+            entries: FunctorLangEntries::Single("game.fun".to_string()),
+            camera_control: Ok(CameraControl::Game),
+            cursor: Some(serde_json::Value::from("visible")),
+        };
+        let err = config.select(None).unwrap_err();
+        assert!(err.to_string().contains("cannot combine"), "{err}");
     }
 
     #[test]
@@ -1536,6 +1629,7 @@ mod tests {
         let config = FunctorLangConfig {
             entries: FunctorLangEntries::Conflicting,
             camera_control: Ok(CameraControl::None),
+            cursor: None,
         };
         let err = config.select(None).unwrap_err();
         assert!(
@@ -1554,6 +1648,7 @@ mod tests {
                 serde_json::Value::from(3),
             )]),
             camera_control: Ok(CameraControl::None),
+            cursor: None,
         };
         let err = config.select(None).unwrap_err();
         assert!(err.to_string().contains("must be a path"), "{err}");

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -27,7 +27,9 @@ fn script_safe(json: String) -> String {
     json.replace("</", "<\\/")
 }
 
-/// Substitute the project's Functor Lang entry + full file list into the Functor Lang index page:
+/// Substitute the project's Functor Lang entry, file list, camera control, and
+/// pointer policy
+/// into the Functor Lang index page:
 ///
 /// - `"__FUNCTOR_LANG_ENTRY__"` becomes a JSON string literal → `window.__functorLangGamePath`,
 ///   the program root.
@@ -37,11 +39,12 @@ fn script_safe(json: String) -> String {
 /// - `"__FUNCTOR_CAMERA_CONTROL__"` becomes the manifest's main-viewport input
 ///   ownership mode.
 ///
-/// Both are valid JS for any path (quotes/backslashes included).
+/// All substitutions are valid JS for any path (quotes/backslashes included).
 pub(crate) fn render_functor_lang_index(
     entry: &str,
     files: &[String],
     camera_control: CameraControl,
+    cursor: &str,
 ) -> String {
     let entry_literal =
         script_safe(serde_json::to_string(entry).expect("a string always serializes"));
@@ -49,10 +52,13 @@ pub(crate) fn render_functor_lang_index(
         script_safe(serde_json::to_string(files).expect("a string slice always serializes"));
     let camera_control_literal =
         serde_json::to_string(camera_control.as_str()).expect("a static string always serializes");
+    let cursor_literal =
+        script_safe(serde_json::to_string(cursor).expect("a string always serializes"));
     INDEX_FUNCTOR_LANG_HTML
         .replace("\"__FUNCTOR_LANG_ENTRY__\"", &entry_literal)
         .replace("\"__FUNCTOR_LANG_PROJECT_FILES__\"", &files_literal)
         .replace("\"__FUNCTOR_CAMERA_CONTROL__\"", &camera_control_literal)
+        .replace("\"__FUNCTOR_CURSOR_POLICY__\"", &cursor_literal)
 }
 
 /// The project's file list as URLs relative to the served directory (entry
@@ -87,11 +93,12 @@ impl WasmDevServer {
         working_directory: &str,
         entry: &str,
         camera_control: CameraControl,
+        cursor: &str,
     ) -> Result<(), io::Error> {
         let files = project_file_urls(working_directory, entry);
         Self::serve(
             working_directory,
-            render_functor_lang_index(entry, &files, camera_control).into_bytes(),
+            render_functor_lang_index(entry, &files, camera_control, cursor).into_bytes(),
         )
         .await
     }
@@ -176,12 +183,18 @@ mod tests {
 
     #[test]
     fn substitutes_the_entry_as_a_js_string() {
-        let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], CameraControl::None);
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            CameraControl::None,
+            "captured",
+        );
         assert!(html.contains("window.__functorLangGamePath = \"game.fun\""));
         assert!(html.contains("const gameCameraControl = \"none\" === \"game\""));
+        assert!(html.contains("window.__functorCursorPolicy = \"captured\""));
         assert!(!html.contains("__FUNCTOR_LANG_ENTRY__"));
         assert!(!html.contains("__FUNCTOR_CAMERA_CONTROL__"));
+        assert!(!html.contains("__FUNCTOR_CURSOR_POLICY__"));
     }
 
     #[test]
@@ -190,9 +203,11 @@ mod tests {
             "game.fun",
             &["game.fun".to_string(), "pieces.fun".to_string()],
             CameraControl::None,
+            "visible",
         );
         assert!(html.contains("(["));
         assert!(html.contains("\"game.fun\",\"pieces.fun\""));
+        assert!(html.contains("window.__functorCursorPolicy = \"visible\""));
         assert!(!html.contains("__FUNCTOR_LANG_PROJECT_FILES__"));
     }
 
@@ -202,6 +217,7 @@ mod tests {
             "we\"ird\\name.fun",
             &["we\"ird\\name.fun".to_string()],
             CameraControl::None,
+            "captured",
         );
         assert!(html.contains("we\\\"ird\\\\name.fun"));
     }
@@ -212,14 +228,19 @@ mod tests {
             "bad</script>.fun",
             &["bad</script>.fun".to_string()],
             CameraControl::None,
+            "captured",
         );
         assert!(html.contains("bad<\\/script>.fun"));
     }
 
     #[test]
     fn substitutes_the_camera_control_mode() {
-        let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], CameraControl::Game);
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            CameraControl::Game,
+            "captured",
+        );
         assert!(html.contains("const gameCameraControl = \"game\" === \"game\""));
         assert!(!html.contains("__FUNCTOR_CAMERA_CONTROL__"));
     }

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -178,7 +178,7 @@ impl WasmDevServer {
 
 #[cfg(test)]
 mod tests {
-    use super::render_functor_lang_index;
+    use super::{render_functor_lang_index, SCRUBBER_JS};
     use functor_runtime_common::viewer::CameraControl;
 
     #[test]
@@ -217,7 +217,8 @@ mod tests {
         for expected in [
             r#"window.addEventListener("mousemove""#,
             "const rect = canvas.getBoundingClientRect();",
-            "e.clientX - rect.left, e.clientY - rect.top",
+            "Math.floor(e.clientX - rect.left)",
+            "Math.floor(e.clientY - rect.top)",
             r#"window.addEventListener("mousedown""#,
             "if (!visiblePointer || (code !== 2 && code !== 3)) return;",
             "if (visiblePointer && code !== 1) return;",
@@ -233,6 +234,16 @@ mod tests {
         assert!(
             !html.contains("functor_lang_mouse_move(e.offsetX, e.offsetY)"),
             "visible movement must not be delivered by both window and canvas"
+        );
+    }
+
+    #[test]
+    fn scrubber_only_captures_primary_pointer_drags() {
+        let scrubber = std::str::from_utf8(SCRUBBER_JS).expect("scrubber source is UTF-8");
+        assert_eq!(
+            scrubber.matches("if (event.button !== 0) return;").count(),
+            3,
+            "playhead, preview, and rail must preserve non-primary compatibility mouse events"
         );
     }
 

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -215,6 +215,9 @@ mod tests {
     fn visible_pointer_keeps_non_primary_webview_input_game_owned() {
         let html = render_functor_lang_index("game.fun", &["game.fun".to_string()], "visible");
         for expected in [
+            r#"window.addEventListener("mousemove""#,
+            "const rect = canvas.getBoundingClientRect();",
+            "e.clientX - rect.left, e.clientY - rect.top",
             r#"window.addEventListener("mousedown""#,
             "if (!visiblePointer || (code !== 2 && code !== 3)) return;",
             "if (visiblePointer && code !== 1) return;",
@@ -227,6 +230,10 @@ mod tests {
                 "rendered wasm host omitted `{expected}`"
             );
         }
+        assert!(
+            !html.contains("functor_lang_mouse_move(e.offsetX, e.offsetY)"),
+            "visible movement must not be delivered by both window and canvas"
+        );
     }
 
     #[test]

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -213,7 +213,12 @@ mod tests {
 
     #[test]
     fn visible_pointer_keeps_non_primary_webview_input_game_owned() {
-        let html = render_functor_lang_index("game.fun", &["game.fun".to_string()], "visible");
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            CameraControl::None,
+            "visible",
+        );
         for expected in [
             r#"window.addEventListener("mousemove""#,
             "const rect = canvas.getBoundingClientRect();",

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -212,6 +212,24 @@ mod tests {
     }
 
     #[test]
+    fn visible_pointer_keeps_non_primary_webview_input_game_owned() {
+        let html = render_functor_lang_index("game.fun", &["game.fun".to_string()], "visible");
+        for expected in [
+            r#"window.addEventListener("mousedown""#,
+            "if (!visiblePointer || (code !== 2 && code !== 3)) return;",
+            "if (visiblePointer && code !== 1) return;",
+            r#"window.addEventListener("wheel""#,
+            "{ capture: true, passive: false }",
+            r#"window.addEventListener("contextmenu""#,
+        ] {
+            assert!(
+                html.contains(expected),
+                "rendered wasm host omitted `{expected}`"
+            );
+        }
+    }
+
+    #[test]
     fn escapes_entries_that_would_break_the_script() {
         let html = render_functor_lang_index(
             "we\"ird\\name.fun",

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -69,6 +69,7 @@ pub fn export_functor_lang_wasm(
     working_directory: &str,
     entry: &str,
     camera_control: CameraControl,
+    cursor: &str,
 ) -> Result<WasmExport, Error> {
     let root = Path::new(working_directory);
 
@@ -120,7 +121,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(
         out.join("index.html"),
-        render_functor_lang_index(entry, &files, camera_control),
+        render_functor_lang_index(entry, &files, camera_control, cursor),
     )?;
     std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
     std::fs::write(out.join("timeline-model.js"), TIMELINE_MODEL_JS)?;
@@ -306,11 +307,13 @@ mod tests {
         dir.write("dist/web/stale.txt", "from a previous export");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", CameraControl::None).unwrap();
+        let export =
+            export_functor_lang_wasm(&wd, "game.fun", CameraControl::None, "visible").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
         assert!(index.contains("window.__functorLangGamePath = \"game.fun\""));
+        assert!(index.contains("window.__functorCursorPolicy = \"visible\""));
         assert!(
             index.contains("\"pieces.fun\""),
             "sibling module in the file list"
@@ -359,7 +362,8 @@ mod tests {
         dir.write("pkg/junk.js", "not the runtime");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", CameraControl::None).unwrap();
+        let export =
+            export_functor_lang_wasm(&wd, "game.fun", CameraControl::None, "captured").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -417,7 +421,8 @@ let g = "pkg/tex.png"
         dir.write(".hidden.fun", "let ghost = 1");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", CameraControl::None).unwrap();
+        let export =
+            export_functor_lang_wasm(&wd, "game.fun", CameraControl::None, "captured").unwrap();
         assert_eq!(export.file_count, 1, "only game.fun ships");
         assert!(
             !export.out_dir.join(".hidden.fun").exists(),
@@ -434,7 +439,8 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path().join("elsewhere"), dir.path().join("dist")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let err = export_functor_lang_wasm(&wd, "game.fun", CameraControl::None).unwrap_err();
+        let err =
+            export_functor_lang_wasm(&wd, "game.fun", CameraControl::None, "captured").unwrap_err();
         assert!(err.to_string().contains("symlink"), "{err}");
         assert!(
             dir.path().join("elsewhere/precious.txt").is_file(),
@@ -457,7 +463,8 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path(), dir.path().join("loop")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", CameraControl::None).unwrap();
+        let export =
+            export_functor_lang_wasm(&wd, "game.fun", CameraControl::None, "captured").unwrap();
         assert_eq!(
             fs::read(export.out_dir.join("linked.glb")).unwrap(),
             b"glb-bytes",

--- a/docs/2d-presentation.md
+++ b/docs/2d-presentation.md
@@ -284,6 +284,39 @@ Concretely: `asteroids2d`'s `shape.fun` is **reduced, not deleted**. Its
 exists. That is why jointed strokes head the follow-up queue rather than sitting
 further down it.
 
+## Slice 3 (landed): resize-correct pointer mapping
+
+Pointer-led Sprite games use the sampled mouse as one indivisible coordinate
+contract:
+
+```functor
+match Camera2D.toWorld(snapshot.mouse, camera) with
+| Option.Some(point) => pick(point)
+| Option.None => model
+```
+
+`snapshot.mouse.x` / `.y` use a top-left origin and travel with
+`surfaceWidth` / `surfaceHeight` in the same logical units: GLFW window points
+on native, CSS pixels on web. They deliberately do not use framebuffer pixels,
+so Retina/device-pixel-ratio changes do not move a pick. `toWorld` shares the
+renderer’s aspect-fit calculation, flips Y into the camera’s Y-up world, applies
+`Camera2D.at` and `zoom`, and returns `Option.None` in letterbox/pillarbox bars.
+The ideal half-open rectangle in logical units is authoritative for picking;
+the renderer rounds that same fit only at the integer framebuffer boundary, so
+a physical raster edge may differ by less than one logical pixel without making
+picks device-pixel-ratio-dependent.
+
+Pointer ownership is explicit in `functor.json`:
+
+```json
+{ "language": "functor-lang", "entry": "game.fun", "cursor": "visible" }
+```
+
+`visible` keeps the system pointer free and delivers absolute motion/buttons;
+`captured` is the compatibility default for relative free-look. On web,
+captured mode still needs the user-gesture “mouse look” button required by
+Pointer Lock. `examples/pointer-2d` is the complete picking reference.
+
 ## Later slices, in priority order
 
 0. **Jointed strokes** — `polyline` / `outline` over a point list, with a
@@ -297,22 +330,19 @@ further down it.
    its absence is what made a jam entry delete its `ui` hook. The insight is
    that a 2D frame has *two* coordinate systems, and no camera feature
    substitutes for admitting it.
-2. **`Camera2D.toWorld` / `Camera2D.viewport`** — mouse picking in a
-   letterboxed, zoomed scene currently requires the game to reverse-engineer
-   letterbox bars whose size it cannot query.
-3. **Atlas regions in the typed asset manifest** — `functor import` should emit
+2. **Atlas regions in the typed asset manifest** — `functor import` should emit
    named regions and animation clips for a sprite sheet the way it emits glTF
    clips, so games write `Assets.heroAtlas.walk1` instead of
    `Sprite.region(96, 0, 96, 96)`. Atlas geometry is the one asset-shaped thing
    the branded manifest does not cover. A `Sprite.animate(frames, fps, tts)`
    convenience belongs with it.
-4. **Blend modes** — `Sprite.blend(Blend.additive, …)`, so vector and neon 2D
+3. **Blend modes** — `Sprite.blend(Blend.additive, …)`, so vector and neon 2D
    can glow. `Scene.emissive` already establishes the vocabulary, and this is
    the one respect in which a 3D original beat its 2D port.
-5. **`Sprite.textBlock`** — multi-line with explicit line height and per-line
+4. **`Sprite.textBlock`** — multi-line with explicit line height and per-line
    alignment (left/center/right), for text blocks that want left alignment
    rather than slice 1's centered lines.
-6. **Font loading** — `Sprite.textFont(color, size, Asset.Font, string)` and
+5. **Font loading** — `Sprite.textFont(color, size, Asset.Font, string)` and
    proportional metrics. `measure` exists partly as the forward-compatible seam
    for exactly this: authors ask for metrics rather than multiplying by `size`
    themselves, so a proportional font is not a breaking change.
@@ -329,15 +359,12 @@ further down it.
   must preserve it, which is the constraint that put glyph expansion in lowering.
 - **Painter-order `group`** is simple, predictable, and composes.
 
-## Documentation debt
+## Documentation (landed)
 
-Worth recording because it is independent of the API, and because it was the
-single highest-leverage finding in the jam: **the manual does not mention 2D at
-all.** Searching the published manual for `Sprite`, `Camera2D`, `create2D`, or
-even the bare string `2D` returns nothing. The manual presents cameras as
-`Camera.lookAt` / `Camera.firstPerson`, both perspective, and reads
-unambiguously as a 3D-only engine — so a user following the docs concludes
-Functor cannot do 2D. Multiple jam entries only learned `Frame.create2D` exists
-by reading `examples/mario` and the `.funi` sources. A complete, well-designed
-2D subsystem is invisible to its audience, and a "2D games" manual section
-belongs alongside "A complete game".
+The jam's highest-leverage documentation finding was that the public manual did
+not mention 2D at all. Slice 3 closes that gap: the Prelude chapter now shows
+`Sprite`, `Camera2D`, `Frame.create2D`, resize-correct `toWorld`, and the
+visible-pointer project policy together, with `examples/pointer-2d` as the
+complete reference. Generated API docs remain derived from the documented
+`.funi` signatures, so the compact reference and the narrative manual share
+one source of truth.

--- a/docs/2d-presentation.md
+++ b/docs/2d-presentation.md
@@ -284,39 +284,6 @@ Concretely: `asteroids2d`'s `shape.fun` is **reduced, not deleted**. Its
 exists. That is why jointed strokes head the follow-up queue rather than sitting
 further down it.
 
-## Slice 3 (landed): resize-correct pointer mapping
-
-Pointer-led Sprite games use the sampled mouse as one indivisible coordinate
-contract:
-
-```functor
-match Camera2D.toWorld(snapshot.mouse, camera) with
-| Option.Some(point) => pick(point)
-| Option.None => model
-```
-
-`snapshot.mouse.x` / `.y` use a top-left origin and travel with
-`surfaceWidth` / `surfaceHeight` in the same logical units: GLFW window points
-on native, CSS pixels on web. They deliberately do not use framebuffer pixels,
-so Retina/device-pixel-ratio changes do not move a pick. `toWorld` shares the
-renderer’s aspect-fit calculation, flips Y into the camera’s Y-up world, applies
-`Camera2D.at` and `zoom`, and returns `Option.None` in letterbox/pillarbox bars.
-The ideal half-open rectangle in logical units is authoritative for picking;
-the renderer rounds that same fit only at the integer framebuffer boundary, so
-a physical raster edge may differ by less than one logical pixel without making
-picks device-pixel-ratio-dependent.
-
-Pointer ownership is explicit in `functor.json`:
-
-```json
-{ "language": "functor-lang", "entry": "game.fun", "cursor": "visible" }
-```
-
-`visible` keeps the system pointer free and delivers absolute motion/buttons;
-`captured` is the compatibility default for relative free-look. On web,
-captured mode still needs the user-gesture “mouse look” button required by
-Pointer Lock. `examples/pointer-2d` is the complete picking reference.
-
 ## Later slices, in priority order
 
 0. **Jointed strokes** — `polyline` / `outline` over a point list, with a
@@ -330,19 +297,22 @@ Pointer Lock. `examples/pointer-2d` is the complete picking reference.
    its absence is what made a jam entry delete its `ui` hook. The insight is
    that a 2D frame has *two* coordinate systems, and no camera feature
    substitutes for admitting it.
-2. **Atlas regions in the typed asset manifest** — `functor import` should emit
+2. **`Camera2D.toWorld` / `Camera2D.viewport`** — mouse picking in a
+   letterboxed, zoomed scene currently requires the game to reverse-engineer
+   letterbox bars whose size it cannot query.
+3. **Atlas regions in the typed asset manifest** — `functor import` should emit
    named regions and animation clips for a sprite sheet the way it emits glTF
    clips, so games write `Assets.heroAtlas.walk1` instead of
    `Sprite.region(96, 0, 96, 96)`. Atlas geometry is the one asset-shaped thing
    the branded manifest does not cover. A `Sprite.animate(frames, fps, tts)`
    convenience belongs with it.
-3. **Blend modes** — `Sprite.blend(Blend.additive, …)`, so vector and neon 2D
+4. **Blend modes** — `Sprite.blend(Blend.additive, …)`, so vector and neon 2D
    can glow. `Scene.emissive` already establishes the vocabulary, and this is
    the one respect in which a 3D original beat its 2D port.
-4. **`Sprite.textBlock`** — multi-line with explicit line height and per-line
+5. **`Sprite.textBlock`** — multi-line with explicit line height and per-line
    alignment (left/center/right), for text blocks that want left alignment
    rather than slice 1's centered lines.
-5. **Font loading** — `Sprite.textFont(color, size, Asset.Font, string)` and
+6. **Font loading** — `Sprite.textFont(color, size, Asset.Font, string)` and
    proportional metrics. `measure` exists partly as the forward-compatible seam
    for exactly this: authors ask for metrics rather than multiplying by `size`
    themselves, so a proportional font is not a breaking change.
@@ -359,12 +329,15 @@ Pointer Lock. `examples/pointer-2d` is the complete picking reference.
   must preserve it, which is the constraint that put glyph expansion in lowering.
 - **Painter-order `group`** is simple, predictable, and composes.
 
-## Documentation (landed)
+## Documentation debt
 
-The jam's highest-leverage documentation finding was that the public manual did
-not mention 2D at all. Slice 3 closes that gap: the Prelude chapter now shows
-`Sprite`, `Camera2D`, `Frame.create2D`, resize-correct `toWorld`, and the
-visible-pointer project policy together, with `examples/pointer-2d` as the
-complete reference. Generated API docs remain derived from the documented
-`.funi` signatures, so the compact reference and the narrative manual share
-one source of truth.
+Worth recording because it is independent of the API, and because it was the
+single highest-leverage finding in the jam: **the manual does not mention 2D at
+all.** Searching the published manual for `Sprite`, `Camera2D`, `create2D`, or
+even the bare string `2D` returns nothing. The manual presents cameras as
+`Camera.lookAt` / `Camera.firstPerson`, both perspective, and reads
+unambiguously as a 3D-only engine — so a user following the docs concludes
+Functor cannot do 2D. Multiple jam entries only learned `Frame.create2D` exists
+by reading `examples/mario` and the `.funi` sources. A complete, well-designed
+2D subsystem is invisible to its audience, and a "2D games" manual section
+belongs alongside "A complete game".

--- a/docs/2d-presentation.md
+++ b/docs/2d-presentation.md
@@ -297,9 +297,9 @@ further down it.
    its absence is what made a jam entry delete its `ui` hook. The insight is
    that a 2D frame has *two* coordinate systems, and no camera feature
    substitutes for admitting it.
-2. **`Camera2D.toWorld` / `Camera2D.viewport`** — mouse picking in a
-   letterboxed, zoomed scene currently requires the game to reverse-engineer
-   letterbox bars whose size it cannot query.
+2. **`Camera2D.viewport`** — `Camera2D.toWorld` now maps pointer input through
+   letterbox bars, pan, and zoom; exposing the fitted viewport remains useful
+   for game-authored layout and diagnostics.
 3. **Atlas regions in the typed asset manifest** — `functor import` should emit
    named regions and animation clips for a sprite sheet the way it emits glTF
    clips, so games write `Assets.heroAtlas.walk1` instead of

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -107,7 +107,7 @@ screenshot run has no reason to grab your mouse.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (keyboard/mouse held + pressed/released sets and optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (keyboard/mouse position, logical surface, held + pressed/released sets, and optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
@@ -172,8 +172,13 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 game's `mouseButton` hook AND updates the held buttons that later steps'
 `sampledInput` sees (`mouse.buttons`), so holding one across several
 `/time advance` steps scripts full-auto fire. A release is delivered only if the
-game saw the press. Unlike window buttons it ignores cursor capture — a
-headless/hidden session has no capture to acquire.
+game saw the press. Injection ignores the project's cursor policy — a
+headless/hidden session has no window pointer to route.
+
+`mouse_move` replaces only `x` / `y`. The runtime-owned
+`surface_width` / `surface_height` remain the live logical window extent, so a
+debug-injected pointer goes through the same resize- and Retina-correct
+`Camera2D.toWorld` path as a physical pointer.
 
 The next fixed step also sees the transition in `pressedKeys`/`releasedKeys` or
 `mouse.pressed`/`mouse.released`. Repeating a down command while it is already
@@ -300,6 +305,8 @@ clients should treat absent edge arrays/button sets as empty.
   "mouse": {
     "x": 0,
     "y": 0,
+    "surface_width": 800,
+    "surface_height": 600,
     "buttons": { "left": false, "right": false, "middle": false },
     "pressed": { "left": false, "right": false, "middle": false },
     "released": { "left": false, "right": false, "middle": false }
@@ -336,6 +343,10 @@ clients should treat absent edge arrays/button sets as empty.
   }
 }
 ```
+
+Mouse surface fields require debug protocol v7. They are logical window points
+on desktop and CSS pixels on web, in the same top-left-origin coordinate space
+as `x` / `y`; `viewport` remains the physical render extent.
 
 Tracked poses use OpenXR's rig-local convention: +X right, +Y up, -Z forward;
 quaternions are `[x, y, z, w]`. Head and controller poses are relative to the

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -107,7 +107,7 @@ screenshot run has no reason to grab your mouse.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (keyboard/mouse position, logical surface, held + pressed/released sets, and optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (keyboard/mouse held + pressed/released sets and optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
@@ -172,13 +172,8 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 game's `mouseButton` hook AND updates the held buttons that later steps'
 `sampledInput` sees (`mouse.buttons`), so holding one across several
 `/time advance` steps scripts full-auto fire. A release is delivered only if the
-game saw the press. Injection ignores the project's cursor policy — a
-headless/hidden session has no window pointer to route.
-
-`mouse_move` replaces only `x` / `y`. The runtime-owned
-`surface_width` / `surface_height` remain the live logical window extent, so a
-debug-injected pointer goes through the same resize- and Retina-correct
-`Camera2D.toWorld` path as a physical pointer.
+game saw the press. Unlike window buttons it ignores cursor capture — a
+headless/hidden session has no capture to acquire.
 
 The next fixed step also sees the transition in `pressedKeys`/`releasedKeys` or
 `mouse.pressed`/`mouse.released`. Repeating a down command while it is already
@@ -305,8 +300,6 @@ clients should treat absent edge arrays/button sets as empty.
   "mouse": {
     "x": 0,
     "y": 0,
-    "surface_width": 800,
-    "surface_height": 600,
     "buttons": { "left": false, "right": false, "middle": false },
     "pressed": { "left": false, "right": false, "middle": false },
     "released": { "left": false, "right": false, "middle": false }
@@ -343,10 +336,6 @@ clients should treat absent edge arrays/button sets as empty.
   }
 }
 ```
-
-Mouse surface fields require debug protocol v7. They are logical window points
-on desktop and CSS pixels on web, in the same top-left-origin coordinate space
-as `x` / `y`; `viewport` remains the physical render extent.
 
 Tracked poses use OpenXR's rig-local convention: +X right, +Y up, -Z forward;
 quaternions are `[x, y, z, w]`. Head and controller poses are relative to the

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -319,8 +319,9 @@ snapshots — no GPU, fully agent-verifiable.
       keeps the cursor free, web hides the mouse-look button, and the runtime
       warns once about otherwise-inert pointer hooks. A
       `"cursor":"visible"` project instead receives absolute pointer motion
-      and button edges while keeping the system cursor free; the two ownership
-      modes are mutually exclusive.
+      and clicks not owned by a primary overlay interaction, while keeping the
+      system cursor free; right/middle buttons and wheel input remain
+      game-owned over overlays. The two ownership modes are mutually exclusive.
       Native capture starts on a non-UI click and Escape releases it. This is
       the rule `mouseMove`/`mouseWheel` already followed and keeps clicks from
       being eaten by free-look capture.

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -693,9 +693,7 @@ Starts once A2 + B3 exist.
         "Up"; since typed as the `Key.t` variant — see the strong-typing
         track entry) — validated at load when present, reload-aware. And
         `functor.json` grows `"language": "functor-lang"` (+ optional `entry`,
-        default `game.fun`; later extended with optional
-        `cursor: "captured" | "visible"`): `functor build` =
-        parse+lower+**check as
+        default `game.fun`): `functor build` = parse+lower+**check as
         errors** (the strict gate; the runner keeps them warnings),
         `run native` spawns the interpreter (proven byte-identical to a
         direct runner invocation), `develop` = `run` (hot reload is built
@@ -799,20 +797,6 @@ Starts once A2 + B3 exist.
         per bind so a shared texture cannot inherit another draw's choice.
         Mario exercises the path with one character atlas and nearest-neighbor
         sampling.
-      - [x] **C4b-8. Resize-correct 2D pointer mapping** (done 2026-07-27):
-        `Input.mouse` carries `surfaceWidth` / `surfaceHeight` in the same
-        top-left-origin logical coordinate space as `x` / `y` (window points
-        natively, CSS pixels on web). `Camera2D.toWorld(mouse, camera)` shares
-        the renderer's aspect-fit math, maps through pan/zoom, and returns
-        `Option.None` in letterbox/pillarbox bars. `functor.json` makes pointer
-        ownership explicit with `"cursor":"visible"|"captured"`; captured is
-        the compatibility default, while visible delivers absolute motion and
-        buttons on both shells. `examples/pointer-2d` is the complete
-        pointer-led Sprite reference.
-        *Verify (done):* shared-camera tests cover resize, mismatched aspect,
-        Retina scaling, pan/zoom, and bar rejection; shell tests pin logical
-        surface sampling and debug injection; native and web captures exercise
-        the visible pointer policy.
 - [x] **C5. Wasm** (done 2026-07-03). `FunctorLangWebGame` in the web runtime — the
       wasm sibling of the desktop producer behind the same `GameProducer`
       seam: identical load-contract validation, MVU subscriptions pump,

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -313,11 +313,14 @@ snapshots — no GPU, fully agent-verifiable.
       `Key.t` design applied to the pointer: an optional
       `mouseButton(model, button, isDown)` entry point whose `button` is the
       built-in `Mouse` module's variant (`<builtin>/Mouse.fun`, injected beside
-      `Key`): `Mouse.Left`/`Right`/`Middle`. Buttons reach game logic **while
-      the cursor is captured**, and capture is now an explicit project opt-in:
+      `Key`): `Mouse.Left`/`Right`/`Middle`. Captured buttons reach game logic
+      only after the explicit project opt-in
       `viewer.camera.control = "game"` in `functor.json`. Without it, native
       keeps the cursor free, web hides the mouse-look button, and the runtime
-      warns once about the inert hooks—especially important for 2D/UI projects.
+      warns once about otherwise-inert pointer hooks. A
+      `"cursor":"visible"` project instead receives absolute pointer motion
+      and button edges while keeping the system cursor free; the two ownership
+      modes are mutually exclusive.
       Native capture starts on a non-UI click and Escape releases it. This is
       the rule `mouseMove`/`mouseWheel` already followed and keeps clicks from
       being eaten by free-look capture.
@@ -690,7 +693,9 @@ Starts once A2 + B3 exist.
         "Up"; since typed as the `Key.t` variant — see the strong-typing
         track entry) — validated at load when present, reload-aware. And
         `functor.json` grows `"language": "functor-lang"` (+ optional `entry`,
-        default `game.fun`): `functor build` = parse+lower+**check as
+        default `game.fun`; later extended with optional
+        `cursor: "captured" | "visible"`): `functor build` =
+        parse+lower+**check as
         errors** (the strict gate; the runner keeps them warnings),
         `run native` spawns the interpreter (proven byte-identical to a
         direct runner invocation), `develop` = `run` (hot reload is built
@@ -794,6 +799,20 @@ Starts once A2 + B3 exist.
         per bind so a shared texture cannot inherit another draw's choice.
         Mario exercises the path with one character atlas and nearest-neighbor
         sampling.
+      - [x] **C4b-8. Resize-correct 2D pointer mapping** (done 2026-07-27):
+        `Input.mouse` carries `surfaceWidth` / `surfaceHeight` in the same
+        top-left-origin logical coordinate space as `x` / `y` (window points
+        natively, CSS pixels on web). `Camera2D.toWorld(mouse, camera)` shares
+        the renderer's aspect-fit math, maps through pan/zoom, and returns
+        `Option.None` in letterbox/pillarbox bars. `functor.json` makes pointer
+        ownership explicit with `"cursor":"visible"|"captured"`; captured is
+        the compatibility default, while visible delivers absolute motion and
+        buttons on both shells. `examples/pointer-2d` is the complete
+        pointer-led Sprite reference.
+        *Verify (done):* shared-camera tests cover resize, mismatched aspect,
+        Retina scaling, pan/zoom, and bar rejection; shell tests pin logical
+        surface sampling and debug injection; native and web captures exercise
+        the visible pointer policy.
 - [x] **C5. Wasm** (done 2026-07-03). `FunctorLangWebGame` in the web runtime — the
       wasm sibling of the desktop producer behind the same `GameProducer`
       seam: identical load-contract validation, MVU subscriptions pump,

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -180,7 +180,7 @@ construction (the invariant physics already proves with goldens).
 | Whole-game frame-clock pause/step/resume | **Shipped** as debug server `POST /time` (pins `dts=0`) — desktop only |
 | egui backend in both shells (real `Context` + `Painter`, v0.34) | **Shipped** (`ui.rs`, both runners) |
 | **egui receiving pointer input / clicks** | *Missing — `RawInput` is empty, every element `.interactable(false)`* |
-| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; buttons reach the game while the cursor is captured |
+| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; captured projects deliver while locked, and `"cursor":"visible"` projects deliver absolute-pointer clicks with primary UI arbitration |
 | Interactive UI (buttons with actions) | *Missing — `View` is `Empty/Text/Row/Column/Panel`, not parameterized over a message* |
 | Web debug server / control channel | *Missing — but egui itself runs on web* |
 | Serializable model (disk/wire) | *Missing (`Closure`/`HostData` aren't `Serialize`) — **not needed** for in-session rewind* |

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -180,7 +180,7 @@ construction (the invariant physics already proves with goldens).
 | Whole-game frame-clock pause/step/resume | **Shipped** as debug server `POST /time` (pins `dts=0`) — desktop only |
 | egui backend in both shells (real `Context` + `Painter`, v0.34) | **Shipped** (`ui.rs`, both runners) |
 | **egui receiving pointer input / clicks** | *Missing — `RawInput` is empty, every element `.interactable(false)`* |
-| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; buttons reach the game while the cursor is captured |
+| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; projects explicitly choose captured free-look or visible absolute pointer input |
 | Interactive UI (buttons with actions) | *Missing — `View` is `Empty/Text/Row/Column/Panel`, not parameterized over a message* |
 | Web debug server / control channel | *Missing — but egui itself runs on web* |
 | Serializable model (disk/wire) | *Missing (`Closure`/`HostData` aren't `Serialize`) — **not needed** for in-session rewind* |

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -180,7 +180,7 @@ construction (the invariant physics already proves with goldens).
 | Whole-game frame-clock pause/step/resume | **Shipped** as debug server `POST /time` (pins `dts=0`) — desktop only |
 | egui backend in both shells (real `Context` + `Painter`, v0.34) | **Shipped** (`ui.rs`, both runners) |
 | **egui receiving pointer input / clicks** | *Missing — `RawInput` is empty, every element `.interactable(false)`* |
-| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; captured projects deliver while locked, and `"cursor":"visible"` projects deliver absolute-pointer clicks with primary UI arbitration |
+| **Mouse clicks reaching game/overlay at all** | **Shipped** as the `mouseButton` hook (`Mouse.Left`/`Right`/`Middle`) plus held `mouse.buttons` on the sampled snapshot; buttons reach the game while the cursor is captured |
 | Interactive UI (buttons with actions) | *Missing — `View` is `Empty/Text/Row/Column/Panel`, not parameterized over a message* |
 | Web debug server / control channel | *Missing — but egui itself runs on web* |
 | Serializable model (disk/wire) | *Missing (`Closure`/`HostData` aren't `Serialize`) — **not needed** for in-session rewind* |

--- a/docs/ui-interaction.md
+++ b/docs/ui-interaction.md
@@ -97,8 +97,9 @@ game's perspective this is fully Elm-controlled.
   the whole session. A `"cursor":"visible"` project instead
   keeps absolute motion/buttons live for pointer-led gameplay; a primary click
   the previous UI pass wanted remains owned by the widget, while right/middle
-  clicks reach the game. Keyboard: when egui wants keyboard (a text field is
-  focused), key events are suppressed from the game's `input` hook.
+  clicks and wheel input remain game-owned over overlays on both native and
+  web. Keyboard: when egui wants keyboard (a text field is focused), key events
+  are suppressed from the game's `input` hook.
 
 - **Headless testability (LLM-native).** Because `UiEvent` is serializable
   and routed through one producer method, the debug server gains

--- a/docs/ui-interaction.md
+++ b/docs/ui-interaction.md
@@ -93,14 +93,12 @@ game's perspective this is fully Elm-controlled.
 
 - **Routing policy.** Pointer: when the cursor is free, events feed egui.
   A click recaptures for free-look only when `functor.json` opts into
-  `viewer.camera.control = "game"`; otherwise the pointer remains available
-  to 2D/UI projects for the whole session. Keyboard: when egui wants keyboard
-  (a text field is focused), key events are suppressed from the game's
-  `input` hook. The raw `mouseButton`
-  game hook (click-to-shoot into the 3D world) has since LANDED on this same
-  plumbing: buttons reach the game only **while the cursor is captured**, which
-  is exactly the state in which egui does not want the pointer — so the two
-  consumers never contend for the same click.
+  `viewer.camera.control = "game"`; otherwise it remains available to UI for
+  the whole session. A `"cursor":"visible"` project instead
+  keeps absolute motion/buttons live for pointer-led gameplay; a primary click
+  the previous UI pass wanted remains owned by the widget, while right/middle
+  clicks reach the game. Keyboard: when egui wants keyboard (a text field is
+  focused), key events are suppressed from the game's `input` hook.
 
 - **Headless testability (LLM-native).** Because `UiEvent` is serializable
   and routed through one producer method, the debug server gains

--- a/examples/pointer-2d/functor.json
+++ b/examples/pointer-2d/functor.json
@@ -1,0 +1,5 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun",
+  "cursor": "visible"
+}

--- a/examples/pointer-2d/game.fun
+++ b/examples/pointer-2d/game.fun
@@ -21,6 +21,8 @@ let hitTarget = (point) =>
   else if inside(5.0) then 1.0
   else 0.0 - 1.0
 
+// Input is resolved at fixed-step granularity: a latched press selects against
+// the latest sampled pointer when the next simulation step begins.
 let sampledInput = (model, snapshot: Input.snapshot) =>
   let pointer = Camera2D.toWorld(snapshot.mouse, camera) in
   match pointer with

--- a/examples/pointer-2d/game.fun
+++ b/examples/pointer-2d/game.fun
@@ -1,0 +1,155 @@
+// A complete pointer-led Sprite game.
+//
+// Resize the window freely: Input.mouse carries its logical surface extent,
+// and Camera2D.toWorld shares the renderer's aspect fit. The pointer therefore
+// keeps landing on the same world-space card across letterboxing and Retina.
+
+let camera =
+  Camera2D.create(24.0, 13.5)
+  |> Camera2D.at(2.0, 0.0)
+  |> Camera2D.zoom(1.08)
+
+let init = {
+  pointer: Option.None,
+  hover: 0.0 - 1.0,
+  selected: 0.0 - 1.0
+}
+
+let hitCard = (point) =>
+  let inCard = (cx, cy) =>
+    point.x >= cx - 2.15 && point.x <= cx + 2.15 &&
+    point.y >= cy - 1.65 && point.y <= cy + 1.65
+  in
+  if inCard(-4.5, 2.0) then 0.0
+  else if inCard(1.0, 2.0) then 1.0
+  else if inCard(6.5, 2.0) then 2.0
+  else if inCard(-1.75, -2.0) then 3.0
+  else if inCard(3.75, -2.0) then 4.0
+  else 0.0 - 1.0
+
+let sampledInput = (model, snapshot: Input.snapshot) =>
+  let pointer = Camera2D.toWorld(snapshot.mouse, camera) in
+  match pointer with
+  | Option.Some(point) =>
+      let hover = hitCard(point) in
+      { model with
+          pointer: pointer,
+          hover: hover }
+  | Option.None =>
+      { model with
+          pointer: Option.None,
+          hover: 0.0 - 1.0 }
+
+let mouseButton = (model, button, isDown) =>
+  if button == Mouse.Left && isDown && model.hover >= 0.0
+  then { model with selected: model.hover }
+  else model
+
+let tick = (model, dt, tts) => model
+
+let bg = Color.rgb(0.025, 0.035, 0.09)
+let panel = Color.rgb(0.075, 0.09, 0.18)
+let panelHot = Color.rgb(0.11, 0.15, 0.28)
+let ink = Color.rgb(0.91, 0.95, 1.0)
+let dim = Color.rgb(0.48, 0.57, 0.74)
+let cyan = Color.rgb(0.18, 0.88, 0.98)
+let pink = Color.rgb(1.0, 0.28, 0.67)
+let amber = Color.rgb(1.0, 0.72, 0.22)
+let violet = Color.rgb(0.53, 0.38, 1.0)
+let mint = Color.rgb(0.28, 0.96, 0.66)
+
+let accent = (index) =>
+  if index == 0.0 then cyan
+  else if index == 1.0 then pink
+  else if index == 2.0 then amber
+  else if index == 3.0 then violet
+  else mint
+
+let title = (index) =>
+  if index == 0.0 then "TIDAL"
+  else if index == 1.0 then "BLOOM"
+  else if index == 2.0 then "SOLAR"
+  else if index == 3.0 then "DUSK"
+  else "ORBIT"
+
+let glyph = (index, color) =>
+  if index == 0.0 then
+    Sprite.group([
+      Sprite.circle(color, 0.58),
+      Sprite.circle(panel, 0.36)
+    ])
+  else if index == 1.0 then
+    Sprite.group([
+      Sprite.circle(color, 0.34) |> Sprite.move(-0.32, 0.0),
+      Sprite.circle(color, 0.34) |> Sprite.move(0.32, 0.0),
+      Sprite.circle(color, 0.34) |> Sprite.move(0.0, 0.32),
+      Sprite.circle(color, 0.34) |> Sprite.move(0.0, -0.32)
+    ])
+  else if index == 2.0 then
+    Sprite.group([
+      Sprite.circle(color, 0.48),
+      Sprite.line(color, 0.12, { x: -0.82, y: 0.0 }, { x: 0.82, y: 0.0 }),
+      Sprite.line(color, 0.12, { x: 0.0, y: -0.82 }, { x: 0.0, y: 0.82 })
+    ])
+  else if index == 3.0 then
+    Sprite.polygon(color, [
+      { x: 0.0, y: 0.72 },
+      { x: 0.66, y: -0.5 },
+      { x: -0.66, y: -0.5 }
+    ])
+  else
+    Sprite.group([
+      Sprite.circle(color, 0.58),
+      Sprite.circle(panel, 0.42),
+      Sprite.circle(color, 0.17)
+    ])
+
+let card = (model, tts, index, x, y) =>
+  let hovered = model.hover == index in
+  let selected = model.selected == index in
+  let color = accent(index) in
+  let lift = if hovered then 0.18 else 0.0 in
+  let pulse = 1.0 + (if selected then Math.sin(tts * 5.0) * 0.035 else 0.0) in
+  Sprite.group([
+    Sprite.rectangle(bg, 4.5, 3.5) |> Sprite.move(0.12, -0.14),
+    Sprite.rectangle(if hovered then color else dim, 4.42, 3.42),
+    Sprite.rectangle(if hovered then panelHot else panel, 4.24, 3.24),
+    glyph(index, color) |> Sprite.moveY(0.48),
+    Sprite.text(ink, 0.54, title(index)) |> Sprite.moveY(-0.86),
+    if selected
+    then Sprite.text(color, 0.28, "SELECTED") |> Sprite.moveY(-1.3)
+    else Sprite.text(dim, 0.28, "CLICK TO CHOOSE") |> Sprite.moveY(-1.3)
+  ])
+  |> Sprite.scale(pulse)
+  |> Sprite.move(x, y + lift)
+
+let pointerSprite = (model) =>
+  match model.pointer with
+  | Option.Some(point) =>
+      Sprite.group([
+        Sprite.circle(ink, 0.18),
+        Sprite.circle(bg, 0.1),
+        Sprite.line(ink, 0.045, { x: -0.32, y: 0.0 }, { x: 0.32, y: 0.0 }),
+        Sprite.line(ink, 0.045, { x: 0.0, y: -0.32 }, { x: 0.0, y: 0.32 })
+      ])
+      |> Sprite.move(point.x, point.y)
+  | Option.None => Sprite.blank()
+
+let draw = (model, tts) =>
+  Sprite.group([
+    Sprite.rectangle(bg, 30.0, 18.0) |> Sprite.move(2.0, 0.0),
+    Sprite.text(ink, 0.92, "POINTER CONSTELLATION") |> Sprite.move(2.0, 5.15),
+    Sprite.text(dim, 0.34, "RESIZE THE WINDOW — PICKS STAY IN WORLD SPACE")
+      |> Sprite.move(2.0, 4.48),
+    card(model, tts, 0.0, -4.5, 2.0),
+    card(model, tts, 1.0, 1.0, 2.0),
+    card(model, tts, 2.0, 6.5, 2.0),
+    card(model, tts, 3.0, -1.75, -2.0),
+    card(model, tts, 4.0, 3.75, -2.0),
+    pointerSprite(model)
+  ])
+  |> Frame.create2D(camera)
+
+expect hitCard({ x: -4.5, y: 2.0 }) == 0.0
+expect hitCard({ x: 3.75, y: -2.0 }) == 4.0
+expect hitCard({ x: 20.0, y: 20.0 }) == 0.0 - 1.0

--- a/examples/pointer-2d/game.fun
+++ b/examples/pointer-2d/game.fun
@@ -1,155 +1,92 @@
-// A complete pointer-led Sprite game.
-//
-// Resize the window freely: Input.mouse carries its logical surface extent,
-// and Camera2D.toWorld shares the renderer's aspect fit. The pointer therefore
-// keeps landing on the same world-space card across letterboxing and Retina.
-
+// Resize freely: Camera2D.toWorld uses the renderer's fit and returns None in
+// letterbox bars, so the pointer stays on the same world-space target.
 let camera =
-  Camera2D.create(24.0, 13.5)
-  |> Camera2D.at(2.0, 0.0)
-  |> Camera2D.zoom(1.08)
+  Camera2D.create(20.0, 12.0)
+  |> Camera2D.at(2.0, -1.0)
+  |> Camera2D.zoom(1.1)
 
 let init = {
   pointer: Option.None,
   hover: 0.0 - 1.0,
-  selected: 0.0 - 1.0
+  selected: 0.0 - 1.0,
+  clickPending: false
 }
 
-let hitCard = (point) =>
-  let inCard = (cx, cy) =>
-    point.x >= cx - 2.15 && point.x <= cx + 2.15 &&
-    point.y >= cy - 1.65 && point.y <= cy + 1.65
+let hitTarget = (point) =>
+  let inside = (cx) =>
+    point.x >= cx - 2.2 && point.x <= cx + 2.2 &&
+    point.y >= -2.8 && point.y <= 0.8
   in
-  if inCard(-4.5, 2.0) then 0.0
-  else if inCard(1.0, 2.0) then 1.0
-  else if inCard(6.5, 2.0) then 2.0
-  else if inCard(-1.75, -2.0) then 3.0
-  else if inCard(3.75, -2.0) then 4.0
+  if inside(-1.0) then 0.0
+  else if inside(5.0) then 1.0
   else 0.0 - 1.0
 
 let sampledInput = (model, snapshot: Input.snapshot) =>
   let pointer = Camera2D.toWorld(snapshot.mouse, camera) in
   match pointer with
   | Option.Some(point) =>
-      let hover = hitCard(point) in
+      let hover = hitTarget(point) in
       { model with
           pointer: pointer,
-          hover: hover }
+          hover: hover,
+          selected:
+            if model.clickPending && hover >= 0.0 then hover else model.selected,
+          clickPending: false }
   | Option.None =>
       { model with
           pointer: Option.None,
-          hover: 0.0 - 1.0 }
+          hover: 0.0 - 1.0,
+          clickPending: false }
 
 let mouseButton = (model, button, isDown) =>
-  if button == Mouse.Left && isDown && model.hover >= 0.0
-  then { model with selected: model.hover }
+  if button == Mouse.Left && isDown
+  then { model with clickPending: true }
   else model
 
 let tick = (model, dt, tts) => model
 
 let bg = Color.rgb(0.025, 0.035, 0.09)
 let panel = Color.rgb(0.075, 0.09, 0.18)
-let panelHot = Color.rgb(0.11, 0.15, 0.28)
 let ink = Color.rgb(0.91, 0.95, 1.0)
 let dim = Color.rgb(0.48, 0.57, 0.74)
 let cyan = Color.rgb(0.18, 0.88, 0.98)
 let pink = Color.rgb(1.0, 0.28, 0.67)
-let amber = Color.rgb(1.0, 0.72, 0.22)
-let violet = Color.rgb(0.53, 0.38, 1.0)
-let mint = Color.rgb(0.28, 0.96, 0.66)
 
-let accent = (index) =>
-  if index == 0.0 then cyan
-  else if index == 1.0 then pink
-  else if index == 2.0 then amber
-  else if index == 3.0 then violet
-  else mint
-
-let title = (index) =>
-  if index == 0.0 then "TIDAL"
-  else if index == 1.0 then "BLOOM"
-  else if index == 2.0 then "SOLAR"
-  else if index == 3.0 then "DUSK"
-  else "ORBIT"
-
-let glyph = (index, color) =>
-  if index == 0.0 then
-    Sprite.group([
-      Sprite.circle(color, 0.58),
-      Sprite.circle(panel, 0.36)
-    ])
-  else if index == 1.0 then
-    Sprite.group([
-      Sprite.circle(color, 0.34) |> Sprite.move(-0.32, 0.0),
-      Sprite.circle(color, 0.34) |> Sprite.move(0.32, 0.0),
-      Sprite.circle(color, 0.34) |> Sprite.move(0.0, 0.32),
-      Sprite.circle(color, 0.34) |> Sprite.move(0.0, -0.32)
-    ])
-  else if index == 2.0 then
-    Sprite.group([
-      Sprite.circle(color, 0.48),
-      Sprite.line(color, 0.12, { x: -0.82, y: 0.0 }, { x: 0.82, y: 0.0 }),
-      Sprite.line(color, 0.12, { x: 0.0, y: -0.82 }, { x: 0.0, y: 0.82 })
-    ])
-  else if index == 3.0 then
-    Sprite.polygon(color, [
-      { x: 0.0, y: 0.72 },
-      { x: 0.66, y: -0.5 },
-      { x: -0.66, y: -0.5 }
-    ])
-  else
-    Sprite.group([
-      Sprite.circle(color, 0.58),
-      Sprite.circle(panel, 0.42),
-      Sprite.circle(color, 0.17)
-    ])
-
-let card = (model, tts, index, x, y) =>
+let target = (model, index, x, label, color) =>
   let hovered = model.hover == index in
   let selected = model.selected == index in
-  let color = accent(index) in
-  let lift = if hovered then 0.18 else 0.0 in
-  let pulse = 1.0 + (if selected then Math.sin(tts * 5.0) * 0.035 else 0.0) in
   Sprite.group([
-    Sprite.rectangle(bg, 4.5, 3.5) |> Sprite.move(0.12, -0.14),
-    Sprite.rectangle(if hovered then color else dim, 4.42, 3.42),
-    Sprite.rectangle(if hovered then panelHot else panel, 4.24, 3.24),
-    glyph(index, color) |> Sprite.moveY(0.48),
-    Sprite.text(ink, 0.54, title(index)) |> Sprite.moveY(-0.86),
-    if selected
-    then Sprite.text(color, 0.28, "SELECTED") |> Sprite.moveY(-1.3)
-    else Sprite.text(dim, 0.28, "CLICK TO CHOOSE") |> Sprite.moveY(-1.3)
+    Sprite.rectangle(if hovered then color else dim, 4.5, 3.7),
+    Sprite.rectangle(panel, 4.25, 3.45),
+    Sprite.text(color, 0.7, label) |> Sprite.moveY(0.35),
+    Sprite.text(if selected then color else dim, 0.3,
+      if selected then "SELECTED" else "CLICK TO CHOOSE")
+      |> Sprite.moveY(-0.75)
   ])
-  |> Sprite.scale(pulse)
-  |> Sprite.move(x, y + lift)
+  |> Sprite.move(x, -1.0)
 
 let pointerSprite = (model) =>
   match model.pointer with
   | Option.Some(point) =>
       Sprite.group([
-        Sprite.circle(ink, 0.18),
-        Sprite.circle(bg, 0.1),
-        Sprite.line(ink, 0.045, { x: -0.32, y: 0.0 }, { x: 0.32, y: 0.0 }),
-        Sprite.line(ink, 0.045, { x: 0.0, y: -0.32 }, { x: 0.0, y: 0.32 })
+        Sprite.circle(ink, 0.16),
+        Sprite.line(ink, 0.04, { x: -0.3, y: 0.0 }, { x: 0.3, y: 0.0 }),
+        Sprite.line(ink, 0.04, { x: 0.0, y: -0.3 }, { x: 0.0, y: 0.3 })
       ])
       |> Sprite.move(point.x, point.y)
   | Option.None => Sprite.blank()
 
 let draw = (model, tts) =>
   Sprite.group([
-    Sprite.rectangle(bg, 30.0, 18.0) |> Sprite.move(2.0, 0.0),
-    Sprite.text(ink, 0.92, "POINTER CONSTELLATION") |> Sprite.move(2.0, 5.15),
-    Sprite.text(dim, 0.34, "RESIZE THE WINDOW — PICKS STAY IN WORLD SPACE")
-      |> Sprite.move(2.0, 4.48),
-    card(model, tts, 0.0, -4.5, 2.0),
-    card(model, tts, 1.0, 1.0, 2.0),
-    card(model, tts, 2.0, 6.5, 2.0),
-    card(model, tts, 3.0, -1.75, -2.0),
-    card(model, tts, 4.0, 3.75, -2.0),
+    Sprite.rectangle(bg, 24.0, 15.0) |> Sprite.move(2.0, -1.0),
+    Sprite.text(ink, 0.85, "RESIZE-CORRECT POINTER") |> Sprite.move(2.0, 3.4),
+    Sprite.text(dim, 0.32, "BARS ARE NOT PICKABLE") |> Sprite.move(2.0, 2.75),
+    target(model, 0.0, -1.0, "CYAN", cyan),
+    target(model, 1.0, 5.0, "PINK", pink),
     pointerSprite(model)
   ])
   |> Frame.create2D(camera)
 
-expect hitCard({ x: -4.5, y: 2.0 }) == 0.0
-expect hitCard({ x: 3.75, y: -2.0 }) == 4.0
-expect hitCard({ x: 20.0, y: 20.0 }) == 0.0 - 1.0
+expect hitTarget({ x: -1.0, y: -1.0 }) == 0.0
+expect hitTarget({ x: 5.0, y: -1.0 }) == 1.0
+expect hitTarget({ x: 10.0, y: 5.0 }) == 0.0 - 1.0

--- a/examples/pointer-2d/game.fun
+++ b/examples/pointer-2d/game.fun
@@ -60,7 +60,7 @@ let target = (model, index, x, label, color) =>
     Sprite.rectangle(panel, 4.25, 3.45),
     Sprite.text(color, 0.7, label) |> Sprite.moveY(0.35),
     Sprite.text(if selected then color else dim, 0.3,
-      if selected then "SELECTED" else "CLICK TO CHOOSE")
+      if selected then "SELECTED" else "CLICK")
       |> Sprite.moveY(-0.75)
   ])
   |> Sprite.move(x, -1.0)
@@ -79,7 +79,7 @@ let pointerSprite = (model) =>
 let draw = (model, tts) =>
   Sprite.group([
     Sprite.rectangle(bg, 24.0, 15.0) |> Sprite.move(2.0, -1.0),
-    Sprite.text(ink, 0.85, "RESIZE-CORRECT POINTER") |> Sprite.move(2.0, 3.4),
+    Sprite.text(ink, 0.85, "POINTER PICKING") |> Sprite.move(2.0, 3.4),
     Sprite.text(dim, 0.32, "BARS ARE NOT PICKABLE") |> Sprite.move(2.0, 2.75),
     target(model, 0.0, -1.0, "CYAN", cyan),
     target(model, 1.0, 5.0, "PINK", pink),

--- a/functor-prelude/prelude/camera2d.funi
+++ b/functor-prelude/prelude/camera2d.funi
@@ -13,3 +13,10 @@ let create : (float, float) => t
 let at : (float, float, t) => t
 /// Set a positive camera zoom; the camera is last for piping.
 let zoom : (float, t) => t
+
+/// Map a sampled mouse position through the camera's fitted viewport.
+///
+/// Returns `Option.None` while the pointer is in a letterbox/pillarbox bar.
+/// The mouse carries its logical surface extent, so this remains correct
+/// across window resizes and Retina/device-pixel-ratio changes.
+let toWorld : (Input.mouse, t) => Option.t<Input.point2>

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -39,12 +39,16 @@ type xr = {
 /// `mouse.pressed` / `mouse.released` use it for one-step transitions.
 type mouseButtons = { left: bool, right: bool, middle: bool }
 
-/// Mouse position in shell-provided surface coordinates, plus held levels and
-/// transitions since the previous fixed simulation step. A quick click may be
+/// Mouse position in top-left-origin logical surface coordinates, the matching
+/// logical extent, plus held levels and transitions since the previous fixed
+/// simulation step. Desktop uses window points; web uses CSS pixels, so this
+/// stays stable across Retina/device-pixel-ratio changes. A quick click may be
 /// both `pressed.left` and `released.left` in one sample.
 type mouse = {
   x: float,
   y: float,
+  surfaceWidth: float,
+  surfaceHeight: float,
   buttons: mouseButtons,
   pressed: mouseButtons,
   released: mouseButtons

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -38,7 +38,11 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// `pressed_keys`, `released_keys`, `mouse.pressed`, and `mouse.released`.
 /// This is additive; clients that support older runtimes can treat absent
 /// fields as empty.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 6;
+///
+/// 7 adds `surface_width` / `surface_height` to `GET /state`'s mouse sample.
+/// They are logical window/CSS dimensions in the same coordinate space as
+/// `x` / `y`; clients using resize-correct pointer mapping need v7.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 7;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -92,7 +96,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse + optional xr), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -433,6 +437,8 @@ mod tests {
                 mouse: crate::MouseSnapshot {
                     x: 10,
                     y: 20,
+                    surface_width: 960,
+                    surface_height: 540,
                     ..Default::default()
                 },
                 xr: None,
@@ -461,6 +467,8 @@ mod tests {
                     "mouse": {
                         "x": 10,
                         "y": 20,
+                        "surface_width": 960,
+                        "surface_height": 540,
                         "buttons": { "left": false, "right": false, "middle": false },
                         "pressed": { "left": false, "right": false, "middle": false },
                         "released": { "left": false, "right": false, "middle": false }
@@ -665,6 +673,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 6);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 7);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -289,7 +289,7 @@ return them beside the model as `(model, effect)`"
     if has_sampled_input {
         require_function(&path, &session, "sampledInput", 2)?;
     }
-    // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
+    // Same deal for the mouse: `mouseMove(model, x, y)` in logical shell coordinates,
     // `mouseWheel(model, delta)`.
     let has_mouse_move = session.global("mouseMove").is_some();
     if has_mouse_move {

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -44,6 +44,7 @@
 //! Frame.create(camera, scene)                               -> Frame
 //! Camera2D.create(width, height)                             -> Camera2D
 //! Camera2D.at(x, y, camera) / Camera2D.zoom(k, camera)       -> Camera2D
+//! Camera2D.toWorld(mouse, camera)                            -> Option<Input.point2>
 //!   (center-origin, Y-up world units, aspect-fitted without stretching)
 //! Sprite.blank() / rectangle(color, w, h) / square(color, n) -> Sprite
 //! Sprite.image(w, h, texture) / imageRegion(w, h, region, texture) -> Sprite
@@ -5449,6 +5450,44 @@ forward: { x: 0, y: 0, z: 1 }, up: { x: 0, y: 1, z: 0 } }"
         assert!(json.contains(r#""sampling":"Linear""#), "json: {json}");
         let back: Frame = serde_json::from_str(&json).expect("sprite frame deserializes");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    #[test]
+    fn camera2d_to_world_maps_input_mouse_and_rejects_bars() {
+        let center = eval(
+            "let main = () =>\n\
+             Camera2D.toWorld(\n\
+               { x: 500.0, y: 500.0, surfaceWidth: 1000.0, surfaceHeight: 1000.0,\n\
+                 buttons: { left: false, right: false, middle: false } },\n\
+               Camera2D.create(16.0, 9.0) |> Camera2D.at(4.0, -3.0) |> Camera2D.zoom(2.0))",
+        );
+        assert!(matches!(
+            center,
+            Value::Variant { ref ctor, ref args }
+                if ctor.as_ref() == "Option.Some"
+                    && matches!(
+                        args.first(),
+                        Some(Value::Record(fields))
+                            if matches!(
+                                fields.as_slice(),
+                                [(x_name, Value::Number(x)), (y_name, Value::Number(y))]
+                                    if x_name == "x" && y_name == "y" && *x == 4.0 && *y == -3.0
+                            )
+                    )
+        ));
+
+        let bar = eval(
+            "let main = () =>\n\
+             Camera2D.toWorld(\n\
+               { x: 500.0, y: 100.0, surfaceWidth: 1000.0, surfaceHeight: 1000.0,\n\
+                 buttons: { left: false, right: false, middle: false } },\n\
+               Camera2D.create(16.0, 9.0))",
+        );
+        assert!(matches!(
+            bar,
+            Value::Variant { ref ctor, ref args }
+                if ctor.as_ref() == "Option.None" && args.is_empty()
+        ));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude/sprite.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude/sprite.rs
@@ -26,6 +26,42 @@ struct FunctorLangSpriteRegion([f32; 4]);
 /// set. One shared point type is the only workable choice.
 struct FunctorLangPoint2([f32; 2]);
 
+/// A sampled mouse position plus the logical surface extent sharing its
+/// top-left-origin coordinate space.
+struct FunctorLangMouse {
+    x: f32,
+    y: f32,
+    surface_width: f32,
+    surface_height: f32,
+}
+
+fn finite_record_number(
+    fields: &[(String, Value)],
+    field: &str,
+    record_name: &str,
+    path: &str,
+    span: Span,
+) -> Result<f32, RunError> {
+    match fields.iter().find(|(name, _)| name == field) {
+        Some((_, Value::Number(n))) if (*n as f32).is_finite() => Ok(*n as f32),
+        Some((_, Value::Number(n))) => Err(RunError {
+            message: format!("{path}: {record_name} `{field}` must be finite, got {n}"),
+            span,
+        }),
+        Some((_, other)) => Err(RunError {
+            message: format!(
+                "{path}: {record_name} `{field}` must be a number, got {}",
+                other.kind_name()
+            ),
+            span,
+        }),
+        None => Err(RunError {
+            message: format!("{path}: expected a {record_name} record, missing `{field}`"),
+            span,
+        }),
+    }
+}
+
 impl crate::host_registry::FromArg for FunctorLangPoint2 {
     fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
         let Value::Record(fields) = value else {
@@ -37,27 +73,30 @@ impl crate::host_registry::FromArg for FunctorLangPoint2 {
                 span,
             });
         };
-        let get = |name: &str| -> Result<f32, RunError> {
-            match fields.iter().find(|(field, _)| field == name) {
-                Some((_, Value::Number(n))) if (*n as f32).is_finite() => Ok(*n as f32),
-                Some((_, Value::Number(n))) => Err(RunError {
-                    message: format!("{path}: point `{name}` must be finite, got {n}"),
-                    span,
-                }),
-                Some((_, other)) => Err(RunError {
-                    message: format!(
-                        "{path}: point `{name}` must be a number, got {}",
-                        other.kind_name()
-                    ),
-                    span,
-                }),
-                None => Err(RunError {
-                    message: format!("{path}: expected a point record {{ x, y }}, missing `{name}`"),
-                    span,
-                }),
-            }
+        Ok(FunctorLangPoint2([
+            finite_record_number(fields, "x", "point", path, span)?,
+            finite_record_number(fields, "y", "point", path, span)?,
+        ]))
+    }
+}
+
+impl crate::host_registry::FromArg for FunctorLangMouse {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        let Value::Record(fields) = value else {
+            return Err(RunError {
+                message: format!(
+                    "{path}: expected an Input.mouse record, got {}",
+                    value.kind_name()
+                ),
+                span,
+            });
         };
-        Ok(FunctorLangPoint2([get("x")?, get("y")?]))
+        Ok(FunctorLangMouse {
+            x: finite_record_number(fields, "x", "mouse", path, span)?,
+            y: finite_record_number(fields, "y", "mouse", path, span)?,
+            surface_width: finite_record_number(fields, "surfaceWidth", "mouse", path, span)?,
+            surface_height: finite_record_number(fields, "surfaceHeight", "mouse", path, span)?,
+        })
     }
 }
 
@@ -692,6 +731,23 @@ pub(super) fn register(reg: &mut crate::host_registry::Registry) {
                 return Err(format!("Camera2D.zoom scale must be positive, got {zoom}"));
             }
             Ok(FunctorLangCamera2D(camera.0.with_zoom(zoom as f32)))
+        },
+    );
+    reg.fn2(
+        "Camera2D.toWorld",
+        "Camera2D.toWorld(mouse, camera)",
+        |mouse: FunctorLangMouse, camera: FunctorLangCamera2D| {
+            crate::input::option_value(
+                camera
+                    .0
+                    .to_world(mouse.x, mouse.y, mouse.surface_width, mouse.surface_height)
+                    .map(|[x, y]| {
+                        crate::input::record([
+                            ("x", Value::Number(x as f64)),
+                            ("y", Value::Number(y as f64)),
+                        ])
+                    }),
+            )
         },
     );
 

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -22,7 +22,8 @@ pub struct InputSnapshot {
     /// step, in canonical discriminant order.
     #[serde(default)]
     pub released_keys: Vec<Key>,
-    /// Last known mouse position in output pixels.
+    /// Last known mouse position and the logical surface extent sharing its
+    /// coordinate space.
     pub mouse: MouseSnapshot,
     /// Live XR tracking/controller state when the target supplies it.
     ///
@@ -32,11 +33,22 @@ pub struct InputSnapshot {
     pub xr: Option<XrInputSnapshot>,
 }
 
-/// Last known mouse position, held buttons, and this step's button transitions.
+/// Last known mouse position in logical shell coordinates, the matching
+/// surface extent, held buttons, and this step's button transitions.
+///
+/// Desktop supplies GLFW window points and web supplies CSS pixels. Keeping
+/// the extent beside the position makes pointer mapping independent of
+/// framebuffer/Retina scale.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MouseSnapshot {
     pub x: i32,
     pub y: i32,
+    /// Logical width in the same coordinate space as [`Self::x`].
+    #[serde(default)]
+    pub surface_width: u32,
+    /// Logical height in the same coordinate space as [`Self::y`].
+    #[serde(default)]
+    pub surface_height: u32,
     /// Buttons held right now — the level complement of the `mouseButton`
     /// edges. Defaulted on the wire so an older `/state` capture (and a
     /// hand-written debug injection) still deserializes.
@@ -563,7 +575,7 @@ pub fn mouse_button_input_value(code: i32) -> Option<functor_lang::Value> {
     })
 }
 
-fn record(
+pub(crate) fn record(
     fields: impl IntoIterator<Item = (&'static str, functor_lang::Value)>,
 ) -> functor_lang::Value {
     functor_lang::Value::Record(std::rc::Rc::new(
@@ -574,7 +586,7 @@ fn record(
     ))
 }
 
-fn option_value(value: Option<functor_lang::Value>) -> functor_lang::Value {
+pub(crate) fn option_value(value: Option<functor_lang::Value>) -> functor_lang::Value {
     match value {
         Some(value) => functor_lang::Value::Variant {
             ctor: std::rc::Rc::from("Option.Some"),
@@ -737,6 +749,14 @@ pub fn input_snapshot_value(snapshot: &InputSnapshot) -> functor_lang::Value {
             record([
                 ("x", functor_lang::Value::Number(snapshot.mouse.x as f64)),
                 ("y", functor_lang::Value::Number(snapshot.mouse.y as f64)),
+                (
+                    "surfaceWidth",
+                    functor_lang::Value::Number(snapshot.mouse.surface_width as f64),
+                ),
+                (
+                    "surfaceHeight",
+                    functor_lang::Value::Number(snapshot.mouse.surface_height as f64),
+                ),
                 ("buttons", mouse_buttons_value(snapshot.mouse.buttons)),
                 ("pressed", mouse_buttons_value(snapshot.mouse.pressed)),
                 ("released", mouse_buttons_value(snapshot.mouse.released)),
@@ -924,6 +944,8 @@ mod tests {
             mouse: MouseSnapshot {
                 x: 10,
                 y: 20,
+                surface_width: 800,
+                surface_height: 600,
                 ..Default::default()
             },
             xr: None,
@@ -939,19 +961,24 @@ mod tests {
                 "mouse": {
                     "x": 10,
                     "y": 20,
+                    "surface_width": 800,
+                    "surface_height": 600,
                     "buttons": { "left": false, "right": false, "middle": false },
                     "pressed": { "left": false, "right": false, "middle": false },
                     "released": { "left": false, "right": false, "middle": false }
                 }
             })
         );
-        // Mouse buttons are defaulted on the wire, so a capture taken before
-        // they existed (and a hand-written injection) still decodes.
+        // Newer mouse fields and edge sets are defaulted on the wire, so a
+        // capture taken before they existed (and a hand-written injection)
+        // still decodes.
         let legacy: InputSnapshot = serde_json::from_value(
             serde_json::json!({ "held_keys": [], "mouse": { "x": 1, "y": 2 } }),
         )
         .unwrap();
         assert_eq!(legacy.mouse.buttons, MouseButtons::default());
+        assert_eq!(legacy.mouse.surface_width, 0);
+        assert_eq!(legacy.mouse.surface_height, 0);
         assert!(legacy.pressed_keys.is_empty());
         assert!(legacy.released_keys.is_empty());
         assert_eq!(legacy.mouse.pressed, MouseButtons::default());
@@ -984,6 +1011,8 @@ mod tests {
             mouse: MouseSnapshot {
                 x: 12,
                 y: -4,
+                surface_width: 1440,
+                surface_height: 900,
                 buttons: MouseButtons {
                     left: true,
                     right: false,
@@ -1017,6 +1046,10 @@ mod tests {
         );
         assert!(rendered.contains("pressedKeys: [Key.Space]"), "{rendered}");
         assert!(rendered.contains("releasedKeys: [Key.Enter]"), "{rendered}");
+        assert!(
+            rendered.contains("surfaceWidth: 1440") && rendered.contains("surfaceHeight: 900"),
+            "{rendered}"
+        );
         assert!(
             rendered.contains(
                 "buttons: { left: true, right: false, middle: false }, pressed: { left: true, right: false, middle: false }, released: { left: false, right: true, middle: false }"

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -15,7 +15,8 @@
 //! - [`crate::InputSnapshot`] — sampled held/device state plus deterministic
 //!   keyboard/mouse transitions, delivered once before each fixed step.
 //! - Input events, as scalars: key code ([`crate::Key`] as `i32`) + down flag,
-//!   mouse position (`i32` pixels), wheel delta (`i32`). The `Key` enum's
+//!   mouse position (`i32` logical window/CSS coordinates), wheel delta
+//!   (`i32`). The `Key` enum's
 //!   **`i32` discriminants** are the wire representation on both sides
 //!   (mirrored by F# `Input.ofKeyCode`) — inserting a variant mid-enum is a
 //!   protocol break even though serde names don't change.
@@ -70,6 +71,9 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v10: logical mouse surface extent — `InputSnapshot.mouse.surface_width` /
+/// `surface_height`, defaulted when decoding older samples.
+///
 /// v9: deterministic fixed-step keyboard/mouse transitions —
 /// [`crate::InputSnapshot::pressed_keys`],
 /// [`crate::InputSnapshot::released_keys`], and the pressed/released button
@@ -99,7 +103,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -282,7 +286,8 @@ pub trait GameProducer {
     /// Deliver a keyboard event. `code` is a [`crate::Key`] as `i32`.
     fn key_event(&mut self, code: i32, is_down: bool);
 
-    /// Deliver a mouse-move event in window pixel coordinates.
+    /// Deliver a mouse-move event in logical shell coordinates (window points
+    /// on desktop, CSS pixels on web).
     fn mouse_move(&mut self, x: i32, y: i32);
 
     /// Deliver a mouse-wheel event (vertical scroll offset).
@@ -466,7 +471,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 9);
+        assert_eq!(PROTOCOL_VERSION, 10);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -493,7 +498,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 9);
+        assert_eq!(PROTOCOL_VERSION, 10);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],

--- a/runtime/functor-runtime-common/src/sprite2d.rs
+++ b/runtime/functor-runtime-common/src/sprite2d.rs
@@ -61,33 +61,94 @@ impl Camera2D {
         )
     }
 
+    /// The ideal, continuous aspect-fitted rectangle shared by rendering and
+    /// pointer mapping.
+    ///
+    /// Coordinates are bottom-left-origin like [`Viewport`]. Keeping this
+    /// calculation in floating point makes its half-open bounds authoritative
+    /// for logical pointer coordinates and invariant across device-pixel
+    /// ratios. [`Self::fitted_viewport`] rounds only when GL requires an
+    /// integer raster viewport, which may move a physical edge by a subpixel
+    /// in logical space.
+    fn fitted_rect(&self, width: f32, height: f32) -> Option<[f32; 4]> {
+        if width <= 0.0
+            || height <= 0.0
+            || !width.is_finite()
+            || !height.is_finite()
+            || self.width <= 0.0
+            || self.height <= 0.0
+            || !self.width.is_finite()
+            || !self.height.is_finite()
+        {
+            return None;
+        }
+        let camera_aspect = self.width / self.height;
+        if camera_aspect <= 0.0 || !camera_aspect.is_finite() {
+            return None;
+        }
+        let surface_aspect = width / height;
+        if surface_aspect > camera_aspect {
+            let fitted_width = height * camera_aspect;
+            Some([(width - fitted_width) * 0.5, 0.0, fitted_width, height])
+        } else {
+            let fitted_height = width / camera_aspect;
+            Some([0.0, (height - fitted_height) * 0.5, width, fitted_height])
+        }
+    }
+
     /// Fit the camera's declared aspect inside `viewport`, preserving its
     /// bottom-left offset for stereo/netsim panes.
     pub(crate) fn fitted_viewport(&self, viewport: Viewport) -> Viewport {
-        if viewport.width == 0 || viewport.height == 0 {
+        let Some([_, _, width, height]) =
+            self.fitted_rect(viewport.width as f32, viewport.height as f32)
+        else {
             return viewport;
+        };
+        let fitted_width = (width.round() as u32).clamp(1, viewport.width);
+        let fitted_height = (height.round() as u32).clamp(1, viewport.height);
+        Viewport::with_offset(
+            viewport.x + (viewport.width - fitted_width) / 2,
+            viewport.y + (viewport.height - fitted_height) / 2,
+            fitted_width,
+            fitted_height,
+        )
+    }
+
+    /// Map a top-left-origin logical surface point into this camera's world.
+    ///
+    /// Returns `None` for points in aspect-fit letterbox/pillarbox bars, for
+    /// points outside the surface, or for a degenerate surface. Surface
+    /// dimensions must share the point's coordinate space (window points on
+    /// desktop, CSS pixels on web), not framebuffer pixels. Bar rejection uses
+    /// the ideal half-open logical fit; it deliberately does not inherit the
+    /// renderer's device-pixel rounding.
+    pub fn to_world(
+        &self,
+        x: f32,
+        y: f32,
+        surface_width: f32,
+        surface_height: f32,
+    ) -> Option<[f32; 2]> {
+        if !x.is_finite()
+            || !y.is_finite()
+            || self.zoom <= 0.0
+            || !self.zoom.is_finite()
+            || !self.center[0].is_finite()
+            || !self.center[1].is_finite()
+        {
+            return None;
         }
-        let camera_aspect = self.width / self.height;
-        let viewport_aspect = viewport.aspect();
-        if viewport_aspect > camera_aspect {
-            let width =
-                ((viewport.height as f32 * camera_aspect).round() as u32).clamp(1, viewport.width);
-            Viewport::with_offset(
-                viewport.x + (viewport.width - width) / 2,
-                viewport.y,
-                width,
-                viewport.height,
-            )
-        } else {
-            let height =
-                ((viewport.width as f32 / camera_aspect).round() as u32).clamp(1, viewport.height);
-            Viewport::with_offset(
-                viewport.x,
-                viewport.y + (viewport.height - height) / 2,
-                viewport.width,
-                height,
-            )
+        let [left, bottom, width, height] = self.fitted_rect(surface_width, surface_height)?;
+        let top = surface_height - bottom - height;
+        if x < left || x >= left + width || y < top || y >= top + height {
+            return None;
         }
+        let normalized_x = (x - left) / width;
+        let normalized_y = (y - top) / height;
+        Some([
+            self.center[0] + (normalized_x - 0.5) * self.width / self.zoom,
+            self.center[1] + (0.5 - normalized_y) * self.height / self.zoom,
+        ])
     }
 }
 
@@ -125,5 +186,88 @@ mod tests {
         let very_wide = Camera2D::new(f32::MAX, 1.0).fitted_viewport(Viewport::new(100, 100));
         assert_eq!(very_wide.width, 100);
         assert_eq!(very_wide.height, 1);
+    }
+
+    #[test]
+    fn to_world_maps_matching_surface_with_top_left_input() {
+        let camera = Camera2D::new(16.0, 9.0);
+        assert_eq!(
+            camera.to_world(800.0, 450.0, 1600.0, 900.0),
+            Some([0.0, 0.0])
+        );
+        assert_eq!(camera.to_world(0.0, 0.0, 1600.0, 900.0), Some([-8.0, 4.5]));
+    }
+
+    #[test]
+    fn to_world_rejects_letterbox_and_pillarbox_bars() {
+        let camera = Camera2D::new(16.0, 9.0);
+        // A square surface has horizontal bars: ideal fitted content is the
+        // half-open interval y=[218.75, 781.25), so 781.25 is the first
+        // rejected coordinate.
+        assert_eq!(camera.to_world(500.0, 100.0, 1000.0, 1000.0), None);
+        assert_eq!(camera.to_world(500.0, 218.74, 1000.0, 1000.0), None);
+        assert!(camera
+            .to_world(500.0, 218.75, 1000.0, 1000.0)
+            .is_some());
+        assert_eq!(camera.to_world(500.0, 781.25, 1000.0, 1000.0), None);
+        assert_eq!(
+            camera.to_world(500.0, 500.0, 1000.0, 1000.0),
+            Some([0.0, 0.0])
+        );
+
+        // A 2:1 surface has vertical bars: fitted content is
+        // x=111.11..1888.89.
+        assert_eq!(camera.to_world(50.0, 500.0, 2000.0, 1000.0), None);
+        assert_eq!(
+            camera.to_world(1000.0, 500.0, 2000.0, 1000.0),
+            Some([0.0, 0.0])
+        );
+    }
+
+    #[test]
+    fn to_world_applies_pan_and_zoom() {
+        let camera = Camera2D::new(20.0, 10.0)
+            .with_center(4.0, -3.0)
+            .with_zoom(2.0);
+        assert_eq!(
+            camera.to_world(100.0, 50.0, 200.0, 100.0),
+            Some([4.0, -3.0])
+        );
+        assert_eq!(camera.to_world(0.0, 0.0, 200.0, 100.0), Some([-1.0, -0.5]));
+    }
+
+    #[test]
+    fn to_world_is_retina_scale_invariant_and_tracks_resize() {
+        let camera = Camera2D::new(16.0, 9.0);
+        let one_x = camera.to_world(300.0, 400.0, 900.0, 1000.0);
+        let retina = camera.to_world(600.0, 800.0, 1800.0, 2000.0);
+        assert_eq!(one_x, retina);
+
+        // Pin the intentional raster-boundary distinction: GL must round this
+        // 506.25-high ideal fit to integer pixels, while logical picking keeps
+        // the continuous [246.875, 753.125) interval. Scaling both the point
+        // and logical surface leaves even that boundary-near pick unchanged.
+        assert_eq!(
+            camera.fitted_viewport(Viewport::new(900, 1000)),
+            Viewport::with_offset(0, 247, 900, 506)
+        );
+        let logical_edge = camera.to_world(450.0, 753.0, 900.0, 1000.0);
+        let scaled_edge = camera.to_world(900.0, 1506.0, 1800.0, 2000.0);
+        assert!(logical_edge.is_some());
+        assert_eq!(logical_edge, scaled_edge);
+
+        let before = camera.to_world(450.0, 500.0, 900.0, 1000.0);
+        let after = camera.to_world(800.0, 450.0, 1600.0, 900.0);
+        assert_eq!(before, Some([0.0, 0.0]));
+        assert_eq!(after, Some([0.0, 0.0]));
+    }
+
+    #[test]
+    fn to_world_rejects_degenerate_and_outside_surfaces() {
+        let camera = Camera2D::new(16.0, 9.0);
+        assert_eq!(camera.to_world(0.0, 0.0, 0.0, 900.0), None);
+        assert_eq!(camera.to_world(-1.0, 0.0, 1600.0, 900.0), None);
+        assert_eq!(camera.to_world(1600.0, 0.0, 1600.0, 900.0), None);
+        assert_eq!(camera.to_world(f32::NAN, 0.0, 1600.0, 900.0), None);
     }
 }

--- a/runtime/functor-runtime-common/src/sprite2d.rs
+++ b/runtime/functor-runtime-common/src/sprite2d.rs
@@ -266,6 +266,7 @@ mod tests {
     fn to_world_rejects_degenerate_and_outside_surfaces() {
         let camera = Camera2D::new(16.0, 9.0);
         assert_eq!(camera.to_world(0.0, 0.0, 0.0, 900.0), None);
+        assert_eq!(camera.to_world(-0.25, 0.0, 1600.0, 900.0), None);
         assert_eq!(camera.to_world(-1.0, 0.0, 1600.0, 900.0), None);
         assert_eq!(camera.to_world(1600.0, 0.0, 1600.0, 900.0), None);
         assert_eq!(camera.to_world(f32::NAN, 0.0, 1600.0, 900.0), None);

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -375,7 +375,7 @@ return them beside the model as `(model, effect)`"
     if has_sampled_input {
         require_function(path, &session, "sampledInput", 2)?;
     }
-    // Same deal for the mouse: `mouseMove(model, x, y)` in window pixels,
+    // Same deal for the mouse: `mouseMove(model, x, y)` in logical window points,
     // `mouseWheel(model, delta)`.
     let has_mouse_move = session.global("mouseMove").is_some();
     if has_mouse_move {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1577,8 +1577,7 @@ Escape releases while captured"
         // arms in the event loop. A hidden window never captures (and never
         // receives the events that would toggle this).
         let visible_pointer = args.cursor == CursorPolicyArg::Visible;
-        let game_camera_control =
-            args.camera_control == CameraControl::Game && !visible_pointer;
+        let game_camera_control = args.camera_control == CameraControl::Game && !visible_pointer;
         let mut cursor_captured = false;
         let mut escape_armed = false;
 

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -137,6 +137,12 @@ fn sampled_input_snapshot(
     snapshot
 }
 
+/// Convert GLFW's fractional visible-cursor coordinates without snapping a
+/// point just above/left of the window inside at zero.
+fn visible_cursor_position(x: f64, y: f64) -> (i32, i32) {
+    (x.floor() as i32, y.floor() as i32)
+}
+
 /// Build this step's sampled input.
 ///
 /// `xr_override` is a debug-injected XR sample (`POST /input` `{"type":"xr"}`).
@@ -1955,9 +1961,9 @@ Escape again to quit"
                     // project also receives this absolute logical position;
                     // captured projects reserve released motion for chrome.
                     glfw::WindowEvent::CursorPos(x, y) if !cursor_captured => {
-                        mouse_pos = (x as i32, y as i32);
+                        mouse_pos = visible_cursor_position(x, y);
                         if args.cursor == CursorPolicyArg::Visible && !ignore_user_input {
-                            game.mouse_move(x as i32, y as i32);
+                            game.mouse_move(mouse_pos.0, mouse_pos.1);
                         }
                     }
                     // F1 recenters head tracking (runner-level, never reaches
@@ -3427,6 +3433,11 @@ mod tests {
         assert_eq!(after.mouse.y, 123);
         assert_eq!(after.mouse.surface_width, 1440);
         assert_eq!(after.mouse.surface_height, 900);
+    }
+
+    #[test]
+    fn visible_cursor_floors_fractional_negative_coordinates() {
+        assert_eq!(visible_cursor_position(-0.25, 10.75), (-1, 10));
     }
 
     /// A pose an emulated desktop rig CANNOT produce: the emulator pins both

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -115,6 +115,7 @@ fn map_mouse_button(button: glfw::MouseButton) -> functor_runtime_common::MouseB
 fn sampled_input_snapshot(
     held_keys: &BTreeSet<InputKey>,
     mouse_pos: (i32, i32),
+    surface: (i32, i32),
     held_buttons: MouseButtons,
     edges: &InputEdges,
     xr: Option<XrInputSnapshot>,
@@ -124,6 +125,8 @@ fn sampled_input_snapshot(
         mouse: MouseSnapshot {
             x: mouse_pos.0,
             y: mouse_pos.1,
+            surface_width: surface.0.max(0) as u32,
+            surface_height: surface.1.max(0) as u32,
             buttons: held_buttons,
             ..MouseSnapshot::default()
         },
@@ -157,7 +160,7 @@ fn desktop_input_snapshot(
             crate::desktop_xr_emulator::sample(held_keys, mouse_pos, xr_primary_down, xr_surface)
         }),
     };
-    sampled_input_snapshot(held_keys, mouse_pos, held_buttons, edges, xr)
+    sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr)
 }
 
 /// Release every mouse button the game currently holds — the button twin of
@@ -234,6 +237,35 @@ fn apply_mouse_button_edge(
         held_buttons.set(button, false);
         edges.mouse_transition(button, true, false);
         game.mouse_button(button as i32, false);
+    }
+}
+
+/// Apply a physical window-button edge while preserving pinned/replay
+/// determinism. A suppressed press never enters the held set; a release always
+/// clears shell state. Only delivered transitions enter the fixed-step edge
+/// accumulator.
+fn apply_window_mouse_button_edge(
+    game: &mut dyn Game,
+    held_buttons: &mut MouseButtons,
+    edges: &mut InputEdges,
+    button: functor_runtime_common::MouseButton,
+    is_down: bool,
+    deliver: bool,
+) {
+    if is_down {
+        if deliver {
+            let was_down = held_buttons.is_down(button);
+            held_buttons.set(button, true);
+            edges.mouse_transition(button, was_down, true);
+            game.mouse_button(button as i32, true);
+        }
+    } else {
+        let was_held = held_buttons.is_down(button);
+        held_buttons.set(button, false);
+        if was_held && deliver {
+            edges.mouse_transition(button, true, false);
+            game.mouse_button(button as i32, false);
+        }
     }
 }
 
@@ -469,6 +501,16 @@ enum CompositeDemoArg {
     Fork,
 }
 
+/// How a project wants the desktop shell to expose the mouse.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CursorPolicyArg {
+    /// Hide/capture the cursor and deliver relative free-look motion.
+    #[default]
+    Captured,
+    /// Keep the system cursor visible and deliver absolute window positions.
+    Visible,
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -522,6 +564,10 @@ pub struct Args {
     /// Implied by --capture-frame. (With --headless there is no window at all.)
     #[arg(long, conflicts_with = "headless")]
     hidden: bool,
+
+    /// Pointer policy selected by the project's `functor.json`.
+    #[arg(long, value_enum, default_value_t = CursorPolicyArg::Captured)]
+    cursor: CursorPolicyArg,
 
     /// Write a PNG of the rendered frame to this path, then exit. The capture
     /// happens on the first frame after --capture-time seconds of wall-clock
@@ -1368,7 +1414,11 @@ then restart the runner"
             // editor while the game runs); a later click recaptures, and
             // Escape while released quits. Losing focus also releases, so
             // cmd-tabbing away hands the pointer back.
-            if !hidden && !args.emulate_xr && args.camera_control == CameraControl::Game {
+            if !hidden
+                && !args.emulate_xr
+                && args.camera_control == CameraControl::Game
+                && args.cursor == CursorPolicyArg::Captured
+            {
                 window.set_cursor_mode(glfw::CursorMode::Normal);
                 eprintln!(
                     "[runner] game mouse control available — click the window to capture; \
@@ -1520,7 +1570,9 @@ Escape releases while captured"
         // entered by a non-overlay click; see the Escape / MouseButton / Focus
         // arms in the event loop. A hidden window never captures (and never
         // receives the events that would toggle this).
-        let game_camera_control = args.camera_control == CameraControl::Game;
+        let visible_pointer = args.cursor == CursorPolicyArg::Visible;
+        let game_camera_control =
+            args.camera_control == CameraControl::Game && !visible_pointer;
         let mut cursor_captured = false;
         let mut escape_armed = false;
 
@@ -1863,6 +1915,15 @@ Escape again to quit"
                                     if webview_wants_keyboard {
                                         webview_keys.push(WebviewKey::Escape);
                                     }
+                                } else if visible_pointer {
+                                    apply_window_mouse_button_edge(
+                                        &mut *game,
+                                        &mut held_buttons,
+                                        &mut input_edges,
+                                        functor_runtime_common::MouseButton::Left,
+                                        true,
+                                        !ignore_user_input,
+                                    );
                                 } else {
                                     // With no camera-control opt-in the pointer
                                     // belongs to the overlays for the whole
@@ -1876,14 +1937,28 @@ Escape again to quit"
                             Action::Release => {
                                 mouse_primary_down = false;
                                 xr_primary_down = false;
+                                if args.cursor == CursorPolicyArg::Visible {
+                                    apply_window_mouse_button_edge(
+                                        &mut *game,
+                                        &mut held_buttons,
+                                        &mut input_edges,
+                                        functor_runtime_common::MouseButton::Left,
+                                        false,
+                                        !ignore_user_input,
+                                    );
+                                }
                             }
                             Action::Repeat => {}
                         }
                     }
-                    // Track the cursor for the scrubber while released (but never
-                    // drive the camera — you're pointing at the overlay).
+                    // Track the cursor for overlays while released. A visible
+                    // project also receives this absolute logical position;
+                    // captured projects reserve released motion for chrome.
                     glfw::WindowEvent::CursorPos(x, y) if !cursor_captured => {
                         mouse_pos = (x as i32, y as i32);
+                        if args.cursor == CursorPolicyArg::Visible && !ignore_user_input {
+                            game.mouse_move(x as i32, y as i32);
+                        }
                     }
                     // F1 recenters head tracking (runner-level, never reaches
                     // the game): current head pose becomes "straight ahead".
@@ -1935,11 +2010,9 @@ Escape again to quit"
                             );
                         }
                     }
-                    // Mouse buttons reach the game only while the cursor is
-                    // CAPTURED — the same rule `CursorPos`/`Scroll` follow
-                    // below. While the cursor is released the pointer belongs
-                    // to the overlays (and the left button recaptures — the
-                    // arm above), so a click there is not a game click.
+                    // Captured-policy mouse buttons reach the game only while
+                    // the cursor is captured. While released, that policy
+                    // reserves the pointer for overlays and click-to-recapture.
                     // Bookkeeping/delivery discipline mirrors keys exactly:
                     // this sits before the `ignore_user_input` catch-all so a
                     // button held at a pin transition can't stick, while the
@@ -1952,25 +2025,61 @@ Escape again to quit"
                         let mapped = map_mouse_button(button);
                         if mapped != functor_runtime_common::MouseButton::Unknown {
                             match action {
-                                Action::Press => {
-                                    // A press the game never saw must not enter
-                                    // the held set, or its release would leak a
-                                    // phantom edge.
-                                    if !ignore_user_input {
-                                        let was_down = held_buttons.is_down(mapped);
-                                        held_buttons.set(mapped, true);
-                                        input_edges.mouse_transition(mapped, was_down, true);
-                                        game.mouse_button(mapped as i32, true);
-                                    }
-                                }
-                                Action::Release => {
-                                    let was_held = held_buttons.is_down(mapped);
-                                    held_buttons.set(mapped, false);
-                                    if was_held && !ignore_user_input {
-                                        input_edges.mouse_transition(mapped, true, false);
-                                        game.mouse_button(mapped as i32, false);
-                                    }
-                                }
+                                Action::Press => apply_window_mouse_button_edge(
+                                    &mut *game,
+                                    &mut held_buttons,
+                                    &mut input_edges,
+                                    mapped,
+                                    true,
+                                    !ignore_user_input,
+                                ),
+                                Action::Release => apply_window_mouse_button_edge(
+                                    &mut *game,
+                                    &mut held_buttons,
+                                    &mut input_edges,
+                                    mapped,
+                                    false,
+                                    !ignore_user_input,
+                                ),
+                                Action::Repeat => {}
+                            }
+                            if clock.is_fixed_time() {
+                                refresh_fixed_input_levels(
+                                    &mut fixed_input_snapshot,
+                                    &held_keys,
+                                    held_buttons,
+                                    xr_primary_down || xr_primary_clicked,
+                                    xr_override.as_ref(),
+                                );
+                            }
+                        }
+                    }
+                    // Visible-pointer games receive right/middle buttons
+                    // directly. Left is handled by the released-pointer arm
+                    // above so interactive overlays can consume it first.
+                    glfw::WindowEvent::MouseButton(button, action, _)
+                        if args.cursor == CursorPolicyArg::Visible
+                            && button != glfw::MouseButtonLeft =>
+                    {
+                        let mapped = map_mouse_button(button);
+                        if mapped != functor_runtime_common::MouseButton::Unknown {
+                            match action {
+                                Action::Press => apply_window_mouse_button_edge(
+                                    &mut *game,
+                                    &mut held_buttons,
+                                    &mut input_edges,
+                                    mapped,
+                                    true,
+                                    !ignore_user_input,
+                                ),
+                                Action::Release => apply_window_mouse_button_edge(
+                                    &mut *game,
+                                    &mut held_buttons,
+                                    &mut input_edges,
+                                    mapped,
+                                    false,
+                                    !ignore_user_input,
+                                ),
                                 Action::Repeat => {}
                             }
                             if clock.is_fixed_time() {
@@ -1992,7 +2101,8 @@ Escape again to quit"
                             }
                         }
                         // Hand the pointer back when the window loses focus
-                        // (cmd-tab to the editor); a click recaptures.
+                        // (cmd-tab to the editor). Captured projects recapture
+                        // on a later click; visible projects remain free.
                         window.set_cursor_mode(glfw::CursorMode::Normal);
                         cursor_captured = false;
                         escape_armed = false;
@@ -2088,7 +2198,9 @@ Escape again to quit"
                         mouse_pos = (x as i32, y as i32);
                         game.mouse_move(x as i32, y as i32)
                     }
-                    glfw::WindowEvent::Scroll(_, y) if cursor_captured => {
+                    glfw::WindowEvent::Scroll(_, y)
+                        if cursor_captured || args.cursor == CursorPolicyArg::Visible =>
+                    {
                         game.mouse_wheel(y as i32)
                     }
                     _ => {}
@@ -3243,6 +3355,8 @@ mod tests {
             MouseSnapshot {
                 x: 100,
                 y: 200,
+                surface_width: 800,
+                surface_height: 600,
                 buttons,
                 ..MouseSnapshot::default()
             }
@@ -3279,6 +3393,40 @@ mod tests {
         assert!(snapshot.mouse.pressed.left);
         assert!(snapshot.mouse.released.left);
         assert!(!snapshot.mouse.buttons.left);
+    }
+
+    #[test]
+    fn desktop_mouse_sample_tracks_logical_resize_and_injected_position() {
+        let before = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (320, 240),
+            MouseButtons::default(),
+            &InputEdges::default(),
+            false,
+            false,
+            (800, 600),
+            None,
+        );
+        assert_eq!(before.mouse.surface_width, 800);
+        assert_eq!(before.mouse.surface_height, 600);
+
+        // This is the snapshot rebuilt after POST /input mouse_move: the
+        // injected x/y changes while the shell-owned logical window extent
+        // follows the current resize.
+        let after = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (777, 123),
+            MouseButtons::default(),
+            &InputEdges::default(),
+            false,
+            false,
+            (1440, 900),
+            None,
+        );
+        assert_eq!(after.mouse.x, 777);
+        assert_eq!(after.mouse.y, 123);
+        assert_eq!(after.mouse.surface_width, 1440);
+        assert_eq!(after.mouse.surface_height, 900);
     }
 
     /// A pose an emulated desktop rig CANNOT produce: the emulator pins both
@@ -3329,6 +3477,8 @@ mod tests {
             MouseSnapshot {
                 x: 700,
                 y: 100,
+                surface_width: 800,
+                surface_height: 600,
                 ..Default::default()
             }
         );

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -55,6 +55,7 @@
         functor_lang_ui_pointer_leave,
         functor_lang_ui_key,
         functor_lang_ui_wants_keyboard,
+        functor_lang_ui_wants_pointer,
         functor_lang_is_running,
         functor_lang_set_source,
         functor_lang_set_project,
@@ -98,7 +99,7 @@
       // functor.json's viewer.camera.control.
       const gameCameraControl = "__FUNCTOR_CAMERA_CONTROL__" === "game";
       const warnMissingCameraControl = () => {
-        if (gameCameraControl) return;
+        if (gameCameraControl || window.__functorCursorPolicy === "visible") return;
         const poll = () => {
           if (functor_lang_is_running() && functor_lang_uses_captured_mouse_input()) {
             console.warn(
@@ -114,6 +115,10 @@
         };
         poll();
       };
+
+      // Absolute pointer input is an independent project opt-in. Captured
+      // mouse look remains gated by viewer.camera.control = "game".
+      window.__functorCursorPolicy = "__FUNCTOR_CURSOR_POLICY__";
 
       // Map a browser KeyboardEvent.code to the canonical key code expected by
       // the game (functor_runtime_common::Key as i32 — the same mapping as
@@ -144,6 +149,9 @@
       };
 
       const setupInput = () => {
+        const visiblePointer = window.__functorCursorPolicy === "visible";
+        const mouseLook = document.getElementById("mouselook");
+        mouseLook.hidden = !gameCameraControl || visiblePointer;
         const canvas = document.getElementById("canvas");
 
         // Keyboard. Ignore auto-repeat (the game tracks held state itself), and
@@ -210,10 +218,8 @@
         // Esc releases the lock (browser default). We accumulate movement into a
         // running position so the game's "delta = current - lastMouse" works the
         // same as on native.
-        const mouseLookButton = document.getElementById("mouselook");
-        if (gameCameraControl) {
-          mouseLookButton.hidden = false;
-          mouseLookButton.addEventListener("click", () => canvas.requestPointerLock());
+        if (gameCameraControl && !visiblePointer) {
+          mouseLook.addEventListener("click", () => canvas.requestPointerLock());
         }
         let ax = 0;
         let ay = 0;
@@ -225,6 +231,9 @@
           ay += e.movementY;
           functor_lang_mouse_move(ax, ay);
         });
+        canvas.addEventListener("mousemove", (e) => {
+          if (visiblePointer) functor_lang_mouse_move(e.offsetX, e.offsetY);
+        });
 
         canvas.addEventListener("wheel", (e) => {
           if (!gameCameraControl || document.pointerLockElement !== canvas) return;
@@ -232,19 +241,24 @@
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
 
-        // Mouse buttons reach the game only while pointer-locked — the same
-        // rule mousemove follows above, and the browser twin of the desktop's
-        // "only while the cursor is captured". While the cursor is FREE it
-        // belongs to the scrubber and the `Ui.*` widget path below.
+        // Captured projects deliver mouse buttons only while pointer-locked.
+        // Visible projects deliver absolute canvas buttons without locking,
+        // with primary-widget arbitration matching native.
         // MouseEvent.button (0 left, 1 middle, 2 right) → the runtime's
         // canonical MouseButton discriminants (1 left, 2 right, 3 middle).
         const buttonCode = (button) =>
           button === 0 ? 1 : button === 2 ? 2 : button === 1 ? 3 : 0;
         const gameButtons = new Set();
         canvas.addEventListener("mousedown", (e) => {
-          if (!gameCameraControl || document.pointerLockElement !== canvas) return;
+          if (
+            !visiblePointer &&
+            (!gameCameraControl || document.pointerLockElement !== canvas)
+          ) return;
           const code = buttonCode(e.button);
           if (code === 0) return;
+          // Same previous-frame arbitration as native: a primary click on a
+          // declarative UI widget belongs to that widget alone.
+          if (visiblePointer && code === 1 && functor_lang_ui_wants_pointer()) return;
           e.preventDefault();
           functor_lang_mouse_button(code, true);
           gameButtons.add(code);
@@ -257,7 +271,10 @@
         });
         // Right-click while aiming must fire, not open the context menu.
         canvas.addEventListener("contextmenu", (e) => {
-          if (gameCameraControl && document.pointerLockElement === canvas) e.preventDefault();
+          if (
+            visiblePointer ||
+            (gameCameraControl && document.pointerLockElement === canvas)
+          ) e.preventDefault();
         });
         // A button released outside the window (or after the lock drops) may
         // never emit a mouseup here — synthesize releases so the edge hook and

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -231,9 +231,14 @@
           ay += e.movementY;
           functor_lang_mouse_move(ax, ay);
         });
-        canvas.addEventListener("mousemove", (e) => {
-          if (visiblePointer) functor_lang_mouse_move(e.offsetX, e.offsetY);
-        });
+        // Native visible-pointer games keep receiving absolute movement over
+        // overlays. Capture at window scope so shadow-DOM webviews do too, then
+        // translate the page point back into the canvas's CSS-pixel space.
+        window.addEventListener("mousemove", (e) => {
+          if (!visiblePointer) return;
+          const rect = canvas.getBoundingClientRect();
+          functor_lang_mouse_move(e.clientX - rect.left, e.clientY - rect.top);
+        }, { capture: true });
 
         const deliverGameWheel = (e) => {
           e.preventDefault();

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -237,7 +237,13 @@
         window.addEventListener("mousemove", (e) => {
           if (!visiblePointer) return;
           const rect = canvas.getBoundingClientRect();
-          functor_lang_mouse_move(e.clientX - rect.left, e.clientY - rect.top);
+          // The wasm export takes integers. Floor rather than relying on the
+          // JS→wasm truncation so a fractional point just above/left of the
+          // canvas stays negative instead of snapping inside at zero.
+          functor_lang_mouse_move(
+            Math.floor(e.clientX - rect.left),
+            Math.floor(e.clientY - rect.top)
+          );
         }, { capture: true });
 
         const deliverGameWheel = (e) => {

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -235,11 +235,21 @@
           if (visiblePointer) functor_lang_mouse_move(e.offsetX, e.offsetY);
         });
 
-        canvas.addEventListener("wheel", (e) => {
-          if (!gameCameraControl || document.pointerLockElement !== canvas) return;
+        const deliverGameWheel = (e) => {
           e.preventDefault();
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
+        };
+        canvas.addEventListener("wheel", (e) => {
+          if (visiblePointer) return;
+          if (!gameCameraControl || document.pointerLockElement !== canvas) return;
+          deliverGameWheel(e);
         });
+        // Native visible-pointer games own wheel input everywhere in the
+        // window, including over an interactive webview rectangle. Shadow-DOM
+        // targets never bubble through the canvas, so capture at window scope.
+        window.addEventListener("wheel", (e) => {
+          if (visiblePointer) deliverGameWheel(e);
+        }, { capture: true, passive: false });
 
         // Captured projects deliver mouse buttons only while pointer-locked.
         // Visible projects deliver absolute canvas buttons without locking,
@@ -249,6 +259,17 @@
         const buttonCode = (button) =>
           button === 0 ? 1 : button === 2 ? 2 : button === 1 ? 3 : 0;
         const gameButtons = new Set();
+        // Match native visible-pointer ownership: only primary is arbitrated
+        // with overlays. Right/middle remain game buttons even when a real DOM
+        // webview descendant is the event target (and therefore bypasses the
+        // canvas listener below).
+        window.addEventListener("mousedown", (e) => {
+          const code = buttonCode(e.button);
+          if (!visiblePointer || (code !== 2 && code !== 3)) return;
+          e.preventDefault();
+          functor_lang_mouse_button(code, true);
+          gameButtons.add(code);
+        }, { capture: true });
         canvas.addEventListener("mousedown", (e) => {
           if (
             !visiblePointer &&
@@ -256,6 +277,8 @@
           ) return;
           const code = buttonCode(e.button);
           if (code === 0) return;
+          // The window capture listener above owns these in visible mode.
+          if (visiblePointer && code !== 1) return;
           // Same previous-frame arbitration as native: a primary click on a
           // declarative UI widget belongs to that widget alone.
           if (visiblePointer && code === 1 && functor_lang_ui_wants_pointer()) return;
@@ -276,6 +299,10 @@
             (gameCameraControl && document.pointerLockElement === canvas)
           ) e.preventDefault();
         });
+        // A shadow-DOM webview target also bypasses the canvas listener.
+        window.addEventListener("contextmenu", (e) => {
+          if (visiblePointer) e.preventDefault();
+        }, { capture: true });
         // A button released outside the window (or after the lock drops) may
         // never emit a mouseup here — synthesize releases so the edge hook and
         // the next sampled snapshot both recover, mirroring `blur` for keys.

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -296,12 +296,14 @@
         };
         canvas.addEventListener("mousemove", uiPointer);
         canvas.addEventListener("mousedown", (e) => {
-          if (e.button !== 0) return;
+          // The earlier game-button listener owns a visible primary press when
+          // no widget wanted it. Keep that same press out of the UI bridge.
+          if (e.button !== 0 || gameButtons.has(1)) return;
           uiButtonDown = true;
           uiPointer(e);
         });
         canvas.addEventListener("mouseup", (e) => {
-          if (e.button !== 0) return;
+          if (e.button !== 0 || gameButtons.has(1)) return;
           uiButtonDown = false;
           uiPointer(e);
         });

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -521,6 +521,7 @@ export function mountScrubber({ hidden = false } = {}) {
 
   const beginAbsoluteDrag = (handle, move) => {
     handle.addEventListener("pointerdown", (event) => {
+      if (event.button !== 0) return;
       event.preventDefault();
       event.stopPropagation();
       handle.setPointerCapture(event.pointerId);
@@ -535,6 +536,7 @@ export function mountScrubber({ hidden = false } = {}) {
 
   let previewDrag = null;
   previewHandle.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
     event.preventDefault();
     event.stopPropagation();
     previewHandle.setPointerCapture(event.pointerId);
@@ -560,6 +562,7 @@ export function mountScrubber({ hidden = false } = {}) {
   previewHandle.addEventListener("lostpointercapture", endPreviewDrag);
 
   rail.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
     if (event.target.closest(".scrub-handle")) return;
     event.preventDefault();
     rail.setPointerCapture(event.pointerId);

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -187,8 +187,9 @@ pub fn functor_lang_key_event(code: i32, is_down: bool) {
     push_input(InputEvent::Key { code, is_down });
 }
 
-/// Deliver a mouse position in window pixels (the page accumulates pointer-lock
-/// movement deltas, matching the desktop's absolute cursor position).
+/// Deliver a mouse position in logical CSS pixels for visible-pointer games.
+/// Captured games accumulate pointer-lock movement deltas, matching the
+/// desktop's relative free-look path.
 #[wasm_bindgen]
 pub fn functor_lang_mouse_move(x: i32, y: i32) {
     push_input(InputEvent::MouseMove { x, y });
@@ -275,6 +276,10 @@ thread_local! {
     /// Whether the overlay wanted the keyboard after the LAST frame's pass —
     /// what the page's keydown handler polls to pick a route.
     static UI_WANTS_KEYBOARD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Whether the overlay wanted primary-pointer input after the last pass.
+    /// Visible-pointer games use this to keep a widget click from also
+    /// reaching the game's `mouseButton` hook.
+    static UI_WANTS_POINTER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Deliver a keydown for a focused text field. `key` is the DOM
@@ -323,6 +328,12 @@ pub fn functor_lang_ui_wants_keyboard() -> bool {
     UI_WANTS_KEYBOARD.with(|w| w.get())
 }
 
+/// Whether the game UI wanted pointer input after its last render.
+#[wasm_bindgen]
+pub fn functor_lang_ui_wants_pointer() -> bool {
+    UI_WANTS_POINTER.with(|w| w.get())
+}
+
 /// Drain the focused-field key queue (the frame loop, before the overlay
 /// pass). `deliver: false` (pinned clock) discards — typing is inert while
 /// pinned, like all other window input.
@@ -338,6 +349,10 @@ pub fn drain_ui_keys(deliver: bool) -> Vec<functor_runtime_common::ui::UiKeyboar
 /// Publish this frame's `wants_keyboard` for the page's keydown routing.
 pub fn set_ui_wants_keyboard(wants: bool) {
     UI_WANTS_KEYBOARD.with(|w| w.set(wants));
+}
+
+pub fn set_ui_wants_pointer(wants: bool) {
+    UI_WANTS_POINTER.with(|w| w.set(wants));
 }
 
 /// Drain the queued page input into the producer, in arrival order. Called by

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1359,6 +1359,11 @@ async fn run_async() -> Result<(), JsValue> {
             // during the sim cannot leave the resumed game stuck.
             let sim_running = sim::is_running();
             let suspended = clock.is_pinned() || sim_running;
+            // Browser mouse events use CSS pixels. Sample the canvas's logical
+            // CSS extent beside them BEFORE sampledInput, independently of the
+            // Retina-scaled drawable buffer updated later in this frame.
+            input_snapshot.mouse.surface_width = canvas.client_width().max(0) as u32;
+            input_snapshot.mouse.surface_height = canvas.client_height().max(0) as u32;
             functor_lang_game::drain_input(
                 &mut **game,
                 &mut input_snapshot,
@@ -1676,6 +1681,7 @@ async fn run_async() -> Result<(), JsValue> {
                 &view,
             );
             functor_lang_game::set_ui_wants_keyboard(ui_out.wants_keyboard);
+            functor_lang_game::set_ui_wants_pointer(ui_out.wants_pointer);
             // `suspended`, not just pinned: a UI event reaches `update` too, so a
             // running sim must swallow it like every other input path.
             if !suspended {

--- a/site/README.md
+++ b/site/README.md
@@ -18,9 +18,8 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
 
 - `player.html` — the runtime host page; the sibling of the CLI dev server's
   `index-functor-lang.html`, but the `.fun` entry comes from `?game=` (one file) or
-  `?project=inline` (the IDE pushes the whole file set by postMessage).
-  `?cursor=visible` selects the absolute-pointer policy (captured is default).
-  Keep its input mapping and set-source/set-project seam in sync with that page.
+  `?project=inline` (the IDE pushes the whole file set by postMessage). Keep its
+  input mapping and set-source/set-project seam in sync with that page.
 - `sandbox.html` / `src/sandbox.tsx` — the single-buffer editor over a served
   example (pushes `functor-lang-set-source`).
 - `ide.html` / `src/ide.tsx` — the multi-file IDE: a file sidebar, per-file

--- a/site/README.md
+++ b/site/README.md
@@ -18,8 +18,9 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
 
 - `player.html` — the runtime host page; the sibling of the CLI dev server's
   `index-functor-lang.html`, but the `.fun` entry comes from `?game=` (one file) or
-  `?project=inline` (the IDE pushes the whole file set by postMessage). Keep its
-  input mapping and set-source/set-project seam in sync with that page.
+  `?project=inline` (the IDE pushes the whole file set by postMessage).
+  `?cursor=visible` selects the absolute-pointer policy (captured is default).
+  Keep its input mapping and set-source/set-project seam in sync with that page.
 - `sandbox.html` / `src/sandbox.tsx` — the single-buffer editor over a served
   example (pushes `functor-lang-set-source`).
 - `ide.html` / `src/ide.tsx` — the multi-file IDE: a file sidebar, per-file

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -70,7 +70,8 @@ npm run build:cli                    # builds the functor CLI + runtimes</pre>
           <p>
             The pointer stays free by default. A game-owned mouse-look controller opts in with
             <code>"viewer": { "camera": { "control": "game" } }</code>; this enables native
-            cursor capture and the web player's mouse-look button. Leave it absent for 2D and UI
+            cursor capture and the web player's mouse-look button. An absolute-pointer game uses
+            <code>"cursor":"visible"</code> instead. Leave both absent for UI and fixed-camera
             projects.
           </p>
           <p>And the game itself — here is the smallest interesting one:</p>
@@ -192,9 +193,9 @@ let draw = (m, tts) =>
               <tr><td><code>draw</code></td><td><code>(model, tts) => Frame</code></td><td>pure frame description</td></tr>
               <tr><td><code>input</code></td><td><code>(model, key, isDown) => model'</code></td><td>optional; <code>key</code> is a <code>Key.t</code> variant such as <code>Key.W</code>, <code>Key.Up</code>, or <code>Key.Space</code> — key <em>repeats</em> arrive as <code>isDown = true</code>, so latch if you need edges</td></tr>
               <tr><td><code>sampledInput</code></td><td><code>(model, snapshot) => model'</code></td><td>optional; held levels plus deterministic pressed/released edges — one <code>Input.snapshot</code> immediately before every fixed step</td></tr>
-              <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; window pixels</td></tr>
+              <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; logical window/CSS coordinates</td></tr>
               <tr><td><code>mouseWheel</code></td><td><code>(model, delta) => model'</code></td><td>optional</td></tr>
-              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Delivered while the cursor is captured, so click-to-shoot works under free-look</td></tr>
+              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Captured projects receive it under free-look; visible projects receive absolute clicks</td></tr>
               <tr><td><code>update</code></td><td><code>(model, msg) => model'</code></td><td>optional; messages are your variant values</td></tr>
               <tr><td><code>subscriptions</code></td><td><code>(model) => Sub</code></td><td>optional (requires <code>update</code>); declarative timers</td></tr>
               <tr><td><code>physics</code></td><td><code>(model) => Physics.scene(…)</code></td><td>optional; declarative bodies, reconciled each frame</td></tr>
@@ -233,7 +234,11 @@ let draw = (m, tts) =>
           <p>
             The snapshot is a plain record. Keyboard has
             <code>heldKeys</code>, <code>pressedKeys</code>, and <code>releasedKeys</code>;
-            mouse has <code>buttons</code>, <code>pressed</code>, and <code>released</code>,
+            mouse position has <code>x</code>, <code>y</code>,
+            <code>surfaceWidth</code>, and <code>surfaceHeight</code> in
+            top-left-origin logical units (window points natively, CSS pixels on web),
+            independent of Retina scale. Mouse also has <code>buttons</code>,
+            <code>pressed</code>, and <code>released</code>,
             each with <code>left</code> / <code>right</code> / <code>middle</code>.
             A quick tap may appear in both edge sets while the held level reports the final state.
             Edges survive render frames with no simulation step, reach the first catch-up step,
@@ -501,6 +506,37 @@ let pos = model.pos |> Vec3.add(step)</pre>
               <tr><td><code>Frame.createLit(camera, scene, [light, …])</code></td><td>lit + shadowed</td></tr>
             </tbody>
           </table>
+
+          <h3 id="prelude-2d">2D sprites and pointer picking</h3>
+          <p>
+            <code>Sprite</code> is a pure picture algebra: compose rectangles,
+            circles, polygons, lines, text, and images, then hand the picture to
+            <code>Frame.create2D</code>. A <code>Camera2D</code> declares its visible
+            world extent and aspect-fits it without stretching.
+          </p>
+          <pre class="functor-lang">let camera =
+  Camera2D.create(24.0, 13.5)
+  |> Camera2D.at(2.0, -1.0)
+  |> Camera2D.zoom(1.2)
+
+let sampledInput = (model, snapshot: Input.snapshot) =>
+  { model with pointer: Camera2D.toWorld(snapshot.mouse, camera) }
+
+let draw = (model, tts) =>
+  Sprite.group([
+    Sprite.rectangle(Color.rgb(0.03, 0.04, 0.1), 24.0, 13.5),
+    Sprite.text(Color.rgb(0.2, 0.9, 1.0), 1.0, "CLICK ME")
+  ])
+  |> Frame.create2D(camera)</pre>
+          <p>
+            <code>Camera2D.toWorld</code> applies the same fit, pan, and zoom as
+            rendering. It returns <code>Option.None</code> in letterbox or
+            pillarbox bars, and stays correct through resize and device-pixel-ratio
+            changes because <code>snapshot.mouse</code> carries its logical surface
+            extent. Use <code>"cursor":"visible"</code> in <code>functor.json</code>
+            for pointer-led games. See <code>examples/pointer-2d</code> for a
+            complete selectable-card game.
+          </p>
 
           <h3>Render targets</h3>
           <pre class="functor-lang">let feed = RenderTarget.named("security") |> RenderTarget.sized(256.0, 256.0)</pre>
@@ -895,7 +931,7 @@ connect_game { "url": "http://127.0.0.1:8123" }</pre>
             <li><code>x |> f(a)</code> is <code>f(a, x)</code> — pipelines <em>append</em> (thread-last).</li>
             <li>Assignment is <code>:=</code> (not <code>&lt;-</code>) and must be followed by <code>;</code> and a continuation.</li>
             <li><code>if</code> is an expression: both branches are required, and chains use <code>else if</code> rather than <code>elif</code>.</li>
-            <li>Mouse buttons only reach <code>mouseButton</code> while the cursor is <em>captured</em> — the same rule <code>mouseMove</code> follows. Opt in with <code>viewer.camera.control = "game"</code> in <code>functor.json</code>; without it the pointer remains free and web hides the mouse-look button. A held button is force-released on focus loss.</li>
+            <li>Pointer ownership is explicit: <code>viewer.camera.control = "game"</code> enables captured free-look; <code>"cursor":"visible"</code> keeps an absolute pointer live. Without either opt-in, the pointer stays with UI. Held buttons are force-released on focus loss.</li>
             <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>
             <li>A nested <code>match</code> inside an arm eats the following arms — parenthesize it.</li>
             <li>Constructor names are global to the file's value namespace; nullary constructors never take parens. Module variants are the exception — <code>Option.Some</code>, never bare <code>Some</code>.</li>

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -193,9 +193,9 @@ let draw = (m, tts) =>
               <tr><td><code>draw</code></td><td><code>(model, tts) => Frame</code></td><td>pure frame description</td></tr>
               <tr><td><code>input</code></td><td><code>(model, key, isDown) => model'</code></td><td>optional; <code>key</code> is a <code>Key.t</code> variant such as <code>Key.W</code>, <code>Key.Up</code>, or <code>Key.Space</code> — key <em>repeats</em> arrive as <code>isDown = true</code>, so latch if you need edges</td></tr>
               <tr><td><code>sampledInput</code></td><td><code>(model, snapshot) => model'</code></td><td>optional; held levels plus deterministic pressed/released edges — one <code>Input.snapshot</code> immediately before every fixed step</td></tr>
-              <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; logical window/CSS coordinates</td></tr>
+              <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; window pixels</td></tr>
               <tr><td><code>mouseWheel</code></td><td><code>(model, delta) => model'</code></td><td>optional</td></tr>
-              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Captured projects receive it under free-look; visible projects receive absolute clicks</td></tr>
+              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Delivered while the cursor is captured, so click-to-shoot works under free-look</td></tr>
               <tr><td><code>update</code></td><td><code>(model, msg) => model'</code></td><td>optional; messages are your variant values</td></tr>
               <tr><td><code>subscriptions</code></td><td><code>(model) => Sub</code></td><td>optional (requires <code>update</code>); declarative timers</td></tr>
               <tr><td><code>physics</code></td><td><code>(model) => Physics.scene(…)</code></td><td>optional; declarative bodies, reconciled each frame</td></tr>
@@ -234,11 +234,7 @@ let draw = (m, tts) =>
           <p>
             The snapshot is a plain record. Keyboard has
             <code>heldKeys</code>, <code>pressedKeys</code>, and <code>releasedKeys</code>;
-            mouse position has <code>x</code>, <code>y</code>,
-            <code>surfaceWidth</code>, and <code>surfaceHeight</code> in
-            top-left-origin logical units (window points natively, CSS pixels on web),
-            independent of Retina scale. Mouse also has <code>buttons</code>,
-            <code>pressed</code>, and <code>released</code>,
+            mouse has <code>buttons</code>, <code>pressed</code>, and <code>released</code>,
             each with <code>left</code> / <code>right</code> / <code>middle</code>.
             A quick tap may appear in both edge sets while the held level reports the final state.
             Edges survive render frames with no simulation step, reach the first catch-up step,
@@ -506,37 +502,6 @@ let pos = model.pos |> Vec3.add(step)</pre>
               <tr><td><code>Frame.createLit(camera, scene, [light, …])</code></td><td>lit + shadowed</td></tr>
             </tbody>
           </table>
-
-          <h3 id="prelude-2d">2D sprites and pointer picking</h3>
-          <p>
-            <code>Sprite</code> is a pure picture algebra: compose rectangles,
-            circles, polygons, lines, text, and images, then hand the picture to
-            <code>Frame.create2D</code>. A <code>Camera2D</code> declares its visible
-            world extent and aspect-fits it without stretching.
-          </p>
-          <pre class="functor-lang">let camera =
-  Camera2D.create(24.0, 13.5)
-  |> Camera2D.at(2.0, -1.0)
-  |> Camera2D.zoom(1.2)
-
-let sampledInput = (model, snapshot: Input.snapshot) =>
-  { model with pointer: Camera2D.toWorld(snapshot.mouse, camera) }
-
-let draw = (model, tts) =>
-  Sprite.group([
-    Sprite.rectangle(Color.rgb(0.03, 0.04, 0.1), 24.0, 13.5),
-    Sprite.text(Color.rgb(0.2, 0.9, 1.0), 1.0, "CLICK ME")
-  ])
-  |> Frame.create2D(camera)</pre>
-          <p>
-            <code>Camera2D.toWorld</code> applies the same fit, pan, and zoom as
-            rendering. It returns <code>Option.None</code> in letterbox or
-            pillarbox bars, and stays correct through resize and device-pixel-ratio
-            changes because <code>snapshot.mouse</code> carries its logical surface
-            extent. Use <code>"cursor":"visible"</code> in <code>functor.json</code>
-            for pointer-led games. See <code>examples/pointer-2d</code> for a
-            complete selectable-card game.
-          </p>
 
           <h3>Render targets</h3>
           <pre class="functor-lang">let feed = RenderTarget.named("security") |> RenderTarget.sized(256.0, 256.0)</pre>

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -195,7 +195,7 @@ let draw = (m, tts) =>
               <tr><td><code>sampledInput</code></td><td><code>(model, snapshot) => model'</code></td><td>optional; held levels plus deterministic pressed/released edges — one <code>Input.snapshot</code> immediately before every fixed step</td></tr>
               <tr><td><code>mouseMove</code></td><td><code>(model, x, y) => model'</code></td><td>optional; window pixels</td></tr>
               <tr><td><code>mouseWheel</code></td><td><code>(model, delta) => model'</code></td><td>optional</td></tr>
-              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Delivered while the cursor is captured, so click-to-shoot works under free-look</td></tr>
+              <tr><td><code>mouseButton</code></td><td><code>(model, button, isDown) => model'</code></td><td>optional; <code>button</code> is a <code>Mouse.t</code> variant — <code>Mouse.Left</code>, <code>Mouse.Right</code>, or <code>Mouse.Middle</code>. Captured delivery supports free-look shooting; visible delivery supports absolute 2D picking</td></tr>
               <tr><td><code>update</code></td><td><code>(model, msg) => model'</code></td><td>optional; messages are your variant values</td></tr>
               <tr><td><code>subscriptions</code></td><td><code>(model) => Sub</code></td><td>optional (requires <code>update</code>); declarative timers</td></tr>
               <tr><td><code>physics</code></td><td><code>(model) => Physics.scene(…)</code></td><td>optional; declarative bodies, reconciled each frame</td></tr>
@@ -204,12 +204,13 @@ let draw = (m, tts) =>
             </tbody>
           </table>
           <p>
-            The three mouse hooks receive live shell input only while the cursor is captured.
-            Opt in with <code>"viewer": { "camera": { "control": "game" } }</code> in
-            <code>functor.json</code>; without it the runtime warns once and leaves them inert.
-            Native capture starts on a non-UI click and <code>Escape</code> releases it.
-            Manifest-less site IDE and inline-sandbox sessions use <code>?camera=game</code>
-            on the page URL.
+            The three mouse hooks receive live shell input only when the project claims a pointer
+            mode. Use <code>"viewer": { "camera": { "control": "game" } }</code> for captured
+            free-look or <code>"cursor":"visible"</code> for absolute pointer input; without
+            either setting the runtime warns once and leaves them inert. Native capture starts on
+            a non-UI click and <code>Escape</code> releases it. Manifest-less site IDE and
+            inline-sandbox sessions use <code>?camera=game</code> or
+            <code>?cursor=visible</code> on the page URL.
           </p>
           <p>
             The model-returning entry points (<code>tick</code>, <code>input</code>,

--- a/site/player.html
+++ b/site/player.html
@@ -117,7 +117,6 @@
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
         functor_lang_ui_wants_keyboard,
-        functor_lang_ui_wants_pointer,
         functor_lang_ui_key,
         functor_lang_webview_html,
         functor_lang_webview_gen,
@@ -299,9 +298,6 @@
           ay += e.movementY;
           functor_lang_mouse_move(ax, ay);
         });
-        canvas.addEventListener("mousemove", (e) => {
-          if (visiblePointer) functor_lang_mouse_move(e.offsetX, e.offsetY);
-        });
 
         canvas.addEventListener("wheel", (e) => {
           if (!gameCameraControl || document.pointerLockElement !== canvas) return;
@@ -309,9 +305,10 @@
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
 
-        // Captured projects deliver mouse buttons only while pointer-locked.
-        // Visible projects deliver absolute canvas buttons without locking,
-        // with primary-widget arbitration matching native.
+        // Mouse buttons reach the game only while pointer-locked — the same
+        // rule mousemove follows above, and the browser twin of the desktop's
+        // "only while the cursor is captured". While the cursor is FREE it
+        // belongs to the scrubber and the `Ui.*` widget path below.
         // MouseEvent.button (0 left, 1 middle, 2 right) → the runtime's
         // canonical MouseButton discriminants (1 left, 2 right, 3 middle).
         // Kept in sync with index-functor-lang.html.
@@ -325,7 +322,6 @@
           ) return;
           const code = buttonCode(e.button);
           if (code === 0) return;
-          if (visiblePointer && code === 1 && functor_lang_ui_wants_pointer()) return;
           e.preventDefault();
           functor_lang_mouse_button(code, true);
           gameButtons.add(code);

--- a/site/player.html
+++ b/site/player.html
@@ -117,6 +117,7 @@
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
         functor_lang_ui_wants_keyboard,
+        functor_lang_ui_wants_pointer,
         functor_lang_ui_key,
         functor_lang_webview_html,
         functor_lang_webview_gen,
@@ -143,8 +144,10 @@
       // file, so `?camera=game` is the host-page equivalent of
       // viewer.camera.control = "game". Absent means no pointer lock/chrome.
       const gameCameraControl = params.get("camera") === "game";
+      window.__functorCursorPolicy =
+        params.get("cursor") === "visible" ? "visible" : "captured";
       const warnMissingCameraControl = () => {
-        if (gameCameraControl) return;
+        if (gameCameraControl || window.__functorCursorPolicy === "visible") return;
         const poll = () => {
           if (functor_lang_is_running() && functor_lang_uses_captured_mouse_input()) {
             console.warn(
@@ -218,6 +221,9 @@
 
       const setupInput = () => {
         const canvas = document.getElementById("canvas");
+        const visiblePointer = window.__functorCursorPolicy === "visible";
+        const mouseLook = document.getElementById("mouselook");
+        mouseLook.hidden = !gameCameraControl || visiblePointer;
 
         // While a Ui.textInput is focused (the runtime reports it after each
         // frame), keydowns route to the OVERLAY instead — the game's input
@@ -280,10 +286,8 @@
         // releases the lock (browser default). We accumulate movement into a
         // running position so the game's "delta = current - lastMouse" works
         // the same as on native.
-        const mouseLookButton = document.getElementById("mouselook");
-        if (gameCameraControl) {
-          mouseLookButton.hidden = false;
-          mouseLookButton.addEventListener("click", () => canvas.requestPointerLock());
+        if (gameCameraControl && !visiblePointer) {
+          mouseLook.addEventListener("click", () => canvas.requestPointerLock());
         }
         let ax = 0;
         let ay = 0;
@@ -295,6 +299,9 @@
           ay += e.movementY;
           functor_lang_mouse_move(ax, ay);
         });
+        canvas.addEventListener("mousemove", (e) => {
+          if (visiblePointer) functor_lang_mouse_move(e.offsetX, e.offsetY);
+        });
 
         canvas.addEventListener("wheel", (e) => {
           if (!gameCameraControl || document.pointerLockElement !== canvas) return;
@@ -302,10 +309,9 @@
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
 
-        // Mouse buttons reach the game only while pointer-locked — the same
-        // rule mousemove follows above, and the browser twin of the desktop's
-        // "only while the cursor is captured". While the cursor is FREE it
-        // belongs to the scrubber and the `Ui.*` widget path below.
+        // Captured projects deliver mouse buttons only while pointer-locked.
+        // Visible projects deliver absolute canvas buttons without locking,
+        // with primary-widget arbitration matching native.
         // MouseEvent.button (0 left, 1 middle, 2 right) → the runtime's
         // canonical MouseButton discriminants (1 left, 2 right, 3 middle).
         // Kept in sync with index-functor-lang.html.
@@ -313,9 +319,13 @@
           button === 0 ? 1 : button === 2 ? 2 : button === 1 ? 3 : 0;
         const gameButtons = new Set();
         canvas.addEventListener("mousedown", (e) => {
-          if (!gameCameraControl || document.pointerLockElement !== canvas) return;
+          if (
+            !visiblePointer &&
+            (!gameCameraControl || document.pointerLockElement !== canvas)
+          ) return;
           const code = buttonCode(e.button);
           if (code === 0) return;
+          if (visiblePointer && code === 1 && functor_lang_ui_wants_pointer()) return;
           e.preventDefault();
           functor_lang_mouse_button(code, true);
           gameButtons.add(code);
@@ -328,7 +338,10 @@
         });
         // Right-click while aiming must fire, not open the context menu.
         canvas.addEventListener("contextmenu", (e) => {
-          if (gameCameraControl && document.pointerLockElement === canvas) e.preventDefault();
+          if (
+            visiblePointer ||
+            (gameCameraControl && document.pointerLockElement === canvas)
+          ) e.preventDefault();
         });
         // A button released outside the window (or after the lock drops) may
         // never emit a mouseup here — synthesize releases so the edge hook and

--- a/site/player.html
+++ b/site/player.html
@@ -305,10 +305,9 @@
           functor_lang_mouse_wheel(Math.sign(e.deltaY));
         });
 
-        // Mouse buttons reach the game only while pointer-locked — the same
-        // rule mousemove follows above, and the browser twin of the desktop's
-        // "only while the cursor is captured". While the cursor is FREE it
-        // belongs to the scrubber and the `Ui.*` widget path below.
+        // Captured projects deliver buttons only while pointer-locked. Visible
+        // projects keep absolute buttons live, with primary-widget arbitration
+        // matching native.
         // MouseEvent.button (0 left, 1 middle, 2 right) → the runtime's
         // canonical MouseButton discriminants (1 left, 2 right, 3 middle).
         // Kept in sync with index-functor-lang.html.

--- a/site/src/demo-editor.ts
+++ b/site/src/demo-editor.ts
@@ -31,7 +31,9 @@ interface DemoEditorSeam {
 const frame = document.getElementById("player") as HTMLIFrameElement;
 const params = new URLSearchParams(location.search);
 const game = params.get("game") || "examples/hero.fun";
-const cameraControl = params.get("camera") === "game" ? "game" : null;
+const cursorPolicy = params.get("cursor") === "visible" ? "visible" : null;
+const cameraControl =
+  !cursorPolicy && params.get("camera") === "game" ? "game" : null;
 
 // wireLiveTrace drives an executions picker through a status bar; the demo has
 // none, so a no-op stub satisfies the contract (the inline live-value overlay
@@ -82,6 +84,7 @@ wireLiveTrace(view, noopStatusBar, frame, langReady);
   programmaticEdit = false;
   const playerParams = new URLSearchParams({ game });
   if (cameraControl) playerParams.set("camera", cameraControl);
+  if (cursorPolicy) playerParams.set("cursor", cursorPolicy);
   frame.src = `player.html?${playerParams}`;
 })();
 

--- a/site/src/ide.tsx
+++ b/site/src/ide.tsx
@@ -88,16 +88,18 @@ interface LangSeam {
 const STORAGE_KEY = "functor-ide-project-v1";
 const ENTRY = "game.fun"; // the program root; every other .fun is a sibling module
 // The in-memory IDE has no functor.json to parse, so its URL is the explicit
-// project-setting seam: `/ide.html?camera=game` opts the preview and downloaded
-// manifest into game-owned captured mouse input. Absent keeps the 2D-safe
-// default; never infer ownership from a source hook.
+// project-setting seam: `?camera=game` selects captured mouse input and
+// `?cursor=visible` selects absolute pointer input for both the preview and the
+// downloaded manifest. Visible wins if a hand-edited URL supplies both; never
+// infer ownership from a source hook.
+const pageParams = new URLSearchParams(window.location.search);
+const cursorPolicy = pageParams.get("cursor") === "visible" ? "visible" : null;
 const cameraControl =
-  new URLSearchParams(window.location.search).get("camera") === "game"
-    ? "game"
-    : null;
+  !cursorPolicy && pageParams.get("camera") === "game" ? "game" : null;
 const playerUrl = () => {
   const params = new URLSearchParams({ project: "inline" });
   if (cameraControl) params.set("camera", cameraControl);
+  if (cursorPolicy) params.set("cursor", cursorPolicy);
   return `player.html?${params}`;
 };
 // A valid project file: a bare module name + `.fun` (the project is a flat
@@ -427,13 +429,14 @@ const deleteFile = (path: string) => {
 const download = () => {
   // Include the functor.json the CLI needs to recognise the project, so the
   // zip drops straight into `functor -d <dir> build wasm` (per the README).
-  const config = cameraControl
-    ? {
-        language: "functor-lang",
-        entry: ENTRY,
-        viewer: { camera: { control: cameraControl } },
-      }
-    : { language: "functor-lang", entry: ENTRY };
+  const config = {
+    language: "functor-lang",
+    entry: ENTRY,
+    ...(cameraControl
+      ? { viewer: { camera: { control: cameraControl } } }
+      : {}),
+    ...(cursorPolicy ? { cursor: cursorPolicy } : {}),
+  };
   const manifest = {
     path: "functor.json",
     source: JSON.stringify(config, null, 2) + "\n",

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -74,10 +74,14 @@ const frame = document.getElementById("player") as HTMLIFrameElement;
 const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
 const pageParams = new URLSearchParams(window.location.search);
 const requested = pageParams.get("example");
-// Inline programs have no manifest, so `?camera=game` is their explicit
-// project-setting seam. Example metadata remains authoritative when present;
-// source hooks never imply ownership.
-const pageCameraControl = pageParams.get("camera") === "game" ? "game" : null;
+// Inline programs have no manifest, so `?camera=game` / `?cursor=visible` are
+// their explicit project-setting seams. Visible wins if a hand-edited URL
+// supplies both. Example metadata remains authoritative when present; source
+// hooks never imply ownership.
+const pageCursorPolicy =
+  pageParams.get("cursor") === "visible" ? "visible" : null;
+const pageCameraControl =
+  !pageCursorPolicy && pageParams.get("camera") === "game" ? "game" : null;
 const initialExample = EXAMPLES.some((e) => e.id === requested) ? requested! : EXAMPLES[0].id;
 
 const picker = createStore<PickerState>({
@@ -358,6 +362,7 @@ const loadInline = (b64u: string) => {
   // mounts the __scrub seam with no bar of its own.
   const params = new URLSearchParams({ src: b64u, scrubber: "hidden" });
   if (pageCameraControl) params.set("camera", pageCameraControl);
+  if (pageCursorPolicy) params.set("cursor", pageCursorPolicy);
   frame.src = `player.html?${params}`;
   mp?.setSrc(frame.src);
   return true;
@@ -407,6 +412,9 @@ const loadExample = async (id: string) => {
   const params = new URLSearchParams({ game: url, scrubber: "hidden" });
   const cameraControl = example?.cameraControl ?? pageCameraControl;
   if (cameraControl) params.set("camera", cameraControl);
+  if (!cameraControl && pageCursorPolicy) {
+    params.set("cursor", pageCursorPolicy);
+  }
   for (const file of files) params.append("file", file);
   frame.src = `player.html?${params}`;
   mp?.setSrc(frame.src);

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -141,11 +141,7 @@ export class FunctorClient {
     return this.key(key, false);
   }
 
-  /** Move the mouse cursor to an absolute logical-surface position.
-   *
-   * The runtime keeps its own surface extent; inspect
-   * `state().input.mouse.surface_width` / `surface_height` (protocol v6+) when
-   * mapping the injected point. */
+  /** Move the mouse cursor to an absolute position. */
   mouseMove(x: number, y: number): Promise<void> {
     return this.input({ type: "mouse_move", x, y });
   }

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -141,7 +141,11 @@ export class FunctorClient {
     return this.key(key, false);
   }
 
-  /** Move the mouse cursor to an absolute position. */
+  /** Move the mouse cursor to an absolute logical-surface position.
+   *
+   * The runtime keeps its own surface extent; inspect
+   * `state().input.mouse.surface_width` / `surface_height` (protocol v6+) when
+   * mapping the injected point. */
   mouseMove(x: number, y: number): Promise<void> {
     return this.input({ type: "mouse_move", x, y });
   }

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -63,13 +63,17 @@ export interface InputSnapshot {
    * A quick tap can place the same key in both edge arrays. Absent on older
    * runtimes. */
   released_keys?: KeyName[];
-  /** Last known cursor position in window pixels, plus held and edge sets.
+  /** Last known cursor position and logical surface extent in the same
+   * top-left-origin coordinate space, plus held and edge sets.
    *
-   * `buttons`, `pressed`, and `released` are absent from older runtimes'
-   * `/state`; treat a missing field as no buttons in that set. */
+   * Desktop reports window points and web reports CSS pixels, independent of
+   * Retina/device-pixel ratio. Surface and button/edge fields are absent from
+   * older runtimes' `/state`; treat a missing button field as an empty set. */
   mouse: {
     x: number;
     y: number;
+    surface_width?: number;
+    surface_height?: number;
     buttons?: MouseButtons;
     pressed?: MouseButtons;
     released?: MouseButtons;

--- a/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
@@ -120,6 +120,16 @@ test(
     assert.equal(dragged.input.mouse.x, 42, "the move applied");
     assert.equal(dragged.input.mouse.y, 7, "the move applied");
     assert.equal(
+      dragged.input.mouse.surface_width,
+      800,
+      "debug injection retains the runtime-owned logical surface width",
+    );
+    assert.equal(
+      dragged.input.mouse.surface_height,
+      600,
+      "debug injection retains the runtime-owned logical surface height",
+    );
+    assert.equal(
       dragged.input.mouse.buttons?.left,
       true,
       "moving the cursor must NOT release a held button",


### PR DESCRIPTION
## Summary

Adds resize- and DPI-stable pointer picking for 2D Sprite games:

- `Input.mouse` now carries logical surface dimensions alongside absolute position and held buttons.
- `Camera2D.toWorld` maps that logical pointer through aspect-fit bars, pan, and zoom, returning `Option.None` outside the fitted scene.
- Projects opt into absolute pointer ownership with `"cursor": "visible"`; captured free-look uses `viewer.camera.control = "game"`, while projects with neither setting retain the free/UI-owned default from `main`.
- Native and web now agree on primary-overlay arbitration, global right/middle/wheel delivery, focus-loss release recovery, and fractional coordinates at window edges.
- `examples/pointer-2d` demonstrates hover and click-to-select behavior across wide and portrait surfaces.

## Scope audit

The exact merge range is `053373d53d7aae22acff57430ac5f5e3ab7ad68b...cf396491c197a1840f4af8870fddd0d14d43b14f`: **34 files, +1,081 / -203**.

The original seven feature commits remain in order. The final `fix(input): compose pointer modes with camera control` commit is the deliberate restack delta:

- preserves the `main` opt-in camera-control gate and free/UI-owned default;
- treats explicit `"cursor": "captured"` as a compatibility alias for game camera control, while `"cursor": "visible"` selects absolute input;
- rejects manifests that combine visible absolute input with game camera control; and
- forwards the visible-pointer query seam through the site sandbox, IDE, demo editor, and downloaded IDE manifest.

The remaining changes are the original focused pointer mapping/runtime work plus the public docs that describe its contract.

## Visual proof

The interaction proof below was captured from pre-restack feature head `f0d020cc0b7b9fd1a4d77bb0ded76fed462126a7`. The restack preserves the rendered scene and picking math; exact rebased head `cf396491c197a1840f4af8870fddd0d14d43b14f` was revalidated across the runtime, site build, and pointer-input checks.

### Native ↔ wasm interaction

![Native and wasm pointer interaction](https://gist.githubusercontent.com/tommy-xr/643374013037b99e4b1d3ad3c7c27df0/raw/pointer-f0d020c-native-wasm.gif)

The loop demonstrates bar rejection, hover, and click-to-selected behavior in both shells.

### Wide aspect

![Wide pointer proof](https://gist.githubusercontent.com/tommy-xr/643374013037b99e4b1d3ad3c7c27df0/raw/pointer-f0d020c-wide-proof.png)

The left bar maps to `None`; the fitted scene maps the cursor into world space without stretching.

### Portrait aspect

![Portrait pointer proof](https://gist.githubusercontent.com/tommy-xr/643374013037b99e4b1d3ad3c7c27df0/raw/pointer-f0d020c-portrait-proof.png)

The top bar is non-pickable; the fitted scene preserves geometry and text proportions.

### All selected states

![All aspect and selected-state proof](https://gist.githubusercontent.com/tommy-xr/643374013037b99e4b1d3ad3c7c27df0/raw/pointer-f0d020c-all-aspects-selected.png)

## Performance

Before the restack, `frame_bench` was run back-to-back in release mode against the prior exact base and feature candidate. The restack does not change sprite lowering or the per-frame mapping path; it reconciles startup/input ownership with `main`. Allocations and bytes were identical:

| Sprites | Base allocs/frame | Head allocs/frame | Base bytes/frame | Head bytes/frame |
| ---: | ---: | ---: | ---: | ---: |
| 400 | 13,877 | 13,877 | 843,379 | 843,379 |
| 1,600 | 54,717 | 54,717 | 3,307,219 | 3,307,219 |
| 3,136 | 106,973 | 106,973 | 6,460,243 | 6,460,243 |

Cross-run wall-clock minima were:

| Sprites | Base min | Head min |
| ---: | ---: | ---: |
| 400 | 597.4 µs | 584.7 µs |
| 1,600 | 2,478.3 µs | 2,313.1 µs |
| 3,136 | 4,850.5 µs | 4,542.6 µs |

Tick minima were 0.53 µs (base) and 0.55 µs (head). These wall-clock differences are within machine/run noise; no speedup is claimed. Changes after the benchmark candidate are confined to event/startup JavaScript, documentation/tests, and the native visible-cursor event helper; the benchmarked per-frame path is unchanged, so a conditional rerun was not triggered.

## Verification

Current rebased head `cf396491c197a1840f4af8870fddd0d14d43b14f`:

- `wasm-pack build runtime/functor-runtime-web --target=web`
- `cargo test -p functor-cli` — 80 passed
- `cargo test -p functor_runtime_common` — 579 unit tests + 10 prelude integration tests passed
- `cargo test -p functor-runtime-desktop --lib` — 79 passed
- `target/debug/functor -d examples/pointer-2d test` — 3 expects passed
- `npm run check:docs`
- `npm run check:site` and `npm run site:build` under the required Node 22 toolchain
- `npm --prefix tools/functor-sdk test` — 13 passed, 12 e2e-only tests skipped
- focused headless mouse-input e2e passed
- real-browser query smoke confirmed `?cursor=visible` reaches sandbox, IDE, and demo players and wins a dual-mode URL
- exact-head GitHub CI: 9/9 passed across native, wasm, headless e2e, wasm golden, and wasm smoke jobs

No Quest/device validation was required or attempted; this change does not touch shaders, materials, texture sampling, or other GPU-cost surfaces.

## Review dispositions

An independent Opus adversarial review inspected the exact rebased range. It raised no surviving Critical/High findings after code-level disposition:

- the proposed web `gameButtons` race is prevented by `functor_lang_ui_wants_pointer()` before the button is added, and listener order deliberately routes the press to exactly one consumer;
- captured native coordinates are relative free-look input, not the visible absolute-coordinate contract whose flooring preserves negative edge positions; and
- visible native button delivery already receives the pause/replay guard through `apply_window_mouse_button_edge(..., !ignore_user_input)`.

The review prompted an adjacent host-page audit that found and fixed one genuine restack gap: `?cursor=visible` was supported by `player.html` but not forwarded by the sandbox, IDE, or demo editor. The IDE download now emits the matching `cursor` manifest field as well, and a browser smoke pins visible-mode precedence for hand-edited dual-mode URLs.

Known scoped limitation: if a press reached the game model before an interactive pause and its release occurs during the pause, the shell-held level clears but the frozen model does not receive or later recover that release edge. Deferred edge recovery remains a separate follow-up.
