### PR TITLE
feat(mcp): add compact unsafe code results

### DIFF
--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -326,6 +326,7 @@ struct NodeCodeOutput {
     captures: Vec<Vec<u8>>,
     calls_executed: usize,
     final_state: Option<Value>,
+    final_state_summary: Option<Value>,
     output_budget: CodeOutputBudget,
 }
 
@@ -925,6 +926,11 @@ pub struct RunGameCodeUnsafeArgs {
     /// bounded and may extend the response. Processes deliberately started by
     /// trusted submitted code are outside this lifecycle boundary.
     pub timeout_ms: Option<u64>,
+    /// Include the complete final `/state` response (default true). Set false
+    /// when submitted code already selects its proof into `return_value`: the
+    /// parent still takes the final snapshot for cleanup/integrity, but returns
+    /// only `final_state_summary` with runtime/input facts and model byte size.
+    pub include_final_state: Option<bool>,
 }
 
 #[tool_router]
@@ -1423,7 +1429,13 @@ MCP server before reconnecting or reusing that runtime URL.",
         };
 
         match self
-            .execute_node_code(&target, &args.code, timeout, &context)
+            .execute_node_code(
+                &target,
+                &args.code,
+                timeout,
+                args.include_final_state.unwrap_or(true),
+                &context,
+            )
             .await
         {
             Ok(output) => match node_code_call_result(output) {
@@ -1950,6 +1962,7 @@ context at all — relaunch it with mode \"hidden\" to capture frames.",
         target: &SessionTarget,
         code: &str,
         timeout: Duration,
+        include_final_state: bool,
         context: &RequestContext<RoleServer>,
     ) -> Result<NodeCodeOutput, String> {
         let timeout = timeout.min(OPERATION_TOTAL_TIMEOUT);
@@ -2005,6 +2018,7 @@ context at all — relaunch it with mode \"hidden\" to capture frames.",
             captures: Vec::new(),
             calls_executed: 0,
             final_state: None,
+            final_state_summary: None,
             output_budget: CodeOutputBudget::default(),
         };
 
@@ -2085,7 +2099,7 @@ still be alive; stop an owned session, or restart both an attached runtime and t
         .await
         {
             Ok(state) => {
-                if let Err(error) = output.output_budget.retain_json(&state) {
+                if let Err(error) = retain_final_snapshot(&mut output, state, include_final_state) {
                     let cause = format!(
                         "submitted code completed but its final state exceeded the output budget: \
 {error}"
@@ -2105,8 +2119,6 @@ still be alive; stop an owned session, or restart both an attached runtime and t
                             .await
                         },
                     );
-                } else {
-                    output.final_state = Some(state);
                 }
             }
             Err(error) => {
@@ -3125,6 +3137,56 @@ fn summarize_state(state: &Value) -> Value {
     })
 }
 
+fn compact_final_state_summary(state: &Value) -> Result<Value, String> {
+    let model_json_bytes = json_encoded_len(state.get("model").unwrap_or(&Value::Null))?;
+    let mut held_mouse_buttons: Vec<&str> = state
+        .pointer("/input/mouse/buttons")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|buttons| buttons.iter())
+        .filter_map(|(button, held)| {
+            held.as_bool()
+                .is_some_and(|held| held)
+                .then_some(button.as_str())
+        })
+        .collect();
+    held_mouse_buttons.sort_unstable();
+
+    let mut summary = serde_json::json!({
+        "frame": state.get("frame").cloned().unwrap_or(Value::Null),
+        "tts": state.get("tts").cloned().unwrap_or(Value::Null),
+        "pending_steps": state.get("pending_steps").cloned().unwrap_or(Value::Null),
+        "held_keys": state.pointer("/input/held_keys").cloned().unwrap_or(Value::Null),
+        "held_mouse_buttons": held_mouse_buttons,
+        "model_json_bytes": model_json_bytes,
+    });
+    // Some future/attached runtimes may expose this clock fact directly.
+    // Current protocol versions do not, so never infer it from pending work.
+    if let Some(paused) = state.get("paused").filter(|value| value.is_boolean()) {
+        summary
+            .as_object_mut()
+            .expect("compact state summary is an object")
+            .insert("paused".into(), paused.clone());
+    }
+    Ok(summary)
+}
+
+fn retain_final_snapshot(
+    output: &mut NodeCodeOutput,
+    state: Value,
+    include_final_state: bool,
+) -> Result<(), String> {
+    if include_final_state {
+        output.output_budget.retain_json(&state)?;
+        output.final_state = Some(state);
+    } else {
+        let summary = compact_final_state_summary(&state)?;
+        output.output_budget.retain_json(&summary)?;
+        output.final_state_summary = Some(summary);
+    }
+    Ok(())
+}
+
 fn summarize_value(value: &Value) -> Value {
     match value {
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => value.clone(),
@@ -3900,7 +3962,7 @@ fn node_code_summary(output: &NodeCodeOutput) -> Result<String, String> {
         })
         .collect();
     let ok = output.failure.is_none() && output.code_error.is_none();
-    let summary = serde_json::json!({
+    let mut summary = serde_json::json!({
         "ok": ok,
         "unsafe": {
             "rce_equivalent": true,
@@ -3917,6 +3979,14 @@ fn node_code_summary(output: &NodeCodeOutput) -> Result<String, String> {
         "captures": captures,
         "final_state": &output.final_state,
     });
+    // Preserve the default result shape exactly. Compact callers get one
+    // additional, explicitly named field while `final_state` remains null.
+    if let Some(final_state_summary) = &output.final_state_summary {
+        summary
+            .as_object_mut()
+            .expect("submitted-code summary is an object")
+            .insert("final_state_summary".into(), final_state_summary.clone());
+    }
     serialize_json_bounded(
         &summary,
         MAX_CODE_TEXT_BYTES,
@@ -4038,10 +4108,11 @@ mod tests {
     use super::{
         acquire_target_operation, base64_encoded_len, checked_output_total, encoded_capture_total,
         ensure_operation_active, extend_bounded, find_guide_section, guide_sections,
-        json_encoded_len, node_code_call_result, read_body, read_bounded_response, render_api_hits,
-        render_guide_contents, render_guide_section, search_api, serialize_json_bounded,
-        spawn_node_child, strip_front_matter, truncate_code_error, CodeInputRestore,
-        CodeOutputBudget, FunctorMcp, NodeCodeOutput, Registry, SessionTarget, LANGUAGE_GUIDE,
+        json_encoded_len, node_code_call_result, node_code_summary, read_body,
+        read_bounded_response, render_api_hits, render_guide_contents, render_guide_section,
+        retain_final_snapshot, search_api, serialize_json_bounded, spawn_node_child,
+        strip_front_matter, truncate_code_error, CodeInputRestore, CodeOutputBudget, FunctorMcp,
+        NodeCodeOutput, Registry, RunGameCodeUnsafeArgs, SessionTarget, LANGUAGE_GUIDE,
         MAX_CODE_CAPTURE_BYTES, MAX_CODE_TEXT_BYTES, QUICK_FACTS_SLUG,
     };
     use functor_docgen::ApiReference;
@@ -4054,6 +4125,22 @@ mod tests {
 
     fn reference() -> ApiReference {
         functor_docgen::generate().expect("the embedded prelude documents itself")
+    }
+
+    fn empty_node_code_output() -> NodeCodeOutput {
+        NodeCodeOutput {
+            node_version: "v22.0.0".into(),
+            return_value: serde_json::Value::Null,
+            code_error: None,
+            failure: None,
+            trace: Vec::new(),
+            logs: Vec::new(),
+            captures: Vec::new(),
+            calls_executed: 0,
+            final_state: None,
+            final_state_summary: None,
+            output_budget: CodeOutputBudget::default(),
+        }
     }
 
     async fn fake_http_url(raw: impl AsRef<[u8]>) -> String {
@@ -4128,6 +4215,132 @@ mod tests {
     }
 
     #[test]
+    fn submitted_code_final_state_defaults_to_the_compatible_full_response() {
+        let args: RunGameCodeUnsafeArgs = serde_json::from_value(serde_json::json!({
+            "session": "game",
+            "code": "async () => null"
+        }))
+        .unwrap();
+        assert_eq!(args.include_final_state, None);
+
+        let state = serde_json::json!({
+            "frame": 42,
+            "tts": 1.5,
+            "pending_steps": 0,
+            "model": {"answer": 42},
+            "model_debug": "answer = 42",
+            "input": {
+                "held_keys": [],
+                "mouse": {"buttons": {"left": false, "right": false, "middle": false}}
+            }
+        });
+        let mut output = empty_node_code_output();
+        retain_final_snapshot(
+            &mut output,
+            state.clone(),
+            args.include_final_state.unwrap_or(true),
+        )
+        .unwrap();
+
+        let result: serde_json::Value =
+            serde_json::from_str(&node_code_summary(&output).unwrap()).unwrap();
+        assert_eq!(result["final_state"], state);
+        assert!(
+            result.get("final_state_summary").is_none(),
+            "the default result shape stays unchanged"
+        );
+    }
+
+    #[test]
+    fn compact_submitted_code_final_state_has_only_runtime_and_input_facts() {
+        let state = serde_json::json!({
+            "frame": 81,
+            "tts": 2.25,
+            "paused": true,
+            "pending_steps": 0,
+            "model": {
+                "boids": [
+                    {"marker": "BOID_MODEL_MUST_NOT_ESCAPE"},
+                    {"marker": "BOID_MODEL_MUST_NOT_ESCAPE"}
+                ]
+            },
+            "model_debug": "MODEL_DEBUG_MUST_NOT_ESCAPE",
+            "input": {
+                "held_keys": ["W"],
+                "mouse": {
+                    "buttons": {"left": true, "right": false, "middle": true}
+                }
+            }
+        });
+        let expected_model_bytes = json_encoded_len(&state["model"]).unwrap();
+        let mut output = empty_node_code_output();
+        retain_final_snapshot(&mut output, state, false).unwrap();
+
+        assert!(output.final_state.is_none());
+        assert_eq!(
+            output.final_state_summary,
+            Some(serde_json::json!({
+                "frame": 81,
+                "tts": 2.25,
+                "paused": true,
+                "pending_steps": 0,
+                "held_keys": ["W"],
+                "held_mouse_buttons": ["left", "middle"],
+                "model_json_bytes": expected_model_bytes,
+            }))
+        );
+        let encoded = node_code_summary(&output).unwrap();
+        assert!(!encoded.contains("BOID_MODEL_MUST_NOT_ESCAPE"));
+        assert!(!encoded.contains("MODEL_DEBUG_MUST_NOT_ESCAPE"));
+        let result: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        assert!(result["final_state"].is_null());
+        assert!(result["final_state_summary"].get("model").is_none());
+        assert!(result["final_state_summary"].get("model_debug").is_none());
+    }
+
+    #[test]
+    fn compact_final_state_is_still_charged_but_not_charged_as_the_full_model() {
+        let state = serde_json::json!({
+            "frame": 1,
+            "tts": 0.0,
+            "pending_steps": 0,
+            "model": "x".repeat(MAX_CODE_TEXT_BYTES),
+            "model_debug": "also deliberately large",
+            "input": {
+                "held_keys": [],
+                "mouse": {"buttons": {}}
+            }
+        });
+
+        let mut full = empty_node_code_output();
+        let full_error = retain_final_snapshot(&mut full, state.clone(), true).unwrap_err();
+        assert!(
+            full_error.contains("submitted-code aggregate text output"),
+            "{full_error}"
+        );
+        assert!(full.final_state.is_none());
+
+        let mut compact = empty_node_code_output();
+        retain_final_snapshot(&mut compact, state.clone(), false).unwrap();
+        let summary = compact.final_state_summary.as_ref().unwrap();
+        assert_eq!(
+            summary["model_json_bytes"],
+            json_encoded_len(&state["model"]).unwrap()
+        );
+        assert!(compact.output_budget.retained_text_bytes < 256);
+
+        let summary_bytes = json_encoded_len(summary).unwrap();
+        let mut exhausted = empty_node_code_output();
+        exhausted.output_budget.retained_text_bytes = MAX_CODE_TEXT_BYTES - summary_bytes + 1;
+        let compact_error = retain_final_snapshot(&mut exhausted, state, false).unwrap_err();
+        assert!(
+            compact_error.contains("submitted-code aggregate text output"),
+            "{compact_error}"
+        );
+        assert!(exhausted.final_state_summary.is_none());
+    }
+
+    #[test]
     fn submitted_code_input_restoration_canonicalizes_serialized_digit_keys() {
         let mut restore = CodeInputRestore::from_state(&serde_json::json!({
             "input": {
@@ -4165,6 +4378,7 @@ mod tests {
             captures: vec![vec![1, 2, 3], vec![4]],
             calls_executed: 0,
             final_state: None,
+            final_state_summary: None,
             output_budget: CodeOutputBudget::default(),
         })
         .unwrap();

--- a/docs/mcp-unsafe-sdk-code.md
+++ b/docs/mcp-unsafe-sdk-code.md
@@ -43,9 +43,17 @@ The MCP request is still JSON. The program is simply its `code` string:
 {
   "session": "s1",
   "code": "async (game) => { ... }",
-  "timeout_ms": 120000
+  "timeout_ms": 120000,
+  "include_final_state": false
 }
 ```
+
+`include_final_state` defaults to `true` for compatibility. Set it to `false`
+when the program already selects its evidence into `return_value`. The parent
+still takes the final `/state` snapshot after the Node child exits, but discards
+the structured model and `model_debug` after producing a small
+`final_state_summary`. This keeps large models from dominating an otherwise
+compact automation result.
 
 ## Architecture
 
@@ -115,7 +123,15 @@ actually happened:
     }
   ],
   "captures": [],
-  "final_state": {}
+  "final_state": null,
+  "final_state_summary": {
+    "frame": 42,
+    "tts": 0.7,
+    "pending_steps": 0,
+    "held_keys": [],
+    "held_mouse_buttons": [],
+    "model_json_bytes": 12345
+  }
 }
 ```
 
@@ -127,6 +143,14 @@ submitted program can select the important fields into `return_value`. Every
 block. Because submitted code is RCE-equivalent, it can deliberately bypass
 the stdout guard and spoof protocol messages. The trace is useful observability
 for trusted automation, not a security attestation of hostile code.
+
+With the default `include_final_state: true`, `final_state` remains the complete
+fresh `/state` object and `final_state_summary` is absent. With `false`,
+`final_state` is `null`; the summary reports frame, game time, pending clock
+steps, held keyboard/mouse-button levels, and the encoded byte size of
+`model`. It includes `paused` only when an attached runtime actually supplies
+that field; it never guesses clock state from `pending_steps`. Neither `model`
+nor `model_debug` is retained in compact mode.
 
 ## Injected SDK
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -219,12 +219,16 @@ async (game) => {
 }
 ```
 
-The request puts that function in the `code` string and may set
-`timeout_ms` up to 120,000. The string is JavaScript evaluated by Node, not a
-TypeScript source file, so omit type annotations. Node.js 20 or newer must be
-installed; `FUNCTOR_NODE` can point to a non-default executable. If Node is
-missing or too old, the tool fails before running submitted code or mutating
-the game.
+The request puts that function in the `code` string and may set `timeout_ms` up
+to 120,000. `include_final_state` defaults to `true`; set it to `false` when
+the function already selects its evidence into `return_value`. The parent still
+takes the final `/state` snapshot, but returns only a
+`final_state_summary`—frame/time, pending steps, held input, and model JSON byte
+size—instead of retaining the structured model and `model_debug`. The string is
+JavaScript evaluated by Node, not a TypeScript source file, so omit type
+annotations. Node.js 20 or newer must be installed; `FUNCTOR_NODE` can point to
+a non-default executable. If Node is missing or too old, the tool fails before
+running submitted code or mutating the game.
 
 The injected object mirrors the standalone `@functor/sdk` method surface within
 the runner's documented bounds: observation, clock, input, project reload,
@@ -241,12 +245,12 @@ stdout; ordinary stdout writes become captured logs. The parent performs the
 existing typed debug-runtime requests while holding the session's operation
 gate. The tool returns the function's
 JSON-serializable value, captured console logs, a structured trace of every SDK
-call that actually ran, capture metadata plus PNG image blocks, and fresh final
-state. For trusted automation, the trace is useful validation evidence: loops,
-branches, and dynamic polling appear as their concrete calls without inventing
-a second serialized plan language. It is not an attestation against hostile
-submitted code, which already has RCE-equivalent authority and can deliberately
-spoof child protocol output.
+call that actually ran, capture metadata plus PNG image blocks, and either the
+fresh final state or its compact summary. For trusted automation, the trace is
+useful validation evidence: loops, branches, and dynamic polling appear as
+their concrete calls without inventing a second serialized plan language. It is
+not an attestation against hostile submitted code, which already has
+RCE-equivalent authority and can deliberately spoof child protocol output.
 
 The `unsafe` suffix is literal. Submitted code is arbitrary local Node code:
 it can import modules, access files and environment variables, use the network,

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -25,6 +25,13 @@ async (game) => {
 }
 ```
 
+For a submitted program that already returns its important proof, pass
+`"include_final_state": false` in the `run_game_code_unsafe` MCP arguments.
+The parent still takes its final integrity snapshot, but the text response
+contains a compact `final_state_summary` (frame/time, pending steps, held input,
+and model JSON byte size) instead of repeating the full `model` and
+`model_debug`. The option defaults to `true`, preserving existing callers.
+
 The standalone TypeScript client and injected MCP object both provide
 `pressKey`, `uiClick`, and `stepUntil`. The first two package common edge
 actions. `stepUntil` accepts an ordinary sync or async predicate, checks current


### PR DESCRIPTION
## Problem

The Boids automation already returned a compact proof, but `run_game_code_unsafe` unconditionally repeated the complete `final_state`, including the large structured model and `model_debug`. That inflated the text result to 34,373 bytes (approximately 8.6k tokens) and caused caller-side truncation.

## Design

- Add optional `include_final_state: false` for callers whose submitted function already selects its proof into `return_value`.
- Preserve exact compatibility by default: omitted or `true` returns the existing full result shape.
- Compact mode still takes the final `/state` snapshot, but retains only a bounded `final_state_summary` with frame/time, pending steps, held input, and `model_json_bytes`.
- Keep the existing child lifecycle, cancellation, input restoration, quarantine, and output-budget enforcement unchanged.

## Verification

- CLI tests: **100/100 passed**.
- Immutable test binary: `/tmp/functor-jam-fix-compact-result`
  - SHA-256: `0e7dc67f5c046099c262ed177632a08241d104a9d355fcd9a94b448de3b709c6`
- Ran the unchanged Boids proof twice against that binary:
  - 43 SDK calls with the exact same method shape each run.
  - Identical game-domain facts, `tts`, model size, released input, and capture hashes.
  - Neither a `boids` array nor `model_debug` appeared in the compact result.
  - Text results were 6,080 and 6,086 bytes versus the carried 34,373-byte full-state baseline: **82.31% / 82.29% smaller**.
  - Absolute hidden-launch frame and trace-byte counters differed by two warm-up frames; the adoption records this shell observability instead of claiming false whole-envelope determinism.
- No visual media required; this changes the MCP text-result envelope only.

## Blocker coverage

| Jam entry | Baseline | Covered blocker | Adoption proof |
| --- | --- | --- | --- |
| Boids | `e6ec5cfea5f28f97359722264ad959c38c4fe3d1` | Unconditional full final-state/model-debug result bloat and downstream truncation | `f3669ed0fc230be3e688a9207a7a2248a8c404ec` — unchanged 43-call automation, two compact runs, native build + 6/6 expects |

The orchestrator independently repeated the compact proof at this exact PR head and artifact checksum: 6,080-byte text result, `final_state: null`, bounded summary, clean input, 43 calls, and capture SHA-256 values `fce11a…e6e74` / `1e3085…73ef9`.

## Review disposition

| Review | Disposition |
| --- | --- |
| Independent adversarial review 1 | Clean — no Critical, High, Medium, or Low findings |
| Independent adversarial review 2 | Clean — no Critical, High, Medium, or Low findings |
| Adoption review | No Critical/High/Medium findings; three Low evidence-wording issues fixed in the notes-only adoption |
