### PR TITLE
feat(camera): add screen-to-world picking rays

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -948,6 +948,17 @@ Camera.firstPerson(eye, yaw, pitch, fov)                   // Vec3 eye; Angles f
                                                            //   orientation, near/far remain
                                                            //   game-owned; OpenXR owns IPD
                                                            //   and per-eye optical FOV
+Camera.toWorldRay(mouse, camera)                           // -> Option.t<{origin: Vec3.t,
+                                                           //     direction: Vec3.t}>; maps an
+                                                           //   Input.mouse's top-left logical
+                                                           //   position through the authored
+                                                           //   perspective. Direction is unit
+                                                           //   length; both fields feed
+                                                           //   Physics.cast/raycast directly.
+                                                           //   None outside the surface or for
+                                                           //   a degenerate camera. Position +
+                                                           //   extent share one coordinate
+                                                           //   space, so resize/DPR stay correct
 Camera.mapTrackedPose(camera, pose)                        // map rig-local Input.pose through
                                                            //   the authored camera; returns
                                                            //   world-space {position,forward,up}

--- a/functor-prelude/prelude/camera.funi
+++ b/functor-prelude/prelude/camera.funi
@@ -9,6 +9,16 @@ let lookAt : (Vec3.t, Vec3.t) => t
 ///
 /// Zero yaw and pitch look down `+Z`.
 let firstPerson : (Vec3.t, Angle.t, Angle.t, Angle.t) => t
+/// A world-space ray from the camera eye through a logical surface point.
+type ray = { origin: Vec3.t, direction: Vec3.t }
+/// Map a sampled mouse position through the authored perspective camera.
+///
+/// Mouse position and extent share one top-left-origin logical coordinate
+/// space, so the result stays stable across resize and Retina/device-pixel
+/// ratio changes. The direction is normalized and both fields feed directly
+/// into `Physics.cast` / `Physics.raycast`. Returns `Option.None` while the
+/// pointer is outside the surface or the camera is degenerate.
+let toWorldRay : (Input.mouse, t) => Option.t<ray>
 /// A tracked pose mapped into world space through an authored camera.
 type mappedPose = { position: Input.point3, forward: Input.point3, up: Input.point3 }
 /// Map a rig-local tracked pose through the authored camera.

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -120,6 +120,26 @@ pub struct MappedTrackingPose {
     pub up: [f32; 3],
 }
 
+/// A world-space ray derived from a point on a camera's logical surface.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WorldRay {
+    pub origin: [f32; 3],
+    pub direction: [f32; 3],
+}
+
+/// The authored camera's normalized world-space axes.
+///
+/// Kept crate-private so tracking, picking, and debug visualization share the
+/// exact same handedness and degeneracy rules without exposing cgmath through
+/// the public protocol surface.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CameraBasis {
+    pub(crate) eye: Vector3<f32>,
+    pub(crate) forward: Vector3<f32>,
+    pub(crate) right: Vector3<f32>,
+    pub(crate) up: Vector3<f32>,
+}
+
 /// A camera description produced by the game's `draw3d`. Stores plain scalars
 /// (so it serializes cleanly across the wasm boundary); the runtime turns it
 /// into view/projection matrices at render time via `view_matrix` /
@@ -206,22 +226,12 @@ impl Camera {
         (shifted(-1.0), shifted(1.0))
     }
 
-    /// Map a live tracking pose into this authored camera's local rig.
-    ///
-    /// `reference` is the tracking-space center-eye pose captured when the rig
-    /// is established. At that pose, the mapped position and orientation equal
-    /// this camera exactly. Subsequent room-scale translation and rotation are
-    /// applied in the camera's local right/up/backward basis, so moving the
-    /// authored camera moves the whole rig without discarding live tracking.
-    pub fn map_tracking_pose(
-        &self,
-        reference: TrackingPose,
-        tracked: TrackingPose,
-    ) -> Option<MappedTrackingPose> {
+    /// Return the normalized authored axes, or `None` when they cannot define
+    /// a finite view basis.
+    pub(crate) fn world_basis(&self) -> Option<CameraBasis> {
         let eye = Vector3::from(self.eye);
-        let target = Vector3::from(self.target);
+        let gaze = Vector3::from(self.target) - eye;
         let authored_up = Vector3::from(self.up);
-        let gaze = target - eye;
         let gaze_distance = gaze.magnitude();
         let right = gaze.cross(authored_up);
         if !eye.x.is_finite()
@@ -236,6 +246,32 @@ impl Camera {
         let forward = gaze / gaze_distance;
         let right = right.normalize();
         let up = right.cross(forward).normalize();
+        Some(CameraBasis {
+            eye,
+            forward,
+            right,
+            up,
+        })
+    }
+
+    /// Map a live tracking pose into this authored camera's local rig.
+    ///
+    /// `reference` is the tracking-space center-eye pose captured when the rig
+    /// is established. At that pose, the mapped position and orientation equal
+    /// this camera exactly. Subsequent room-scale translation and rotation are
+    /// applied in the camera's local right/up/backward basis, so moving the
+    /// authored camera moves the whole rig without discarding live tracking.
+    pub fn map_tracking_pose(
+        &self,
+        reference: TrackingPose,
+        tracked: TrackingPose,
+    ) -> Option<MappedTrackingPose> {
+        let CameraBasis {
+            eye,
+            forward,
+            right,
+            up,
+        } = self.world_basis()?;
         let backward = -forward;
         let to_world = |v: Vector3<f32>| right * v.x + up * v.y + backward * v.z;
 
@@ -284,6 +320,64 @@ impl Camera {
 
     pub fn projection_matrix(&self, aspect: f32) -> Matrix4<f32> {
         perspective(Rad(self.fov_radians), aspect, self.near, self.far)
+    }
+
+    /// Map a top-left-origin logical surface point through this camera's
+    /// perspective projection.
+    ///
+    /// The ray begins at the camera eye and its direction is normalized.
+    /// Position and surface extent must share one coordinate space (window
+    /// points or CSS pixels), so scaling both by a device-pixel ratio leaves
+    /// the result unchanged. Returns `None` for an outside/degenerate surface
+    /// point or a degenerate camera.
+    pub fn to_world_ray(
+        &self,
+        x: f32,
+        y: f32,
+        surface_width: f32,
+        surface_height: f32,
+    ) -> Option<WorldRay> {
+        if !x.is_finite()
+            || !y.is_finite()
+            || !surface_width.is_finite()
+            || !surface_height.is_finite()
+            || !(self.fov_radians > 0.0 && self.fov_radians < std::f32::consts::PI)
+            || surface_width <= 0.0
+            || surface_height <= 0.0
+            || x < 0.0
+            || y < 0.0
+            || x >= surface_width
+            || y >= surface_height
+        {
+            return None;
+        }
+
+        let CameraBasis {
+            eye,
+            forward,
+            right,
+            up,
+        } = self.world_basis()?;
+        let aspect = surface_width / surface_height;
+        let half_fov_tan = (self.fov_radians * 0.5).tan();
+        if !aspect.is_normal()
+            || !half_fov_tan.is_normal()
+            || half_fov_tan <= 0.0
+        {
+            return None;
+        }
+
+        let ndc_x = 2.0 * x / surface_width - 1.0;
+        let ndc_y = 1.0 - 2.0 * y / surface_height;
+        let direction = (forward
+            + right * (ndc_x * half_fov_tan * aspect)
+            + up * (ndc_y * half_fov_tan))
+            .normalize();
+        (direction.x.is_finite() && direction.y.is_finite() && direction.z.is_finite())
+            .then_some(WorldRay {
+                origin: eye.into(),
+                direction: direction.into(),
+            })
     }
 
     /// Build an asymmetric perspective projection from four view-space field-
@@ -368,6 +462,137 @@ mod tests {
         // Horizontal scale shrinks by exactly the aspect ratio (so geometry
         // keeps its proportions; you just see more to the sides).
         assert!(approx(wide.x.x, square.x.x / 2.0));
+    }
+
+    #[test]
+    fn center_surface_point_rays_along_the_camera_gaze() {
+        let camera = Camera::look_at(
+            [4.0, 2.0, -3.0],
+            [7.0, 4.0, 5.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(55.0),
+        );
+        let ray = camera.to_world_ray(800.0, 450.0, 1600.0, 900.0).unwrap();
+        let expected = (Vector3::from(camera.target) - Vector3::from(camera.eye)).normalize();
+        let direction = Vector3::from(ray.direction);
+
+        assert_eq!(ray.origin, camera.eye);
+        assert!(direction.dot(expected) > 0.99999);
+        assert!(approx(direction.magnitude(), 1.0));
+    }
+
+    #[test]
+    fn surface_corners_follow_top_left_input_and_projection_aspect() {
+        let camera = Camera::first_person(
+            [0.0, 0.0, 0.0],
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(0.0),
+            Angle::from_degrees(90.0),
+        );
+        let top_left = Vector3::from(
+            camera
+                .to_world_ray(0.0, 0.0, 200.0, 100.0)
+                .unwrap()
+                .direction,
+        );
+        let near_bottom_right = Vector3::from(
+            camera
+                .to_world_ray(199.999, 99.999, 200.0, 100.0)
+                .unwrap()
+                .direction,
+        );
+
+        // Looking down +Z means this camera's screen-right axis is -X.
+        assert!(top_left.x > 0.0);
+        assert!(top_left.y > 0.0);
+        assert!(top_left.z > 0.0);
+        assert!(near_bottom_right.x < 0.0);
+        assert!(near_bottom_right.y < 0.0);
+        assert!(near_bottom_right.z > 0.0);
+        // The 2:1 surface has twice the horizontal half-span at a 90° fov.
+        assert!(approx((top_left.x / top_left.z).abs(), 2.0));
+        assert!(approx((top_left.y / top_left.z).abs(), 1.0));
+    }
+
+    #[test]
+    fn world_ray_is_logical_scale_invariant_and_tracks_resize() {
+        let camera = Camera::default();
+        let one_x = camera.to_world_ray(300.0, 200.0, 900.0, 1000.0).unwrap();
+        let retina = camera
+            .to_world_ray(600.0, 400.0, 1800.0, 2000.0)
+            .unwrap();
+        for i in 0..3 {
+            assert!(approx(one_x.direction[i], retina.direction[i]));
+        }
+
+        let resized = camera.to_world_ray(800.0, 450.0, 1600.0, 900.0).unwrap();
+        let expected = (Vector3::from(camera.target) - Vector3::from(camera.eye)).normalize();
+        assert!(Vector3::from(resized.direction).dot(expected) > 0.99999);
+    }
+
+    #[test]
+    fn world_ray_projects_back_to_the_requested_surface_point() {
+        use cgmath::Vector4;
+
+        let camera = Camera::look_at(
+            [4.0, 2.0, -3.0],
+            [7.0, 4.0, 5.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(55.0),
+        );
+        let (x, y, width, height) = (123.0, 456.0, 1600.0, 900.0);
+        let ray = camera.to_world_ray(x, y, width, height).unwrap();
+        let point = Vector3::from(ray.origin) + Vector3::from(ray.direction) * 10.0;
+        let clip = camera.projection_matrix(width / height)
+            * camera.view_matrix()
+            * Vector4::new(point.x, point.y, point.z, 1.0);
+
+        assert!(approx(clip.x / clip.w, 2.0 * x / width - 1.0));
+        assert!(approx(clip.y / clip.w, 1.0 - 2.0 * y / height));
+    }
+
+    #[test]
+    fn world_ray_rejects_outside_surfaces_and_degenerate_cameras() {
+        let camera = Camera::default();
+        assert!(camera.to_world_ray(0.0, 0.0, 0.0, 900.0).is_none());
+        assert!(camera.to_world_ray(-0.1, 0.0, 1600.0, 900.0).is_none());
+        assert!(camera
+            .to_world_ray(1600.0, 450.0, 1600.0, 900.0)
+            .is_none());
+        assert!(camera
+            .to_world_ray(800.0, 900.0, 1600.0, 900.0)
+            .is_none());
+
+        let zero_gaze = Camera::look_at(
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        let parallel_up = Camera::look_at(
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        assert!(zero_gaze
+            .to_world_ray(10.0, 10.0, 100.0, 100.0)
+            .is_none());
+        assert!(parallel_up
+            .to_world_ray(10.0, 10.0, 100.0, 100.0)
+            .is_none());
+
+        for degrees in [0.0, 180.0, 360.0, 450.0] {
+            let invalid_fov = Camera::look_at(
+                [0.0, 0.0, -5.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                Angle::from_degrees(degrees),
+            );
+            assert!(invalid_fov
+                .to_world_ray(50.0, 50.0, 100.0, 100.0)
+                .is_none());
+        }
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -41,6 +41,9 @@
 //!   (a self-lit textured surface, fullbright — F#'s `Material.emissiveTexture`)
 //! Camera.lookAt(Vec3.make(ex, ey, ez), Vec3.make(tx, ty, tz))                     -> Camera
 //!   (up is +Y; vertical fov pinned at 45°, near/far at protocol defaults)
+//! Camera.toWorldRay(mouse, camera)                         -> Option<{ origin, direction }>
+//!   (top-left logical mouse coordinates through the authored perspective;
+//!    both fields are Vec3 values and direction is normalized)
 //! Frame.create(camera, scene)                               -> Frame
 //! Camera2D.create(width, height)                             -> Camera2D
 //! Camera2D.at(x, y, camera) / Camera2D.zoom(k, camera)       -> Camera2D
@@ -181,6 +184,63 @@ pub struct FunctorLangTerrain(pub TerrainDescription);
 
 /// A [`Camera`] as an opaque Functor Lang value.
 pub struct FunctorLangCamera(pub Camera);
+
+/// A sampled mouse position plus the logical surface extent sharing its
+/// top-left-origin coordinate space. Camera2D and Camera deliberately share
+/// this decoder so their screen-to-world APIs accept the exact same input.
+struct FunctorLangMouse {
+    x: f32,
+    y: f32,
+    surface_width: f32,
+    surface_height: f32,
+}
+
+fn finite_record_number(
+    fields: &[(String, Value)],
+    field: &str,
+    record_name: &str,
+    path: &str,
+    span: Span,
+) -> Result<f32, RunError> {
+    match fields.iter().find(|(name, _)| name == field) {
+        Some((_, Value::Number(n))) if (*n as f32).is_finite() => Ok(*n as f32),
+        Some((_, Value::Number(n))) => Err(RunError {
+            message: format!("{path}: {record_name} `{field}` must be finite, got {n}"),
+            span,
+        }),
+        Some((_, other)) => Err(RunError {
+            message: format!(
+                "{path}: {record_name} `{field}` must be a number, got {}",
+                other.kind_name()
+            ),
+            span,
+        }),
+        None => Err(RunError {
+            message: format!("{path}: expected a {record_name} record, missing `{field}`"),
+            span,
+        }),
+    }
+}
+
+impl crate::host_registry::FromArg for FunctorLangMouse {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        let Value::Record(fields) = value else {
+            return Err(RunError {
+                message: format!(
+                    "{path}: expected an Input.mouse record, got {}",
+                    value.kind_name()
+                ),
+                span,
+            });
+        };
+        Ok(FunctorLangMouse {
+            x: finite_record_number(fields, "x", "mouse", path, span)?,
+            y: finite_record_number(fields, "y", "mouse", path, span)?,
+            surface_width: finite_record_number(fields, "surfaceWidth", "mouse", path, span)?,
+            surface_height: finite_record_number(fields, "surfaceHeight", "mouse", path, span)?,
+        })
+    }
+}
 
 /// A [`Frame`] as an opaque Functor Lang value — what a Functor Lang `draw` returns.
 pub struct FunctorLangFrame(pub Frame);
@@ -2132,6 +2192,31 @@ fn register_camera(reg: &mut crate::host_registry::Registry) {
                 ("forward".to_string(), point(mapped.forward)),
                 ("up".to_string(), point(mapped.up)),
             ])))
+        },
+    );
+    reg.fn2(
+        "Camera.toWorldRay",
+        "Camera.toWorldRay(mouse, camera)",
+        |mouse: FunctorLangMouse, camera: FunctorLangCamera| {
+            crate::input::option_value(
+                camera
+                    .0
+                    .to_world_ray(
+                        mouse.x,
+                        mouse.y,
+                        mouse.surface_width,
+                        mouse.surface_height,
+                    )
+                    .map(|ray| {
+                        let vec3 = |[x, y, z]: [f32; 3]| {
+                            Value::HostData(Rc::new(FunctorLangVec3((x, y, z))))
+                        };
+                        Value::Record(Rc::new(vec![
+                            ("origin".to_string(), vec3(ray.origin)),
+                            ("direction".to_string(), vec3(ray.direction)),
+                        ]))
+                    }),
+            )
         },
     );
     reg.fn3(
@@ -5464,6 +5549,53 @@ module is CLOSED, so games referencing these break at load: {missing:?}"
             "{ position: { x: 4, y: 2, z: -3 }, \
 forward: { x: 0, y: 0, z: 1 }, up: { x: 0, y: 1, z: 0 } }"
         );
+    }
+
+    #[test]
+    fn camera_world_ray_is_normalized_and_uses_vec3_fields() {
+        let value = eval(
+            "let main = () =>\n\
+             Camera.toWorldRay(\n\
+               { x: 400.0, y: 300.0, surfaceWidth: 800.0, surfaceHeight: 600.0 },\n\
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)))",
+        );
+        let Value::Variant { ctor, args } = value else {
+            panic!("world ray should return an Option");
+        };
+        assert_eq!(ctor.as_ref(), "Option.Some");
+        let [Value::Record(fields)] = args.as_slice() else {
+            panic!("Some should carry the ray record");
+        };
+        let field = |name: &str| {
+            &fields
+                .iter()
+                .find(|(field, _)| field == name)
+                .unwrap_or_else(|| panic!("ray should contain `{name}`"))
+                .1
+        };
+        let span = Span::new(0, 0);
+        assert_eq!(
+            vec3_of(field("origin"), "ray origin", span).unwrap(),
+            (0.0, 0.0, -5.0)
+        );
+        assert_eq!(
+            vec3_of(field("direction"), "ray direction", span).unwrap(),
+            (0.0, 0.0, 1.0)
+        );
+    }
+
+    #[test]
+    fn camera_world_ray_returns_none_for_an_invalid_surface() {
+        let value = eval(
+            "let main = () => Camera.toWorldRay(\n\
+               { x: 0.0, y: 0.0, surfaceWidth: 0.0, surfaceHeight: 600.0 },\n\
+               Camera.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)))",
+        );
+        assert!(matches!(
+            value,
+            Value::Variant { ref ctor, ref args }
+                if ctor.as_ref() == "Option.None" && args.is_empty()
+        ));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude/sprite.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude/sprite.rs
@@ -26,42 +26,6 @@ struct FunctorLangSpriteRegion([f32; 4]);
 /// set. One shared point type is the only workable choice.
 struct FunctorLangPoint2([f32; 2]);
 
-/// A sampled mouse position plus the logical surface extent sharing its
-/// top-left-origin coordinate space.
-struct FunctorLangMouse {
-    x: f32,
-    y: f32,
-    surface_width: f32,
-    surface_height: f32,
-}
-
-fn finite_record_number(
-    fields: &[(String, Value)],
-    field: &str,
-    record_name: &str,
-    path: &str,
-    span: Span,
-) -> Result<f32, RunError> {
-    match fields.iter().find(|(name, _)| name == field) {
-        Some((_, Value::Number(n))) if (*n as f32).is_finite() => Ok(*n as f32),
-        Some((_, Value::Number(n))) => Err(RunError {
-            message: format!("{path}: {record_name} `{field}` must be finite, got {n}"),
-            span,
-        }),
-        Some((_, other)) => Err(RunError {
-            message: format!(
-                "{path}: {record_name} `{field}` must be a number, got {}",
-                other.kind_name()
-            ),
-            span,
-        }),
-        None => Err(RunError {
-            message: format!("{path}: expected a {record_name} record, missing `{field}`"),
-            span,
-        }),
-    }
-}
-
 impl crate::host_registry::FromArg for FunctorLangPoint2 {
     fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
         let Value::Record(fields) = value else {
@@ -77,26 +41,6 @@ impl crate::host_registry::FromArg for FunctorLangPoint2 {
             finite_record_number(fields, "x", "point", path, span)?,
             finite_record_number(fields, "y", "point", path, span)?,
         ]))
-    }
-}
-
-impl crate::host_registry::FromArg for FunctorLangMouse {
-    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
-        let Value::Record(fields) = value else {
-            return Err(RunError {
-                message: format!(
-                    "{path}: expected an Input.mouse record, got {}",
-                    value.kind_name()
-                ),
-                span,
-            });
-        };
-        Ok(FunctorLangMouse {
-            x: finite_record_number(fields, "x", "mouse", path, span)?,
-            y: finite_record_number(fields, "y", "mouse", path, span)?,
-            surface_width: finite_record_number(fields, "surfaceWidth", "mouse", path, span)?,
-            surface_height: finite_record_number(fields, "surfaceHeight", "mouse", path, span)?,
-        })
     }
 }
 

--- a/runtime/functor-runtime-common/src/viewer.rs
+++ b/runtime/functor-runtime-common/src/viewer.rs
@@ -574,32 +574,20 @@ pub fn camera_frustum_lines(authored: &Camera, aspect: f32) -> Vec<DebugLine> {
         return Vec::new();
     }
 
-    let eye = Vector3::from(authored.eye);
-    let gaze = Vector3::from(authored.target) - eye;
-    let authored_up = Vector3::from(authored.up);
-    let right = gaze.cross(authored_up);
-    if !eye.x.is_finite()
-        || !eye.y.is_finite()
-        || !eye.z.is_finite()
-        || !gaze.magnitude().is_normal()
-        || !right.magnitude().is_normal()
-    {
+    let Some(basis) = authored.world_basis() else {
         return Vec::new();
-    }
+    };
 
-    let forward = gaze.normalize();
-    let right = right.normalize();
-    let up = right.cross(forward).normalize();
     let half_tan = (authored.fov_radians * 0.5).tan();
     let corners = |distance: f32| {
-        let center = eye + forward * distance;
+        let center = basis.eye + basis.forward * distance;
         let half_height = half_tan * distance;
         let half_width = half_height * aspect;
         [
-            center - right * half_width - up * half_height,
-            center + right * half_width - up * half_height,
-            center + right * half_width + up * half_height,
-            center - right * half_width + up * half_height,
+            center - basis.right * half_width - basis.up * half_height,
+            center + basis.right * half_width - basis.up * half_height,
+            center + basis.right * half_width + basis.up * half_height,
+            center - basis.right * half_width + basis.up * half_height,
         ]
     };
     let near = corners(authored.near);

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -59,6 +59,24 @@ fn host_calls_have_real_types() {
     assert!(diags.iter().any(|m| m.contains("Frame.t")), "{diags:?}");
 }
 
+/// A camera ray is optional at the surface boundary, and its branded origin
+/// and direction feed the existing Physics.cast Vec3 parameters directly.
+#[test]
+fn camera_world_ray_checks_as_physics_cast_input() {
+    let diags = check(
+        "let camera = Camera.lookAt(\n\
+           Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0))\n\
+         let pick = (mouse: Input.mouse): Option.t<Physics.rayHit> =>\n\
+           match Camera.toWorldRay(mouse, camera) with\n\
+           | Option.Some(ray) => Option.Some(Physics.cast(ray.origin, ray.direction, 100.0))\n\
+           | Option.None => Option.None",
+    );
+    assert!(
+        diags.is_empty(),
+        "Camera.toWorldRay should feed Physics.cast directly: {diags:?}"
+    );
+}
+
 /// Engine-owned `.fun` modules participate in the same typecheck as the host
 /// interfaces they build upon.
 #[test]


### PR DESCRIPTION
## Summary

- Add `Camera.toWorldRay(mouse, camera)` to map top-left logical mouse coordinates through the authored perspective camera.
- Return an optional normalized world ray whose branded `origin` and `direction` feed `Physics.cast` / `Physics.raycast` directly.
- Keep picking stable across surface resize and device-pixel ratio changes, and return `Option.None` outside the surface or for invalid camera geometry.
- Share both the existing `Input.mouse` decoder with `Camera2D.toWorld` and one camera-basis implementation across tracking, picking, and debug-frustum visualization.

## Stack

Follows #572, which promoted the head-look and procedural hand samples to the sandbox. This is the non-visual interaction foundation for the next follow-ups: general look-at IK, then hand-reach targets and draggable spheres.

## Verification

- `cargo test -p functor_runtime_common` — 613 unit tests + 11 prelude integration tests passed.
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` passed.
- `npm run check:docs` passed.
- Projection round-trip, center/corner orientation, resize/DPR invariance, outside-surface, degenerate-camera, and invalid-FOV cases are covered.
- All 9 GitHub checks passed: native and wasm builds on macOS/Linux/Windows, headless e2e, wasm golden, and wasm smoke.

## Performance

Three alternating release runs per binary on the same machine and Cargo lockfile; table uses the best `us/frame(min)`. Deterministic allocation counts and bytes are exactly identical.

| Cells | `main` | PR | Delta | Allocs/frame | Bytes/frame |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 400 | 515.2 µs | 524.6 µs | +1.8% | 13,877 | 843,387 |
| 1,600 | 2,054.1 µs | 2,038.7 µs | −0.7% | 54,717 | 3,307,227 |
| 3,136 | 4,015.0 µs | 3,984.0 µs | −0.8% | 106,973 | 6,460,251 |

Wall-clock deltas are inside the observed run-to-run spread; there is no deterministic per-frame allocation regression.

## Review dispositions

- Fixed: explicitly reject FOV values outside the renderer-valid `0 < fov < π` range; regression coverage includes 180°, 360°, and 450°.
- Fixed: semantic duplication review found three copies of the authored camera-basis invariants. Tracking, picking, and debug-frustum visualization now use one crate-private `CameraBasis` helper.
- Final adversarial review after both fixes found no remaining Critical, High, or Medium correctness or simplicity issues.
- Final duplication pass found only intentional domain neighbors (`Camera2D.toWorld`, camera consumers, and standard typed-registry conversions), with no remaining actionable reuse. The token-clone subprocess was unavailable in this environment.
- The Codex CLI second review engine was unavailable because its local optional native package is missing; the independent reviewer was rerun after the final fix and returned clean.

## Visuals

No rendered surface changes in this foundation PR; the draggable-target follow-up will carry visual media.