### PR TITLE
feat(physics): add body rotation builders

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1299,15 +1299,20 @@ Physics.tag("name")                                        // BRANDED body ident
                                                            //   tags works). A bare string
                                                            //   where a tag goes is a check
                                                            //   error
-Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents)
+Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)       // -> Shape (box = FULL extents
+                                                           //   in the body's local axes)
 Physics.heightfield(terrainTag, world)                     // fixed body from the SAME Terrain.t;
                                                            //   one collider capped at 1025²
                                                            //   collision samples; supports translation
                                                            //   via Physics.at only — pair with an
-                                                           //   unrotated, unscaled Scene.terrain
+                                                           //   unrotated, unscaled Scene.terrain;
+                                                           //   Physics.rotateX/Y/Z rejects it
 Physics.dynamic(tag, shape)                                // simulated body
 Physics.kinematic(tag, shape) / Physics.fixed(tag, shape)
 body |> Physics.at(v)                                      // body-last: pipes
+body |> Physics.rotateX(angle) / rotateY / rotateZ         // Angle VALUES; rotate about the body
+                                                           //   center. Outer pipe applies last
+                                                           //   in world space, like Scene
 body |> Physics.velocity(v)
 body |> Physics.mass(m) / Physics.friction(f) / Physics.restitution(r)
 body |> Physics.sensor                                     // overlap-only, no forces

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1361,7 +1361,10 @@ a **spanned runtime error** (there is no Option-shaped return to match on),
 so only read tags your `physics` hook declares. The tag is cross-frame
 identity: same tag = same body; drop a body by not declaring it.
 Re-declaring an *unchanged* body leaves the simulation alone; *changing*
-its declared position teleports it (the divergence rule, docs/physics.md).
+its declared position or rotation drives that field (the divergence rule,
+docs/physics.md): dynamic/fixed bodies teleport the changed fields immediately,
+while a kinematic body receives the changed pose as its next-step target so it
+carries velocity into contacts.
 
 Physics **command effects** are returned beside the model like any effect
 — `(model, Physics.applyImpulse(ballTag, Vec3.make(0.0, 5.0, 0.0)))` — but carry no

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -13,7 +13,8 @@ Rigid-body physics is live in `runtime/functor-runtime-common/src/physics/`
 the vocabulary reference). Every phase below is annotated **Shipped** in the
 roadmap table; the highlights:
 
-- **Declarative bodies** (`Physics.scene`/`dynamic`/`kinematic`/`fixed` + the
+- **Declarative bodies** (`Physics.scene`/`dynamic`/`kinematic`/`fixed` +
+  body-centered `rotateX`/`rotateY`/`rotateZ` + the
   divergence rule), **live reads** (`Physics.position`/`transformed`),
   **commands** (impulse/force/velocity/teleport), **raycast queries**, and
   **collision events** (`Physics.events`) — all on the Functor Lang prelude,
@@ -134,13 +135,24 @@ let crateTag = Physics.tag("crate")            // branded identity: declared onc
 let physics = (model) =>                       // OPTIONAL game hook
   Physics.scene(Vec3.make(0.0, -9.81, 0.0), [
     Physics.fixed(Physics.tag("ground"), Physics.box(20.0, 0.2, 20.0)),
-    Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0)) |> Physics.at(Vec3.make(0.0, 5.0, 0.0)),
+    Physics.dynamic(crateTag, Physics.box(1.0, 1.0, 1.0))
+      |> Physics.rotateY(Angle.degrees(30.0))
+      |> Physics.at(Vec3.make(0.0, 5.0, 0.0)),
   ])
 
 let draw = (model, tts) =>
   Frame.create(camera,
     Scene.cube() |> Scene.lit(Color.rgb(0.8, 0.5, 0.2)) |> Physics.transformed(crateTag))
 ```
+
+Body transforms are subject-last. `body |> Physics.rotateX(x) |>
+Physics.rotateY(y)` stores `qY * qX`: the outer pipe applies last in world
+space, matching the `Scene.rotate*` rule. Rotation is around the body's center
+and boxes use their local axes, so fixed ramps and rotating kinematic obstacles
+need no special shape. Angles are branded values—bare numbers are rejected.
+`Physics.heightfield` remains translation-only because `Scene.terrain`
+rendering cannot rotate; applying any `Physics.rotate*` modifier to one is a
+teaching error.
 
 Functor Lang dissolves the read-back boundary problem outright: the interpreter runs in
 the **shell's own process**, sharing the crate statics that hold the physics

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -442,7 +442,12 @@ for (const example of examples) {
   );
   await page.locator("#api-search").fill("Scene.rotateY");
   const visibleDeclarations = await page.locator(".api-item:visible").count();
-  check("API reference search narrows declarations", visibleDeclarations === 1, `${visibleDeclarations} visible`);
+  const targetVisible = await page.locator("#api-scene-rotatey:visible").count();
+  check(
+    "API reference search finds the target and narrows declarations",
+    targetVisible === 1 && visibleDeclarations > 0 && visibleDeclarations < declarations,
+    `${visibleDeclarations}/${declarations} visible; target=${targetVisible}`
+  );
 
   await page.goto(`${BASE}/docs.html#get-started`);
   await page.waitForURL(/\/manual\/#get-started$/);

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -34,7 +34,7 @@ type collisionEvent = { started: bool, a: tag, b: tag, sensor: bool }
 /// The empty tag is reserved as the no-body sentinel in a raycast miss.
 let tag : (string) => tag
 
-/// Create a box shape from its width, height, and depth.
+/// Create a local-axis box shape from its full width, height, and depth.
 let box : (float, float, float) => shape
 /// Create a sphere shape from its radius.
 let sphere : (float) => shape
@@ -59,6 +59,24 @@ let fixed : (tag, shape) => body
 
 /// Set a body's initial world position; the body is last for piping.
 let at : (Vec3.t, body) => body
+/// Rotate a body about world X around its center; the body is last for piping.
+///
+/// An outer rotation applies last in world space, matching `Scene.rotateX`.
+/// Heightfield bodies reject rotation because terrain rendering is
+/// translation-only.
+let rotateX : (Angle.t, body) => body
+/// Rotate a body about world Y around its center; the body is last for piping.
+///
+/// An outer rotation applies last in world space, matching `Scene.rotateY`.
+/// Heightfield bodies reject rotation because terrain rendering is
+/// translation-only.
+let rotateY : (Angle.t, body) => body
+/// Rotate a body about world Z around its center; the body is last for piping.
+///
+/// An outer rotation applies last in world space, matching `Scene.rotateZ`.
+/// Heightfield bodies reject rotation because terrain rendering is
+/// translation-only.
+let rotateZ : (Angle.t, body) => body
 /// Set a body's initial linear velocity; the body is last for piping.
 let velocity : (Vec3.t, body) => body
 /// Set a body's mass; the body is last for piping.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -115,6 +115,7 @@
 //! Physics.box(w, h, d) / sphere(r) / capsule(hh, r)         -> Shape
 //! Physics.dynamic/kinematic/fixed(tag, shape)               -> Body
 //! Physics.at/velocity(v, body)                        -> Body
+//! Physics.rotateX/rotateY/rotateZ(angle, body)              -> Body
 //! Physics.mass/friction/restitution(n, body)                -> Body
 //! Physics.sensor(body)                                      -> Body
 //! Physics.upright(body)                                     -> Body
@@ -2342,6 +2343,76 @@ paths (+X, -X, +Y, -Y, +Z, -Z)";
 /// `Physics.tag` (registered with the branded constructors) is the body
 /// identity — check-time only, so at runtime a tag IS its string: the tag
 /// parameters here take the string directly.
+///
+/// Body rotations use the protocol's existing quaternion field. The prelude
+/// composes and canonicalizes them here so the shells only see ordinary body
+/// declarations and need no rotation-specific path.
+fn rotate_physics_body(
+    path: &str,
+    axis: [f32; 3],
+    angle: FunctorLangAngle,
+    body: FunctorLangBody,
+) -> Result<FunctorLangBody, String> {
+    if matches!(&body.0.shape, physics::Shape::Heightfield { .. }) {
+        return Err(format!(
+            "{path}: heightfield bodies cannot be rotated — terrain rendering is \
+translation-only; use Physics.at with an unrotated Scene.terrain"
+        ));
+    }
+
+    let angle: cgmath::Rad<f32> = angle.0.into();
+    // One canonical turn keeps equivalent angles (90° and 450°) on the same
+    // side of the quaternion double cover before multiplication.
+    let radians =
+        (angle.0 + std::f32::consts::PI).rem_euclid(std::f32::consts::TAU) - std::f32::consts::PI;
+    let (sin, cos) = (radians * 0.5).sin_cos();
+    let axis_rotation = [axis[0] * sin, axis[1] * sin, axis[2] * sin, cos];
+    // Match Scene's subject-last transform semantics: the outer pipe modifier
+    // applies last in world space, so compose q_axis * q_current.
+    let rotation = canonical_quaternion(quaternion_product(axis_rotation, body.0.rotation));
+    Ok(FunctorLangBody(body.0.facing(rotation)))
+}
+
+/// Hamilton product for `[x, y, z, w]` quaternions.
+fn quaternion_product(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
+    [
+        a[3] * b[0] + a[0] * b[3] + a[1] * b[2] - a[2] * b[1],
+        a[3] * b[1] - a[0] * b[2] + a[1] * b[3] + a[2] * b[0],
+        a[3] * b[2] + a[0] * b[1] - a[1] * b[0] + a[2] * b[3],
+        a[3] * b[3] - a[0] * b[0] - a[1] * b[1] - a[2] * b[2],
+    ]
+}
+
+fn canonical_quaternion(mut q: [f32; 4]) -> [f32; 4] {
+    let length_squared = q.iter().map(|component| component * component).sum::<f32>();
+    if !length_squared.is_finite() || length_squared <= f32::EPSILON {
+        return [0.0, 0.0, 0.0, 1.0];
+    }
+    let inverse_length = length_squared.sqrt().recip();
+    for component in &mut q {
+        *component *= inverse_length;
+    }
+
+    // A quaternion and its negation encode the same rotation. Pick one stable
+    // hemisphere (then a lexicographic tie-breaker at exactly 180°) so hot
+    // reload and debug-state comparisons do not churn between q and -q.
+    let negate = q[3] < 0.0
+        || (q[3] == 0.0
+            && (q[0] < 0.0
+                || (q[0] == 0.0 && (q[1] < 0.0 || (q[1] == 0.0 && q[2] < 0.0)))));
+    if negate {
+        for component in &mut q {
+            *component = -*component;
+        }
+    }
+    for component in &mut q {
+        if *component == 0.0 {
+            *component = 0.0;
+        }
+    }
+    q
+}
+
 fn register_physics(reg: &mut crate::host_registry::Registry) {
     // Shapes: dimensions are strictly positive (Rapier accepts a negative
     // radius and silently builds a degenerate collider that misbehaves far
@@ -2420,6 +2491,27 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
         |v: FunctorLangVec3, body: FunctorLangBody| {
             let (x, y, z) = v.0;
             FunctorLangBody(body.0.at([x, y, z]))
+        },
+    );
+    reg.fn2(
+        "Physics.rotateX",
+        "Physics.rotateX(angle, body)",
+        |angle: FunctorLangAngle, body: FunctorLangBody| {
+            rotate_physics_body("Physics.rotateX", [1.0, 0.0, 0.0], angle, body)
+        },
+    );
+    reg.fn2(
+        "Physics.rotateY",
+        "Physics.rotateY(angle, body)",
+        |angle: FunctorLangAngle, body: FunctorLangBody| {
+            rotate_physics_body("Physics.rotateY", [0.0, 1.0, 0.0], angle, body)
+        },
+    );
+    reg.fn2(
+        "Physics.rotateZ",
+        "Physics.rotateZ(angle, body)",
+        |angle: FunctorLangAngle, body: FunctorLangBody| {
+            rotate_physics_body("Physics.rotateZ", [0.0, 0.0, 1.0], angle, body)
         },
     );
     reg.fn2(
@@ -7587,6 +7679,94 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         assert_eq!(scene.bodies[1].mass, Some(2.0));
         assert_eq!(scene.bodies[1].restitution, 0.5);
         assert!(scene.bodies[2].sensor);
+    }
+
+    #[test]
+    fn physics_body_axis_rotations_are_canonical_and_body_centered() {
+        let value = eval(
+            "let shape = Physics.box(4.0, 1.0, 2.0)\n\
+             let main = () => Physics.scene(Vec3.make(0.0, 0.0, 0.0), [\n\
+               Physics.fixed(Physics.tag(\"x\"), shape)\n\
+                 |> Physics.at(Vec3.make(3.0, 4.0, 5.0))\n\
+                 |> Physics.rotateX(Angle.degrees(90.0)),\n\
+               Physics.fixed(Physics.tag(\"y\"), shape)\n\
+                 |> Physics.rotateY(Angle.degrees(90.0)),\n\
+               Physics.fixed(Physics.tag(\"z\"), shape)\n\
+                 |> Physics.rotateZ(Angle.degrees(90.0)),\n\
+               Physics.fixed(Physics.tag(\"y-plus-turn\"), shape)\n\
+                 |> Physics.rotateY(Angle.degrees(450.0)),\n\
+             ])",
+        );
+        let scene = physics_scene_value(&value).expect("a PhysicsScene");
+        let half_sqrt = std::f32::consts::FRAC_1_SQRT_2;
+        let assert_close = |actual: [f32; 4], expected: [f32; 4]| {
+            for (actual, expected) in actual.into_iter().zip(expected) {
+                assert!(
+                    (actual - expected).abs() < 1e-6,
+                    "quaternion component: expected {expected}, got {actual}"
+                );
+            }
+        };
+
+        assert_close(scene.bodies[0].rotation, [half_sqrt, 0.0, 0.0, half_sqrt]);
+        assert_close(scene.bodies[1].rotation, [0.0, half_sqrt, 0.0, half_sqrt]);
+        assert_close(scene.bodies[2].rotation, [0.0, 0.0, half_sqrt, half_sqrt]);
+        assert_close(scene.bodies[3].rotation, scene.bodies[1].rotation);
+        assert_eq!(scene.bodies[0].position, [3.0, 4.0, 5.0]);
+        for body in &scene.bodies {
+            let norm = body.rotation.iter().map(|component| component * component).sum::<f32>();
+            assert!((norm - 1.0).abs() < 1e-6, "rotation was not normalized: {norm}");
+            assert!(body.rotation[3] >= 0.0, "rotation was not canonical: {:?}", body.rotation);
+        }
+    }
+
+    #[test]
+    fn physics_body_rotation_pipeline_applies_the_outer_modifier_last() {
+        let value = eval(
+            "let shape = Physics.box(1.0, 2.0, 3.0)\n\
+             let main = () => Physics.scene(Vec3.make(0.0, 0.0, 0.0), [\n\
+               Physics.fixed(Physics.tag(\"xy\"), shape)\n\
+                 |> Physics.rotateX(Angle.degrees(90.0))\n\
+                 |> Physics.rotateY(Angle.degrees(90.0)),\n\
+               Physics.fixed(Physics.tag(\"yx\"), shape)\n\
+                 |> Physics.rotateY(Angle.degrees(90.0))\n\
+                 |> Physics.rotateX(Angle.degrees(90.0)),\n\
+             ])",
+        );
+        let scene = physics_scene_value(&value).expect("a PhysicsScene");
+        let assert_close = |actual: [f32; 4], expected: [f32; 4]| {
+            for (actual, expected) in actual.into_iter().zip(expected) {
+                assert!(
+                    (actual - expected).abs() < 1e-6,
+                    "quaternion component: expected {expected}, got {actual}"
+                );
+            }
+        };
+
+        assert_close(scene.bodies[0].rotation, [0.5, 0.5, -0.5, 0.5]);
+        assert_close(scene.bodies[1].rotation, [0.5, 0.5, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn physics_body_rotation_requires_angles_and_rejects_heightfields() {
+        assert_eq!(
+            fail_message(
+                "let main = () => Physics.fixed(Physics.tag(\"ramp\"), \
+Physics.box(4.0, 1.0, 2.0)) |> Physics.rotateY(1.57)"
+            ),
+            "Physics.rotateY: expected an Angle, got a bare number — say which unit: \
+Angle.degrees(…) or Angle.radians(…)"
+        );
+        assert_eq!(
+            fail_message(
+                "let terrain = Terrain.heightmap(Asset.texture(\"terrain.png\"), \
+20.0, 20.0, -1.0, 4.0)\n\
+                 let main = () => Physics.heightfield(Physics.tag(\"terrain\"), terrain) \
+|> Physics.rotateX(Angle.degrees(5.0))"
+            ),
+            "Physics.rotateX: heightfield bodies cannot be rotated — terrain rendering is \
+translation-only; use Physics.at with an unrotated Scene.terrain"
+        );
     }
 
     // `Physics.upright` locks a body's rotation — the character-capsule

--- a/runtime/functor-runtime-common/src/physics/scene.rs
+++ b/runtime/functor-runtime-common/src/physics/scene.rs
@@ -19,7 +19,8 @@ pub const DEFAULT_GRAVITY: [f32; 3] = [0.0, -9.81, 0.0];
 /// `scene3d` shapes: physics extents are gameplay data, not visuals.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Shape {
-    /// Axis-aligned box, given as *full* extents (width, height, depth).
+    /// Box in the body's local axes, given as *full* extents
+    /// (width, height, depth).
     Cuboid { extents: [f32; 3] },
     Sphere { radius: f32 },
     /// Capsule along the local Y axis: a segment of `2 * half_height` with

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -813,9 +813,18 @@ impl World {
             }
             let live = self.tags.get(&next.tag).and_then(|(rb, _)| {
                 let rb = self.bodies.get(*rb)?;
+                let live_pose = *rb.position();
+                // Rapier documents next_position() as unspecified for
+                // non-kinematic bodies. Only a kinematic predecessor can
+                // contribute a meaningful queued target across this rebuild.
+                let pending_pose = if prev.kind == BodyKind::Kinematic {
+                    *rb.next_position()
+                } else {
+                    live_pose
+                };
                 Some((
-                    *rb.position(),
-                    *rb.next_position(),
+                    live_pose,
+                    pending_pose,
                     rb.linvel(),
                     rb.angvel(),
                 ))
@@ -1588,6 +1597,45 @@ mod tests {
         assert_eq!(after_step, identity);
         let (rb_handle, _) = retargeted.tags["spinner"];
         assert!(retargeted.bodies[rb_handle].angvel().length() < 1e-6);
+    }
+
+    #[test]
+    fn kind_change_to_kinematic_seeds_target_from_live_pose() {
+        let quarter_turn = std::f32::consts::FRAC_1_SQRT_2;
+        let shape = Shape::Cuboid {
+            extents: [1.0, 1.0, 1.0],
+        };
+        let live_pose = pose_of(
+            &Body::kinematic("pose".to_string(), shape.clone())
+                .at([2.0, 3.0, 4.0])
+                .facing([0.0, quarter_turn, 0.0, quarter_turn]),
+        );
+
+        for old_kind in [BodyKind::Dynamic, BodyKind::Fixed] {
+            let original = match old_kind {
+                BodyKind::Dynamic => Body::dynamic("mover".to_string(), shape.clone()),
+                BodyKind::Fixed => Body::fixed("mover".to_string(), shape.clone()),
+                BodyKind::Kinematic => unreachable!(),
+            };
+            let mut w = World::new([0.0, 0.0, 0.0]);
+            w.reconcile(&scene(vec![original]));
+            let (rb_handle, _) = w.tags["mover"];
+            w.bodies[rb_handle].set_position(live_pose, true);
+
+            // The kind changes, but neither declared pose field does. The new
+            // kinematic body's current and next poses must both inherit the
+            // old body's live pose; a non-kinematic next_position is not a
+            // defined source for the target.
+            w.reconcile(&scene(vec![Body::kinematic(
+                "mover".to_string(),
+                shape.clone(),
+            )]));
+            let (kinematic_handle, _) = w.tags["mover"];
+            assert_eq!(*w.bodies[kinematic_handle].position(), live_pose);
+            assert_eq!(*w.bodies[kinematic_handle].next_position(), live_pose);
+            w.step_fixed();
+            assert_eq!(*w.bodies[kinematic_handle].position(), live_pose);
+        }
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -813,24 +813,53 @@ impl World {
             }
             let live = self.tags.get(&next.tag).and_then(|(rb, _)| {
                 let rb = self.bodies.get(*rb)?;
-                Some((*rb.position(), rb.linvel(), rb.angvel()))
+                Some((
+                    *rb.position(),
+                    *rb.next_position(),
+                    rb.linvel(),
+                    rb.angvel(),
+                ))
             });
             self.despawn(&next.tag);
             let spawned = self.spawn(next);
             debug_assert!(spawned);
-            if let (Some((live_pose, linvel, angvel)), Some((rb_handle, _))) =
+            if let (
+                Some((live_pose, pending_pose, linvel, angvel)),
+                Some((rb_handle, _)),
+            ) =
                 (live, self.tags.get(&next.tag).copied())
             {
                 let rb = &mut self.bodies[rb_handle];
-                let mut rebuilt_pose = *rb.position();
-                if prev.position == next.position {
-                    rebuilt_pose.translation = live_pose.translation;
-                }
-                if prev.rotation == next.rotation {
-                    rebuilt_pose.rotation = live_pose.rotation;
-                }
-                if *rb.position() != rebuilt_pose {
-                    rb.set_position(rebuilt_pose, true);
+                if next.kind == BodyKind::Kinematic {
+                    // A structural rebuild must preserve both halves of a
+                    // position-based kinematic body's state. Its current pose
+                    // remains live, while unchanged declaration fields retain
+                    // any already-queued target and changed fields target the
+                    // new declaration for the next step.
+                    let declared_pose = pose_of(next);
+                    let mut target_pose = pending_pose;
+                    if prev.position != next.position {
+                        target_pose.translation = declared_pose.translation;
+                    }
+                    if prev.rotation != next.rotation {
+                        target_pose.rotation = declared_pose.rotation;
+                    }
+                    if live_pose.rotation.dot(target_pose.rotation) < 0.0 {
+                        target_pose.rotation = -target_pose.rotation;
+                    }
+                    rb.set_position(live_pose, true);
+                    rb.set_next_kinematic_position(target_pose);
+                } else {
+                    let mut rebuilt_pose = *rb.position();
+                    if prev.position == next.position {
+                        rebuilt_pose.translation = live_pose.translation;
+                    }
+                    if prev.rotation == next.rotation {
+                        rebuilt_pose.rotation = live_pose.rotation;
+                    }
+                    if *rb.position() != rebuilt_pose {
+                        rb.set_position(rebuilt_pose, true);
+                    }
                 }
                 if prev.velocity == next.velocity {
                     rb.set_linvel(linvel, true);
@@ -1511,6 +1540,54 @@ mod tests {
         }
         let (rb_handle, _) = w.tags["spinner"];
         assert!(w.bodies[rb_handle].angvel().length() < 1e-6);
+    }
+
+    #[test]
+    fn structural_rebuild_preserves_and_retargets_kinematic_pose() {
+        let quarter_turn = std::f32::consts::FRAC_1_SQRT_2;
+        let identity = [0.0, 0.0, 0.0, 1.0];
+        let turned = [0.0, quarter_turn, 0.0, quarter_turn];
+        let cuboid = |rotation| {
+            Body::kinematic(
+                "spinner".to_string(),
+                Shape::Cuboid {
+                    extents: [1.0, 1.0, 1.0],
+                },
+            )
+            .facing(rotation)
+        };
+        let sphere = |rotation| {
+            Body::kinematic("spinner".to_string(), Shape::Sphere { radius: 1.0 })
+                .facing(rotation)
+        };
+
+        // An unchanged declaration field retains its pending target when a
+        // shape change rebuilds the body.
+        let mut preserved = World::new([0.0, 0.0, 0.0]);
+        preserved.reconcile(&scene(vec![cuboid(identity)]));
+        preserved.reconcile(&scene(vec![cuboid(turned)]));
+        preserved.reconcile(&scene(vec![sphere(turned)]));
+        let (_, before_step) = preserved.body_transform("spinner").unwrap();
+        assert_eq!(before_step, identity);
+        preserved.step_fixed();
+        let (_, after_step) = preserved.body_transform("spinner").unwrap();
+        for (actual, expected) in after_step.into_iter().zip(turned) {
+            assert!((actual - expected).abs() < 1e-6);
+        }
+
+        // A changed field alongside the rebuild replaces the pending target;
+        // it does not teleport immediately or leave the old target queued.
+        let mut retargeted = World::new([0.0, 0.0, 0.0]);
+        retargeted.reconcile(&scene(vec![cuboid(identity)]));
+        retargeted.reconcile(&scene(vec![cuboid(turned)]));
+        retargeted.reconcile(&scene(vec![sphere(identity)]));
+        let (_, before_step) = retargeted.body_transform("spinner").unwrap();
+        assert_eq!(before_step, identity);
+        retargeted.step_fixed();
+        let (_, after_step) = retargeted.body_transform("spinner").unwrap();
+        assert_eq!(after_step, identity);
+        let (rb_handle, _) = retargeted.tags["spinner"];
+        assert!(retargeted.bodies[rb_handle].angvel().length() < 1e-6);
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -848,8 +848,16 @@ impl World {
         let (rb_handle, col_handle) = self.tags[&next.tag];
 
         if prev.position != next.position || prev.rotation != next.rotation {
-            let pose = pose_of(next);
+            let mut pose = pose_of(next);
             let rb = &mut self.bodies[rb_handle];
+            if next.kind == BodyKind::Kinematic && rb.rotation().dot(pose.rotation) < 0.0 {
+                // q and -q describe the same orientation, but Rapier derives a
+                // position-based kinematic body's angular velocity from the
+                // raw quaternion delta. Keep the target on the live pose's
+                // hemisphere so crossing 180° takes the short arc instead of
+                // generating an almost-full-turn contact velocity.
+                pose.rotation = -pose.rotation;
+            }
             // Skip the write when the declaration merely caught up with the
             // simulation (the `Physics.synced` steady state: the model
             // re-declares last frame's physics output). The values would be a
@@ -1383,6 +1391,40 @@ mod tests {
         let snap = w.snapshot();
         let mut r = World::new([0.0, 0.0, 0.0]);
         r.restore(&snap).unwrap();
+    }
+
+    #[test]
+    fn kinematic_rotation_crosses_180_degrees_on_the_short_arc() {
+        let half_179_degrees = 179.0_f32.to_radians() / 2.0;
+        let (sin, cos) = half_179_degrees.sin_cos();
+        let before = [0.0, sin, 0.0, cos];
+        // The canonical rotation builder wraps 181° to -179° so `w` stays
+        // positive. This is the same orientation as +181°, but lies on the
+        // opposite quaternion hemisphere from `before`.
+        let after = [0.0, -sin, 0.0, cos];
+        let body = |rotation| {
+            Body::kinematic(
+                "spinner".to_string(),
+                Shape::Cuboid {
+                    extents: [1.0, 1.0, 1.0],
+                },
+            )
+            .facing(rotation)
+        };
+
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![body(before)]));
+        w.reconcile(&scene(vec![body(after)]));
+        w.step_fixed();
+
+        let (rb_handle, _) = w.tags["spinner"];
+        let angular_velocity = w.bodies[rb_handle].angvel().y;
+        let expected = 2.0_f32.to_radians() / FIXED_DT;
+        assert!(
+            (angular_velocity - expected).abs() < 0.001,
+            "expected a +2° short-arc step ({expected:.3} rad/s), got \
+             {angular_velocity:.3} rad/s"
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -818,12 +818,19 @@ impl World {
             self.despawn(&next.tag);
             let spawned = self.spawn(next);
             debug_assert!(spawned);
-            if let (Some((pose, linvel, angvel)), Some((rb_handle, _))) =
+            if let (Some((live_pose, linvel, angvel)), Some((rb_handle, _))) =
                 (live, self.tags.get(&next.tag).copied())
             {
                 let rb = &mut self.bodies[rb_handle];
-                if prev.position == next.position && prev.rotation == next.rotation {
-                    rb.set_position(pose, true);
+                let mut rebuilt_pose = *rb.position();
+                if prev.position == next.position {
+                    rebuilt_pose.translation = live_pose.translation;
+                }
+                if prev.rotation == next.rotation {
+                    rebuilt_pose.rotation = live_pose.rotation;
+                }
+                if *rb.position() != rebuilt_pose {
+                    rb.set_position(rebuilt_pose, true);
                 }
                 if prev.velocity == next.velocity {
                     rb.set_linvel(linvel, true);
@@ -848,8 +855,24 @@ impl World {
         let (rb_handle, col_handle) = self.tags[&next.tag];
 
         if prev.position != next.position || prev.rotation != next.rotation {
-            let mut pose = pose_of(next);
             let rb = &mut self.bodies[rb_handle];
+            let live_pose = *rb.position();
+            // Kinematic declarations may be reconciled more than once before
+            // a step. Build on the queued target so a change to one field
+            // preserves the other pending field; dynamic/fixed bodies instead
+            // preserve their live simulated pose.
+            let mut pose = if next.kind == BodyKind::Kinematic {
+                *rb.next_position()
+            } else {
+                live_pose
+            };
+            let declared_pose = pose_of(next);
+            if prev.position != next.position {
+                pose.translation = declared_pose.translation;
+            }
+            if prev.rotation != next.rotation {
+                pose.rotation = declared_pose.rotation;
+            }
             if next.kind == BodyKind::Kinematic && rb.rotation().dot(pose.rotation) < 0.0 {
                 // q and -q describe the same orientation, but Rapier derives a
                 // position-based kinematic body's angular velocity from the
@@ -858,19 +881,15 @@ impl World {
                 // generating an almost-full-turn contact velocity.
                 pose.rotation = -pose.rotation;
             }
-            // Skip the write when the declaration merely caught up with the
-            // simulation (the `Physics.synced` steady state: the model
-            // re-declares last frame's physics output). The values would be a
-            // no-op, but `wake_up = true` isn't — writing would keep every
-            // synced body permanently awake.
-            if *rb.position() != pose {
-                match next.kind {
-                    // Kinematic bodies are *driven*: the next pose is a target
-                    // the solver moves them to over the step (so they carry
-                    // velocity into contacts) rather than an instant teleport.
-                    BodyKind::Kinematic => rb.set_next_kinematic_position(pose),
-                    _ => rb.set_position(pose, true),
-                }
+            match next.kind {
+                // Always refresh a changed kinematic declaration, even when it
+                // returns to the live pose: an earlier reconcile may have
+                // queued a target that this declaration is canceling.
+                BodyKind::Kinematic => rb.set_next_kinematic_position(pose),
+                // Skip a no-op teleport so a declaration that catches up with
+                // the simulation does not wake a settled dynamic body.
+                _ if live_pose != pose => rb.set_position(pose, true),
+                _ => {}
             }
         }
         if prev.velocity != next.velocity {
@@ -1394,6 +1413,44 @@ mod tests {
     }
 
     #[test]
+    fn rotation_only_divergence_preserves_live_translation() {
+        let quarter_turn = std::f32::consts::FRAC_1_SQRT_2;
+        let rotated = [0.0, quarter_turn, 0.0, quarter_turn];
+
+        for structural in [false, true] {
+            let mut w = World::new([0.0, -9.81, 0.0]);
+            let original = crate_at("a", [0.0, 5.0, 0.0]);
+            w.reconcile(&scene(vec![original.clone()]));
+            for _ in 0..30 {
+                w.step_fixed();
+            }
+            let (fallen, _) = w.body_transform("a").unwrap();
+            assert!(fallen[1] < 5.0);
+
+            let changed = if structural {
+                Body::dynamic(
+                    "a".to_string(),
+                    Shape::Sphere { radius: 0.5 },
+                )
+                .at([0.0, 5.0, 0.0])
+                .facing(rotated)
+            } else {
+                original.facing(rotated)
+            };
+            w.reconcile(&scene(vec![changed]));
+
+            let (position, rotation) = w.body_transform("a").unwrap();
+            assert_eq!(
+                position, fallen,
+                "rotation-only divergence reset translation (structural={structural})"
+            );
+            for (actual, expected) in rotation.into_iter().zip(rotated) {
+                assert!((actual - expected).abs() < 1e-6);
+            }
+        }
+    }
+
+    #[test]
     fn kinematic_rotation_crosses_180_degrees_on_the_short_arc() {
         let half_179_degrees = 179.0_f32.to_radians() / 2.0;
         let (sin, cos) = half_179_degrees.sin_cos();
@@ -1425,6 +1482,35 @@ mod tests {
             "expected a +2° short-arc step ({expected:.3} rad/s), got \
              {angular_velocity:.3} rad/s"
         );
+    }
+
+    #[test]
+    fn kinematic_rotation_target_can_be_canceled_before_a_step() {
+        let quarter_turn = std::f32::consts::FRAC_1_SQRT_2;
+        let identity = [0.0, 0.0, 0.0, 1.0];
+        let turned = [0.0, quarter_turn, 0.0, quarter_turn];
+        let body = |rotation| {
+            Body::kinematic(
+                "spinner".to_string(),
+                Shape::Cuboid {
+                    extents: [1.0, 1.0, 1.0],
+                },
+            )
+            .facing(rotation)
+        };
+
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![body(identity)]));
+        w.reconcile(&scene(vec![body(turned)]));
+        w.reconcile(&scene(vec![body(identity)]));
+        w.step_fixed();
+
+        let (_, rotation) = w.body_transform("spinner").unwrap();
+        for (actual, expected) in rotation.into_iter().zip(identity) {
+            assert!((actual - expected).abs() < 1e-6);
+        }
+        let (rb_handle, _) = w.tags["spinner"];
+        assert!(w.bodies[rb_handle].angvel().length() < 1e-6);
     }
 
     #[test]

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -538,9 +538,10 @@ let pos = model.pos |> Vec3.add(step)</pre>
           <h3>Physics</h3>
           <table>
             <tbody>
-              <tr><td><code>Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)</code></td><td>shapes; box takes <em>full</em> extents</td></tr>
+              <tr><td><code>Physics.box(w, h, d) / sphere(r) / capsule(halfH, r)</code></td><td>shapes; box takes <em>full</em> extents in the body’s local axes</td></tr>
               <tr><td><code>Physics.dynamic(tag, shape)</code></td><td>simulated; also <code>kinematic</code> / <code>fixed</code>; tags are <code>Physics.tag("name")</code> values</td></tr>
-              <tr><td><code>body |> Physics.at(Vec3.make(x, y, z))</code></td><td>spawn pose; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
+              <tr><td><code>body |> Physics.at(Vec3.make(x, y, z))</code></td><td>spawn position; also <code>velocity</code>, <code>mass</code>, <code>friction</code>, <code>restitution</code>, <code>sensor</code></td></tr>
+              <tr><td><code>body |> Physics.rotateX/Y/Z(angle)</code></td><td>body-centered rotation; Angles are branded, and the outer pipe applies last in world space</td></tr>
               <tr><td><code>Physics.scene(Vec3.make(gx, gy, gz), [body, …])</code></td><td>what the <code>physics</code> hook returns</td></tr>
               <tr><td><code>Physics.position(tag)</code></td><td><code>{x, y, z}</code> of the live body</td></tr>
               <tr><td><code>scene |> Physics.transformed(tag)</code></td><td>draw a scene at the body's live pose</td></tr>

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -569,9 +569,11 @@ let pos = model.pos |> Vec3.add(step)</pre>
           </p>
           <p>
             The tag is cross-frame identity: same tag = same body; drop a body by not declaring
-            it. Re-declaring an unchanged body leaves the simulation alone; changing its declared
-            position teleports it. Reading a tag your <code>physics</code> hook doesn't declare
-            is a runtime error. The physics world survives hot reload, like the model.
+            it. Re-declaring an unchanged body leaves the simulation alone. Changing its declared
+            position or rotation teleports those fields on a dynamic/fixed body; a kinematic body
+            instead receives the changed pose as its next-step target, carrying velocity into
+            contacts. Reading a tag your <code>physics</code> hook doesn't declare is a runtime
+            error. The physics world survives hot reload, like the model.
           </p>
 
           <h3 id="prelude-ui">UI</h3>


### PR DESCRIPTION
## Problem

The MCP game jam's Pinball entry could not author a conventional sloped table
or rotating kinematic flippers. Physics bodies had translation but no
orientation surface, so the entry used +Z gravity, sliding paddles, and
game-authored proximity impulses instead.

## Change

- add typed, subject-last `Physics.rotateX/Y/Z(Angle, body)` builders;
- compose rotations outer-last (`body |> rotateX(x) |> rotateY(y)` stores
  `qY * qX`), matching `Scene.rotate*`;
- normalize and canonicalize `[x, y, z, w]` body quaternions;
- reject rotation on heightfields because their render path remains
  translation-only;
- make declaration divergence field-wise for position and rotation;
- preserve current and queued kinematic poses across structural rebuilds;
- align kinematic target quaternion hemispheres so a 179°→181° change takes
  the 2° short arc;
- document body-centered/local-axis behavior and dynamic/fixed teleport versus
  kinematic next-step semantics in the physics guide, hosted manual, and
  `functor-lang` skill.

## Game-jam adoption

Pinball adopted this exact PR head from baseline `7d5ffd2` in entry commit
`784cf39e27da030524e99c88cbf292dba245db18`.

The adoption deletes all three original compromises: conditional +Z gravity,
sideways-sliding flippers, and proximity `Physics.applyImpulse` kicks. It now
uses ordinary `Vec3.make(0.0, -12.0, 0.0)` gravity, a cohesive +7° tilted
table/collider layout, mirrored kinematic flippers rotating around authored
hinges, and `Physics.transformed` for the live ball and flipper renders. The
ready ball is kinematic and becomes dynamic only on a valid launch edge.

The entry used the worktree-local exact-head release binary (SHA-256
`ecc81adc2d16d80311cb969429be983c0f5e9498df9900844d506c1fe3084f2`);
its generated API exposed all three new builders before adoption. Independent
root verification after the final commit:

- native build passed and all 8 inline expects passed;
- the checked-in unsafe MCP automation passed twice under Node `v22.20.0`,
  protocol 8, with 196 SDK calls and byte-identical selected results;
- the unlaunched ball stayed parked for 120 steps under ordinary gravity;
- launch reached speed `13.7775` and traveled up-table;
- a real bumper contact scored 100 and a real sensor drain consumed one life;
- both alias-composed flippers and all key releases were verified; and
- final state had three reset lives, score 0, and no held keys.

Both final capture pairs repeated byte-for-byte across the agent and root runs:
active hinged-left `bd274a83…c5c86bf`, and complete reset/rest
`518ef57f…a6e823`.

## Review dispositions

- Fixed: canonical quaternion sign changes around 180° could produce an
  almost-full-turn kinematic contact velocity.
- Fixed: a rotation-only declaration could reset a simulated body's live
  translation, including after a shape/mass rebuild.
- Fixed: multiple reconciles before a physics step could leave a canceled
  kinematic target queued.
- Fixed: structural kinematic rebuilds could discard or immediately apply
  their pending target.
- Fixed: dynamic/fixed → kinematic rebuilds consulted Rapier's unspecified
  non-kinematic `next_position`; they now seed from the live pose.
- Fixed: the skill/manual did not spell out field-wise divergence semantics.
- Fixed after the first CI run: the API-search smoke test assumed a query
  always had exactly one textual match. The new Physics docs legitimately
  cross-reference `Scene.rotateY`, so the test now verifies that the intended
  declaration is visible and the result set is nonempty and narrower than the
  full reference.

## Verification

- `cargo test -p functor_runtime_common`: 598 unit + 10 prelude typecheck
  tests passed; 1 doctest ignored
- `npm run check:docs`: pass
- `npm run check:site`: pass
- `npm run test:site`: all checks passed at exact head
- `npm run build:cli`: pass at exact head (release CLI + wasm)
- native/wasm smoke: pass locally and in exact-head CI
- `git diff --check`: pass
- independent adversarial review: clean; all findings below dispositioned
- Pinball MCP adoption: pass twice at entry commit `784cf39`

CI at exact `1880a30`: all 9 required checks pass. The first
`e2e-headless` attempt hit an unrelated macOS runner collision on debug port
`8096`; the same-SHA failed-job rerun passed without a code change.

Performance-sensitive acceptance:

- allocations/bytes per frame remain exactly equal to base at all benchmark
  sizes: `13,877 / 843,387`, `54,717 / 3,307,227`, and
  `106,973 / 6,460,251`;
- base minimum wall times were `431.8 / 1700.8 / 3334.8 µs`; the three
  exact-final-head runs were `639.8 / 2249.4 / 4616.9` (cold/load outlier),
  `436.8 / 1702.0 / 3318.6`, and `438.8 / 1719.7 / 3294.2 µs`. Per the
  benchmark contract, the compared exact-head minimum is
  `436.8 / 1702.0 / 3294.2 µs`: within normal run-to-run noise at 20×20 and
  40×40, and slightly faster at 56×56.

## Visual proof

Exact-head engine proof:

![Physics rotation loop](https://gist.githubusercontent.com/tommy-xr/27f267491a5105e3c9ea3b68eb408178/raw/6ea5207bc06dc19a6f219f1660fb1de506e2ac34/functor-physics-rotation-1880a30.gif)

![Physics rotation still](https://gist.githubusercontent.com/tommy-xr/27f267491a5105e3c9ea3b68eb408178/raw/6ea5207bc06dc19a6f219f1660fb1de506e2ac34/functor-physics-rotation-still-1880a30.png)

[Four-pose audit](https://gist.githubusercontent.com/tommy-xr/27f267491a5105e3c9ea3b68eb408178/raw/6ea5207bc06dc19a6f219f1660fb1de506e2ac34/functor-physics-rotation-quarter-poses-1880a30.png)

Hosted-manual before/after (`373a27a → 1880a30`):

![Desktop manual comparison](https://gist.githubusercontent.com/tommy-xr/27f267491a5105e3c9ea3b68eb408178/raw/6ea5207bc06dc19a6f219f1660fb1de506e2ac34/functor-physics-manual-before-after-desktop-1880a30.png)

![Mobile manual comparison](https://gist.githubusercontent.com/tommy-xr/27f267491a5105e3c9ea3b68eb408178/raw/6ea5207bc06dc19a6f219f1660fb1de506e2ac34/functor-physics-manual-before-after-mobile-1880a30.png)

All 24 GIF frames are unique; a repeated start capture is byte-identical and
the loop seam matches ordinary adjacent transitions. Remote gist bytes,
content types, and hashes were verified.
