### PR TITLE
docs(site): add a raw debug-runtime recipe

### DIFF
--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -835,6 +835,7 @@ step       { "session": "s1" }
           <pre class="shell">functor -d examples/counter run native --debug-port 8077 --hidden &amp;
 RUNTIME_PID=$!
 H=http://127.0.0.1:8077
+until curl -sf $H/ &gt;/dev/null; do sleep 0.05; done
 
 curl -s $H/state | jq '.frame, .tts, .model'
 curl -s -X POST $H/time -d '{"type":"set","tts":0}'              # pause
@@ -843,6 +844,7 @@ curl -s -X POST $H/input -d '{"type":"mouse_move","x":120,"y":80}'
 curl -s -X POST $H/input -d '{"type":"mouse_button","button":"left","down":true}'
 curl -s -X POST $H/input -d '{"type":"ui_event","slot":0,"kind":"Clicked"}'
 curl -s -X POST $H/time -d '{"type":"advance","dts":0.016}'
+until [ "$(curl -s $H/state | jq -r .pending_steps)" = 0 ]; do sleep 0.01; done
 curl -s $H/state | jq '.model'
 curl -s -X POST $H/capture -o frame.png
 

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -832,26 +832,42 @@ step       { "session": "s1" }
             with <code>--debug-port</code>. <code>--hidden</code> keeps pixels available for capture
             without showing a window:
           </p>
-          <pre class="shell">functor -d examples/counter run native --debug-port 8077 --hidden &amp;
-RUNTIME_PID=$!
+          <pre class="shell">(
+set -euo pipefail
 H=http://127.0.0.1:8077
-until curl -sf $H/ &gt;/dev/null; do sleep 0.05; done
+RUNTIME_LOG=$(mktemp)
+functor -d examples/counter run native --debug-port 8077 --hidden 2&gt;"$RUNTIME_LOG" &amp;
+RUNTIME_PID=$!
+cleanup() { kill "$RUNTIME_PID" 2&gt;/dev/null || true; wait "$RUNTIME_PID" 2&gt;/dev/null || true; rm -f "$RUNTIME_LOG"; }
+trap cleanup EXIT INT TERM
 
-curl -s $H/state | jq '.frame, .tts, .model'
-curl -s -X POST $H/time -d '{"type":"set","tts":0}'              # pause
-curl -s -X POST $H/input -d '{"type":"key","key":"3","down":true}' # digits are bare "0"…"9"
-curl -s -X POST $H/input -d '{"type":"mouse_move","x":120,"y":80}'
-curl -s -X POST $H/input -d '{"type":"mouse_button","button":"left","down":true}'
-curl -s -X POST $H/input -d '{"type":"ui_event","slot":0,"kind":"Clicked"}'
-curl -s -X POST $H/time -d '{"type":"advance","dts":0.016}'
-until [ "$(curl -s $H/state | jq -r .pending_steps)" = 0 ]; do sleep 0.01; done
-curl -s $H/state | jq '.model'
-curl -s -X POST $H/capture -o frame.png
+for _ in {1..200}; do
+  grep -q '\[debug-server\] listening' "$RUNTIME_LOG" &amp;&amp; break
+  kill -0 "$RUNTIME_PID" 2&gt;/dev/null || { wait "$RUNTIME_PID"; exit 1; }
+  sleep 0.05
+done
+grep -q '\[debug-server\] listening' "$RUNTIME_LOG" || { echo "debug server timed out" &gt;&amp;2; exit 1; }
 
-curl -s -X POST $H/input -d '{"type":"key","key":"3","down":false}'
-curl -s -X POST $H/input -d '{"type":"mouse_button","button":"left","down":false}'
-curl -s -X POST $H/time -d '{"type":"resume"}'
-kill $RUNTIME_PID</pre>
+curl -fsS $H/state | jq '.frame, .tts, .model'
+curl -fsS -X POST $H/time -d '{"type":"set","tts":0}'               # pause
+curl -fsS -X POST $H/input -d '{"type":"key","key":"3","down":true}' # digits are bare "0"…"9"
+curl -fsS -X POST $H/input -d '{"type":"mouse_move","x":120,"y":80}'
+curl -fsS -X POST $H/input -d '{"type":"mouse_button","button":"left","down":true}'
+curl -fsS -X POST $H/input -d '{"type":"ui_event","slot":0,"kind":"Clicked"}'
+curl -fsS -X POST $H/time -d '{"type":"advance","dts":0.016}'
+for _ in {1..200}; do
+  PENDING=$(curl -fsS $H/state | jq -er .pending_steps)
+  [ "$PENDING" = 0 ] &amp;&amp; break
+  sleep 0.01
+done
+[ "$PENDING" = 0 ] || { echo "step timed out" &gt;&amp;2; exit 1; }
+curl -fsS $H/state | jq '.model'
+curl -fsS -X POST $H/capture -o frame.png
+
+curl -fsS -X POST $H/input -d '{"type":"key","key":"3","down":false}'
+curl -fsS -X POST $H/input -d '{"type":"mouse_button","button":"left","down":false}'
+curl -fsS -X POST $H/time -d '{"type":"resume"}'
+)</pre>
           <p>
             The URL is the <code>[debug-server] listening on …</code> address printed at launch.
             Input is held until its matching release, and UI slots follow interactive-widget

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -825,6 +825,42 @@ step       { "session": "s1" }
             time when the game must see input or I/O between steps.
           </p>
 
+          <h3>Raw HTTP from a shell</h3>
+          <p>
+            MCP is the convenient agent workflow above. Use the runtime's raw HTTP surface when a
+            shell script or test needs a few direct requests, or to attach to a game already running
+            with <code>--debug-port</code>. <code>--hidden</code> keeps pixels available for capture
+            without showing a window:
+          </p>
+          <pre class="shell">functor -d examples/counter run native --debug-port 8077 --hidden &amp;
+RUNTIME_PID=$!
+H=http://127.0.0.1:8077
+
+curl -s $H/state | jq '.frame, .tts, .model'
+curl -s -X POST $H/time -d '{"type":"set","tts":0}'              # pause
+curl -s -X POST $H/input -d '{"type":"key","key":"3","down":true}' # digits are bare "0"…"9"
+curl -s -X POST $H/input -d '{"type":"mouse_move","x":120,"y":80}'
+curl -s -X POST $H/input -d '{"type":"mouse_button","button":"left","down":true}'
+curl -s -X POST $H/input -d '{"type":"ui_event","slot":0,"kind":"Clicked"}'
+curl -s -X POST $H/time -d '{"type":"advance","dts":0.016}'
+curl -s $H/state | jq '.model'
+curl -s -X POST $H/capture -o frame.png
+
+curl -s -X POST $H/input -d '{"type":"key","key":"3","down":false}'
+curl -s -X POST $H/input -d '{"type":"mouse_button","button":"left","down":false}'
+curl -s -X POST $H/time -d '{"type":"resume"}'
+kill $RUNTIME_PID</pre>
+          <p>
+            The URL is the <code>[debug-server] listening on …</code> address printed at launch.
+            Input is held until its matching release, and UI slots follow interactive-widget
+            construction order. Keep an inspectable persistent model as plain data: a
+            <code>{"$host":"…"}</code> value in <code>/state</code> is a lossy marker for opaque
+            engine data that should normally stay in <code>draw</code> or another host-facing hook.
+            See the
+            <a href="https://github.com/tommy-xr/functor/blob/main/docs/debug-runtime.md">full debug-runtime reference</a>
+            for every endpoint, payload, headless mode, batched stepping, and remote-device setup.
+          </p>
+
           <h3>Authoring without a filesystem</h3>
           <p>
             An agent with no disk of its own can still go from nothing to a durable project.

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -827,10 +827,10 @@ step       { "session": "s1" }
 
           <h3>Raw HTTP from a shell</h3>
           <p>
-            MCP is the convenient agent workflow above. Use the runtime's raw HTTP surface when a
-            shell script or test needs a few direct requests, or to attach to a game already running
-            with <code>--debug-port</code>. <code>--hidden</code> keeps pixels available for capture
-            without showing a window:
+            <strong>Bash or zsh.</strong> MCP is the convenient agent workflow above. Use the
+            runtime's raw HTTP surface when a shell script or test needs a few direct requests, or
+            to attach to a game already running with <code>--debug-port</code>.
+            <code>--hidden</code> keeps pixels available for capture without showing a window:
           </p>
           <pre class="shell">(
 set -euo pipefail


### PR DESCRIPTION
## Summary

- add a copy-pasteable Bash/zsh recipe for attaching directly to the debug runtime over HTTP
- cover state inspection, deterministic clock control, digit-key/mouse/UI injection, and frame capture
- explain when raw HTTP is useful alongside the existing MCP workflow
- call out opaque `$host` model values and link the full debug-runtime reference

## Verification

- `CARGO_TARGET_DIR=~/code/functor2/target npm run check:docs`
- `npm run check:site`
- `npm run site:build`
- direct release-runtime smoke against `examples/counter`
  - startup tied to the spawned child log and liveness
  - `GET /state` returned the structured model
  - injected digit `"3"` appeared as held `Num3`
  - injected mouse state reported `{x:120,y:80,left:true}`
  - UI slot 0 changed `count` from 0 to 1 after one pinned step
  - `pending_steps` drained to 0
  - `POST /capture` returned a valid 1600×1200 PNG
- desktop 1440×1000 and mobile 390×844 manual screenshots inspected
- 20-frame after-section scroll checked; first/last frame diff is non-empty

## Review

xreview ran in degraded mode: Claude/Opus was unavailable and the local Codex CLI could not start because its platform-specific optional package was missing. An independent adversarial agent plus a manual protocol/source audit reviewed `main...HEAD` and the local visual media.

- **Medium — startup/cleanup and silent HTTP failures:** fixed with child-log/liveness startup checks, bounded waits, `set -euo pipefail`, `curl -fsS`, and trap-based kill/reap cleanup.
- **Medium — shell portability was implicit:** fixed by explicitly labeling the recipe Bash/zsh.
- **Critical/High:** none.

The AGENTS-required `frontend-design` skill was unavailable in this session. The change therefore reuses the manual's established `h3` / `p` / `pre.shell` markup and existing responsive styling without introducing layout or CSS.

## Visuals

### Before → after · desktop

| Before | After |
| --- | --- |
| ![Manual before at desktop width](https://gist.githubusercontent.com/tommy-xr/8d1f20f93d618178c3a34e10c0f197eb/raw/before-desktop.png) | ![Manual after at desktop width](https://gist.githubusercontent.com/tommy-xr/8d1f20f93d618178c3a34e10c0f197eb/raw/after-desktop.png) |

### Before → after · mobile

| Before | After |
| --- | --- |
| ![Manual before at mobile width](https://gist.githubusercontent.com/tommy-xr/8d1f20f93d618178c3a34e10c0f197eb/raw/before-mobile.png) | ![Manual after at mobile width](https://gist.githubusercontent.com/tommy-xr/8d1f20f93d618178c3a34e10c0f197eb/raw/after-mobile.png) |

### Final section scroll

![Raw debug-runtime recipe scrolling demo](https://gist.githubusercontent.com/tommy-xr/8d1f20f93d618178c3a34e10c0f197eb/raw/after-scroll.gif)

<sub>Built from final HEAD and captured headlessly with Playwright. The GIF scrolls from the existing deterministic MCP loop through the full raw-HTTP recipe and its model-data guidance.</sub>
