### PR TITLE
docs: teach unsafe MCP automation in the hosted manual

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -202,7 +202,7 @@ await writeFile(
 - [API reference (JSON)](https://functor.games/docs/api.json): the same reference as structured data (modules → items with \`qualified_name\`, \`kind\`, \`declaration\`, \`docs\`).
 - [API reference (HTML)](https://functor.games/docs/): the searchable rendering of the same data.
 - [Manual](https://functor.games/manual/): getting started, the MVU game contract, language principles, topic guides.
-- [Driving games with agents](https://functor.games/manual/#agents): register \`functor mcp\` and drive a game over MCP — launch or attach a session, read its model, pause and step the clock, inject input, capture frames, hot-reload source.
+- [Driving games with agents](https://functor.games/manual/#agents): register \`functor mcp\`, then prefer \`run_game_code_unsafe\` with one bare \`async (game) => { ... }\` JavaScript function for trusted multi-step automation. It requires Node.js 20+ (\`FUNCTOR_NODE\` overrides the executable) and is deliberately RCE-equivalent, not sandboxed. The injected SDK observes state/scene/trace/captures, controls time and release-safe input, waits deterministically, reloads/rewinds, and returns a concrete call trace plus final state; captures are MCP image blocks. Use the lower-level tools for one-offs and clients without Node.
 - [Sandbox](https://functor.games/sandbox.html): run and edit the sample games in the browser.
 
 ## Source

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -826,14 +826,65 @@ type t&lt;'value, 'error> = | Ok(value: 'value) | Error(error: 'error)   // Resu
               <tr><td><strong>Sessions</strong><br /><code>launch_game</code> · <code>connect_game</code> · <code>list_sessions</code> · <code>stop_game</code></td><td>spawn a game as a child process on a free port, or attach to a runtime someone else is running (another <code>--debug-port</code>, or a Quest). <code>launch_game</code>'s <code>mode</code> is <code>hidden</code> (the default — it renders, so frames can be captured) or <code>headless</code> (no GL context at all — CI-friendly, but nothing to read back)</td></tr>
               <tr><td><strong>Observing</strong><br /><code>get_state</code> · <code>get_scene</code> · <code>get_trace</code> · <code>capture_frame</code></td><td>the model as structured JSON alongside <code>frame</code>/<code>tts</code>/sampled input; the camera, scene graph, and lights <code>draw</code> produced; the paused inspector trace; a PNG of the next frame</td></tr>
               <tr><td><strong>Driving</strong><br /><code>pause</code> · <code>step</code> · <code>resume</code> · <code>send_input</code> · <code>rewind</code> · <code>reload_source</code> / <code>reload_project</code></td><td>pin the clock, run <em>n</em> frames of a fixed <em>dt</em>, inject a key / mouse / UI / XR command, restore the model and physics to a recorded frame, or hot-reload the source with the live model preserved</td></tr>
+              <tr><td><strong>Trusted automation</strong><br /><code>run_game_code_unsafe</code></td><td>run one Playwright-style JavaScript function against an injected, session-bound game SDK; this is the preferred surface for trusted multi-step automation</td></tr>
               <tr><td><strong>Authoring</strong><br /><code>init_game</code> · <code>save_project</code></td><td>scaffold the same starter <code>functor init</code> writes, and write a session's <em>current</em> source out to a directory</td></tr>
               <tr><td><strong>Knowledge</strong><br /><code>language_guide</code> · <code>api_reference</code></td><td>the two halves of learning Functor, and neither needs a session: the language guide (syntax, semantics, the game contract) and a search over the same <code>.funi</code> prelude this site's <a href="../docs/">API reference</a> is generated from</td></tr>
             </tbody>
           </table>
 
-          <h3>A deterministic loop</h3>
+          <h3>One trusted automation function</h3>
           <p>
-            Pin the clock, act, step, read. Nothing advances on its own in between, and
+            After <code>launch_game</code> or <code>connect_game</code>, prefer one
+            <code>run_game_code_unsafe</code> call for a trusted multi-step workflow. Its
+            <code>code</code> must be a bare JavaScript function expression — Node invokes it as
+            <code>await program(game)</code>:
+          </p>
+          <pre class="shell">run_game_code_unsafe {
+  "session": "s1",
+  "code": "async (game) => { await game.pause(); await game.pressKey(\"3\"); return await game.stepUntil((state) => state.model.enemies.length > 0, { maxFrames: 120, dts: 1 / 60, description: \"the first enemy\" }); }"
+}</pre>
+          <p>
+            This is ordinary JavaScript, not TypeScript. It requires Node.js 20 or newer;
+            <code>FUNCTOR_NODE</code> can name a non-default executable. The
+            <code>unsafe</code> suffix is literal: submitted code can import modules, access files,
+            environment variables, and the network, and start processes with the same OS authority
+            as <code>functor mcp</code>. It is RCE-equivalent and the child process is
+            <strong>not</strong> a security or process-tree sandbox. Use only code and MCP clients
+            you trust with equivalent developer-machine access.
+          </p>
+          <p>
+            The injected methods cover observation
+            (<code>state</code> / <code>scene</code> / <code>trace</code> /
+            <code>capture</code>), the clock
+            (<code>pause</code> / <code>resume</code> / <code>step</code> /
+            <code>stepFrames</code>), input
+            (<code>input</code> / <code>pressKey</code>), waits
+            (<code>waitForState</code> / <code>stepUntil</code>), reload
+            (<code>reloadSource</code> / <code>reloadProject</code> /
+            <code>reloadAsset</code> / <code>reloadAssets</code>), and
+            <code>rewind</code>. Prefer <code>pressKey</code> for a press-and-step: it attempts the
+            release even if the action fails, and failed runs restore SDK-touched key and mouse
+            button levels to their pre-run state.
+          </p>
+          <p>
+            <code>stepUntil</code> is the deterministic wait: it checks current state, then advances
+            and observes one fixed frame at a time. Its <code>maxFrames</code> defaults to 600 and
+            is capped at 10,000; <code>dts</code> defaults to 1/60 second; exhaustion throws.
+            <code>waitForState</code> instead polls a running game without advancing it.
+          </p>
+          <p>
+            State and scene values keep Functor's JSON encoding in Node. Pattern-match ADT variants
+            such as <code>{"$ctor":"Playing","args":[7.0]}</code>, and maps such as
+            <code>{"$map":[["a",1.0],["b",2.0]]}</code>. The tool's first MCP content block
+            includes the function's JSON return value, concrete SDK-call trace, logs, capture
+            metadata, and fresh final state. Every <code>game.capture()</code> also arrives as a
+            following PNG MCP image block.
+          </p>
+
+          <h3>Lower-level one-offs</h3>
+          <p>
+            Use the individual tools for one-off operations, protocol debugging, or clients without
+            Node.js. Pin the clock, act, step, read. Nothing advances on its own in between, and
             <code>step</code> does not return until the steps have actually landed — so what comes
             back is the effect of the input, not a sample of a still-moving game:
           </p>


### PR DESCRIPTION
## Problem

The hosted “Driving games with agents” manual still described only the individual MCP tools after `run_game_code_unsafe` merged. A hosted-docs-first agent could not discover the preferred one-function automation path, its injected SDK, Node requirement, trust boundary, deterministic waits, JSON encoding, or result/capture shape.

That gap was independently hit by the Breakout, Memory, Roguelike, and Stealth game-jam entries. Each had to leave the hosted docs and fall back to repository-only MCP/SDK documentation or source before it could author and validate its automation.

## Scope

- Add `run_game_code_unsafe` to the hosted MCP tool overview.
- Add one copyable bare async-function example.
- Document the injected observation, clock, input, wait, reload, rewind, and capture surface.
- Document `stepUntil` defaults/bounds, `waitForState`, `$ctor`/`$map` JSON, returned trace/log/final-state evidence, and MCP image blocks.
- Keep the existing individual-tool workflow as the lower-level path.
- Update the generated `llms.txt` MCP summary so agents can discover the same preferred route without rendering the manual.

Only `site/manual/index.html` and `site/build.mjs` change.

## Trust boundary

The new hosted text is deliberately explicit: this tool evaluates ordinary JavaScript in a local Node.js 20+ child (`FUNCTOR_NODE` may select the executable). Submitted code has the same OS authority as `functor mcp`; it can access files, environment variables, modules, the network, and child processes. It is RCE-equivalent and is neither a security sandbox nor a process-tree sandbox.

## Verification

- `npm run check:site`
- Node 22: `npm run site:build`
- Desktop and mobile before/after captures inspected.
- Exact rendered artifact independently served and fetched: SHA-256 `67353dc0c86e69a18be8fef438b33c2b179701bc187b5b864d8536be1a70f88f`.
- All nine GitHub checks passed at exact head `aad4577c287bd0241bed05ce2eeb4354123e9aba`.

## Review disposition

Two independent adversarial reviews checked correctness, simplicity, implementation parity, and the desktop/mobile media. Both were clean: no Critical, High, Medium, or Low findings.

## Game-jam blocker coverage

| Entry | Baseline | Hosted-doc blocker exercised | Coverage in this PR | Adoption |
| --- | --- | --- | --- | --- |
| Breakout | `92a3fff097ec8e7dbd014634018e16c02969f6de` | Hosted manual omitted the runner, preferred workflow, SDK helpers, trust/bounds, and result encoding; repository MCP docs/source were required. | Tool overview, preferred function, helper categories, security/Node requirements, deterministic wait bounds, JSON/result/capture shape. | `3ecf0f92ba4462085374d0fe3bb01f6705a6cbe3`: unchanged game/automation reran in 130 calls; pointer + held-key paths passed and first brick hit was exact (`score=100`, `bricks=39`). |
| Memory | `6dbbd05abae437e6d08cfdb2df975cd568c7c4d1` | Hosted docs omitted `run_game_code_unsafe`, injected `game`, `stepUntil`, selected returns, image captures, Node selection, and RCE boundary. | Function example, SDK/wait/result coverage, `FUNCTOR_NODE`, Node 20+, RCE/process-tree warning, capture blocks. | `c93b9006dd8d13f169b5a5cf3b0014bba8bbca4e`: unchanged automation completed 58 calls, derived a mismatch and matching pair from state, then reached `score=100`, `moves=2` with three captures. |
| Roguelike | `f70c5b601e24441a4a5a287406d52299ca7e1fcd` | Hosted docs omitted the full async-function form, injected SDK, return behavior, `stepUntil`, and `$map` state encoding. | Exact code shape, injected methods, return/trace/final-state description, deterministic wait, `$ctor`/`$map` examples. | `c8af255bc6bcfb8f075f76fef6811f244e2d2e48`: unchanged 26-call automation proved collision/no-turn, hunting AI, pickup, and combat kill (`score=125`) with clean held input. |
| Stealth | `b801444d5006cc63dc732ae4d01c1fb72ff8bbe6` | A hosted-only agent could not discover the runner, source shape, methods, limits/results, cleanup behavior, or ADT encoding. | Preferred tool and function shape, key/button cleanup guarantee, wait bounds, result/capture structure, `$ctor`/`$map`, Node/RCE caveats. | `e280a360c7b373a85db42d70385092300611923d`: unchanged 247-call automation proved cover occlusion, Patrol → Suspicious → Search → Patrol, and extraction with zero detections plus three captures. |

Each adoption changed `JAM_NOTES.md` only. The orchestrator independently served the exact generated docs artifact and reran all four unchanged MCP automations after adoption.

## Visual proof

### Desktop before → after

![Desktop hosted MCP manual before and after](https://gist.githubusercontent.com/tommy-xr/92968091ea6cbc50c77b2fff7f5be847/raw/hosted-mcp-docs-desktop-before-after.png)

<sub>The previous page stopped at individual MCP tools; the updated page adds the trusted automation tool, executable example, security boundary, SDK workflow, deterministic waits, and result encoding.</sub>

### Mobile before → after

![Mobile hosted MCP manual before and after](https://gist.githubusercontent.com/tommy-xr/92968091ea6cbc50c77b2fff7f5be847/raw/hosted-mcp-docs-mobile-before-after.png)

<sub>The same content remains readable within the existing narrow-screen docs layout. No GIF is needed for this static documentation change.</sub>
