### PR TITLE
feat(skill): add per-entry game jam fix rounds

### DIFF
--- a/.claude/skills/game-jam/SKILL.md
+++ b/.claude/skills/game-jam/SKILL.md
@@ -1,43 +1,57 @@
 ---
 name: game-jam
 description: >-
-  Host a multi-agent Functor game jam: spawn parallel high-capability subagents
-  (Opus on Claude, GPT-5.6 Sol on OpenAI by default) that each build a sample
-  game in an isolated worktree, working docs-first against
-  https://functor.games to stress-test the manual/API reference, and return a
-  ranked friction log of engine + doc gaps. Then judge the entries (usefulness,
-  canonicality), promote the best into examples/, and turn the consolidated gap
-  list into roadmap work. Use when asked to run a game jam, stress-test the
-  Functor API/docs by building games, or generate candidate examples at scale.
-  Args: optional `--model MODEL` override and optional list of game briefs
-  (e.g. `/game-jam --model gpt-5.6-terra tower-defense, tetris`); no briefs =
-  pick from the backlog below.
+  Host a 1–10 entry multi-agent Functor game jam: high-capability subagents
+  build sample games in isolated worktrees, docs-first against
+  https://functor.games, and return ranked engine/doc friction. Then implement
+  one evidence-backed blocker fix for every entry, make each game adopt its
+  fix, judge usefulness/canonicality, promote the best into examples/, and turn
+  remaining gaps into roadmap work. Use when asked to run a game jam,
+  stress-test the Functor API/docs by building games, fix the blockers those
+  games expose, or generate candidate examples at scale. Args: optional
+  `--entries N` (1–10; no briefs defaults to 10), optional `--model MODEL`, and
+  optional game briefs (e.g. `/game-jam --entries 8 --model gpt-5.6-terra
+  tower-defense, tetris`).
 ---
 
 # game-jam — parallel sample-building to find API & doc gaps
 
 A game jam is a discovery instrument, not just content production. Each entry
-produces **two deliverables of equal weight**:
+produces **three deliverables of equal weight**:
 
 1. **A sample-quality game** under `examples/<slug>/` — a candidate for the
    example corpus.
 2. **A friction log** — every missing API, ergonomic gap, confusing error, doc
    gap, and workaround, ranked. A game that needed ugly workarounds plus a
    sharp friction log is MORE valuable than a smooth game with no notes.
+3. **A blocker fix and adoption proof** — one real impediment is implemented
+   in a reviewed fix PR, then the game removes its workaround or repeats the
+   previously blocked workflow and proves the fix end to end.
 
-The orchestrator (you) then judges the entries, consolidates the gap lists into
-roadmap items, and promotes the best sample(s).
+The orchestrator (you) owns the roster, blocker coverage matrix, final judging,
+consolidated roadmap, and promotion.
 
 ## Phase 0 — shared setup (orchestrator, before spawning)
 
-1. Build the release CLI **once** and fetch shared assets:
+1. Resolve the roster before spawning. `--entries N` is the total roster size
+   and must be `1..10`. With `B` explicit briefs, require `B <= N` and add
+   exactly `N-B` backlog briefs. Without `--entries`, use the explicit briefs,
+   or 10 backlog briefs when `B=0`. Reject `B>N`, more than 10 explicit briefs,
+   and duplicate slugs; never discard an explicit brief.
+2. Create a dedicated clean bootstrap worktree at the exact baseline SHA every
+   jam branch uses. Build the release CLI **once** there and fetch shared assets:
    `npm run build:cli && npm run fetch:assets`. Run it in the background and
    launch agents immediately — they spend their first stretch reading docs.
-2. All agents share `/…/functor4/target/release/functor` (absolute path into
-   the MAIN repo). The binary interprets each game's `.fun` files, so worktree
-   agents can use it directly; they must never build it themselves (7 parallel
-   cargo builds would thrash the machine).
-3. Skim `examples/` first so briefs don't duplicate existing samples (e.g.
+   A SHA recorded from a dirty checkout is not valid provenance. No agent may
+   build, capture, or run debug verification until the orchestrator confirms
+   setup succeeded and records the binary's source SHA.
+3. All Phase 1 game-builder agents share the bootstrap worktree's
+   `target/release/functor` by absolute path. The binary interprets each game's
+   `.fun` files, so builders must never build it themselves (ten cargo builds
+   would thrash the machine). Phase 1.5 fixers build changed code only inside
+   their dedicated fixer worktrees.
+4. Skim `examples/` and recent `jam/*` branches first so briefs do not duplicate
+   existing or just-completed samples (e.g.
    `mario` is already a 2D sprite platformer; `asteroids` is top-down 3D).
 
 ## Phase 1 — one agent per game
@@ -52,27 +66,35 @@ Choose the game-builder model before spawning:
   applies only to those agents, not to nested tools such as `xreview`, which
   retain their own model policy.
 
-Spawn one subagent per brief with the chosen model, `isolation: worktree`,
-running in the background — but **pace the fleet; do not run everything at
-once** (see "Concurrency limits" below). Each prompt must include:
+Create a git worktree and `jam/<slug>` branch for every brief, then spawn one
+subagent per brief with the chosen model and its absolute worktree path. Require
+that path as the cwd for every command; use a host-provided worktree-isolation
+option when available. On OpenAI, use a non-full-history fork when passing an
+explicit model and include all required context in the prompt. Pace the fleet;
+do not run everything at once (see "Concurrency limits" below). Each prompt
+must include:
 
 - **The brief**: game, slug, and the specific engine surfaces it exists to
   stress (physics, XR input, 2D ergonomics, chase camera, UI/dialog, …).
 - **Docs-first rule**: work like an external user — primary references are
-  https://functor.games/manual/ and https://functor.games/docs/ (via WebFetch).
-  Fall back to the `functor-lang` skill / existing examples only when the docs
-  fail, and record **every fallback as a doc-gap finding**. This is how the jam
-  stress-tests the docs, not just the engine.
+  https://functor.games/manual/ and https://functor.games/docs/ (via the host's
+  browser/fetch tool). Fall back to the `functor-lang` skill / existing examples
+  only when the docs fail, and record **every fallback as a doc-gap finding**.
+  This is how the jam stress-tests the docs, not just the engine.
 - **Hard rules**: no engine/runtime/language/site edits — work around gaps in
   game code and log them (keeps friction reports honest and diffs reviewable);
   new files only under `examples/<slug>/`; commit locally on `jam/<slug>`; no
   pushes or PRs; never guess Functor Lang syntax from F#/OCaml intuition.
 - **Verification loop**: `functor -d <dir> build native` must be clean;
   iterate on headless captures (`run native --capture-frame … --fixed-time …`,
-  then Read the PNG) until it genuinely looks like the game; use the debug
-  server (`docs/debug-runtime.md`: `--debug-port`, `--headless`, input
-  injection) to prove input-driven behavior works, not just still frames.
-  Keep 2–4 final PNGs in `examples/<slug>/.captures/` (uncommitted).
+  then inspect the PNG with the host's image viewer) until it genuinely looks
+  like the game. Prefer a reusable `tools/functor-sdk` scenario for multi-step
+  lifecycle/assertion work (currently use waited `stepFrames(1)`, not the
+  queue-only `step`), or `functor mcp` for agent-driven tool calls; raw
+  debug-runtime HTTP is for one-off protocol probes. Preserve the scenario or
+  exact tool sequence in `JAM_NOTES.md` as a durable proof that drives input and
+  inspects state, not just still frames. Keep 2–4 final PNGs in
+  `examples/<slug>/.captures/` (uncommitted).
 - **Assets**: primitives/procedural first; otherwise the branded-asset
   pipeline (`<name>.asset.json` CDN sidecars + `functor import`, commit
   `assets.fun`, never `.glb`); CC0 sounds copyable from
@@ -84,10 +106,12 @@ once** (see "Concurrency limits" below). Each prompt must include:
 - **`JAM_NOTES.md`** (committed): what the game demonstrates, controls, and
   the friction log ranked **P0** blocked / **P1** painful workaround /
   **P2** ergonomic annoyance / **P3** nice-to-have, with doc gaps as their own
-  section.
+  section. Add a **Fix-round candidate** section naming the best evidence-backed
+  blocker, the ideal path attempted, observed failure/workaround, smallest
+  useful fix, and an entry-level acceptance proof.
 - **Final report** (returned text, machine-consumable): worktree/branch/SHA,
   game summary, capture paths, xreview outcome, the full friction log inline,
-  and a 1–5 self-assessment on the two judging criteria below.
+  fix-round candidate, and a 1–5 self-assessment on the judging criteria below.
 
 ## Concurrency limits (learned the hard way — 2026-07 jam)
 
@@ -119,17 +143,21 @@ numbers. Rules:
 - Sequencing mechanic: resume/spawn one agent, wait for its completion
   notification, then start the next — nearest-to-completion first so results
   land early.
+- Count the orchestrator and nested reviewer subagents against the host's global
+  slot limit. On a four-slot host, run at most two builders and admit only one
+  builder to `xreview` at a time. Temporary slot exhaustion means wait; use the
+  self-review fallback only when the host lacks subagent spawning entirely.
 - **Disk hygiene between fixers (learned mid-run: a full disk killed a fixer
   mid-build).** Every heavy fixer leaves a multi-GB `target/` cache in its
-  worktree; a long fixer queue fills the drive. Once a fixer's PR is pushed,
-  its `target/` is pure rebuildable cache — sweep finished fixers' caches
-  BEFORE starting the next heavy agent (`rm -rf .claude/worktrees/agent-*/target`
-  for done agents only; never the running one's), and check free space
-  (`df -h`) as part of each heavy launch. Don't wait for end-of-jam cleanup;
-  by then the drive may already be full. Long-running heavy agents should also
-  self-monitor: instruct them to delete their OWN cache as their last action,
-  and to report (not self-remediate outside their worktree) if disk runs low
-  mid-task.
+  worktree; a long fixer queue fills the drive. Before deleting a fixer's
+  `target/`, copy the verified release CLI (with its embedded wasm bundle) to
+  `/tmp/functor-jam/<fix-head-sha>/functor`, record its checksum, and use that
+  immutable artifact for covered adoptions; otherwise retain the cache through
+  adoption. Resolve finished worktrees individually, validate each absolute
+  path against `git worktree list --porcelain`, and remove only the explicit
+  `<finished-worktree>/target` — never use a fleet-wide wildcard. Check `df -h`
+  before each heavy launch. Long-running heavy agents should report, not
+  self-remediate outside their worktree, if disk runs low mid-task.
 - **Local verification is single-platform — the CI matrix is part of the
   gate.** A fixer with 600 green local tests still shipped an x86-vs-ARM
   divergence (`f64::total_cmp` orders computed NaNs by sign bit, which differs
@@ -147,55 +175,86 @@ numbers. Rules:
   goes in a PR body.
 - **Orchestrator CI watchers: verify, then flip.** Agents' CI monitors die
   with their process — the orchestrator finishes the watch. Use strict logic
-  (count checks, require ALL pass, print offenders otherwise); a sloppy
-  one-liner once flipped a PR ready with a red check.
+  for the current PR head SHA: require a non-zero expected check set with every
+  job present and terminal-success. Zero checks, a missing expected job, a
+  pending job, or a mismatched head SHA is not green.
 
-## Phase 1.5 — gap fixers (sequential, after entries complete)
+## Phase 1.5 — one qualifying blocker removed for every entry
 
-Triage blockers as friction reports land, but run the fixing **sequentially,
-after the jam entries finish** — fixers cold-build Rust worktrees and run
-xreview, exactly the load the concurrency limits exist for. One fixer at a
-time, nearest-to-mergeable first.
+Triage while reports land, but start fixes only after all entry commits are
+recorded as immutable **pre-fix baselines**; later entry commits are
+adoption-only. Maintain a coverage table:
 
-**Prefer the game's own agent for low-lift fixes.** If the gap is small and
-blocks that agent's game (a doc wording, a missing signature, a small prelude
-register), resume the entry's agent after its game is committed and have it
-open the fix PR itself — it has the full context and the motivating example.
-Spawn dedicated assessor/fixer agents only for cross-cutting or heavier gaps.
-Per cluster:
+`entry | baseline SHA | blocker | cluster | fix PR@tested-head-SHA | ordered dependency SHAs | artifact checksum | adoption SHA | before proof | after proof`
 
-- **Doc gaps** are usually same-day: fix in the `.funi` doc comments and/or the
-  `site/` manual, verify with `npm run check:docs` + a site build, open a
-  draft PR right away. Accuracy over coverage — every documented signature must
-  be verified against source, and stale `functor-lang`-skill content updates in
-  the same PR.
-- **Engine gaps** get a feasibility pass first: verify the jam agent's claims
-  against the actual architecture (they may have missed an existing surface),
-  design the smallest principled change, and implement + draft-PR **only if
-  genuinely low-lift** (registry-registered prelude surface, both producers
-  wired, `.funi` docs, determinism under fake/replay runners, frame_bench
-  before/after, skill sync). Otherwise return a design sketch with a
-  stacked-PR breakdown for the synthesis phase.
+The jam is not complete until every entry has a ready fix PR (shared when the
+root cause is genuinely the same) and its own adoption proof.
+Any fixer PR head change or rebase — standalone, shared, or dependent —
+invalidates every adoption row naming the prior SHA; rerun CI, rebuild the
+immutable artifact, and rerun all affected adoption proofs.
 
-Point fixers at the jam entry's `JAM_NOTES.md` (read-only) as evidence, and
-keep them off the jam worktrees.
+### Select blockers
 
-**Docs changes are visual changes.** A PR that edits a manual/docs/site page
-embeds before/after screenshots of the rendered page (base ref vs change), the
-same as any rendering PR — reviewers judge the page users will see, not the
-markup diff.
+- Reproduce each claim against source/current docs before accepting it; agents
+  sometimes miss an existing surface.
+- Choose the highest P0/P1 that prevents the ideal or canonical implementation.
+  If none exists, use the highest P2 that blocks a trustworthy external-user
+  workflow. Never pad the round with cosmetic P3 work.
+- If an entry has no qualifying P0/P1 or workflow-blocking P2, run one
+  additional targeted docs-first stress workflow. If that still yields none,
+  replace the brief; if no replacement exposes a real blocker, report the jam
+  blocked rather than fabricate work or count the entry complete.
+- For a large gap, ship the smallest principled slice that removes one proven
+  workaround from the entry. An issue or design sketch alone does not count.
+- Dedupe shared root causes. One PR may cover several entries only when it has
+  separate acceptance evidence for each; do not create duplicate APIs merely
+  to preserve a one-PR-per-game ratio.
 
-**PR lifecycle:** fixers open PRs as drafts (repo convention), and once
-verification is re-run post-review and every Critical/High is dispositioned in
-the body — plus media embedded for visual changes — the PR gets marked ready
-**in the same breath** (`gh pr ready`), by the fixer or the orchestrator.
-Draft is a "review/captures still landing" signal, not a resting state; a
-fully-verified PR parked in draft just hides finished work from reviewers.
+### Implement fixes sequentially
+
+1. Create a fresh fixer worktree/branch from the correct base; never edit engine,
+   language, runtime, or site code in a jam entry worktree. Prefer the original
+   builder for a low-lift fix; use a dedicated fixer for cross-cutting work.
+2. Capture a failing before-proof, implement the smallest complete change, and
+   add regression coverage at the owning layer. Docs fixes must update the
+   manual/reference/skill together where applicable; site docs include rendered
+   desktop/mobile before-after media. Engine/prelude fixes wire every producer,
+   preserve fake/replay determinism, rebuild wasm for web claims, and run the
+   required before/after benchmarks for hot-path changes.
+3. Run `xreview`, fix every Critical/High, disposition all findings in a draft
+   PR, rerun verification, wait for the complete CI matrix, then mark the PR
+   ready. Run one cargo-building fixer at a time and clear only its rebuildable
+   worktree cache before launching the next.
+4. For dependent fixes, branch and target each downstream PR on its immediate
+   dependency. Record each PR's own commit range and tested head.
+
+### Make the entry adopt the fix
+
+After its fix PR is ready, resume the original builder in `jam/<slug>`:
+
+- For code-facing fixes, remove the workaround/use the new surface, update
+  `JAM_NOTES.md` with before/after evidence and the PR, rerun tests, scripted
+  input/state proof, wasm when relevant, and final captures, then commit the
+  adoption. Use the immutable verified fix artifact by absolute path.
+- For docs/tooling fixes, repeat the formerly blocked docs-first workflow from
+  the rendered/generated artifact and record the successful transcript. Do not
+  invent a game-code change.
+- Run `xreview commit <adoption-sha>` on the adoption delta. If the entry cannot
+  prove the blocker is gone, reopen the fixer; a green unit test alone is
+  insufficient. The orchestrator independently reruns every row's acceptance
+  proof before declaring it complete.
+
+When several unmerged fixes are needed for final gallery testing, create a
+disposable local integration branch from their common base. Cherry-pick only
+each PR's own commit range in topological order, build the release CLI/wasm
+once, and record the complete ordered fix-SHA set and artifact checksum in
+every dependent proof. Do not push the integration branch.
 
 ## Phase 2 — judging (orchestrator)
 
-Score each entry yourself — don't take self-assessments at face value; look at
-the captures and read the code:
+Score each final, post-fix entry yourself — don't take self-assessments at face
+value; look at the captures, read the code, and record the pre/post-fix
+canonicality delta:
 
 - **Usefulness** — does it demonstrate things no other sample does? An entry
   that overlaps an existing example needs a distinct angle to score well.
@@ -229,27 +288,30 @@ with `SPACE` described as "click to shoot" reads as broken.
 Two things to know: `--out` is **wiped on every run** (it refuses to delete a
 directory it didn't create, so don't point it at anything you care about), and
 it needs a **release** binary — `target/release/functor`, or `--functor <path>`.
-The gallery output is scratch: build it under `/tmp`, don't commit it.
+The gallery output is scratch: build it under `/tmp`, don't commit it. If fixes
+are not merged, pass the disposable integration branch's release binary so the
+gallery exercises the adopted APIs rather than a stale main build.
 
 ## Phase 3 — synthesis
 
-1. **Consolidate friction logs** across entries: dedupe, keep per-gap evidence
-   ("hit by 4/7 entries"), rank by frequency × severity. Multi-entry gaps are
-   the roadmap items; single-entry P2/P3s are candidates, not mandates.
+1. **Consolidate friction and fixes** across entries: preserve the blocker
+   coverage table and before/after evidence, dedupe remaining gaps, keep
+   frequency ("hit by 6/10 entries"), and rank by frequency × severity.
+   Multi-entry gaps are roadmap items; single-entry P2/P3s are candidates.
 2. **Promote the winner(s)**: cherry-pick the sample from its jam worktree
    onto a fresh branch, adapt to corpus conventions (README/ASSETS.md,
    golden-scenario candidacy, `pr-visuals` GIF+PNG), and open a draft PR per
-   the repo's stacked-PR conventions. Delete `JAM_NOTES.md` from the promoted
-   copy — its content belongs in the synthesis report / issues, not the corpus.
-3. **File the gap work**: turn the consolidated list into issues or follow-up
-   PRs (engine gaps vs doc gaps separately — doc gaps are often same-day
-   fixes to `site/` or the generated reference).
+   the repo's stacked-PR conventions. If the sample uses unmerged blocker
+   fixes, stack its PR on the top of the complete recorded dependency chain.
+   Delete `JAM_NOTES.md` from the promoted copy; its content belongs in
+   synthesis.
+3. **File only remaining gap work**: link the implemented blocker PRs and turn
+   unresolved consolidated gaps into issues (engine vs docs separately).
 4. Clean up. Two kinds, and both matter:
    - **Processes, immediately after any agent stops or is killed**: sweep for
-     orphaned `functor` debug servers, `cargo`/`rustc`/`sccache` trees, and
-     Codex reviewer processes (`ps aux | grep -E 'functor|cargo|rustc|codex'`)
-     — killed agents routinely leave runaway compiles and hung reviewers
-     burning CPU.
+     orphaned work by consulting the process IDs/groups recorded at launch.
+     Verify each PID's command, cwd, parentage, and jam ownership, then stop only
+     recorded jam descendants; never kill by executable-name match alone.
    - **Worktrees, only after synthesis**: first confirm every entry's work is
      committed to its `jam/<slug>` branch (branches survive worktree removal;
      staged-but-uncommitted work does not), save JAM_NOTES content into the
@@ -261,21 +323,19 @@ The gallery output is scratch: build it under `/tmp`, don't commit it.
 Already run (2026-07): pool (physics/sensors), shooting-range (FPS camera,
 raycast, recoil), bow (XR two-handed, no-device XR loop), racer (procedural
 track, chase cam), platformer (3D character controller, moving platforms),
-rpg (2D/tilemap/dialog), asteroids2d (ortho/sprite 2D migration).
+rpg (2D/tilemap/dialog), asteroids2d (ortho/sprite 2D migration), tower-defense
+(picking/pathing), marble-golf (physics/events), swarm-survival
+(spatial/perf), space-dogfight (flight/state), and photo-mode
+(render targets/camera).
 
 Candidates, chosen to cover surfaces the corpus doesn't yet exercise:
 
-- **Tower defense** — mouse picking/placement UI, enemy pathing over a grid,
-  wave scheduling via `Sub`, range queries at scale.
 - **Tetris / falling-block puzzle** — pure grid model, rotation systems, timed
   gravity, line-clear animation; a canonicality showcase (zero physics).
 - **Breakout / pong** — minimal-2D starter-tier sample; paddle/ball/brick in
   ~150 lines; tests how small a real game can be.
 - **Twin-stick arena shooter** — gamepad input domain (`Input.snapshot`
   siblings), analog-stick handling, hundreds of entities.
-- **Vampire-survivors-lite / boids swarm** — interpreter perf ceiling: how
-  many entities before `frame_bench`-visible cost; spatial partitioning in
-  pure Functor Lang.
 - **Rhythm game** — audio/gameplay sync, beat timing, latency compensation;
   stresses the sound API's scheduling precision.
 - **Roguelike floor** — procgen with seeded `Effect.random`, turn-based (no
@@ -286,18 +346,19 @@ Candidates, chosen to cover surfaces the corpus doesn't yet exercise:
   `examples/mp`: prediction, interpolation, authoritative physics.
 - **Idle/incremental clicker** — save/load persistence effects (does the
   engine have any? that's the point), big-number formatting, offline progress.
-- **Golf / marble course** — physics + terrain heightfield interplay
-  (`terrain` showcase exists; putting a controlled impulse game on it doesn't).
-- **Space dogfight / flight sim** — full 3D rotation (quaternion ergonomics),
-  relative-velocity aiming, 6DoF camera.
 - **Stealth vignette** — AI state machines in a pure model, vision cones,
   light/shadow as gameplay.
+- **Inventory/crafting sandbox** — drag/drop, tooltips, focus, typed item data,
+  save/load, and UI state at scale.
+- **Turn-based tactics** — grid picking, path/range overlays, deterministic AI,
+  action queues, and camera transitions.
 - **Beat-saber-like XR exercise** — XR at frame-rate budget on device,
   velocity-based scoring; pairs with the `vr-device-loop` skill for real
   measurements.
-- **Walking-sim / photo mode** — atmosphere, skybox, fog, render targets,
-  camera paths; stresses the rendering surface with near-zero game logic.
 
-When picking a slate, mix: at least one physics-heavy, one input-surface, one
-UI-heavy, one perf-stress, and one presentation-only brief — gaps cluster by
-surface, and a diverse slate maximizes coverage per jam.
+With no briefs, choose 10 distinct candidates. Substitute a non-device brief
+for XR when no headset is attached. For `N >= 6`, cover at least one
+physics/simulation-heavy, one input-surface, one UI-heavy, one perf-stress, one
+network/effect-heavy, and one presentation-first brief. For `N < 6`, maximize
+surface diversity without expanding the requested briefs into kitchen-sink
+projects.

--- a/.claude/skills/game-jam/SKILL.md
+++ b/.claude/skills/game-jam/SKILL.md
@@ -240,7 +240,8 @@ immutable artifact, and rerun all affected adoption proofs.
 
 ### Make the entry adopt the fix
 
-After its fix PR is ready, resume the original builder in `jam/<slug>`:
+After the draft fixer PR passes implementation review, verification, and CI at
+its recorded head, resume the original builder in `jam/<slug>`:
 
 - For code-facing fixes, remove the workaround/use the new surface, update
   `JAM_NOTES.md` with before/after evidence and the PR, rerun tests, scripted
@@ -291,7 +292,7 @@ put every entry behind one URL and hand it over:
 ```sh
 node .claude/skills/game-jam/scripts/build-gallery.mjs \
   platformer=<worktree>/examples/platformer racer=<worktree>/examples/racer \
-  --out /tmp/jam-gallery --serve 8321
+  --out <run-root>/gallery --serve 8321
 ```
 
 It builds each project, copies the bundles, and generates a card index —

--- a/.claude/skills/game-jam/SKILL.md
+++ b/.claude/skills/game-jam/SKILL.md
@@ -38,19 +38,24 @@ consolidated roadmap, and promotion.
    exactly `N-B` backlog briefs. Without `--entries`, use the explicit briefs,
    or 10 backlog briefs when `B=0`. Reject `B>N`, more than 10 explicit briefs,
    and duplicate slugs; never discard an explicit brief.
-2. Create a dedicated clean bootstrap worktree at the exact baseline SHA every
+2. Create one exclusive per-run root outside the checkout (for example, the
+   exact path returned by `mktemp -d /tmp/functor-jam.XXXXXX`). Put bootstrap,
+   entry/fixer worktrees, immutable artifacts, gallery output, and a run ledger
+   beneath it. Record every agent id/worktree and every shell-launched
+   background process's PID, process group, cwd, command, and owner at launch.
+3. Create a dedicated clean bootstrap worktree at the exact baseline SHA every
    jam branch uses. Build the release CLI **once** there and fetch shared assets:
    `npm run build:cli && npm run fetch:assets`. Run it in the background and
    launch agents immediately — they spend their first stretch reading docs.
    A SHA recorded from a dirty checkout is not valid provenance. No agent may
    build, capture, or run debug verification until the orchestrator confirms
    setup succeeded and records the binary's source SHA.
-3. All Phase 1 game-builder agents share the bootstrap worktree's
+4. All Phase 1 game-builder agents share the bootstrap worktree's
    `target/release/functor` by absolute path. The binary interprets each game's
    `.fun` files, so builders must never build it themselves (ten cargo builds
    would thrash the machine). Phase 1.5 fixers build changed code only inside
    their dedicated fixer worktrees.
-4. Skim `examples/` and recent `jam/*` branches first so briefs do not duplicate
+5. Skim `examples/` and recent `jam/*` branches first so briefs do not duplicate
    existing or just-completed samples (e.g.
    `mario` is already a 2D sprite platformer; `asteroids` is top-down 3D).
 
@@ -66,13 +71,13 @@ Choose the game-builder model before spawning:
   applies only to those agents, not to nested tools such as `xreview`, which
   retain their own model policy.
 
-Create a git worktree and `jam/<slug>` branch for every brief, then spawn one
-subagent per brief with the chosen model and its absolute worktree path. Require
-that path as the cwd for every command; use a host-provided worktree-isolation
-option when available. On OpenAI, use a non-full-history fork when passing an
-explicit model and include all required context in the prompt. Pace the fleet;
-do not run everything at once (see "Concurrency limits" below). Each prompt
-must include:
+Create every git worktree beneath the exclusive per-run root and a
+`jam/<slug>` branch for every brief, then spawn one subagent per brief with the
+chosen model and its absolute worktree path. Require that path as the cwd for
+every command; use a host-provided worktree-isolation option when available.
+On OpenAI, use a non-full-history fork when passing an explicit model and
+include all required context in the prompt. Pace the fleet; do not run
+everything at once (see "Concurrency limits" below). Each prompt must include:
 
 - **The brief**: game, slug, and the specific engine surfaces it exists to
   stress (physics, XR input, 2D ergonomics, chase camera, UI/dialog, …).
@@ -150,11 +155,13 @@ numbers. Rules:
 - **Disk hygiene between fixers (learned mid-run: a full disk killed a fixer
   mid-build).** Every heavy fixer leaves a multi-GB `target/` cache in its
   worktree; a long fixer queue fills the drive. Before deleting a fixer's
-  `target/`, copy the verified release CLI (with its embedded wasm bundle) to
-  `/tmp/functor-jam/<fix-head-sha>/functor`, record its checksum, and use that
-  immutable artifact for covered adoptions; otherwise retain the cache through
-  adoption. Resolve finished worktrees individually, validate each absolute
-  path against `git worktree list --porcelain`, and remove only the explicit
+  `target/`, create a new non-existing artifact directory under the exclusive
+  run root, copy the verified release CLI (with embedded wasm) through a
+  temporary name and atomically rename it, make it read-only, and record its
+  checksum. Verify that checksum immediately before every adoption/gallery use;
+  otherwise retain the cache through adoption. Resolve finished worktrees
+  individually, validate each absolute path against
+  `git worktree list --porcelain`, and remove only the explicit
   `<finished-worktree>/target` — never use a fleet-wide wildcard. Check `df -h`
   before each heavy launch. Long-running heavy agents should report, not
   self-remediate outside their worktree, if disk runs low mid-task.
@@ -202,8 +209,10 @@ immutable artifact, and rerun all affected adoption proofs.
   workflow. Never pad the round with cosmetic P3 work.
 - If an entry has no qualifying P0/P1 or workflow-blocking P2, run one
   additional targeted docs-first stress workflow. If that still yields none,
-  replace the brief; if no replacement exposes a real blocker, report the jam
-  blocked rather than fabricate work or count the entry complete.
+  replace an auto-filled backlog brief in the same roster slot. Never replace
+  an explicit user brief without their authorization: report that entry blocked
+  and request direction. If no permitted replacement exposes a real blocker,
+  report the jam blocked rather than fabricate work or change the requested N.
 - For a large gap, ship the smallest principled slice that removes one proven
   workaround from the entry. An issue or design sketch alone does not count.
 - Dedupe shared root causes. One PR may cover several entries only when it has
@@ -222,9 +231,10 @@ immutable artifact, and rerun all affected adoption proofs.
    preserve fake/replay determinism, rebuild wasm for web claims, and run the
    required before/after benchmarks for hot-path changes.
 3. Run `xreview`, fix every Critical/High, disposition all findings in a draft
-   PR, rerun verification, wait for the complete CI matrix, then mark the PR
-   ready. Run one cargo-building fixer at a time and clear only its rebuildable
-   worktree cache before launching the next.
+   PR, rerun verification, and wait for the complete CI matrix at the recorded
+   head — but keep the PR draft until every covered entry proves adoption. Run
+   one cargo-building fixer at a time and clear only its rebuildable worktree
+   cache before launching the next.
 4. For dependent fixes, branch and target each downstream PR on its immediate
    dependency. Record each PR's own commit range and tested head.
 
@@ -243,6 +253,12 @@ After its fix PR is ready, resume the original builder in `jam/<slug>`:
   prove the blocker is gone, reopen the fixer; a green unit test alone is
   insufficient. The orchestrator independently reruns every row's acceptance
   proof before declaring it complete.
+
+Only after every adoption row covered by a fixer head passes, its adoption
+reviews are dispositioned, and the orchestrator's proof reruns succeed: confirm
+the fixer PR still has that exact head, require the full expected CI set green,
+then mark it ready as the final action. A changed head invokes the invalidation
+rule above and returns the PR to the proof cycle.
 
 When several unmerged fixes are needed for final gallery testing, create a
 disposable local integration branch from their common base. Cherry-pick only
@@ -314,9 +330,14 @@ gallery exercises the adopted APIs rather than a stale main build.
      recorded jam descendants; never kill by executable-name match alone.
    - **Worktrees, only after synthesis**: first confirm every entry's work is
      committed to its `jam/<slug>` branch (branches survive worktree removal;
-     staged-but-uncommitted work does not), save JAM_NOTES content into the
-     synthesis report, then remove the worktrees — including their multi-GB
-     `target/` dirs from fixer builds.
+     staged-but-uncommitted work does not), save JAM_NOTES and required captures
+     outside the per-run root, and inspect `git status --porcelain` in each
+     worktree. The only permitted untracked paths are explicitly inventoried
+     disposable captures; archive them, remove those exact paths, and use normal
+     `git worktree remove` without `--force`. After every registered worktree and
+     process is gone and final evidence is preserved elsewhere, validate the
+     exact per-run root and remove it, retiring bootstrap, artifact, gallery,
+     and ledger scratch together.
 
 ## Backlog — future jam briefs and what each stresses
 


### PR DESCRIPTION
## Summary

- support explicit 1–10 entry rosters, defaulting to 10 when no briefs are supplied
- require one qualifying blocker to be removed for every entry, with SHA-pinned before/after adoption proof
- deduplicate shared root causes and define stacked dependent-fix/integration-artifact handling
- make four-slot scheduling, bootstrap provenance, CI gates, cache cleanup, and process cleanup explicit and safe
- prefer durable TypeScript SDK or MCP verification over one-off raw HTTP

## Verification

- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/game-jam` — Skill is valid
- `git diff --check`
- independent forward audit across: default 10-entry run on four slots; `--entries 3 brief-a`; four entries sharing one blocker; P3-only friction; dependent unmerged fixes
- follow-up audit: no remaining Critical issues; all identified Critical/High workflow contradictions resolved
- final xreview at head `b71456b`: validation and diff checks clean; no Critical/High findings remain
- all 9 expected GitHub Actions checks passed at final head `b71456b`

## Review

Final adversarial review verdict: **ship** — no Critical or High findings remain.

Findings fixed during review:

- kept fixer PRs draft until every covered entry completes adoption, review, and orchestrator proof
- removed the draft/ready adoption deadlock with an explicit reviewed + verified + CI-green draft checkpoint
- protected explicit briefs from unauthorized substitution
- moved all worktrees/artifacts/gallery scratch under an exclusive per-run root with ledgered, validated cleanup
- made copied fix artifacts atomic, read-only, checksum-recorded, and checksum-verified before use