### PR TITLE
feat(lang): same-file entries — roles resolve prefixed bindings, native + wasm

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -221,8 +221,17 @@ SAME directory of sibling modules; `functor --entry <name>` picks one
 (default `client`, or the sole entry). Each entry is its own program (its
 bindings are the bare `init`/`tick`/`draw` roots; the other entry is just a
 qualified sibling module), so roles share code — `examples/mp`'s client and
-server share a `protocol.fun` wire codec — without drifting. `entry` and
-`entries` together are refused.
+server share a `protocol.fun` wire codec — without drifting. A role may also
+be an object pointing at a **shared file** with a binding prefix —
+`"server": { "file": "game.fun", "prefix": "server" }` — resolving every
+canonical entry binding through the prefix as camelCase
+(`serverInit`/`serverTick`/`serverDraw`/…; empty/absent prefix = the plain
+names), so two roles live in ONE file and hot-reload atomically.
+`examples/orbs` is the same-file reference (both roles prefixed). Prefixed
+roles run on native and wasm (`run wasm`/`build wasm` bake the prefix into
+the page's boot config; the site player takes `?prefix=<ident>`); vr still
+loads the unprefixed contract only. `entry` and `entries` together are
+refused.
 
 ```functor
 // utils.fun                                  // → module Utils

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,14 @@ Instead of one `entry`, a project may declare named **`entries`**
 directory of sibling modules (file = module). `--entry <name>` picks the role
 (default: `client`, or the sole entry), anywhere on the line:
 `functor -d examples/mp run native --entry server`. `examples/mp` is the reference —
-client + authoritative server over a shared `protocol.fun`.
+client + authoritative server over a shared `protocol.fun`. A role may also be an
+object pointing at a **shared file** with a binding prefix —
+`"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical
+entry binding through the prefix as camelCase (`serverInit`/`serverTick`/`serverDraw`/…;
+empty/absent prefix = the plain names), so two roles live in ONE file and an edit
+hot-reloads both atomically. `build` validates every declared role's contract with its
+prefixed names; prefixed roles run native-only for now. `examples/orbs` is the
+same-file reference (its `server` role wraps the SERVER section).
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,8 +241,10 @@ object pointing at a **shared file** with a binding prefix —
 entry binding through the prefix as camelCase (`serverInit`/`serverTick`/`serverDraw`/…;
 empty/absent prefix = the plain names), so two roles live in ONE file and an edit
 hot-reloads both atomically. `build` validates every declared role's contract with its
-prefixed names; prefixed roles run native-only for now. `examples/orbs` is the
-same-file reference (its `server` role wraps the SERVER section).
+prefixed names; prefixed roles run on native and wasm (`run wasm`/`build wasm` bake the
+prefix into the page's boot config; the site player takes `?prefix=<ident>`) — vr still
+loads the unprefixed contract only. `examples/orbs` is the same-file reference (both
+roles are prefixed: `client` wraps the CLIENT section, `server` the SERVER section).
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -227,6 +227,14 @@ name → .fun path (e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"
         }
     }
 
+    /// Does this project use the named-`entries` form? `build`'s contract
+    /// gate — which EVALUATES the role's top-level defs to resolve its
+    /// (possibly prefixed) bindings — is scoped to it, so a classic single
+    /// `entry` keeps the old "typecheck only, run nothing" build semantics.
+    pub fn is_named(&self) -> bool {
+        matches!(self.entries, FunctorLangEntries::Named(_))
+    }
+
     /// Every declared entry, resolved — `build` validates each role's
     /// contract, and the example-sweep test typechecks each.
     pub fn all(&self) -> Result<Vec<FunctorLangProject>, Error> {

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -539,13 +539,14 @@ impl FunctorLangProject {
         develop: bool,
     ) -> Result<(), Error> {
         refresh_manifest(working_directory);
-        // A prefixed role is native-only for now: the wasm page and the VR
-        // push path build the embedded producer with the unprefixed contract,
-        // so running them would silently play the wrong role.
-        if !self.prefix.is_empty() && !matches!(environment, Environment::Native) {
+        // A prefixed role can't run on VR yet: the device push path boots the
+        // APK's embedded producer with the unprefixed contract, so running it
+        // would silently play the wrong role. (Native passes --entry-prefix;
+        // wasm bakes the prefix into the served page's boot config.)
+        if !self.prefix.is_empty() && matches!(environment, Environment::Vr) {
             return Err(Error::other(format!(
-                "entry prefix `{}` is native-only for now — run this role with \
-`run native` (the wasm/vr shells load the unprefixed contract)",
+                "entry prefix `{}` is not supported on vr yet — run this role with \
+`run native` or `run wasm` (the vr shell loads the unprefixed contract)",
                 self.prefix
             )));
         }
@@ -877,14 +878,6 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         #[cfg(feature = "web")]
         {
             self.entry_path(working_directory)?;
-            // The exported page boots the unprefixed contract (see `run`).
-            if !self.prefix.is_empty() {
-                return Err(Error::other(format!(
-                    "entry prefix `{}` is native-only for now — the exported web bundle \
-loads the unprefixed contract",
-                    self.prefix
-                )));
-            }
             // Same constraint as `run wasm`: the bundle carries the project
             // directory, so the entry must live inside it.
             if entry_escapes_project(&self.entry) {
@@ -899,6 +892,7 @@ relative path inside it (got {})",
                 &self.entry,
                 self.mouse_capture,
                 self.cursor.as_str(),
+                &self.prefix,
             )?;
             for name in &export.shadowed {
                 emit(Event::Warning {
@@ -996,6 +990,7 @@ relative path inside it (got {})",
                 &self.entry,
                 self.mouse_capture,
                 self.cursor.as_str(),
+                &self.prefix,
             );
             if no_open {
                 emit(Event::Info {

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -1775,6 +1775,8 @@ mod tests {
                     .map(|(k, v)| (k.to_string(), v.clone()))
                     .collect(),
             ),
+            mouse_capture: Ok(None),
+            cursor: None,
         }
     }
 

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -33,6 +33,12 @@ use crate::Environment;
 pub struct FunctorLangProject {
     /// The game source, relative to the project dir (default `game.fun`).
     pub entry: String,
+    /// The role's entry-point binding prefix (same-file entries): every
+    /// canonical entry binding resolves through it as camelCase (`"server"`
+    /// → `serverInit`/`serverTick`/…). Empty = the classic unprefixed
+    /// contract. Declared per role as `{ "file": "game.fun", "prefix":
+    /// "server" }` so two roles can share one file.
+    pub prefix: String,
     /// Whether physical relative mouse input is captured and routed to the game.
     pub mouse_capture: bool,
     /// Whether the shell exposes an absolute pointer to the game.
@@ -162,8 +168,9 @@ because capture is now the default",
         // capture unless the manifest explicitly asks for the contradictory
         // combination above.
         let mouse_capture = requested_mouse_capture.unwrap_or(cursor != CursorPolicy::Visible);
-        let project = |entry: String| FunctorLangProject {
+        let project = |entry: String, prefix: String| FunctorLangProject {
             entry,
+            prefix,
             mouse_capture,
             cursor,
         };
@@ -172,11 +179,11 @@ because capture is now the default",
                 "functor.json declares both `entry` and `entries` — keep one",
             )),
             FunctorLangEntries::Malformed => Err(Error::other(
-                "functor.json `entries` must be a map of name → .fun path \
-(e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"})",
+                "functor.json `entries` must be a map of name → .fun path (or \
+{ \"file\": …, \"prefix\": … }) — e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"}",
             )),
             FunctorLangEntries::Single(entry) => match requested {
-                None => Ok(project(entry.clone())),
+                None => Ok(project(entry.clone(), String::new())),
                 Some(name) => Err(Error::other(format!(
                     "--entry {name}: this project has a single `entry` — `--entry` picks from \
 an `entries` map in functor.json"
@@ -189,11 +196,8 @@ an `entries` map in functor.json"
                         .collect::<Vec<_>>()
                         .join(", ")
                 };
-                let pick = |name: &str, value: &serde_json::Value| match value.as_str() {
-                    Some(entry) if !entry.is_empty() => Ok(project(entry.to_string())),
-                    _ => Err(Error::other(format!(
-                        "functor.json entry `{name}` must be a path to a .fun file"
-                    ))),
+                let pick = |name: &str, value: &serde_json::Value| {
+                    pick_entry(name, value).map(|(entry, prefix)| project(entry, prefix))
                 };
                 match requested {
                     Some(name) => match map.iter().find(|(k, _)| k == name) {
@@ -223,15 +227,79 @@ name → .fun path (e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"
         }
     }
 
-    /// Every declared entry, resolved — the example-sweep test typechecks each.
-    #[cfg(test)]
-    fn all(&self) -> Result<Vec<FunctorLangProject>, Error> {
+    /// Every declared entry, resolved — `build` validates each role's
+    /// contract, and the example-sweep test typechecks each.
+    pub fn all(&self) -> Result<Vec<FunctorLangProject>, Error> {
         match &self.entries {
             FunctorLangEntries::Named(map) => {
                 map.iter().map(|(k, _)| self.select(Some(k))).collect()
             }
             _ => self.select(None).map(|p| vec![p]),
         }
+    }
+}
+
+/// Resolve one `entries` value: the classic string form (`"client.fun"`) or
+/// the object form (`{ "file": "game.fun", "prefix": "server" }` — same-file
+/// entries, where the role's entry bindings resolve through the prefix as
+/// camelCase: `serverInit`/`serverTick`/…). Malformed shapes get teaching
+/// errors naming the exact fix. Returns the `(entry, prefix)` pair; the
+/// caller folds in the project-wide settings.
+fn pick_entry(name: &str, value: &serde_json::Value) -> Result<(String, String), Error> {
+    match value {
+        serde_json::Value::String(entry) if !entry.is_empty() => {
+            Ok((entry.clone(), String::new()))
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(unknown) = map.keys().find(|k| k.as_str() != "file" && k.as_str() != "prefix")
+            {
+                return Err(Error::other(format!(
+                    "functor.json entry `{name}`: unknown key \"{unknown}\" — the object form \
+takes \"file\" and an optional \"prefix\""
+                )));
+            }
+            let entry = match map.get("file") {
+                Some(serde_json::Value::String(file)) if !file.is_empty() => file.clone(),
+                _ => {
+                    return Err(Error::other(format!(
+                        "functor.json entry `{name}`: the object form needs a \"file\" — \
+{{ \"file\": \"game.fun\", \"prefix\": \"{name}\" }}"
+                    )))
+                }
+            };
+            let prefix = match map.get("prefix") {
+                None | Some(serde_json::Value::Null) => String::new(),
+                Some(serde_json::Value::String(prefix)) => prefix.clone(),
+                Some(_) => {
+                    return Err(Error::other(format!(
+                        "functor.json entry `{name}`: \"prefix\" must be a string — the \
+camelCase binding prefix (e.g. \"server\" resolves serverInit/serverTick/…)"
+                    )))
+                }
+            };
+            // A prefix concatenates into binding NAMES, so it must itself be a
+            // valid identifier — refuse `"my server"` here, not as a baffling
+            // "has no top-level `let my serverInit`" later.
+            let mut chars = prefix.chars();
+            let valid = match chars.next() {
+                None => true,
+                Some(first) => {
+                    (first.is_ascii_alphabetic() || first == '_')
+                        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+                }
+            };
+            if !valid {
+                return Err(Error::other(format!(
+                    "functor.json entry `{name}`: \"prefix\" must be a valid identifier \
+(it becomes the binding prefix: `{prefix}Init`, `{prefix}Tick`, …)"
+                )));
+            }
+            Ok((entry, prefix))
+        }
+        _ => Err(Error::other(format!(
+            "functor.json entry `{name}` must be a path to a .fun file, or \
+{{ \"file\": \"game.fun\", \"prefix\": \"{name}\" }} for a same-file role"
+        ))),
     }
 }
 
@@ -373,6 +441,34 @@ impl FunctorLangProject {
         Ok(project)
     }
 
+    /// `build`'s per-role contract gate (same-file entries): load a Session
+    /// under the ENGINE prelude from the project [`Self::build`] already
+    /// typechecked, and validate THIS role's entry-point contract — its
+    /// (possibly prefixed) names at their required arities. A project
+    /// declaring a server role whose `serverTick` is missing or misarityed
+    /// fails here with an error naming `serverTick`, instead of at launch.
+    /// The validation body is the exact one the runtimes use at load
+    /// (`functor_runtime_common::functor_lang_producer::validate_contract`).
+    pub fn check_contract(
+        &self,
+        project: &functor_lang::project::Project,
+    ) -> Result<(), Error> {
+        use functor_runtime_common::functor_lang_prelude::FunctorHost;
+        use functor_runtime_common::functor_lang_producer::{validate_contract, EntryNames};
+        let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
+            .map_err(|f| {
+                Error::other(format!(
+                    "cannot load the {} project: {}",
+                    self.entry,
+                    project.sources.render(f.error.span.start, &f.error.message)
+                ))
+            })?;
+        let names = EntryNames::with_prefix(&self.prefix);
+        validate_contract(&self.entry, &session, &names)
+            .map(|_| ())
+            .map_err(Error::other)
+    }
+
     /// Run the project's inline `expect` tests headlessly under the ENGINE
     /// prelude (no GL context, no window, no game loop) — the thin CLI shell
     /// over [`functor_runtime_common::functor_lang_test::run_expects_in`].
@@ -443,6 +539,16 @@ impl FunctorLangProject {
         develop: bool,
     ) -> Result<(), Error> {
         refresh_manifest(working_directory);
+        // A prefixed role is native-only for now: the wasm page and the VR
+        // push path build the embedded producer with the unprefixed contract,
+        // so running them would silently play the wrong role.
+        if !self.prefix.is_empty() && !matches!(environment, Environment::Native) {
+            return Err(Error::other(format!(
+                "entry prefix `{}` is native-only for now — run this role with \
+`run native` (the wasm/vr shells load the unprefixed contract)",
+                self.prefix
+            )));
+        }
         if matches!(environment, Environment::Vr) {
             if !runner_args.is_empty() {
                 emit(Event::Warning {
@@ -491,6 +597,12 @@ impl FunctorLangProject {
             "--cursor".to_string(),
             self.cursor.as_str().to_string(),
         ];
+        if !self.prefix.is_empty() {
+            // The role's entry-point prefix (same-file entries): the runtime
+            // resolves `serverInit`/`serverTick`/… through it.
+            argv.push("--entry-prefix".to_string());
+            argv.push(self.prefix.clone());
+        }
         if self.mouse_capture {
             argv.push("--mouse-capture".to_string());
         }
@@ -765,6 +877,14 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         #[cfg(feature = "web")]
         {
             self.entry_path(working_directory)?;
+            // The exported page boots the unprefixed contract (see `run`).
+            if !self.prefix.is_empty() {
+                return Err(Error::other(format!(
+                    "entry prefix `{}` is native-only for now — the exported web bundle \
+loads the unprefixed contract",
+                    self.prefix
+                )));
+            }
             // Same constraint as `run wasm`: the bundle carries the project
             // directory, so the entry must live inside it.
             if entry_escapes_project(&self.entry) {
@@ -1650,6 +1770,83 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("no entry named `sever`"), "{err}");
         assert!(err.to_string().contains("client"), "{err}");
+    }
+
+    fn named_json(pairs: &[(&str, serde_json::Value)]) -> FunctorLangConfig {
+        FunctorLangConfig {
+            entries: FunctorLangEntries::Named(
+                pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.clone()))
+                    .collect(),
+            ),
+        }
+    }
+
+    #[test]
+    fn an_object_entry_resolves_file_and_prefix() {
+        let config = named_json(&[
+            ("client", serde_json::json!("game.fun")),
+            (
+                "server",
+                serde_json::json!({ "file": "game.fun", "prefix": "server" }),
+            ),
+        ]);
+        let client = config.select(Some("client")).unwrap();
+        assert_eq!((client.entry.as_str(), client.prefix.as_str()), ("game.fun", ""));
+        let server = config.select(Some("server")).unwrap();
+        assert_eq!(
+            (server.entry.as_str(), server.prefix.as_str()),
+            ("game.fun", "server")
+        );
+    }
+
+    #[test]
+    fn an_object_entry_without_prefix_is_unprefixed() {
+        let config = named_json(&[("client", serde_json::json!({ "file": "client.fun" }))]);
+        let client = config.select(None).unwrap();
+        assert_eq!(
+            (client.entry.as_str(), client.prefix.as_str()),
+            ("client.fun", "")
+        );
+    }
+
+    #[test]
+    fn an_object_entry_without_file_is_refused() {
+        let config = named_json(&[("server", serde_json::json!({ "prefix": "server" }))]);
+        let err = config.select(Some("server")).unwrap_err();
+        assert!(err.to_string().contains("needs a \"file\""), "{err}");
+        assert!(err.to_string().contains("server"), "{err}");
+    }
+
+    #[test]
+    fn a_non_string_prefix_is_refused() {
+        let config = named_json(&[(
+            "server",
+            serde_json::json!({ "file": "game.fun", "prefix": 3 }),
+        )]);
+        let err = config.select(Some("server")).unwrap_err();
+        assert!(err.to_string().contains("must be a string"), "{err}");
+    }
+
+    #[test]
+    fn a_non_identifier_prefix_is_refused() {
+        let config = named_json(&[(
+            "server",
+            serde_json::json!({ "file": "game.fun", "prefix": "my server" }),
+        )]);
+        let err = config.select(Some("server")).unwrap_err();
+        assert!(err.to_string().contains("valid identifier"), "{err}");
+    }
+
+    #[test]
+    fn an_unknown_object_key_is_refused() {
+        let config = named_json(&[(
+            "server",
+            serde_json::json!({ "file": "game.fun", "prefx": "server" }),
+        )]);
+        let err = config.select(Some("server")).unwrap_err();
+        assert!(err.to_string().contains("unknown key \"prefx\""), "{err}");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -417,13 +417,21 @@ async fn run(args: &Args) -> io::Result<()> {
                 // The strict gate validates EVERY declared role, not just the
                 // selected one: the sibling-module set is shared, so asset
                 // verification runs once (the first role), while each role
-                // re-roots the typecheck at its own entry and validates its
-                // own — possibly prefixed — entry-point contract
+                // re-roots the typecheck at its own entry.
+                //
+                // The contract gate on top of that is scoped to named
+                // `entries`: it EVALUATES the role's top-level defs to resolve
+                // its — possibly prefixed — entry points
                 // (`serverInit`/`serverTick`/… for a `{ "file", "prefix" }`
-                // role; see check_contract).
+                // role; see check_contract), which is the feature there. A
+                // classic single `entry` keeps the old boundary: `build`
+                // typechecks and runs no game code.
+                let named = config.is_named();
                 for (i, role) in config.all()?.iter().enumerate() {
                     let loaded = role.build(&working_directory_str, i == 0)?;
-                    role.check_contract(&loaded)?;
+                    if named {
+                        role.check_contract(&loaded)?;
+                    }
                 }
                 match environment {
                     Some(Environment::Wasm) => project.export_wasm(&working_directory_str),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -414,7 +414,17 @@ async fn run(args: &Args) -> io::Result<()> {
             // either target (native interprets the file; wasm ships it as
             // text). `build wasm` then also writes the static web bundle.
             Command::Build { environment } => {
-                project.build(&working_directory_str, true)?;
+                // The strict gate validates EVERY declared role, not just the
+                // selected one: the sibling-module set is shared, so asset
+                // verification runs once (the first role), while each role
+                // re-roots the typecheck at its own entry and validates its
+                // own — possibly prefixed — entry-point contract
+                // (`serverInit`/`serverTick`/… for a `{ "file", "prefix" }`
+                // role; see check_contract).
+                for (i, role) in config.all()?.iter().enumerate() {
+                    let loaded = role.build(&working_directory_str, i == 0)?;
+                    role.check_contract(&loaded)?;
+                }
                 match environment {
                     Some(Environment::Wasm) => project.export_wasm(&working_directory_str),
                     _ => Ok(()),

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn substitutes_the_mouse_capture_boolean() {
         let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "captured");
+            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "captured", "");
         assert!(html.contains("const gameMouseCapture = false"));
         assert!(!html.contains("__FUNCTOR_MOUSE_CAPTURE__"));
     }

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -37,6 +37,9 @@ fn script_safe(json: String) -> String {
 ///   module`) load EVERY module, not just the entry (docs/functor-lang.md Track C5).
 /// - `"__FUNCTOR_MOUSE_CAPTURE__"` becomes the manifest's captured-game-input
 ///   boolean.
+/// - `"__FUNCTOR_LANG_ENTRY_PREFIX__"` becomes a JSON string literal →
+///   `window.__functorLangEntryPrefix`, the role's binding prefix (same-file
+///   entries; empty = the classic unprefixed contract).
 ///
 /// All substitutions are valid JS for any path (quotes/backslashes included).
 pub(crate) fn render_functor_lang_index(
@@ -44,6 +47,7 @@ pub(crate) fn render_functor_lang_index(
     files: &[String],
     mouse_capture: bool,
     cursor: &str,
+    prefix: &str,
 ) -> String {
     let entry_literal =
         script_safe(serde_json::to_string(entry).expect("a string always serializes"));
@@ -53,11 +57,14 @@ pub(crate) fn render_functor_lang_index(
         serde_json::to_string(&mouse_capture).expect("a boolean always serializes");
     let cursor_literal =
         script_safe(serde_json::to_string(cursor).expect("a string always serializes"));
+    let prefix_literal =
+        script_safe(serde_json::to_string(prefix).expect("a string always serializes"));
     INDEX_FUNCTOR_LANG_HTML
         .replace("\"__FUNCTOR_LANG_ENTRY__\"", &entry_literal)
         .replace("\"__FUNCTOR_LANG_PROJECT_FILES__\"", &files_literal)
         .replace("\"__FUNCTOR_MOUSE_CAPTURE__\"", &mouse_capture_literal)
         .replace("\"__FUNCTOR_CURSOR_POLICY__\"", &cursor_literal)
+        .replace("\"__FUNCTOR_LANG_ENTRY_PREFIX__\"", &prefix_literal)
 }
 
 /// The project's file list as URLs relative to the served directory (entry
@@ -93,11 +100,12 @@ impl WasmDevServer {
         entry: &str,
         mouse_capture: bool,
         cursor: &str,
+        prefix: &str,
     ) -> Result<(), io::Error> {
         let files = project_file_urls(working_directory, entry);
         Self::serve(
             working_directory,
-            render_functor_lang_index(entry, &files, mouse_capture, cursor).into_bytes(),
+            render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix).into_bytes(),
         )
         .await
     }
@@ -181,8 +189,13 @@ mod tests {
 
     #[test]
     fn substitutes_the_entry_as_a_js_string() {
-        let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], true, "captured");
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            true,
+            "captured",
+            "",
+        );
         assert!(html.contains("window.__functorLangGamePath = \"game.fun\""));
         assert!(html.contains("const gameMouseCapture = true"));
         assert!(html.contains("Press <kbd>Esc</kbd> to release mouse"));
@@ -200,6 +213,7 @@ mod tests {
             &["game.fun".to_string(), "pieces.fun".to_string()],
             false,
             "visible",
+            "",
         );
         assert!(html.contains("(["));
         assert!(html.contains("\"game.fun\",\"pieces.fun\""));
@@ -209,8 +223,13 @@ mod tests {
 
     #[test]
     fn visible_pointer_keeps_non_primary_webview_input_game_owned() {
-        let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "visible");
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            false,
+            "visible",
+            "",
+        );
         for expected in [
             r#"window.addEventListener("mousemove""#,
             "if (!visiblePointer || debugCameraOwnsInput()) return;",
@@ -254,6 +273,7 @@ mod tests {
             &["we\"ird\\name.fun".to_string()],
             true,
             "captured",
+            "",
         );
         assert!(html.contains("we\\\"ird\\\\name.fun"));
     }
@@ -265,6 +285,7 @@ mod tests {
             &["bad</script>.fun".to_string()],
             true,
             "captured",
+            "",
         );
         assert!(html.contains("bad<\\/script>.fun"));
     }

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -290,6 +290,21 @@ mod tests {
         assert!(html.contains("bad<\\/script>.fun"));
     }
 
+    /// The role's binding prefix reaches the page: the web producer reads
+    /// `window.__functorLangEntryPrefix` to resolve `serverInit`/`serverTick`/….
+    #[test]
+    fn substitutes_the_entry_prefix() {
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            true,
+            "captured",
+            "server",
+        );
+        assert!(html.contains("window.__functorLangEntryPrefix = \"server\""));
+        assert!(!html.contains("__FUNCTOR_LANG_ENTRY_PREFIX__"));
+    }
+
     #[test]
     fn substitutes_the_mouse_capture_boolean() {
         let html =

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -352,6 +352,20 @@ mod tests {
         assert!(export.shadowed.is_empty());
     }
 
+    /// A role's binding prefix rides the exported bundle's page, not just the
+    /// dev server's.
+    #[test]
+    fn exports_the_entry_prefix() {
+        let dir = TestDir::new("prefix");
+        dir.write("game.fun", "let init = 0");
+
+        let wd = dir.path().to_string_lossy().to_string();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "server").unwrap();
+
+        let index = fs::read_to_string(export.out_dir.join("index.html")).unwrap();
+        assert!(index.contains("window.__functorLangEntryPrefix = \"server\""));
+    }
+
     #[test]
     fn reserved_root_names_are_skipped_and_reported() {
         let dir = TestDir::new("reserved");

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -68,6 +68,7 @@ pub fn export_functor_lang_wasm(
     entry: &str,
     mouse_capture: bool,
     cursor: &str,
+    prefix: &str,
 ) -> Result<WasmExport, Error> {
     let root = Path::new(working_directory);
 
@@ -119,7 +120,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(
         out.join("index.html"),
-        render_functor_lang_index(entry, &files, mouse_capture, cursor),
+        render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix),
     )?;
     std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
     std::fs::write(out.join("timeline-model.js"), TIMELINE_MODEL_JS)?;
@@ -305,7 +306,7 @@ mod tests {
         dir.write("dist/web/stale.txt", "from a previous export");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -359,7 +360,7 @@ mod tests {
         dir.write("pkg/junk.js", "not the runtime");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -417,7 +418,7 @@ let g = "pkg/tex.png"
         dir.write(".hidden.fun", "let ghost = 1");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
         assert_eq!(export.file_count, 1, "only game.fun ships");
         assert!(
             !export.out_dir.join(".hidden.fun").exists(),
@@ -434,7 +435,7 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path().join("elsewhere"), dir.path().join("dist")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let err = export_functor_lang_wasm(&wd, "game.fun", true, "captured").unwrap_err();
+        let err = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap_err();
         assert!(err.to_string().contains("symlink"), "{err}");
         assert!(
             dir.path().join("elsewhere/precious.txt").is_file(),
@@ -457,7 +458,7 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path(), dir.path().join("loop")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
         assert_eq!(
             fs::read(export.out_dir.join("linked.glb")).unwrap(),
             b"glb-bytes",

--- a/examples/orbs/functor.json
+++ b/examples/orbs/functor.json
@@ -1,4 +1,7 @@
 {
   "language": "functor-lang",
-  "entry": "game.fun"
+  "entries": {
+    "client": "game.fun",
+    "server": { "file": "game.fun", "prefix": "server" }
+  }
 }

--- a/examples/orbs/functor.json
+++ b/examples/orbs/functor.json
@@ -1,7 +1,7 @@
 {
   "language": "functor-lang",
   "entries": {
-    "client": "game.fun",
+    "client": { "file": "game.fun", "prefix": "client" },
     "server": { "file": "game.fun", "prefix": "server" }
   }
 }

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -156,6 +156,8 @@ let botIntent = (ship: Ship, orbs: List<Orb>): Intent =>
       thrust: not arrived, claim: arrived }
 
 // ===========================  CLIENT  =================================
+// The `client` role: functor.json maps it to { "file": "game.fun",
+// "prefix": "client" }, so the runner resolves clientInit/clientTick/… here.
 // YOU (cyan) and the bot (pink) join through the real protocol path; both
 // Intents fold in as Steers + Claims, then `step` runs. With a real
 // transport the client keeps only its OWN sends; nothing changes shape.
@@ -168,14 +170,14 @@ let orbFree = () => Color.rgb(0.85, 0.88, 0.95)   // unclaimed: dim white glow
 let wallColor = () => Color.rgb(0.3, 0.35, 0.55)
 let bg = () => Color.rgb(0.02, 0.025, 0.06)
 
-let init =
+let clientInit =
   let (w1, meWelcome) = join(newWorld()) in
   let (w2, botWelcome) = join(w1) in
   { myPid: welcomePid(meWelcome), botPid: welcomePid(botWelcome),
     world: w2, intent: coast }
 
 // Held LEVELS, read once per tick — exactly what a transport forwards as a Steer.
-let sampledInput = (m, snap: Input.snapshot) =>
+let clientSampledInput = (m, snap: Input.snapshot) =>
   let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
   { m with intent: {
       turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
@@ -194,7 +196,7 @@ let sendClaim = (pid: float, intent: Intent, w: World): World =>
        | Option.Some(o) => w |> recv(pid, Claim(o.id))
        | Option.None => w)
 
-let tick = (m, dt: float, tts: float) =>
+let clientTick = (m, dt: float, tts: float) =>
   let bot =
     (match shipOf(m.botPid, m.world) with
      | Option.None => coast
@@ -232,7 +234,7 @@ let hud = (m) =>
     Text.concat("BOT ", Text.fixed(scoreOf(m.botPid, m.world.orbs), 0.0))
       |> Sprite.text(pink(), 1.2) |> Sprite.move(halfW * 0.5, halfH + 2.2)])
 
-let draw = (m, tts: float) =>
+let clientDraw = (m, tts: float) =>
   Frame.create2D(
     Camera2D.create((halfW + 2.0) * 2.0, (halfH + 3.0) * 2.0),
     Sprite.group(
@@ -251,7 +253,7 @@ let draw = (m, tts: float) =>
 // role is the authoritative SERVER section stepped directly, with the bot
 // steering both seats so the view moves on its own.
 
-let serverInit = init
+let serverInit = clientInit
 
 let serverTick = (m, dt: float, tts: float) =>
   let steer = (pid: float, w: World): World =>
@@ -262,4 +264,4 @@ let serverTick = (m, dt: float, tts: float) =>
        w |> recv(pid, Steer(i)) |> sendClaim(pid, i)) in
   { m with world: m.world |> steer(m.myPid) |> steer(m.botPid) |> step(dt) }
 
-let serverDraw = draw   // the same board, seen from the authority
+let serverDraw = clientDraw   // the same board, seen from the authority

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -242,3 +242,24 @@ let draw = (m, tts: float) =>
         |> List.append(m.world.pilots |> List.map((p) => shipSprite(m, p)))
         |> List.append([hud(m)])))
     |> Frame.withClearColor(bg())
+
+// ========================  SERVER ROLE  ===============================
+// The same file is ALSO the `server` entry: functor.json maps the role to
+// { "file": "game.fun", "prefix": "server" }, so the runner resolves
+// serverInit/serverTick/serverDraw here (functor -d examples/orbs run
+// native --entry server) — one buffer, both roles, one hot reload. The
+// role is the authoritative SERVER section stepped directly, with the bot
+// steering both seats so the view moves on its own.
+
+let serverInit = init
+
+let serverTick = (m, dt: float, tts: float) =>
+  let steer = (pid: float, w: World): World =>
+    (match shipOf(pid, w) with
+     | Option.None => w
+     | Option.Some(s) =>
+       let i = botIntent(s, w.orbs) in
+       w |> recv(pid, Steer(i)) |> sendClaim(pid, i)) in
+  { m with world: m.world |> steer(m.myPid) |> steer(m.botPid) |> step(dt) }
+
+let serverDraw = draw   // the same board, seen from the authority

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -27,11 +27,12 @@ use functor_lang::{Session, Value};
 
 use crate::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, clear_preload_completions,
-    contains_effect, frame_value, html_node_value, now_ms, take_ui_handlers, view_value, EffectLog,
+    frame_value, html_node_value, now_ms, take_ui_handlers, view_value, EffectLog,
     EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
-    journal_arm, journal_swap, FrameCtx, JournalEntry, Reporter, SpanSource,
+    journal_arm, journal_swap, validate_contract, EntryNames, FrameCtx, JournalEntry, Reporter,
+    SpanSource,
 };
 use crate::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use crate::physics;
@@ -84,6 +85,10 @@ impl ProducerPlatform for NativePlatform {
 
 pub struct FunctorLangEmbeddedGame {
     path: String,
+    /// The role's resolved entry-point names (same-file entries): built once
+    /// from the role's prefix at create time and reused by every reload —
+    /// every canonical lookup and contract error goes through it.
+    names: EntryNames,
     /// The project's source files (entry FIRST, then siblings) as
     /// `(path, source)` — the in-memory stand-in for the on-disk directory the
     /// desktop producer re-reads on reload. A push (`reload_source`) replaces
@@ -225,7 +230,7 @@ struct Loaded {
 /// is every project file as `(path, source)`, the ENTRY first, then siblings
 /// (`file = module`, so `pieces.fun` is module `Pieces`). Errors come back as
 /// fully rendered strings (`path:line:col: message`).
-fn load_source(sources: &[(String, String)]) -> Result<Loaded, String> {
+fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loaded, String> {
     let path = sources
         .first()
         .map(|(p, _)| p.clone())
@@ -257,110 +262,26 @@ fn load_source(sources: &[(String, String)]) -> Result<Loaded, String> {
             source_map.render(f.error.span.start, &f.error.message)
         )
     })?;
-    // The producer contract is knowable at load — fail here, not once per
-    // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
-    // right arity.
-    let init = session
-        .global("init")
-        .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
-    if matches!(
-        init,
-        Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
-    ) {
-        return Err(format!(
-            "{path}: `init` must be a model value, not a function"
-        ));
-    }
-    if contains_effect(&init) {
-        return Err(format!(
-            "{path}: `init` contains an Effect value — Effects are commands, not data; \
-return them beside the model as `(model, effect)`"
-        ));
-    }
-    require_function(&path, &session, "tick", 3)?;
-    require_function(&path, &session, "draw", 2)?;
-    // `input` is optional (many games are non-interactive), but when
-    // present it must honor the contract: (model, key, isDown) => model.
-    let has_input = session.global("input").is_some();
-    if has_input {
-        require_function(&path, &session, "input", 3)?;
-    }
-    let has_sampled_input = session.global("sampledInput").is_some();
-    if has_sampled_input {
-        require_function(&path, &session, "sampledInput", 2)?;
-    }
-    // Same deal for the mouse: `mouseMove(model, x, y)` in logical shell coordinates,
-    // `mouseWheel(model, delta)`.
-    let has_mouse_move = session.global("mouseMove").is_some();
-    if has_mouse_move {
-        require_function(&path, &session, "mouseMove", 3)?;
-    }
-    let has_mouse_wheel = session.global("mouseWheel").is_some();
-    if has_mouse_wheel {
-        require_function(&path, &session, "mouseWheel", 2)?;
-    }
-    // `mouseButton(model, button, isDown)` — the `input` twin for the pointer.
-    let has_mouse_button = session.global("mouseButton").is_some();
-    if has_mouse_button {
-        require_function(&path, &session, "mouseButton", 3)?;
-    }
-    // The MVU pair: `subscriptions(model)` declares timers whose fired
-    // messages fold through `update(model, msg)` — so subscriptions
-    // without an update have nowhere to deliver.
-    let has_subscriptions = session.global("subscriptions").is_some();
-    if has_subscriptions {
-        require_function(&path, &session, "subscriptions", 1)?;
-        if session.global("update").is_none() {
-            return Err(format!(
-                "{path}: `subscriptions` produces messages but there is no \
-`let update = (model, msg) => …` to receive them"
-            ));
-        }
-    }
-    if session.global("update").is_some() {
-        require_function(&path, &session, "update", 2)?;
-    }
-    // Optional physics: `physics(model) => Physics.scene(…)` declares the
-    // bodies that should exist; the host reconciles + fixed-steps the
-    // world after each tick (docs/physics.md).
-    let has_physics = session.global("physics").is_some();
-    if has_physics {
-        require_function(&path, &session, "physics", 1)?;
-    }
-    // Optional soundscape: `soundScape(model)` returns an AudioScene (the
-    // continuous, reconciled half of audio). No `update` requirement — the
-    // scene is reconciled by the shell, not folded back as a message.
-    let has_soundscape = session.global("soundScape").is_some();
-    if has_soundscape {
-        require_function(&path, &session, "soundScape", 1)?;
-    }
-    // Optional HUD: `ui(model)` returns a View (Ui.text / Ui.column /
-    // Ui.panel), lowered to the shared text overlay.
-    let has_ui = session.global("ui").is_some();
-    if has_ui {
-        require_function(&path, &session, "ui", 1)?;
-    }
-    // Optional webview: `webview(model)` returns an Html node (Html.div /
-    // Html.text / …), rendered by shells that have an HTML overlay.
-    let has_webview = session.global("webview").is_some();
-    if has_webview {
-        require_function(&path, &session, "webview", 1)?;
-    }
+    // The producer contract (init a value, tick/draw functions of the right
+    // arity, optional hooks well-shaped) is shared with the desktop producer
+    // and the CLI's build gate — errors name the ROLE'S resolved bindings
+    // (`serverTick`, not `tick`) via `names`.
+    let contract = validate_contract(&path, &session, names)?;
     Ok(Loaded {
         sources: source_map,
         module,
         session,
-        init,
-        has_input,
-        has_sampled_input,
-        has_mouse_move,
-        has_mouse_wheel,
-        has_mouse_button,
-        has_subscriptions,
-        has_physics,
-        has_soundscape,
-        has_ui,
-        has_webview,
+        init: contract.init,
+        has_input: contract.has_input,
+        has_sampled_input: contract.has_sampled_input,
+        has_mouse_move: contract.has_mouse_move,
+        has_mouse_wheel: contract.has_mouse_wheel,
+        has_mouse_button: contract.has_mouse_button,
+        has_subscriptions: contract.has_subscriptions,
+        has_physics: contract.has_physics,
+        has_soundscape: contract.has_soundscape,
+        has_ui: contract.has_ui,
+        has_webview: contract.has_webview,
     })
 }
 
@@ -372,14 +293,27 @@ impl FunctorLangEmbeddedGame {
         sources: Vec<(String, String)>,
         platform: Box<dyn ProducerPlatform>,
     ) -> Result<FunctorLangEmbeddedGame, String> {
+        Self::create_with_prefix(sources, "", platform)
+    }
+
+    /// [`Self::create`] for a PREFIXED role (same-file entries): every
+    /// canonical entry binding resolves through `prefix` as camelCase
+    /// (`"server"` → `serverInit`/`serverTick`/…). An empty prefix is the
+    /// classic unprefixed contract.
+    pub fn create_with_prefix(
+        sources: Vec<(String, String)>,
+        prefix: &str,
+        platform: Box<dyn ProducerPlatform>,
+    ) -> Result<FunctorLangEmbeddedGame, String> {
         // Install the shell's diagnostics sinks BEFORE the first load so load
         // errors surface (native: the `log` sink; web: console/event bridge).
         platform.install_sinks();
+        let names = EntryNames::with_prefix(prefix);
         let path = sources
             .first()
             .map(|(p, _)| p.clone())
             .unwrap_or_else(|| "game.fun".to_string());
-        let loaded = load_source(&sources)?;
+        let loaded = load_source(&sources, &names)?;
         log::info!("[functor-lang] loaded {path}");
         // Arm the paused-inspector journal on this thread: from now on every
         // live model-updating call is journaled (a cheap Rc-clone push).
@@ -395,6 +329,7 @@ impl FunctorLangEmbeddedGame {
             source_hashes,
             sources,
             path,
+            names,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -506,6 +441,7 @@ impl FunctorLangEmbeddedGame {
         let replay_started = now_ms();
         let history_replay = match crate::functor_lang_producer::materialize_counterfactual_history(
             &self.session,
+            &self.names,
             &mut self.model,
             &mut self.recorder,
             self.has_physics,
@@ -597,6 +533,7 @@ impl FunctorLangEmbeddedGame {
     fn ctx(&mut self) -> FrameCtx<'_> {
         FrameCtx {
             session: &self.session,
+            names: &self.names,
             model: &mut self.model,
             physics_rt: &mut self.physics_rt,
             physics_frame: &mut self.physics_frame,
@@ -653,7 +590,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
         } else {
             sources.push((self.path.clone(), source.to_string()));
         }
-        let loaded = load_source(&sources)?;
+        let loaded = load_source(&sources, &self.names)?;
         self.sources = sources;
         let (rebound, history_replay) = self.swap_in(loaded);
         let stored = if rebound > 0 {
@@ -680,7 +617,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = now_ms();
-        let loaded = load_source(files)?;
+        let loaded = load_source(files, &self.names)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
         let (rebound, history_replay) = self.swap_in(loaded);
@@ -706,7 +643,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = now_ms();
-        let loaded = load_source(files)?;
+        let loaded = load_source(files, &self.names)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
         self.reset_in(loaded);
@@ -804,6 +741,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
     ) -> Vec<(Frame, FrameTime)> {
         crate::functor_lang_producer::ghost_frames(
             &self.session,
+            &self.names,
             &self.model,
             &self.recorder,
             self.has_physics,
@@ -859,9 +797,9 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return; // unrecognized code / Key::Unknown — never delivered.
         };
         let args = vec![self.model.clone(), key_value, Value::Bool(is_down)];
-        match self.session.call("input", args, &mut FunctorHost) {
+        match self.session.call(self.names.input, args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("input", &err),
+            Err(err) => self.reporter.frame_error(self.names.input, &err),
         }
         // Buffer the raw event for the frame-indexed input log (T6b): flushed
         // into the recorder by `record_frame`, replayed by the forward-step.
@@ -878,9 +816,12 @@ impl GameProducer for FunctorLangEmbeddedGame {
             Value::Number(x as f64),
             Value::Number(y as f64),
         ];
-        match self.session.call("mouseMove", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.mouse_move, args, &mut FunctorHost)
+        {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("mouseMove", &err),
+            Err(err) => self.reporter.frame_error(self.names.mouse_move, &err),
         }
         self.input_buf
             .push(crate::RecordedInput::MouseMove { x, y });
@@ -891,9 +832,12 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return;
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
-        match self.session.call("mouseWheel", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.mouse_wheel, args, &mut FunctorHost)
+        {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("mouseWheel", &err),
+            Err(err) => self.reporter.frame_error(self.names.mouse_wheel, &err),
         }
         self.input_buf
             .push(crate::RecordedInput::MouseWheel { delta });
@@ -910,9 +854,12 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return; // unrecognized code / MouseButton::Unknown — never delivered.
         };
         let args = vec![self.model.clone(), button_value, Value::Bool(is_down)];
-        match self.session.call("mouseButton", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.mouse_button, args, &mut FunctorHost)
+        {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("mouseButton", &err),
+            Err(err) => self.reporter.frame_error(self.names.mouse_button, &err),
         }
         self.input_buf
             .push(crate::RecordedInput::MouseButton { button, is_down });
@@ -956,7 +903,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             .scrub_render_tts()
             .unwrap_or(frame_time.tts as f64);
         let args = vec![self.model.clone(), Value::Number(tts)];
-        match self.session.call("draw", args, &mut FunctorHost) {
+        match self.session.call(self.names.draw, args, &mut FunctorHost) {
             Ok(value) => match frame_value(&value) {
                 Some(frame) => {
                     self.last_frame = frame.clone();
@@ -966,7 +913,8 @@ impl GameProducer for FunctorLangEmbeddedGame {
                 }
                 None => {
                     let rendered = format!(
-                        "[functor-lang] draw must return Frame.create(camera, scene), got {}",
+                        "[functor-lang] {} must return Frame.create(camera, scene), got {}",
+                        self.names.draw,
                         value.kind_name()
                     );
                     self.platform.set_draw_overlay(Some(&rendered));
@@ -974,7 +922,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
                 }
             },
             Err(err) => {
-                let rendered = self.reporter.render_frame_error("draw", &err);
+                let rendered = self.reporter.render_frame_error(self.names.draw, &err);
                 self.platform.set_draw_overlay(Some(&rendered));
                 self.reporter.report_once(rendered);
             }
@@ -985,7 +933,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
         if self.has_ui {
             match self
                 .session
-                .call("ui", vec![self.model.clone()], &mut FunctorHost)
+                .call(self.names.ui, vec![self.model.clone()], &mut FunctorHost)
             {
                 Ok(value) => match view_value(&value) {
                     Some(view) => {
@@ -997,7 +945,8 @@ impl GameProducer for FunctorLangEmbeddedGame {
                     None => {
                         let _ = take_ui_handlers();
                         self.reporter.report_once(format!(
-                            "[functor-lang] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
+                            "[functor-lang] {} must return a View (Ui.text / Ui.column / Ui.panel), got {}",
+                            self.names.ui,
                             value.kind_name()
                         ))
                     }
@@ -1006,17 +955,18 @@ impl GameProducer for FunctorLangEmbeddedGame {
                     // A failed evaluation keeps the last good view AND its
                     // handlers; drop the partial table it registered.
                     let _ = take_ui_handlers();
-                    self.reporter.frame_error("ui", &err)
+                    self.reporter.frame_error(self.names.ui, &err)
                 }
             }
         }
         // The optional webview, evaluated beside `draw` like `ui` — same
         // caching, same handler-adoption lockstep, its own handler table.
         if self.has_webview {
-            match self
-                .session
-                .call("webview", vec![self.model.clone()], &mut FunctorHost)
-            {
+            match self.session.call(
+                self.names.webview,
+                vec![self.model.clone()],
+                &mut FunctorHost,
+            ) {
                 Ok(value) => match html_node_value(&value) {
                     Some(node) => {
                         self.last_webview = Some(node.clone());
@@ -1025,14 +975,15 @@ impl GameProducer for FunctorLangEmbeddedGame {
                     None => {
                         let _ = take_ui_handlers();
                         self.reporter.report_once(format!(
-                            "[functor-lang] webview must return an Html node (Html.div / Html.text / …), got {}",
+                            "[functor-lang] {} must return an Html node (Html.div / Html.text / …), got {}",
+                            self.names.webview,
                             value.kind_name()
                         ))
                     }
                 },
                 Err(err) => {
                     let _ = take_ui_handlers();
-                    self.reporter.frame_error("webview", &err)
+                    self.reporter.frame_error(self.names.webview, &err)
                 }
             }
         }
@@ -1040,19 +991,21 @@ impl GameProducer for FunctorLangEmbeddedGame {
         // model) and cached — `audio_scene_json` is a `&self` accessor, and
         // errors need `&mut` dedupe (the `ui` pattern).
         if self.has_soundscape {
-            match self
-                .session
-                .call("soundScape", vec![self.model.clone()], &mut FunctorHost)
-            {
+            match self.session.call(
+                self.names.sound_scape,
+                vec![self.model.clone()],
+                &mut FunctorHost,
+            ) {
                 Ok(value) => match audio_scene_of(&value) {
                     Some(scene) => self.last_soundscape_json = crate::audio::scene_to_json(scene),
                     None => self.reporter.report_once(format!(
-                        "[functor-lang] soundScape must return an AudioScene (AudioScene.create / \
+                        "[functor-lang] {} must return an AudioScene (AudioScene.create / \
 AudioScene.empty), got {}",
+                        self.names.sound_scape,
                         value.kind_name()
                     )),
                 },
-                Err(err) => self.reporter.frame_error("soundScape", &err),
+                Err(err) => self.reporter.frame_error(self.names.sound_scape, &err),
             }
         }
         // On failure this is the last good frame — a bad draw must not blank
@@ -1171,23 +1124,6 @@ AudioScene.empty), got {}",
     }
 }
 
-/// `name` must be a function of `arity` params — a contract violation is
-/// reportable at load, and the alternative is one error per frame, forever.
-fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> Result<(), String> {
-    match session.global(name) {
-        Some(Value::Closure(closure)) if closure.params.len() == arity => Ok(()),
-        Some(Value::Closure(closure)) => Err(format!(
-            "{path}: `{name}` must take {arity} parameter(s), takes {}",
-            closure.params.len()
-        )),
-        Some(other) => Err(format!(
-            "{path}: `{name}` must be a function, got {}",
-            other.kind_name()
-        )),
-        None => Err(format!("{path} has no top-level `let {name} = …`")),
-    }
-}
-
 /// The embedded `Reporter` sink: per-frame problems go through the `log`
 /// facade (the shell owns the logger).
 fn report_to_log(message: &str) {
@@ -1276,6 +1212,52 @@ let draw = (model, tts) =>
         let ft = frame_time(0.1, 0.016);
         game.tick(ft.clone());
         let _ = game.render(ft); // still renders under the old program
+    }
+
+    #[test]
+    fn a_prefixed_role_resolves_and_names_the_prefixed_contract() {
+        // The boot scene as a `server` role (same-file entries): every entry
+        // binding resolves through the prefix as camelCase.
+        let server_boot = BOOT
+            .replace("let init", "let serverInit")
+            .replace("let tick", "let serverTick")
+            .replace("let draw", "let serverDraw");
+        let mut game = FunctorLangEmbeddedGame::create_with_prefix(
+            vec![("game.fun".to_string(), server_boot)],
+            "server",
+            Box::new(NativePlatform),
+        )
+        .expect("prefixed role loads");
+        let ft = frame_time(0.016, 0.016);
+        game.tick(ft.clone());
+        let frame = game.render(ft);
+        assert!(
+            !matches!(&frame.scene.obj, crate::SceneObject::Group(children) if children.is_empty()),
+            "serverDraw produced the game's scene, not the empty fallback"
+        );
+        assert!(game.state_debug().contains("spin"), "serverTick advanced the model");
+
+        // The prefixed sibling of the broken-push case below: a push missing
+        // the role's tick names `serverTick`, never the canonical `tick`.
+        let err = game
+            .reload_source("let serverInit = { spin: 0.0 }")
+            .expect_err("missing serverTick/serverDraw is a load error");
+        assert!(
+            err.contains("serverTick"),
+            "the error names the prefixed contract: {err}"
+        );
+
+        // An UNPREFIXED program under the server role misses the contract —
+        // and the error teaches the resolved name it looked for.
+        let err = match FunctorLangEmbeddedGame::create_with_prefix(
+            vec![("game.fun".to_string(), BOOT.to_string())],
+            "server",
+            Box::new(NativePlatform),
+        ) {
+            Err(err) => err,
+            Ok(_) => panic!("unprefixed bindings don't satisfy a prefixed role"),
+        };
+        assert!(err.contains("serverInit"), "{err}");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -1051,7 +1051,7 @@ AudioScene.empty), got {}",
             tts,
             &self.source_hashes,
             &self.last_frame_journal,
-            Some(&draw_args),
+            Some((self.names.draw, &draw_args)),
             &ring,
             &self.runnable,
             &self.session,
@@ -1258,6 +1258,35 @@ let draw = (model, tts) =>
             Ok(_) => panic!("unprefixed bindings don't satisfy a prefixed role"),
         };
         assert!(err.contains("serverInit"), "{err}");
+    }
+
+    /// A prefixed role's EFFECTS must fold through the role's own update
+    /// (`serverUpdate`), not the canonical `update` — the drain would
+    /// otherwise fail its call and silently drop every message.
+    #[test]
+    fn a_prefixed_role_drains_its_effects_through_its_own_update() {
+        let source = "\
+type Msg = | GotTime(t: Float)\n\
+let serverInit = { ticks: 0.0, stamped: 0.0 }\n\
+let serverUpdate = (m, msg) =>\n\
+  match msg with\n\
+  | GotTime(t) => { m with stamped: m.stamped + 1.0 }\n\
+let serverTick = (m, dt, tts) =>\n\
+  ({ m with ticks: m.ticks + dt }, Effect.now((t) => GotTime(t)))\n\
+let serverDraw = (m, tts) =>\n\
+  Frame.create(Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
+        let mut game = FunctorLangEmbeddedGame::create_with_prefix(
+            vec![("game.fun".to_string(), source.to_string())],
+            "server",
+            Box::new(NativePlatform),
+        )
+        .expect("prefixed role loads");
+        game.tick(frame_time(0.016, 0.016));
+        let model = game.state_debug();
+        assert!(
+            model.contains("stamped: 1"),
+            "serverTick's Effect.now result reached serverUpdate: {model}"
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -4572,6 +4572,7 @@ pub fn physics_event_value(event: &physics::PhysicsEvent) -> Value {
 /// answer immediately, further commands queue for the next step).
 pub fn deliver_physics_events(
     session: &functor_lang::Session,
+    update_name: &'static str,
     model: &mut Value,
     taggers: &[Value],
     events: &[physics::PhysicsEvent],
@@ -4600,17 +4601,18 @@ pub fn deliver_physics_events(
             // (PR2); a no-op unless journaling is armed.
             let args = vec![model.clone(), msg];
             crate::functor_lang_producer::journal_push(
-                "update",
+                update_name,
                 &args,
                 crate::functor_lang_producer::Provenance::Collision,
             );
-            match session.call("update", args, &mut FunctorHost) {
+            match session.call(update_name, args, &mut FunctorHost) {
                 Ok(returned) => {
                     let (next_model, more) = split_model_effect(returned);
                     *model = next_model;
                     if let Some(more) = more {
                         drain_mode(
                             session,
+                            update_name,
                             model,
                             vec![more],
                             runner,
@@ -4621,7 +4623,9 @@ pub fn deliver_physics_events(
                         );
                     }
                 }
-                Err(e) => report(format!("[functor-lang] update error: {}", e.message)),
+                Err(e) => {
+                    report(format!("[functor-lang] {update_name} error: {}", e.message))
+                }
             }
         }
     }
@@ -4694,7 +4698,9 @@ pub fn contains_effect(value: &Value) -> bool {
 /// F# executor's `maxEffectsPerFrame` discipline). Every performed effect
 /// is appended to `log` (the structured effect log; replay's input).
 /// Errors report through `report` (deduped by the producer) and drop that
-/// effect — one bad tagger must not stall the rest.
+/// effect — one bad tagger must not stall the rest. `update_name` is the
+/// ROLE's resolved update binding (`EntryNames::update` — `serverUpdate`
+/// under a prefix), so a same-file role's messages land in its own hook.
 ///
 /// Physics QUERIES are not performed here: they come back in the returned
 /// list for the driver to hold until after the frame's physics step, then
@@ -4703,6 +4709,7 @@ pub fn contains_effect(value: &Value) -> bool {
 #[must_use = "deferred physics queries must be performed after the step"]
 pub fn drain_effects(
     session: &functor_lang::Session,
+    update_name: &'static str,
     model: &mut Value,
     first: EffectTree,
     runner: &mut dyn EffectRunner,
@@ -4713,6 +4720,7 @@ pub fn drain_effects(
     let mut deferred = Vec::new();
     drain_mode(
         session,
+        update_name,
         model,
         vec![first],
         runner,
@@ -4762,6 +4770,7 @@ pub fn needs_update(tree: &EffectTree) -> bool {
 /// queue for the next frame's step, as always.
 pub fn perform_deferred_queries(
     session: &functor_lang::Session,
+    update_name: &'static str,
     model: &mut Value,
     deferred: Vec<EffectTree>,
     runner: &mut dyn EffectRunner,
@@ -4774,6 +4783,7 @@ pub fn perform_deferred_queries(
     }
     drain_mode(
         session,
+        update_name,
         model,
         deferred,
         runner,
@@ -4786,6 +4796,7 @@ pub fn perform_deferred_queries(
 
 fn drain_mode(
     session: &functor_lang::Session,
+    update_name: &'static str,
     model: &mut Value,
     queue: Vec<EffectTree>,
     runner: &mut dyn EffectRunner,
@@ -5084,8 +5095,8 @@ dropping the rest"
         } else {
             crate::functor_lang_producer::Provenance::EffectResult
         };
-        crate::functor_lang_producer::journal_push("update", &args, provenance);
-        match session.call("update", args, &mut FunctorHost) {
+        crate::functor_lang_producer::journal_push(update_name, &args, provenance);
+        match session.call(update_name, args, &mut FunctorHost) {
             Ok(returned) => {
                 let (next_model, more) = split_model_effect(returned);
                 *model = next_model;
@@ -5093,7 +5104,7 @@ dropping the rest"
                     queue.push(more);
                 }
             }
-            Err(e) => report(format!("[functor-lang] update error: {}", e.message)),
+            Err(e) => report(format!("[functor-lang] {update_name} error: {}", e.message)),
         }
     }
 }
@@ -6465,6 +6476,7 @@ Asset.model(\"shark.glb\") at the data boundary"
             let effect = effect_of(&session.global(name).unwrap()).unwrap().0.clone();
             let _ = drain_effects(
                 &session,
+                "update",
                 &mut model,
                 effect,
                 &mut FakeEffects::new(0.0, vec![]),
@@ -8168,6 +8180,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut runner = FakeEffects::new(0.0, vec![]);
         let deferred = drain_effects(
             &session,
+            "update",
             &mut model,
             tree.clone(),
             &mut runner,
@@ -8316,6 +8329,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
             let mut runner = FakeEffects::new(0.0, vec![]);
             let deferred = drain_effects(
                 &session,
+                "update",
                 &mut model,
                 tree.clone(),
                 &mut runner,
@@ -8397,6 +8411,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut runner = FakeEffects::new(0.0, vec![]);
         let deferred = drain_effects(
             &session,
+            "update",
             &mut model,
             tree.clone(),
             &mut runner,
@@ -8457,6 +8472,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
             let mut runner = FakeEffects::new(0.0, vec![]);
             let deferred = drain_effects(
                 &session,
+                "update",
                 &mut model,
                 tree.clone(),
                 &mut runner,
@@ -8487,6 +8503,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut runner = FakeEffects::new(0.0, vec![]);
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             tree.clone(),
             &mut runner,
@@ -8663,6 +8680,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
             model = m;
             let deferred = drain_effects(
                 &session,
+                "update",
                 &mut model,
                 fx.expect("an effect"),
                 runner,
@@ -8756,7 +8774,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
 
         // Pre-step drain: DEFERRED — nothing performed, nothing logged.
         let deferred =
-            drain_effects(&session, &mut model, tree, &mut runner, &mut log, &mut fail, false);
+            drain_effects(&session, "update", &mut model, tree, &mut runner, &mut log, &mut fail, false);
         assert_eq!(deferred.len(), 1);
         assert!(log.is_empty());
         assert!(matches!(model, Value::Number(_)), "model must be untouched");
@@ -8764,6 +8782,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         // Post-step drain: performed against the live world.
         perform_deferred_queries(
             &session,
+            "update",
             &mut model,
             deferred,
             &mut runner,
@@ -8794,6 +8813,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut replay = ReplayEffects::new(log.clone());
         let deferred = drain_effects(
             &session,
+            "update",
             &mut replay_model,
             EffectTree::Raycast {
                 origin: [0.0, 5.0, 0.0],
@@ -8808,6 +8828,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         );
         perform_deferred_queries(
             &session,
+            "update",
             &mut replay_model,
             deferred,
             &mut replay,
@@ -8889,6 +8910,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut runner = FakeEffects::new(0.0, vec![]);
         deliver_physics_events(
             &session,
+            "update",
             &mut model,
             &taggers,
             &[event],
@@ -9179,6 +9201,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut reports = Vec::new();
         let deferred = drain_effects(
             &session,
+            "update",
             &mut model,
             EffectTree::Random {
                 tagger: session.global("again").expect("tagger fn"),
@@ -9210,6 +9233,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         let mut reports = Vec::new();
         let deferred = drain_effects(
             &session,
+            "update",
             &mut model,
             EffectTree::Batch(vec![EffectTree::None; 1500]),
             &mut FakeEffects::new(0.0, vec![0.5]),
@@ -9836,6 +9860,7 @@ the game dir"
         let mut log = EffectLog::new();
         drain_effects(
             &session,
+            "update",
             &mut model,
             effect.expect("a Send effect"),
             &mut FakeEffects::new(0.0, vec![]),
@@ -9946,6 +9971,7 @@ the game dir"
         let mut log = EffectLog::new();
         let _ = drain_effects(
             &session,
+            "update",
             &mut m,
             fx.expect("an effect"),
             &mut FakeEffects::new(0.0, vec![]),
@@ -10063,6 +10089,7 @@ the game dir"
         let mut log = EffectLog::new();
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             fetch,
             &mut FakeEffects::new(0.0, vec![]),
@@ -10127,6 +10154,7 @@ the game dir"
         for effect in [fetch, shoot] {
             let _ = drain_effects(
                 &session,
+                "update",
                 &mut model,
                 effect,
                 &mut FakeEffects::new(0.0, vec![]),
@@ -10170,6 +10198,7 @@ the game dir"
         let shoot = effect_of(&session.global("shoot").unwrap()).unwrap().0.clone();
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             shoot,
             &mut FakeEffects::new(0.0, vec![]),
@@ -10182,6 +10211,7 @@ the game dir"
         let blast = effect_of(&session.global("blast").unwrap()).unwrap().0.clone();
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             blast,
             &mut FakeEffects::new(0.0, vec![]),
@@ -10235,6 +10265,7 @@ the game dir"
         let ping = effect_of(&session.global("ping").unwrap()).unwrap().0.clone();
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             ping,
             &mut FakeEffects::new(0.0, vec![]),
@@ -10297,6 +10328,7 @@ the game dir"
         let warm = effect_of(&session.global("warm").unwrap()).unwrap().0.clone();
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             warm,
             &mut FakeEffects::new(0.0, vec![]),
@@ -10381,6 +10413,7 @@ the game dir"
         let warm = effect_of(&session.global("warm").unwrap()).unwrap().0.clone();
         let _ = drain_effects(
             &session,
+            "update",
             &mut model,
             warm,
             &mut FakeEffects::new(0.0, vec![]),
@@ -10572,6 +10605,7 @@ a number",
             if let Some(tree) = fx {
                 let _ = drain_effects(
                     session,
+                    "update",
                     &mut m,
                     tree,
                     &mut FakeEffects::new(0.0, vec![]),
@@ -10682,6 +10716,7 @@ a number",
                 let mut log = EffectLog::new();
                 let _ = drain_effects(
                     session,
+                    "update",
                     &mut m,
                     tree,
                     &mut FakeEffects::new(0.0, vec![]),

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -45,6 +45,259 @@ use crate::timetravel::SceneRecorder;
 use crate::{Frame, FrameTime};
 
 // ---------------------------------------------------------------------------
+// Per-role entry-point names (same-file entries).
+// ---------------------------------------------------------------------------
+
+/// Intern a resolved entry name as `&'static str`, deduped process-wide so
+/// repeated hot reloads of the same role never grow the leak (the distinct
+/// set is tiny: one batch of names per prefix ever seen).
+fn intern(name: String) -> &'static str {
+    use std::sync::{Mutex, OnceLock};
+    static INTERNED: OnceLock<Mutex<Vec<&'static str>>> = OnceLock::new();
+    let mut names = INTERNED
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("entry-name intern table");
+    if let Some(existing) = names.iter().find(|s| **s == name) {
+        return existing;
+    }
+    let leaked: &'static str = Box::leak(name.into_boxed_str());
+    names.push(leaked);
+    leaked
+}
+
+/// The resolved entry-point binding names for one ROLE (same-file entries).
+/// A functor.json role declared as `{ "file": "game.fun", "prefix": "server" }`
+/// resolves every canonical entry binding through the prefix as camelCase —
+/// `serverInit`, `serverTick`, `serverDraw`, … — so two roles can share one
+/// file (and hot-reload atomically from one buffer). An empty prefix is the
+/// classic unprefixed contract. Built once per load; every canonical-name
+/// lookup, contract check, journal entry, and user-facing error message goes
+/// through these fields — never ad-hoc string concatenation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EntryNames {
+    pub init: &'static str,
+    pub tick: &'static str,
+    pub draw: &'static str,
+    pub update: &'static str,
+    pub input: &'static str,
+    pub sampled_input: &'static str,
+    pub mouse_move: &'static str,
+    pub mouse_wheel: &'static str,
+    pub mouse_button: &'static str,
+    pub subscriptions: &'static str,
+    pub physics: &'static str,
+    pub sound_scape: &'static str,
+    pub ui: &'static str,
+    pub webview: &'static str,
+}
+
+impl EntryNames {
+    /// The classic contract: plain `init`/`tick`/`draw`/… binding names.
+    pub const UNPREFIXED: EntryNames = EntryNames {
+        init: "init",
+        tick: "tick",
+        draw: "draw",
+        update: "update",
+        input: "input",
+        sampled_input: "sampledInput",
+        mouse_move: "mouseMove",
+        mouse_wheel: "mouseWheel",
+        mouse_button: "mouseButton",
+        subscriptions: "subscriptions",
+        physics: "physics",
+        sound_scape: "soundScape",
+        ui: "ui",
+        webview: "webview",
+    };
+
+    /// The name-mapping rule: `prefix` + the Capitalized canonical base, as
+    /// camelCase (`"server"` → `serverInit`, `serverSampledInput`, …). An
+    /// empty prefix resolves to the unprefixed names.
+    pub fn with_prefix(prefix: &str) -> EntryNames {
+        if prefix.is_empty() {
+            return EntryNames::UNPREFIXED;
+        }
+        let n = |base: &'static str| {
+            let mut name = String::with_capacity(prefix.len() + base.len());
+            name.push_str(prefix);
+            let mut chars = base.chars();
+            if let Some(first) = chars.next() {
+                name.extend(first.to_uppercase());
+                name.push_str(chars.as_str());
+            }
+            intern(name)
+        };
+        let u = EntryNames::UNPREFIXED;
+        EntryNames {
+            init: n(u.init),
+            tick: n(u.tick),
+            draw: n(u.draw),
+            update: n(u.update),
+            input: n(u.input),
+            sampled_input: n(u.sampled_input),
+            mouse_move: n(u.mouse_move),
+            mouse_wheel: n(u.mouse_wheel),
+            mouse_button: n(u.mouse_button),
+            subscriptions: n(u.subscriptions),
+            physics: n(u.physics),
+            sound_scape: n(u.sound_scape),
+            ui: n(u.ui),
+            webview: n(u.webview),
+        }
+    }
+}
+
+/// A load-time-validated game contract: the role's `init` value plus which
+/// optional entry points the program defines. One shared implementation for
+/// the desktop and embedded producers' load paths AND the CLI's `build`
+/// gate, so the rules — and their teaching errors, which name the role's
+/// RESOLVED bindings (`serverTick`, never `tick`) — cannot drift.
+pub struct GameContract {
+    pub init: Value,
+    pub has_input: bool,
+    pub has_sampled_input: bool,
+    pub has_mouse_move: bool,
+    pub has_mouse_wheel: bool,
+    pub has_mouse_button: bool,
+    pub has_subscriptions: bool,
+    pub has_physics: bool,
+    pub has_soundscape: bool,
+    pub has_ui: bool,
+    pub has_webview: bool,
+}
+
+/// Contract-validate a loaded session against a role's entry names. The
+/// producer contract is knowable at load — fail here, not once per frame:
+/// `init` must be a model VALUE, `tick`/`draw` functions of the right arity,
+/// and each OPTIONAL entry point, when present, must honor its shape.
+pub fn validate_contract(
+    path: &str,
+    session: &Session,
+    names: &EntryNames,
+) -> Result<GameContract, String> {
+    let init = session
+        .global(names.init)
+        .ok_or_else(|| format!("{path} has no top-level `let {} = …`", names.init))?;
+    if matches!(
+        init,
+        Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
+    ) {
+        return Err(format!(
+            "{path}: `{}` must be a model value, not a function",
+            names.init
+        ));
+    }
+    if contains_effect(&init) {
+        return Err(format!(
+            "{path}: `{}` contains an Effect value — Effects are commands, not data; \
+return them beside the model as `(model, effect)`",
+            names.init
+        ));
+    }
+    require_function(path, session, names.tick, 3)?;
+    require_function(path, session, names.draw, 2)?;
+    // `input` is optional (many games are non-interactive), but when
+    // present it must honor the contract: (model, key, isDown) => model.
+    let has_input = session.global(names.input).is_some();
+    if has_input {
+        require_function(path, session, names.input, 3)?;
+    }
+    let has_sampled_input = session.global(names.sampled_input).is_some();
+    if has_sampled_input {
+        require_function(path, session, names.sampled_input, 2)?;
+    }
+    // Same deal for the mouse: `mouseMove(model, x, y)` in logical shell coordinates,
+    // `mouseWheel(model, delta)`.
+    let has_mouse_move = session.global(names.mouse_move).is_some();
+    if has_mouse_move {
+        require_function(path, session, names.mouse_move, 3)?;
+    }
+    let has_mouse_wheel = session.global(names.mouse_wheel).is_some();
+    if has_mouse_wheel {
+        require_function(path, session, names.mouse_wheel, 2)?;
+    }
+    // `mouseButton(model, button, isDown)` — the `input` twin for the pointer.
+    let has_mouse_button = session.global(names.mouse_button).is_some();
+    if has_mouse_button {
+        require_function(path, session, names.mouse_button, 3)?;
+    }
+    // The MVU pair: `subscriptions(model)` declares timers whose fired
+    // messages fold through `update(model, msg)` — so subscriptions
+    // without an update have nowhere to deliver.
+    let has_subscriptions = session.global(names.subscriptions).is_some();
+    if has_subscriptions {
+        require_function(path, session, names.subscriptions, 1)?;
+        if session.global(names.update).is_none() {
+            return Err(format!(
+                "{path}: `{}` produces messages but there is no \
+`let {} = (model, msg) => …` to receive them",
+                names.subscriptions, names.update
+            ));
+        }
+    }
+    if session.global(names.update).is_some() {
+        require_function(path, session, names.update, 2)?;
+    }
+    // Optional physics: `physics(model) => Physics.scene(…)` declares the
+    // bodies that should exist; the host reconciles + fixed-steps the
+    // world after each tick (docs/physics.md).
+    let has_physics = session.global(names.physics).is_some();
+    if has_physics {
+        require_function(path, session, names.physics, 1)?;
+    }
+    // Optional soundscape: `soundScape(model)` returns an AudioScene (the
+    // continuous, reconciled half of audio). No `update` requirement — the
+    // scene is reconciled by the shell, not folded back as a message.
+    let has_soundscape = session.global(names.sound_scape).is_some();
+    if has_soundscape {
+        require_function(path, session, names.sound_scape, 1)?;
+    }
+    // Optional HUD: `ui(model)` returns a View (Ui.text / Ui.column /
+    // Ui.panel), lowered to the shared text overlay.
+    let has_ui = session.global(names.ui).is_some();
+    if has_ui {
+        require_function(path, session, names.ui, 1)?;
+    }
+    // Optional webview: `webview(model)` returns an Html node (Html.div /
+    // Html.text / …), rendered by shells that have an HTML overlay.
+    let has_webview = session.global(names.webview).is_some();
+    if has_webview {
+        require_function(path, session, names.webview, 1)?;
+    }
+    Ok(GameContract {
+        init,
+        has_input,
+        has_sampled_input,
+        has_mouse_move,
+        has_mouse_wheel,
+        has_mouse_button,
+        has_subscriptions,
+        has_physics,
+        has_soundscape,
+        has_ui,
+        has_webview,
+    })
+}
+
+/// `name` must be a function of `arity` params — a contract violation is
+/// reportable at load, and the alternative is one error per frame, forever.
+fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> Result<(), String> {
+    match session.global(name) {
+        Some(Value::Closure(closure)) if closure.params.len() == arity => Ok(()),
+        Some(Value::Closure(closure)) => Err(format!(
+            "{path}: `{name}` must take {arity} parameter(s), takes {}",
+            closure.params.len()
+        )),
+        Some(other) => Err(format!(
+            "{path}: `{name}` must be a function, got {}",
+            other.kind_name()
+        )),
+        None => Err(format!("{path} has no top-level `let {name} = …`")),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // The paused-inspector replay journal (visual-debugger PR2).
 //
 // During normal play the producer records nothing and renders no Display text —
@@ -324,6 +577,9 @@ impl Reporter {
 /// needs to run frame work, and dropped at the end of the call.
 pub struct FrameCtx<'a> {
     pub session: &'a Session,
+    /// The role's resolved entry-point names (same-file entries) — every
+    /// canonical lookup and error message in the frame body goes through it.
+    pub names: &'a EntryNames,
     pub model: &'a mut Value,
     pub physics_rt: &'a mut SteppedPhysics,
     /// The physics world's current fixed frame (what the coupled scene
@@ -426,10 +682,10 @@ impl FrameCtx<'_> {
             Value::Number(frame_time.dts as f64),
             Value::Number(frame_time.tts as f64),
         ];
-        journal_push("tick", &args, Provenance::Tick);
-        match self.session.call("tick", args, &mut FunctorHost) {
+        journal_push(self.names.tick, &args, Provenance::Tick);
+        match self.session.call(self.names.tick, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("tick", &err),
+            Err(err) => self.reporter.frame_error(self.names.tick, &err),
         }
     }
 
@@ -472,10 +728,11 @@ impl FrameCtx<'_> {
         // CURRENT model's subscriptions — post-step, alongside query answers.
         let events = std::mem::take(self.pending_events);
         if !events.is_empty() && self.has_subscriptions {
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
+            match self.session.call(
+                self.names.subscriptions,
+                vec![self.model.clone()],
+                &mut FunctorHost,
+            ) {
                 Ok(subs) => match physics_event_taggers(&subs) {
                     Ok(taggers) if !taggers.is_empty() => {
                         let mut reports: Vec<String> = Vec::new();
@@ -498,7 +755,7 @@ impl FrameCtx<'_> {
                         .reporter
                         .report_once(format!("[functor-lang] {message}")),
                 },
-                Err(err) => self.reporter.frame_error("subscriptions", &err),
+                Err(err) => self.reporter.frame_error(self.names.subscriptions, &err),
             }
         }
     }
@@ -611,14 +868,14 @@ impl FrameCtx<'_> {
                     let ui_handlers = events
                         .iter()
                         .any(|e| matches!(e, RecordedInput::UiEvent(_)))
-                        .then(|| self.eval_handler_table("ui"))
+                        .then(|| self.eval_handler_table(self.names.ui))
                         .unwrap_or_default();
                     // Webview events carry their OWN table: same step-top
                     // rebuild, from `webview(model)` instead of `ui(model)`.
                     let webview_handlers = events
                         .iter()
                         .any(|e| matches!(e, RecordedInput::WebviewEvent(_)))
-                        .then(|| self.eval_handler_table("webview"))
+                        .then(|| self.eval_handler_table(self.names.webview))
                         .unwrap_or_default();
                     for event in events {
                         match event {
@@ -731,12 +988,12 @@ impl FrameCtx<'_> {
                     return; // unrecognized code / Key::Unknown — dropped, like live.
                 };
                 (
-                    "input",
+                    self.names.input,
                     vec![self.model.clone(), key_value, Value::Bool(is_down)],
                 )
             }
             RecordedInput::MouseMove { x, y } => (
-                "mouseMove",
+                self.names.mouse_move,
                 vec![
                     self.model.clone(),
                     Value::Number(x as f64),
@@ -744,7 +1001,7 @@ impl FrameCtx<'_> {
                 ],
             ),
             RecordedInput::MouseWheel { delta } => (
-                "mouseWheel",
+                self.names.mouse_wheel,
                 vec![self.model.clone(), Value::Number(delta as f64)],
             ),
             RecordedInput::MouseButton { button, is_down } => {
@@ -752,7 +1009,7 @@ impl FrameCtx<'_> {
                     return; // unrecognized code / Unknown — dropped, like live.
                 };
                 (
-                    "mouseButton",
+                    self.names.mouse_button,
                     vec![self.model.clone(), button_value, Value::Bool(is_down)],
                 )
             }
@@ -783,14 +1040,17 @@ impl FrameCtx<'_> {
     /// snapshot beside edge events; dry-run replay calls the same body with
     /// `record = false`.
     pub fn deliver_sampled_input(&mut self, snapshot: &crate::InputSnapshot, record: bool) {
-        if self.session.global("sampledInput").is_none() {
+        if self.session.global(self.names.sampled_input).is_none() {
             return;
         }
         let args = vec![self.model.clone(), crate::input_snapshot_value(snapshot)];
-        journal_push("sampledInput", &args, Provenance::SampledInput);
-        match self.session.call("sampledInput", args, &mut FunctorHost) {
+        journal_push(self.names.sampled_input, &args, Provenance::SampledInput);
+        match self
+            .session
+            .call(self.names.sampled_input, args, &mut FunctorHost)
+        {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("sampledInput", &err),
+            Err(err) => self.reporter.frame_error(self.names.sampled_input, &err),
         }
         if record {
             self.input_buf
@@ -817,12 +1077,12 @@ not data; return them beside the model as `(model, effect)` instead of storing t
         let Some(effects) = effects else { return };
         // Only MESSAGE-producing effects need an `update` to receive them —
         // tagger-less physics commands must not be dropped over a missing hook.
-        if needs_update(&effects) && self.session.global("update").is_none() {
-            self.reporter.report_once(
-                "[functor-lang] effects returned but there is no `let update = (model, msg) => …` \
-to receive their messages; dropping them"
-                    .to_string(),
-            );
+        if needs_update(&effects) && self.session.global(self.names.update).is_none() {
+            self.reporter.report_once(format!(
+                "[functor-lang] effects returned but there is no `let {} = (model, msg) => …` \
+to receive their messages; dropping them",
+                self.names.update
+            ));
             return;
         }
         let mut reports: Vec<String> = Vec::new();
@@ -860,14 +1120,14 @@ to receive their messages; dropping them"
             }
             return;
         }
-        let subs =
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => subs,
-                Err(err) => return self.reporter.frame_error("subscriptions", &err),
-            };
+        let subs = match self.session.call(
+            self.names.subscriptions,
+            vec![self.model.clone()],
+            &mut FunctorHost,
+        ) {
+            Ok(subs) => subs,
+            Err(err) => return self.reporter.frame_error(self.names.subscriptions, &err),
+        };
         // Reconcile connections EVERY frame — including frame one (before the
         // timer window exists), so a declared connection opens immediately.
         self.reconcile_connections(&subs);
@@ -887,10 +1147,10 @@ to receive their messages; dropping them"
         };
         for msg in msgs {
             let args = vec![self.model.clone(), msg];
-            journal_push("update", &args, Provenance::Subscription);
-            match self.session.call("update", args, &mut FunctorHost) {
+            journal_push(self.names.update, &args, Provenance::Subscription);
+            match self.session.call(self.names.update, args, &mut FunctorHost) {
                 Ok(returned) => self.absorb(returned),
-                Err(err) => self.reporter.frame_error("update", &err),
+                Err(err) => self.reporter.frame_error(self.names.update, &err),
             }
         }
     }
@@ -935,10 +1195,10 @@ to receive their messages; dropping them"
             };
             any_delivered = true;
             let args = vec![self.model.clone(), msg];
-            journal_push("update", &args, Provenance::Subscription);
-            match self.session.call("update", args, &mut FunctorHost) {
+            journal_push(self.names.update, &args, Provenance::Subscription);
+            match self.session.call(self.names.update, args, &mut FunctorHost) {
                 Ok(returned) => self.absorb(returned),
-                Err(err) => self.reporter.frame_error("update", &err),
+                Err(err) => self.reporter.frame_error(self.names.update, &err),
             }
         }
         // Only mark delivered when a tagger actually received it — an
@@ -961,7 +1221,10 @@ to receive their messages; dropping them"
             return 0;
         }
         let args = vec![self.model.clone()];
-        match self.session.call("physics", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.physics, args, &mut FunctorHost)
+        {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
                     // The recorded drive (Phase 6): every fixed frame goes
@@ -985,7 +1248,7 @@ to receive their messages; dropping them"
                     value.kind_name()
                 )),
             },
-            Err(err) => self.reporter.frame_error("physics", &err),
+            Err(err) => self.reporter.frame_error(self.names.physics, &err),
         }
         0
     }
@@ -1055,14 +1318,14 @@ to receive their messages; dropping them"
         if !self.has_subscriptions {
             return;
         }
-        let subs =
-            match self
-                .session
-                .call("subscriptions", vec![self.model.clone()], &mut FunctorHost)
-            {
-                Ok(subs) => subs,
-                Err(err) => return self.reporter.frame_error("subscriptions", &err),
-            };
+        let subs = match self.session.call(
+            self.names.subscriptions,
+            vec![self.model.clone()],
+            &mut FunctorHost,
+        ) {
+            Ok(subs) => subs,
+            Err(err) => return self.reporter.frame_error(self.names.subscriptions, &err),
+        };
         let conns = match net_conn_subs(&subs) {
             Ok(conns) => conns,
             Err(message) => {
@@ -1085,10 +1348,10 @@ to receive their messages; dropping them"
             Err(err) => return self.reporter.frame_error("net event", &err),
         };
         let args = vec![self.model.clone(), msg];
-        journal_push("update", &args, Provenance::NetEvent);
-        match self.session.call("update", args, &mut FunctorHost) {
+        journal_push(self.names.update, &args, Provenance::NetEvent);
+        match self.session.call(self.names.update, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("update", &err),
+            Err(err) => self.reporter.frame_error(self.names.update, &err),
         }
     }
 
@@ -1109,10 +1372,10 @@ to receive their messages; dropping them"
             Err(err) => return self.reporter.frame_error("http response", &err),
         };
         let args = vec![self.model.clone(), msg];
-        journal_push("update", &args, Provenance::HttpResponse);
-        match self.session.call("update", args, &mut FunctorHost) {
+        journal_push(self.names.update, &args, Provenance::HttpResponse);
+        match self.session.call(self.names.update, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("update", &err),
+            Err(err) => self.reporter.frame_error(self.names.update, &err),
         }
     }
 
@@ -1128,12 +1391,12 @@ to receive their messages; dropping them"
         // Check the receiver exists before doing any work (the `absorb` rule)
         // — a game with widgets but no `update` gets the teaching error, not
         // a wasted tagger application.
-        if self.session.global("update").is_none() {
-            return self.reporter.report_once(
+        if self.session.global(self.names.update).is_none() {
+            return self.reporter.report_once(format!(
                 "[functor-lang] a ui widget produced a message but there is no \
-`let update = (model, msg) => …` to receive it; dropping it"
-                    .to_string(),
-            );
+`let {} = (model, msg) => …` to receive it; dropping it",
+                self.names.update
+            ));
         }
         let Some(handler) = handlers.get(event.slot as usize) else {
             return self.reporter.report_once(format!(
@@ -1175,10 +1438,10 @@ carries no payload to tag; dropped",
             }
         };
         let args = vec![self.model.clone(), msg];
-        journal_push("update", &args, Provenance::UiEvent);
-        match self.session.call("update", args, &mut FunctorHost) {
+        journal_push(self.names.update, &args, Provenance::UiEvent);
+        match self.session.call(self.names.update, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("update", &err),
+            Err(err) => self.reporter.frame_error(self.names.update, &err),
         }
     }
 
@@ -1192,10 +1455,10 @@ carries no payload to tag; dropped",
             return;
         };
         let args = vec![self.model.clone(), message];
-        journal_push("update", &args, Provenance::AudioFinished);
-        match self.session.call("update", args, &mut FunctorHost) {
+        journal_push(self.names.update, &args, Provenance::AudioFinished);
+        match self.session.call(self.names.update, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("update", &err),
+            Err(err) => self.reporter.frame_error(self.names.update, &err),
         }
     }
 
@@ -1208,10 +1471,10 @@ carries no payload to tag; dropped",
             return;
         };
         let args = vec![self.model.clone(), message];
-        journal_push("update", &args, Provenance::PreloadSettled);
-        match self.session.call("update", args, &mut FunctorHost) {
+        journal_push(self.names.update, &args, Provenance::PreloadSettled);
+        match self.session.call(self.names.update, args, &mut FunctorHost) {
             Ok(returned) => self.absorb(returned),
-            Err(err) => self.reporter.frame_error("update", &err),
+            Err(err) => self.reporter.frame_error(self.names.update, &err),
         }
     }
 }
@@ -1291,6 +1554,7 @@ impl Drop for DryWorld {
 #[allow(clippy::too_many_arguments)]
 fn forward_step_scene_with_error(
     session: &Session,
+    names: &EntryNames,
     model: &Value,
     has_physics: bool,
     has_subscriptions: bool,
@@ -1368,6 +1632,7 @@ fn forward_step_scene_with_error(
         let mut clock = clock;
         let mut ctx = FrameCtx {
             session,
+            names,
             model: &mut model,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
@@ -1409,6 +1674,7 @@ fn forward_step_scene_with_error(
 #[allow(clippy::too_many_arguments)]
 pub fn forward_step_scene(
     session: &Session,
+    names: &EntryNames,
     model: &Value,
     has_physics: bool,
     has_subscriptions: bool,
@@ -1421,6 +1687,7 @@ pub fn forward_step_scene(
 ) -> Vec<(Value, Option<physics::PhysicsSnapshot>)> {
     forward_step_scene_with_error(
         session,
+        names,
         model,
         has_physics,
         has_subscriptions,
@@ -1451,19 +1718,20 @@ pub fn forward_step_scene(
 /// yet capture. Physics games likewise need historical world replay.
 pub fn materialize_counterfactual_history(
     session: &Session,
+    names: &EntryNames,
     model: &mut Value,
     recorder: &mut SceneRecorder,
     has_physics: bool,
     has_subscriptions: bool,
     preserve_selected_model: bool,
 ) -> Result<Option<usize>, String> {
-    if has_physics || session.global("update").is_some() {
+    if has_physics || session.global(names.update).is_some() {
         return Ok(None);
     }
     let Some((lo, _, hi)) = recorder.counterfactual_replay_span()? else {
         return Ok(None);
     };
-    let Some(init) = session.global("init") else {
+    let Some(init) = session.global(names.init) else {
         return Ok(None);
     };
     let recorded_frames = hi as usize + 1;
@@ -1471,6 +1739,7 @@ pub fn materialize_counterfactual_history(
     let steps = prefix_len + recorded_frames;
     let (stepped, replay_error) = forward_step_scene_with_error(
         session,
+        names,
         &init,
         false,
         has_subscriptions,
@@ -1531,6 +1800,7 @@ pub fn materialize_counterfactual_history(
 #[allow(clippy::too_many_arguments)]
 pub fn ghost_frames(
     session: &Session,
+    names: &EntryNames,
     model: &Value,
     recorder: &SceneRecorder,
     has_physics: bool,
@@ -1568,6 +1838,7 @@ pub fn ghost_frames(
         .and_then(|frame| recorder.sampled_input_at_or_before(frame));
     let stepped = forward_step_scene_with_error(
         session,
+        names,
         model,
         has_physics,
         has_subscriptions,
@@ -1613,7 +1884,7 @@ pub fn ghost_frames(
         let tts = start_tts as f32 + (i as f32 + 1.0) * steps_per_division as f32 * sub_dt;
         let args = vec![model_i.clone(), Value::Number(tts as f64)];
         // A draw error or non-Frame return for a division is skipped, not fatal.
-        if let Ok(value) = session.call("draw", args, &mut FunctorHost) {
+        if let Ok(value) = session.call(names.draw, args, &mut FunctorHost) {
             if let Some(frame) = frame_value(&value) {
                 frames.push((frame.clone(), FrameTime { dts: 0.0, tts }));
             }
@@ -1659,6 +1930,30 @@ mod tests {
     }
 
     #[test]
+    fn entry_names_resolve_the_prefix_as_camel_case() {
+        let names = EntryNames::with_prefix("server");
+        assert_eq!(names.init, "serverInit");
+        assert_eq!(names.tick, "serverTick");
+        assert_eq!(names.draw, "serverDraw");
+        assert_eq!(names.update, "serverUpdate");
+        assert_eq!(names.input, "serverInput");
+        assert_eq!(names.sampled_input, "serverSampledInput");
+        assert_eq!(names.mouse_move, "serverMouseMove");
+        assert_eq!(names.mouse_wheel, "serverMouseWheel");
+        assert_eq!(names.mouse_button, "serverMouseButton");
+        assert_eq!(names.subscriptions, "serverSubscriptions");
+        assert_eq!(names.physics, "serverPhysics");
+        assert_eq!(names.sound_scape, "serverSoundScape");
+        assert_eq!(names.ui, "serverUi");
+        assert_eq!(names.webview, "serverWebview");
+        // Empty/absent prefix = the classic unprefixed contract.
+        assert_eq!(EntryNames::with_prefix(""), EntryNames::UNPREFIXED);
+        // Interned: rebuilding the same prefix (every hot reload) reuses the
+        // same leaked names instead of growing the table.
+        assert!(std::ptr::eq(EntryNames::with_prefix("server").tick, names.tick));
+    }
+
+    #[test]
     fn failed_counterfactual_replay_keeps_the_old_history_atomically() {
         let src = "\
             let init = 0.0\n\
@@ -1684,6 +1979,7 @@ mod tests {
         let error =
             materialize_counterfactual_history(
                 &session,
+                &EntryNames::UNPREFIXED,
                 &mut model,
                 &mut recorder,
                 false,
@@ -1733,6 +2029,7 @@ mod tests {
         recorder.finish_reload(&model, physics_frame, true);
         materialize_counterfactual_history(
             &session,
+            &EntryNames::UNPREFIXED,
             &mut model,
             &mut recorder,
             false,
@@ -1797,6 +2094,7 @@ mod tests {
         assert_eq!(
             materialize_counterfactual_history(
                 &session,
+                &EntryNames::UNPREFIXED,
                 &mut model,
                 &mut recorder,
                 false,
@@ -1838,6 +2136,7 @@ mod tests {
         };
         let stepped = forward_step_scene(
             &session,
+            &EntryNames::UNPREFIXED,
             &Value::Number(0.0),
             false,
             false,
@@ -1866,6 +2165,7 @@ mod tests {
         };
         let (from_live_tail, error) = forward_step_scene_with_error(
             &session,
+            &EntryNames::UNPREFIXED,
             &Value::Number(0.0),
             false,
             false,
@@ -1968,6 +2268,7 @@ mod tests {
 
         let stepped = forward_step_scene(
             &session,
+            &EntryNames::UNPREFIXED,
             &Value::Number(0.0),
             false,
             false,
@@ -2017,6 +2318,7 @@ mod tests {
         );
         let mut ctx = FrameCtx {
             session,
+            names: &EntryNames::UNPREFIXED,
             model,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
@@ -2182,6 +2484,7 @@ mod tests {
         );
         let mut ctx = FrameCtx {
             session,
+            names: &EntryNames::UNPREFIXED,
             model,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
@@ -2242,6 +2545,7 @@ mod tests {
         );
         let mut ctx = FrameCtx {
             session,
+            names: &EntryNames::UNPREFIXED,
             model,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
@@ -2390,6 +2694,7 @@ mod tests {
         // the freshly-armed journal is still empty (ghost calls excluded).
         let _ = forward_step_scene(
             &session,
+            &EntryNames::UNPREFIXED,
             &m,
             false, // has_physics
             true,  // has_subscriptions

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -712,6 +712,7 @@ impl FrameCtx<'_> {
             let mut reports: Vec<String> = Vec::new();
             perform_deferred_queries(
                 self.session,
+                self.names.update,
                 self.model,
                 deferred,
                 self.effect_runner,
@@ -738,6 +739,7 @@ impl FrameCtx<'_> {
                         let mut reports: Vec<String> = Vec::new();
                         deliver_physics_events(
                             self.session,
+                            self.names.update,
                             self.model,
                             &taggers,
                             &events,
@@ -1088,6 +1090,7 @@ to receive their messages; dropping them",
         let mut reports: Vec<String> = Vec::new();
         let deferred = drain_effects(
             self.session,
+            self.names.update,
             self.model,
             effects,
             self.effect_runner,

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -2213,6 +2213,7 @@ mod tests {
 
         let stepped = forward_step_scene(
             &session,
+            &EntryNames::UNPREFIXED,
             &Value::Number(0.0),
             false,
             false,

--- a/runtime/functor-runtime-common/src/inspector.rs
+++ b/runtime/functor-runtime-common/src/inspector.rs
@@ -91,7 +91,8 @@ fn sources_json(sources: &[InspectorSource]) -> Vec<serde_json::Value> {
 
 /// Replay the last real frame's journal into the wire-contract `invocations`,
 /// plus one synthesized `draw` invocation against the frozen model when the
-/// caller supplies its args (draw is pure and never journaled during play —
+/// caller supplies the role's draw name and its args (draw is pure and never
+/// journaled during play —
 /// replaying it once at trace-build time is exact and free). Each call is
 /// re-run through `Session::call_recorded` — entry points are pure functions
 /// of their args, so the record is exact, and effects are plain data (nothing
@@ -99,7 +100,7 @@ fn sources_json(sources: &[InspectorSource]) -> Vec<serde_json::Value> {
 /// within its entry name; binding spans map to `(file, local offsets)`.
 fn build_invocations(
     journal: &[JournalEntry],
-    draw_args: Option<&[Value]>,
+    draw: Option<(&str, &[Value])>,
     sources: &[InspectorSource],
     session: &Session,
 ) -> (Vec<serde_json::Value>, Vec<usize>) {
@@ -125,9 +126,11 @@ fn build_invocations(
             replayed.push((e.entry, Provenance::render(&e.provenance, &e.args), inv));
         }
     }
-    if let Some(args) = draw_args {
-        if let Ok((_discard, inv)) = session.call_recorded("draw", args.to_vec(), &mut FunctorHost) {
-            replayed.push(("draw", Provenance::Draw.render(args), inv));
+    if let Some((draw_name, args)) = draw {
+        if let Ok((_discard, inv)) =
+            session.call_recorded(draw_name, args.to_vec(), &mut FunctorHost)
+        {
+            replayed.push((draw_name, Provenance::Draw.render(args), inv));
         }
     }
     let _replay_pushed = crate::functor_lang_prelude::take_ui_handlers();
@@ -223,11 +226,11 @@ pub fn build_trace_doc(
     tts: f64,
     sources: &[InspectorSource],
     journal: &[JournalEntry],
-    draw_args: Option<&[Value]>,
+    draw: Option<(&str, &[Value])>,
     session: &Session,
 ) -> String {
     build_trace_doc_with_coverage(
-        paused, frame, tts, sources, journal, draw_args, &[], &[], session,
+        paused, frame, tts, sources, journal, draw, &[], &[], session,
     )
 }
 
@@ -254,7 +257,7 @@ pub fn build_trace_doc_with_coverage(
     tts: f64,
     sources: &[InspectorSource],
     journal: &[JournalEntry],
-    draw_args: Option<&[Value]>,
+    draw: Option<(&str, &[Value])>,
     ring: &[(u64, Vec<JournalEntry>)],
     runnable: &[usize],
     session: &Session,
@@ -267,7 +270,7 @@ pub fn build_trace_doc_with_coverage(
         })
         .to_string();
     }
-    let (invocations, paused_coverage) = build_invocations(journal, draw_args, sources, session);
+    let (invocations, paused_coverage) = build_invocations(journal, draw, sources, session);
     serde_json::json!({
         "frame": frame,
         "tts": tts,
@@ -676,7 +679,7 @@ mod tests {
             1.5,
             &sources,
             &[],
-            Some(&draw_args),
+            Some(("draw", &draw_args)),
             &session,
         ))
         .unwrap();
@@ -701,7 +704,7 @@ mod tests {
             0.5,
             &sources2,
             &[],
-            Some(&args2),
+            Some(("draw", &args2)),
             &session2,
         ))
         .unwrap();

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -40,8 +40,8 @@ use functor_runtime_common::functor_lang_prelude::{
     EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
-    journal_arm, journal_push, journal_swap, FrameCtx, JournalEntry, Provenance, Reporter,
-    SpanSource,
+    journal_arm, journal_push, journal_swap, validate_contract, EntryNames, FrameCtx,
+    JournalEntry, Provenance, Reporter, SpanSource,
 };
 use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use functor_runtime_common::physics;
@@ -62,6 +62,10 @@ fn replay_status(history_replay: Option<(usize, f64)>) -> String {
 
 pub struct FunctorLangGame {
     path: String,
+    /// The role's resolved entry-point names (same-file entries): built once
+    /// from the role's prefix at create time and reused by every reload —
+    /// every canonical lookup and contract error goes through it.
+    names: EntryNames,
     /// Per-file mtimes of the WHOLE project (every sibling `.fun` — B8:
     /// file = module), so editing a non-entry module hot-reloads too; a
     /// file appearing or disappearing changes the stamp as well.
@@ -256,18 +260,18 @@ struct Loaded {
 /// every sibling `.fun` file — file = module). Errors come back as fully
 /// rendered strings (`path:line:col: message`) so `create` can exit loud with
 /// them and hot-reload can print-and-keep-running with the same text.
-fn load_game(path: &str) -> Result<Loaded, String> {
-    load_project(path, None)
+fn load_game(path: &str, names: &EntryNames) -> Result<Loaded, String> {
+    load_project(path, None, names)
 }
 
 /// The source-shaped half of [`load_game`]: the pushed source stands in for
 /// the ENTRY file (the network reload path, `reload_source`); sibling
 /// modules still load from disk.
-fn load_source(path: &str, src: String) -> Result<Loaded, String> {
-    load_project(path, Some(src))
+fn load_source(path: &str, src: String, names: &EntryNames) -> Result<Loaded, String> {
+    load_project(path, Some(src), names)
 }
 
-fn load_project(path: &str, entry_src: Option<String>) -> Result<Loaded, String> {
+fn load_project(path: &str, entry_src: Option<String>, names: &EntryNames) -> Result<Loaded, String> {
     let entry = std::path::Path::new(path);
     // A pushed buffer (network reload) stands in for the entry file; siblings
     // still load from disk.
@@ -282,13 +286,13 @@ fn load_project(path: &str, entry_src: Option<String>) -> Result<Loaded, String>
         &functor_prelude::bundled_modules(),
     )
     .map_err(|e| format!("cannot load {}", e.render()))?;
-    finish_load(path, project)
+    finish_load(path, project, names)
 }
 
 /// Load an exact in-memory project: entry first, then sibling modules. This
 /// is the desktop counterpart of the embedded/Quest producer's whole-project
 /// push and deliberately performs no filesystem reads.
-fn load_sources(files: &[(String, String)]) -> Result<Loaded, String> {
+fn load_sources(files: &[(String, String)], names: &EntryNames) -> Result<Loaded, String> {
     let path = files
         .first()
         .map(|(path, _)| path.as_str())
@@ -302,7 +306,7 @@ fn load_sources(files: &[(String, String)]) -> Result<Loaded, String> {
         &functor_prelude::bundled_modules(),
     )
     .map_err(|e| format!("cannot load {}", e.render()))?;
-    finish_load(path, project)
+    finish_load(path, project, names)
 }
 
 /// The project's OWN files out of a linked source map: bundled prelude and
@@ -327,7 +331,11 @@ fn project_sources_of(sources: &SourceMap) -> Vec<(String, String)> {
 
 /// Contract-check the already linked project. Both disk-backed and pushed
 /// projects pass through this one validation path.
-fn finish_load(path: &str, project: functor_lang::project::Project) -> Result<Loaded, String> {
+fn finish_load(
+    path: &str,
+    project: functor_lang::project::Project,
+    names: &EntryNames,
+) -> Result<Loaded, String> {
     // Type diagnostics are advisory in the dev loop: print, keep going.
     for diag in project.check() {
         eprintln!(
@@ -343,110 +351,26 @@ fn finish_load(path: &str, project: functor_lang::project::Project) -> Result<Lo
             sources.render(f.error.span.start, &f.error.message)
         )
     })?;
-    // The producer contract is knowable at load — fail here, not once per
-    // frame: `init` must be a model VALUE, `tick`/`draw` functions of the
-    // right arity.
-    let init = session
-        .global("init")
-        .ok_or_else(|| format!("{path} has no top-level `let init = …`"))?;
-    if matches!(
-        init,
-        Value::Closure(_) | Value::Builtin(_) | Value::HostFn(_)
-    ) {
-        return Err(format!(
-            "{path}: `init` must be a model value, not a function"
-        ));
-    }
-    if functor_runtime_common::functor_lang_prelude::contains_effect(&init) {
-        return Err(format!(
-            "{path}: `init` contains an Effect value — Effects are commands, not data; \
-return them beside the model as `(model, effect)`"
-        ));
-    }
-    require_function(path, &session, "tick", 3)?;
-    require_function(path, &session, "draw", 2)?;
-    // `input` is optional (many games are non-interactive), but when present
-    // it must honor the contract: (model, key, isDown) => model.
-    let has_input = session.global("input").is_some();
-    if has_input {
-        require_function(path, &session, "input", 3)?;
-    }
-    let has_sampled_input = session.global("sampledInput").is_some();
-    if has_sampled_input {
-        require_function(path, &session, "sampledInput", 2)?;
-    }
-    // Same deal for the mouse: `mouseMove(model, x, y)` in logical window points,
-    // `mouseWheel(model, delta)`.
-    let has_mouse_move = session.global("mouseMove").is_some();
-    if has_mouse_move {
-        require_function(path, &session, "mouseMove", 3)?;
-    }
-    let has_mouse_wheel = session.global("mouseWheel").is_some();
-    if has_mouse_wheel {
-        require_function(path, &session, "mouseWheel", 2)?;
-    }
-    // `mouseButton(model, button, isDown)` — the `input` twin for the pointer.
-    let has_mouse_button = session.global("mouseButton").is_some();
-    if has_mouse_button {
-        require_function(path, &session, "mouseButton", 3)?;
-    }
-    // The MVU pair: `subscriptions(model)` declares timers whose fired
-    // messages fold through `update(model, msg)` — so subscriptions without
-    // an update have nowhere to deliver.
-    let has_subscriptions = session.global("subscriptions").is_some();
-    if has_subscriptions {
-        require_function(path, &session, "subscriptions", 1)?;
-        if session.global("update").is_none() {
-            return Err(format!(
-                "{path}: `subscriptions` produces messages but there is no \
-`let update = (model, msg) => …` to receive them"
-            ));
-        }
-    }
-    if session.global("update").is_some() {
-        require_function(path, &session, "update", 2)?;
-    }
-    // Optional physics: `physics(model) => Physics.scene(…)` declares the
-    // bodies that should exist; the host reconciles + fixed-steps the world
-    // after each tick (docs/physics.md).
-    let has_physics = session.global("physics").is_some();
-    if has_physics {
-        require_function(path, &session, "physics", 1)?;
-    }
-    // Optional soundscape: `soundScape(model)` returns an AudioScene (the
-    // continuous, reconciled half of audio). No `update` requirement — the
-    // scene is reconciled by the shell, not folded back as a message.
-    let has_soundscape = session.global("soundScape").is_some();
-    if has_soundscape {
-        require_function(path, &session, "soundScape", 1)?;
-    }
-    // Optional HUD: `ui(model)` returns a View (Ui.text / Ui.column /
-    // Ui.panel), lowered to the shared text overlay — the F# `ui` hook.
-    let has_ui = session.global("ui").is_some();
-    if has_ui {
-        require_function(path, &session, "ui", 1)?;
-    }
-    // Optional webview: `webview(model)` returns an Html node (Html.div /
-    // Html.text / …), rendered as an HTML/CSS overlay above the frame.
-    let has_webview = session.global("webview").is_some();
-    if has_webview {
-        require_function(path, &session, "webview", 1)?;
-    }
+    // The producer contract (init a value, tick/draw functions of the right
+    // arity, optional hooks well-shaped) is shared with the embedded producer
+    // and the CLI's build gate — errors name the ROLE'S resolved bindings
+    // (`serverTick`, not `tick`) via `names`.
+    let contract = validate_contract(path, &session, names)?;
     Ok(Loaded {
         sources,
         module,
         session,
-        init,
-        has_input,
-        has_sampled_input,
-        has_mouse_move,
-        has_mouse_wheel,
-        has_mouse_button,
-        has_subscriptions,
-        has_physics,
-        has_soundscape,
-        has_ui,
-        has_webview,
+        init: contract.init,
+        has_input: contract.has_input,
+        has_sampled_input: contract.has_sampled_input,
+        has_mouse_move: contract.has_mouse_move,
+        has_mouse_wheel: contract.has_mouse_wheel,
+        has_mouse_button: contract.has_mouse_button,
+        has_subscriptions: contract.has_subscriptions,
+        has_physics: contract.has_physics,
+        has_soundscape: contract.has_soundscape,
+        has_ui: contract.has_ui,
+        has_webview: contract.has_webview,
     })
 }
 
@@ -476,15 +400,24 @@ fn project_stamp(path: &str) -> Vec<(PathBuf, SystemTime)> {
 
 impl FunctorLangGame {
     pub fn create(path: &str) -> FunctorLangGame {
+        Self::create_with_prefix(path, "")
+    }
+
+    /// [`Self::create`] for a PREFIXED role (same-file entries): every
+    /// canonical entry binding resolves through `prefix` as camelCase
+    /// (`"server"` → `serverInit`/`serverTick`/…). An empty prefix is the
+    /// classic unprefixed contract.
+    pub fn create_with_prefix(path: &str, prefix: &str) -> FunctorLangGame {
         // Route Functor Lang `Debug.log` traces into the region-aware event stream (once
         // per process; survives hot-reload's Session rebuild — the sink is
         // installed on the process, not the Session). See functor_lang_prelude.
         functor_runtime_common::functor_lang_prelude::install_debug_log_sink();
+        let names = EntryNames::with_prefix(prefix);
         // Stat BEFORE reading: an edit that lands mid-load then compares
         // unequal on the next frame and triggers a reload, instead of being
         // silently absorbed into a stale session.
         let stamp = project_stamp(path);
-        let loaded = match load_game(path) {
+        let loaded = match load_game(path, &names) {
             Ok(loaded) => loaded,
             Err(message) => {
                 eprintln!("error: {message}");
@@ -501,6 +434,7 @@ impl FunctorLangGame {
         let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         FunctorLangGame {
             path: path.to_string(),
+            names,
             stamp,
             pushed_entry: None,
             pushed_project: None,
@@ -559,6 +493,7 @@ impl FunctorLangGame {
     fn ctx(&mut self) -> FrameCtx<'_> {
         FrameCtx {
             session: &self.session,
+            names: &self.names,
             model: &mut self.model,
             physics_rt: &mut self.physics_rt,
             physics_frame: &mut self.physics_frame,
@@ -673,6 +608,7 @@ impl FunctorLangGame {
         let history_replay = match
             functor_runtime_common::functor_lang_producer::materialize_counterfactual_history(
                 &self.session,
+                &self.names,
                 &mut self.model,
                 &mut self.recorder,
                 self.has_physics,
@@ -819,8 +755,8 @@ impl Game for FunctorLangGame {
         }
         let started = Instant::now();
         let loaded = match &self.pushed_entry {
-            Some(src) => load_source(&self.path, src.clone()),
-            None => load_game(&self.path),
+            Some(src) => load_source(&self.path, src.clone(), &self.names),
+            None => load_game(&self.path, &self.names),
         };
         match loaded {
             Ok(loaded) => {
@@ -876,8 +812,8 @@ impl Game for FunctorLangGame {
             files
         });
         let loaded = match &pushed_project {
-            Some(files) => load_sources(files),
-            None => load_source(&self.path, source.to_string()),
+            Some(files) => load_sources(files, &self.names),
+            None => load_source(&self.path, source.to_string(), &self.names),
         }?;
         if let Some(files) = pushed_project {
             self.pushed_project = Some(files);
@@ -911,7 +847,7 @@ impl Game for FunctorLangGame {
         }
         let started = Instant::now();
         let stamp = project_stamp(&self.path);
-        let loaded = load_sources(files)?;
+        let loaded = load_sources(files, &self.names)?;
         self.pushed_project = Some(files.to_vec());
         self.pushed_entry = None;
         let (rebound, history_replay) = self.swap_in(loaded);
@@ -941,7 +877,7 @@ impl Game for FunctorLangGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = Instant::now();
-        let loaded = load_sources(files)?;
+        let loaded = load_sources(files, &self.names)?;
         self.pushed_project = Some(files.to_vec());
         self.pushed_entry = None;
         self.reset_in(loaded);
@@ -1045,6 +981,7 @@ impl Game for FunctorLangGame {
         // through one impl; this just hands it the producer's state.
         functor_runtime_common::functor_lang_producer::ghost_frames(
             &self.session,
+            &self.names,
             &self.model,
             &self.recorder,
             self.has_physics,
@@ -1135,9 +1072,9 @@ impl Game for FunctorLangGame {
         };
         let args = vec![self.model.clone(), key_value, Value::Bool(is_down)];
         journal_push("input", &args, Provenance::Input);
-        match self.session.call("input", args, &mut FunctorHost) {
+        match self.session.call(self.names.input, args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("input", &err),
+            Err(err) => self.reporter.frame_error(self.names.input, &err),
         }
         // Buffer the raw event for the frame-indexed input log (T6b): flushed
         // into the recorder by `record_frame`, replayed by the forward-step.
@@ -1154,9 +1091,12 @@ impl Game for FunctorLangGame {
             Value::Number(y as f64),
         ];
         journal_push("mouseMove", &args, Provenance::MouseMove);
-        match self.session.call("mouseMove", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.mouse_move, args, &mut FunctorHost)
+        {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("mouseMove", &err),
+            Err(err) => self.reporter.frame_error(self.names.mouse_move, &err),
         }
         self.input_buf
             .push(functor_runtime_common::RecordedInput::MouseMove { x, y });
@@ -1168,9 +1108,12 @@ impl Game for FunctorLangGame {
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
         journal_push("mouseWheel", &args, Provenance::MouseWheel);
-        match self.session.call("mouseWheel", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.mouse_wheel, args, &mut FunctorHost)
+        {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("mouseWheel", &err),
+            Err(err) => self.reporter.frame_error(self.names.mouse_wheel, &err),
         }
         self.input_buf
             .push(functor_runtime_common::RecordedInput::MouseWheel { delta });
@@ -1188,9 +1131,12 @@ impl Game for FunctorLangGame {
         };
         let args = vec![self.model.clone(), button_value, Value::Bool(is_down)];
         journal_push("mouseButton", &args, Provenance::MouseButton);
-        match self.session.call("mouseButton", args, &mut FunctorHost) {
+        match self
+            .session
+            .call(self.names.mouse_button, args, &mut FunctorHost)
+        {
             Ok(returned) => self.ctx().absorb(returned),
-            Err(err) => self.reporter.frame_error("mouseButton", &err),
+            Err(err) => self.reporter.frame_error(self.names.mouse_button, &err),
         }
         self.input_buf
             .push(functor_runtime_common::RecordedInput::MouseButton { button, is_down });
@@ -1237,15 +1183,16 @@ impl Game for FunctorLangGame {
             .scrub_render_tts()
             .unwrap_or(frame_time.tts as f64);
         let args = vec![self.model.clone(), Value::Number(tts)];
-        match self.session.call("draw", args, &mut FunctorHost) {
+        match self.session.call(self.names.draw, args, &mut FunctorHost) {
             Ok(value) => match frame_value(&value) {
                 Some(frame) => self.last_frame = frame.clone(),
                 None => self.reporter.report_once(format!(
-                    "[functor-lang] draw must return Frame.create(camera, scene), got {}",
+                    "[functor-lang] {} must return Frame.create(camera, scene), got {}",
+                    self.names.draw,
                     value.kind_name()
                 )),
             },
-            Err(err) => self.reporter.frame_error("draw", &err),
+            Err(err) => self.reporter.frame_error(self.names.draw, &err),
         }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `Game::ui` is a `&self` accessor, and errors need `&mut`
@@ -1253,7 +1200,7 @@ impl Game for FunctorLangGame {
         if self.has_ui {
             match self
                 .session
-                .call("ui", vec![self.model.clone()], &mut FunctorHost)
+                .call(self.names.ui, vec![self.model.clone()], &mut FunctorHost)
             {
                 Ok(value) => match view_value(&value) {
                     Some(view) => {
@@ -1265,7 +1212,8 @@ impl Game for FunctorLangGame {
                     None => {
                         let _ = take_ui_handlers();
                         self.reporter.report_once(format!(
-                            "[functor-lang] ui must return a View (Ui.text / Ui.column / Ui.panel), got {}",
+                            "[functor-lang] {} must return a View (Ui.text / Ui.column / Ui.panel), got {}",
+                            self.names.ui,
                             value.kind_name()
                         ))
                     }
@@ -1274,17 +1222,18 @@ impl Game for FunctorLangGame {
                     // A failed evaluation keeps the last good view AND its
                     // handlers; drop the partial table it registered.
                     let _ = take_ui_handlers();
-                    self.reporter.frame_error("ui", &err)
+                    self.reporter.frame_error(self.names.ui, &err)
                 }
             }
         }
         // The optional webview, evaluated beside `draw` like `ui` — same
         // caching, same handler-adoption lockstep, its own handler table.
         if self.has_webview {
-            match self
-                .session
-                .call("webview", vec![self.model.clone()], &mut FunctorHost)
-            {
+            match self.session.call(
+                self.names.webview,
+                vec![self.model.clone()],
+                &mut FunctorHost,
+            ) {
                 Ok(value) => match html_node_value(&value) {
                     Some(node) => {
                         self.last_webview = Some(node.clone());
@@ -1293,14 +1242,15 @@ impl Game for FunctorLangGame {
                     None => {
                         let _ = take_ui_handlers();
                         self.reporter.report_once(format!(
-                            "[functor-lang] webview must return an Html node (Html.div / Html.text / …), got {}",
+                            "[functor-lang] {} must return an Html node (Html.div / Html.text / …), got {}",
+                            self.names.webview,
                             value.kind_name()
                         ))
                     }
                 },
                 Err(err) => {
                     let _ = take_ui_handlers();
-                    self.reporter.frame_error("webview", &err)
+                    self.reporter.frame_error(self.names.webview, &err)
                 }
             }
         }
@@ -1309,22 +1259,24 @@ impl Game for FunctorLangGame {
         // need `&mut` dedupe. A bad frame keeps the last good scene (the
         // last_frame rule).
         if self.has_soundscape {
-            match self
-                .session
-                .call("soundScape", vec![self.model.clone()], &mut FunctorHost)
-            {
+            match self.session.call(
+                self.names.sound_scape,
+                vec![self.model.clone()],
+                &mut FunctorHost,
+            ) {
                 Ok(value) => match audio_scene_of(&value) {
                     Some(scene) => {
                         self.last_soundscape_json =
                             functor_runtime_common::audio::scene_to_json(scene)
                     }
                     None => self.reporter.report_once(format!(
-                        "[functor-lang] soundScape must return an AudioScene (AudioScene.create / \
+                        "[functor-lang] {} must return an AudioScene (AudioScene.create / \
 AudioScene.empty), got {}",
+                        self.names.sound_scape,
                         value.kind_name()
                     )),
                 },
-                Err(err) => self.reporter.frame_error("soundScape", &err),
+                Err(err) => self.reporter.frame_error(self.names.sound_scape, &err),
             }
         }
         self.draw_ns += started.elapsed().as_nanos() as u64;
@@ -1481,23 +1433,6 @@ AudioScene.empty), got {}",
 
     fn quit(&mut self) {
         self.ctx().close_all_connections();
-    }
-}
-
-/// `name` must be a function of `arity` params — a contract violation is
-/// reportable at load, and the alternative is one error per frame, forever.
-fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> Result<(), String> {
-    match session.global(name) {
-        Some(Value::Closure(closure)) if closure.params.len() == arity => Ok(()),
-        Some(Value::Closure(closure)) => Err(format!(
-            "{path}: `{name}` must take {arity} parameter(s), takes {}",
-            closure.params.len()
-        )),
-        Some(other) => Err(format!(
-            "{path}: `{name}` must be a function, got {}",
-            other.kind_name()
-        )),
-        None => Err(format!("{path} has no top-level `let {name} = …`")),
     }
 }
 
@@ -1718,7 +1653,7 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         let path = dir.join("game.fun");
         std::fs::write(&path, src).expect("write temp game");
-        let err = load_game(path.to_str().expect("utf-8 temp path"))
+        let err = load_game(path.to_str().expect("utf-8 temp path"), &EntryNames::UNPREFIXED)
             .err()
             .expect("load should fail");
         let _ = std::fs::remove_dir_all(&dir);
@@ -2368,6 +2303,7 @@ mod tests {
         // the fork — a dry run over throwaway state.
         let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
             &game.session,
+            &EntryNames::UNPREFIXED,
             &fork_model,
             game.has_physics,
             game.has_subscriptions,
@@ -2533,6 +2469,7 @@ mod tests {
         // SUB-STEPPED at 1/60 (STEPS_PER_DIV fine ticks per division snapshot).
         let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
             &game.session,
+            &EntryNames::UNPREFIXED,
             &fork_model,
             game.has_physics,
             game.has_subscriptions,
@@ -2653,6 +2590,7 @@ mod tests {
         const STEPS_PER_DIV: usize = 5;
         let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
             &game.session,
+            &EntryNames::UNPREFIXED,
             &game.model, // the scrubbed model = seek(k)
             game.has_physics,
             game.has_subscriptions,
@@ -2777,6 +2715,7 @@ mod tests {
         // steps of 1, so each boundary is one rendered frame).
         let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
             &game.session,
+            &EntryNames::UNPREFIXED,
             &fork_model,
             game.has_physics,
             game.has_subscriptions,
@@ -2912,6 +2851,7 @@ mod tests {
         let anchor = game.model.clone();
         let forward = functor_runtime_common::functor_lang_producer::forward_step_scene(
             &game.session,
+            &EntryNames::UNPREFIXED,
             &anchor,
             game.has_physics,
             game.has_subscriptions,

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -1071,7 +1071,7 @@ impl Game for FunctorLangGame {
             return; // unrecognized code / Key::Unknown — never delivered.
         };
         let args = vec![self.model.clone(), key_value, Value::Bool(is_down)];
-        journal_push("input", &args, Provenance::Input);
+        journal_push(self.names.input, &args, Provenance::Input);
         match self.session.call(self.names.input, args, &mut FunctorHost) {
             Ok(returned) => self.ctx().absorb(returned),
             Err(err) => self.reporter.frame_error(self.names.input, &err),
@@ -1090,7 +1090,7 @@ impl Game for FunctorLangGame {
             Value::Number(x as f64),
             Value::Number(y as f64),
         ];
-        journal_push("mouseMove", &args, Provenance::MouseMove);
+        journal_push(self.names.mouse_move, &args, Provenance::MouseMove);
         match self
             .session
             .call(self.names.mouse_move, args, &mut FunctorHost)
@@ -1107,7 +1107,7 @@ impl Game for FunctorLangGame {
             return;
         }
         let args = vec![self.model.clone(), Value::Number(delta as f64)];
-        journal_push("mouseWheel", &args, Provenance::MouseWheel);
+        journal_push(self.names.mouse_wheel, &args, Provenance::MouseWheel);
         match self
             .session
             .call(self.names.mouse_wheel, args, &mut FunctorHost)
@@ -1130,7 +1130,7 @@ impl Game for FunctorLangGame {
             return; // unrecognized code / MouseButton::Unknown — never delivered.
         };
         let args = vec![self.model.clone(), button_value, Value::Bool(is_down)];
-        journal_push("mouseButton", &args, Provenance::MouseButton);
+        journal_push(self.names.mouse_button, &args, Provenance::MouseButton);
         match self
             .session
             .call(self.names.mouse_button, args, &mut FunctorHost)
@@ -1339,7 +1339,7 @@ AudioScene.empty), got {}",
             tts,
             &self.source_hashes,
             &self.last_frame_journal,
-            Some(&draw_args),
+            Some((self.names.draw, &draw_args)),
             &ring,
             &self.runnable,
             &self.session,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -568,6 +568,14 @@ pub struct Args {
     #[arg(long)]
     mouse_capture: bool,
 
+    /// The role's entry-point prefix (same-file entries): resolve every
+    /// canonical entry binding through it as camelCase (`server` →
+    /// `serverInit`/`serverTick`/…). Empty = the classic unprefixed names.
+    /// The CLI passes it for a functor.json role declared as
+    /// `{ "file": …, "prefix": … }`.
+    #[arg(long, default_value = "")]
+    entry_prefix: String,
+
     /// Treat --game-path as a frame-recording JSON (a single serialized `Frame`
     /// or a JSON array of them — the exact format `GET /scene` emits) and replay
     /// it instead of loading a game dylib. A proof producer for the
@@ -1295,8 +1303,9 @@ pub fn run(args: Args) {
     let mut game: Box<dyn Game> = if args.replay {
         Box::new(replay_game::ReplayGame::create(game_path.as_str()))
     } else if args.functor_lang {
-        Box::new(functor_lang_game::FunctorLangGame::create(
+        Box::new(functor_lang_game::FunctorLangGame::create_with_prefix(
             game_path.as_str(),
+            &args.entry_prefix,
         ))
     } else {
         // Functor Lang is the only game producer now (the F#/dylib path was removed in

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -119,6 +119,11 @@
       window.__functorLangProjectFiles = ("__FUNCTOR_LANG_PROJECT_FILES__")
         .map((p) => p.split("/").map(encodeURIComponent).join("/"));
 
+      // The role's entry-point binding prefix (same-file entries): the runtime
+      // resolves `serverInit`/`serverTick`/… through it. Empty = the classic
+      // unprefixed contract. Substituted by the CLI like the entry above.
+      window.__functorLangEntryPrefix = "__FUNCTOR_LANG_ENTRY_PREFIX__";
+
       // Captured game mouse input defaults on. A project can opt out with
       // mouseCapture: false; programs without captured mouse hooks never show
       // capture chrome. The debug camera owns its input independently.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -147,6 +147,21 @@ fn functor_lang_game_path() -> Option<String> {
         .and_then(|v| v.as_string())
 }
 
+/// The role's entry-point binding prefix (same-file entries, mirroring the
+/// desktop `--entry-prefix` flag): the page sets
+/// `window.__functorLangEntryPrefix` before initializing this module (the
+/// CLI's Functor Lang index page substitutes the role's declared prefix;
+/// the site's player.html reads `?prefix=<ident>`), and the producer
+/// resolves every canonical entry binding through it as camelCase
+/// (`"server"` → `serverInit`/`serverTick`/…). Absent or empty = the
+/// classic unprefixed contract.
+fn functor_lang_entry_prefix() -> String {
+    js_sys::Reflect::get(&window(), &JsValue::from_str("__functorLangEntryPrefix"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default()
+}
+
 /// The project's full file list (entry FIRST, then siblings), as the CLI's Functor Lang
 /// index page injects it (`window.__functorLangProjectFiles`, mirroring `__functorLangGamePath`
 /// — see `wasm_dev_server.rs`). Absent (a page that only set the single entry,
@@ -199,7 +214,11 @@ fn parse_project_files(value: &JsValue) -> Option<Vec<(String, String)>> {
 /// `run_async` to fail loud with.
 async fn create_functor_lang_game(entry: &str) -> Result<FunctorLangEmbeddedGame, String> {
     let sources = load_project_sources(entry).await?;
-    FunctorLangEmbeddedGame::create(sources, Box::new(WebPlatform::new()))
+    FunctorLangEmbeddedGame::create_with_prefix(
+        sources,
+        &functor_lang_entry_prefix(),
+        Box::new(WebPlatform::new()),
+    )
 }
 
 /// The project's `(path, source)` pairs, however this page supplies them —

--- a/site/player.html
+++ b/site/player.html
@@ -209,6 +209,18 @@
         requested && !requested.startsWith("/") && !requested.includes(":")
           ? requested
           : "examples/hero.fun";
+      // ?prefix=<ident>: the role's entry-point binding prefix (same-file
+      // entries) — the runtime resolves clientInit/clientTick/… through it.
+      // Identifier or absent; anything else warns and boots unprefixed (the
+      // scrubber param's fail-visible style).
+      const prefix = params.get("prefix");
+      if (prefix !== null) {
+        if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(prefix)) {
+          window.__functorLangEntryPrefix = prefix;
+        } else {
+          console.warn(`[player] invalid ?prefix=${prefix} (not an identifier); booting the unprefixed contract`);
+        }
+      }
       if (!inlineProject) {
         window.__functorLangGamePath = src
           ? "data:text/plain;base64," + src.replace(/-/g, "+").replace(/_/g, "/")

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -41,6 +41,12 @@ export interface Example {
    * control only for those.
    */
   multiplayer?: boolean;
+  /**
+   * The entry-point binding prefix of the role the sandbox plays (same-file
+   * entries, like examples/orbs's `client` role resolving
+   * clientInit/clientTick/…). Passed to the player as `?prefix=`.
+   */
+  prefix?: string;
 }
 
 /**
@@ -123,6 +129,9 @@ export const EXAMPLES: Example[] = [
     label: "Orbs (multiplayer)",
     source: "examples/orbs/game.fun",
     multiplayer: true,
+    // The sandbox plays the `client` role of the same-file entries —
+    // functor.json maps it to { "file": "game.fun", "prefix": "client" }.
+    prefix: "client",
   },
   {
     id: "mario",

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -418,6 +418,9 @@ const loadExample = async (id: string) => {
     params.set("cursor", cursorPolicy);
   }
   for (const file of files) params.append("file", file);
+  // A same-file-entries sample plays its declared role: the player boots the
+  // prefixed contract (e.g. orbs' clientInit/clientTick/…).
+  if (example?.prefix) params.set("prefix", example.prefix);
   frame.src = `player.html?${params}`;
   mp?.setSrc(frame.src);
 };


### PR DESCRIPTION
Opening move of the netsim transport arc (design: the multiplayer-IDE design doc, Addendum 3): `functor.json` roles may now share one file, resolving their entry contract through a prefix — on **native and wasm**.

```json
{ "entries": {
    "client": { "file": "game.fun", "prefix": "client" },
    "server": { "file": "game.fun", "prefix": "server" }
} }
```

Each role resolves `<prefix>Init` / `<prefix>Tick` / … / `<prefix>Webview` (prefix + Capitalized base) from the shared module. One buffer holds the whole distributed program, and **one edit hot-reloads every role atomically** — no cross-file version skew mid-session. This is what lets the sandbox's single buffer contain a real client *and* server when the transport lands.

**Implementation notes.** `EntryNames` resolves once per load as interned `&'static` strings (journal type unchanged; **frame_bench allocs/bytes identical to base**); contract validation de-duplicated into one shared `validate_contract` used by load, hot-reload, and `functor build`; prefixes must be identifiers; unknown object keys are refused (keeps the config strict for the future `module:` form — in-file modules are the agreed end state, recorded as their own initiative with LSP folding). On wasm, the CLI substitutes the prefix into the host page (`window.__functorLangEntryPrefix`, same sentinel channel as the entry) for `run wasm` and the `build wasm` export; the site player takes `?prefix=` (identifier-validated) and the sandbox passes `Example.prefix` — orbs boots its client role in the sandbox. `run vr` still refuses prefixed roles with a teaching error.

`examples/orbs` is the reference: both roles are prefixed (`clientInit`/`clientTick`/… and a ~15-line SERVER ROLE of thin wrappers over the same World) — `functor -d examples/orbs run native --entry server` renders the authoritative board.

**Cross-engine review (Claude + Codex), all findings dispositioned:**
- **Fixed (High, Claude):** the effect broker and physics-event folds called the literal `"update"`, so prefixed roles silently dropped effect results and collision messages. The resolved `update` name now threads through `drain_effects`/`drain_mode`/`perform_deferred_queries`/`deliver_physics_events`; regression test (`a_prefixed_role_drains_its_effects_through_its_own_update`) confirmed failing pre-fix.
- **Fixed (Medium, agreed by both engines):** four `journal_push` sites and the inspector's `draw` replay used canonical names while calling prefixed bindings — prefixed roles lost inspector invocations/coverage. Journal + trace builders now take the resolved names.
- **Fixed (Medium, Codex):** three test-only restack slips (missing new args/fields at test call sites).
- **Fixed (Medium, Claude):** `functor build`'s new contract gate eagerly evaluated top-level defs for *every* project; it is now scoped to named-`entries` projects, so classic single-entry builds keep the old never-runs-game-code semantics.
- **Fixed (Medium, both):** added positive tests that a non-empty prefix actually reaches the rendered wasm host page and the static export.
- **Deferred (Codex):** the web `sim.rs` multi-instance path can't yet express same-file roles (it boots the unprefixed contract). That's the sim-mode substrate work in the next arc (netsim transport, orbs as its fixture) — role descriptors land with the transport.
- **Noted (design tradeoff):** prefixing the *client* role means orbs' sandbox source teaches `clientInit`/`clientTick` where docs teach `init`/`tick`, and the file no longer boots under an unprefixed consumer. Chosen deliberately for symmetry/clarity of the two-role sample; in-file `module Client/Server` supersedes prefixes later.
- Codex's explicit merge-audit of the restack found no dropped contract checks; `validate_contract` matches both deleted inline blocks item-for-item.

**Verification (at final state):** cargo tests green — functor_runtime_common 616+11, functor-runtime-desktop 80+, functor-cli 108 (incl. the prefixed-effects regression test, prefixed-contract tests, config-shape parsing tests, and the example sweep over orbs' two roles); `--features=strict` build clean (CI parity); frame_bench allocs/bytes identical branch vs origin/main; both orbs role captures render (plus a positive proof: a scratch orbs with a distinct red `serverDraw` renders differently under `--entry server` while `--entry client` stays byte-identical); negative proof — a bogus prefix fails `build` naming `bogusInit`; wasm + site rebuilt, `npm run test:site` ALL CHECKS PASSED; Playwright sandbox proof — orbs boots with `player.html?…&prefix=client`, status pill `● live`, zero page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
