### PR TITLE
feat(anim): add model-space look-at IK

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -939,6 +939,18 @@ anim |> Anim.rotate("jointName", ax, ay, az)               // additive local XYZ
                                                            //   fully driven (masks BENEATH
                                                            //   this node can't drop it; an
                                                            //   enclosing mask still can)
+anim |> Anim.lookAt("jointName", target, maxAngle, weight)  // post-pass: aim the joint's local
+                                                           //   +Z axis at a MODEL-SPACE Vec3
+                                                           //   after the anim beneath it has
+                                                           //   settled (so blended/animated
+                                                           //   parents are included). maxAngle
+                                                           //   is an Angle in [0, 180°];
+                                                           //   weight clamps to [0,1]. The
+                                                           //   target is baked into the Anim
+                                                           //   value at draw time; Scene
+                                                           //   transforms are intentionally
+                                                           //   outside the solver, so invert
+                                                           //   them before constructing target
 Camera.lookAt(eye, target)                                 // two Vec3s; up=+Y, fov 45°
 Camera.firstPerson(eye, yaw, pitch, fov)                   // Vec3 eye; Angles for the rest
                                                            //   On XR this is the authored

--- a/cli/src/commands/import.rs
+++ b/cli/src/commands/import.rs
@@ -15,11 +15,11 @@
 //!
 //! `file = module`, so games write `Scene.model(Assets.xbot)` and
 //! `Anim.clip(Assets.xbotClips.walk.name, tts)`, or pass
-//! `Assets.xbotJoints.mixamorig_Head` to `Anim.rotate` / `Anim.mask` — a typo
-//! is a check-time error instead of a silent fallback. The file is meant to be
-//! CHECKED IN (it typechecks without the binary assets, which are fetched, not
-//! committed); `run`/`build` call [`ensure_fresh`] to regenerate it
-//! automatically when the project's assets change.
+//! `Assets.xbotJoints.mixamorig_Head` to `Anim.rotate` / `Anim.lookAt` /
+//! `Anim.mask` — a typo is a check-time error instead of a silent fallback.
+//! The file is meant to be CHECKED IN (it typechecks without the binary assets,
+//! which are fetched, not committed); `run`/`build` call [`ensure_fresh`] to
+//! regenerate it automatically when the project's assets change.
 //!
 //! The pure generator (layout, identifier sanitization, determinism) lives in
 //! [`functor_runtime_common::manifest`] — shared so future tooling (the wasm
@@ -529,8 +529,8 @@ fn vetted_joints(file: &str, joints: Vec<String>) -> Vec<String> {
         if !dups.is_empty() {
             emit(Event::Warning {
                 message: format!(
-                    "{file}: duplicate joint name(s) {} — Anim.rotate/Anim.mask resolve \
-by name (rotation: smallest id; mask: all matching subtrees), so one constant \
+                    "{file}: duplicate joint name(s) {} — Anim.rotate/Anim.lookAt/Anim.mask resolve \
+by name (rotation/look-at: smallest id; mask: all matching subtrees), so one constant \
 per name is generated",
                     dups.join(", ")
                 ),

--- a/examples/animation/game.fun
+++ b/examples/animation/game.fun
@@ -1,23 +1,25 @@
-// Locomotion blending + programmatic head-look — the `Scene.animate` /
-// `Anim.blend` / `Anim.rotate` demo.
+// Locomotion blending + model-space head look — the `Scene.animate` /
+// `Anim.blend` / `Anim.lookAt` demo.
 //
 // Xbot's idle/walk/run clips are mixed by a single speed parameter
 // (0 = idle, 0.5 = walk, 1 = run — a 1D blend space), and the head joint is
-// aimed with an additive `Anim.rotate` on top of the blend. The playheads,
-// weights, and head angles are derived here, in game code, from `tts` and
-// the model — the engine owns no animation clock, so scrubbing time-travel
-// replays the exact pose.
+// aimed at a model-space point after the blend has animated its whole parent
+// chain. The playheads, weights, and target are derived here, in game code,
+// from `tts` and the model — the engine owns no animation clock or hidden IK
+// state, so scrubbing time-travel replays the exact pose.
 //
 // Keys: 1 = idle, 2 = walk, 3 = run, 0 = auto-cycle (default). Speed eases
 // toward the target, so clip transitions crossfade smoothly. Move the mouse
 // to make the head follow the pointer (the auto mode sweeps it until then).
 
+let camera =
+  Camera.lookAt(Vec3.make(0.0, 1.4, -3.2), Vec3.make(0.0, 0.9, 0.0))
+
 let init = {
   speed: 0.0,
   target: 0.0,
   auto: true,
-  head: { yaw: 0.0, pitch: 0.0 },
-  surface: { width: 800.0, height: 600.0 },
+  headTarget: { x: 0.0, y: 1.55, z: 1.2 },
   pointerDrivesHead: false,
 }
 
@@ -32,21 +34,38 @@ let input = (model, key, isDown) =>
     | Key.Num0 => { model with auto: true, pointerDrivesHead: false }
     | _ => model
 
-// Sample the logical surface size alongside the pointer. Mouse position and
-// extent share one coordinate space on native + web, so this stays correct
-// across resizing and Retina/device-pixel-ratio changes.
-let sampledInput = (model, snapshot: Input.snapshot) =>
-  { model with surface: {
-      width: Math.max(1.0, snapshot.mouse.surfaceWidth),
-      height: Math.max(1.0, snapshot.mouse.surfaceHeight),
-    } }
+// Pick a point on a plane between the camera and Xbot, then undo the model's
+// 180-degree scene rotation: Anim.lookAt targets live in model space because
+// the animation evaluator intentionally knows nothing about Scene transforms.
+let pointerTarget = (mouse: Input.mouse) =>
+  match Camera.toWorldRay(mouse, camera) with
+  | Option.None => Option.None
+  | Option.Some(ray) =>
+    let dz = Vec3.z(ray.direction) in
+    match dz > 0.0001 with
+    | false => Option.None
+    | true =>
+      let distance = ((0.0 - 1.2) - Vec3.z(ray.origin)) / dz in
+      let worldTarget =
+        ray.origin |> Vec3.add(ray.direction |> Vec3.scale(distance)) in
+      Option.Some({
+        x: 0.0 - Vec3.x(worldTarget),
+        y: Vec3.y(worldTarget),
+        z: 0.0 - Vec3.z(worldTarget),
+      })
 
-// Pointer position -> head aim: the pointer's offset from the window center
-// becomes yaw/pitch targets, clamped to a natural range.
+let sampledInput = (model, snapshot: Input.snapshot) =>
+  match model.pointerDrivesHead with
+  | false => model
+  | true =>
+    match pointerTarget(snapshot.mouse) with
+    | Option.None => model
+    | Option.Some(target) => { model with headTarget: target }
+
+// The edge handler only switches control modes. sampledInput owns the actual
+// ray conversion so the target is sampled deterministically at fixed steps.
 let mouseMove = (model, x, y) =>
-  let yaw = (Math.clamp01(x / model.surface.width) - 0.5) * 1.6 in
-  let pitch = (Math.clamp01(y / model.surface.height) - 0.5) * 0.9 in
-  { model with head: { yaw: yaw, pitch: pitch }, pointerDrivesHead: true }
+  { model with pointerDrivesHead: true }
 
 let tick = (model, dt, tts) =>
   // Auto mode sweeps the target through idle -> walk -> run and back.
@@ -55,12 +74,19 @@ let tick = (model, dt, tts) =>
      | true => (1.0 - Math.cos(tts * 0.6)) * 0.5
      | false => model.target) in
   let rate = Math.clamp01(dt * 4.0) in
-  // Until the pointer takes over, sweep the head so the look-at is visible.
-  let head =
+  // Until the pointer takes over, sweep a point in front of the character so
+  // the engine-side look-at remains obvious in a hands-off preview.
+  let headTarget =
     (match model.pointerDrivesHead with
-     | true => model.head
-     | false => { yaw: Math.sin(tts * 0.9) * 0.6, pitch: Math.sin(tts * 1.7) * 0.25 }) in
-  { model with speed: model.speed + (target - model.speed) * rate, head: head }
+     | true => model.headTarget
+     | false => {
+         x: Math.sin(tts * 0.9) * 0.9,
+         y: 1.55 + Math.sin(tts * 1.7) * 0.22,
+         z: 1.2,
+       }) in
+  { model with
+      speed: model.speed + (target - model.speed) * rate,
+      headTarget: headTarget }
 
 let absF = (x: float): float =>
   match x < 0.0 with
@@ -85,18 +111,20 @@ let locomotion = (s: float, tts: float): Anim.t =>
     (Anim.clip(Assets.xbotClips.run.name, tts), runWeight(s)),
   ])
 
-// The full pose: the locomotion blend with the head aimed on top — an
-// additive local rotation on the head joint (survives the blend beneath it).
+// The full pose: solve the head after locomotion has animated its spine.
+// local +Z is Xbot's authored facing axis; the explicit limit keeps targets
+// behind the character from producing a full turn.
 let pose = (model, tts) =>
   locomotion(model.speed, tts)
-    |> Anim.rotate(Assets.xbotJoints.mixamorig_Head,
-         Angle.radians(model.head.pitch),
-         Angle.radians(model.head.yaw),
-         Angle.radians(0.0))
+    |> Anim.lookAt(
+         Assets.xbotJoints.mixamorig_Head,
+         Vec3.make(model.headTarget.x, model.headTarget.y, model.headTarget.z),
+         Angle.degrees(75.0),
+         1.0)
 
 let draw = (model, tts) =>
   Frame.createLit(
-    Camera.lookAt(Vec3.make(0.0, 1.4, -3.2), Vec3.make(0.0, 0.9, 0.0)),
+    camera,
     Scene.group([
       Scene.plane() |> Scene.scale(10.0) |> Scene.lit(Color.rgb(0.42, 0.47, 0.55)),
       // Xbot stands ~1.8 units tall, Y-up, at authored scale; glTF forward
@@ -104,6 +132,15 @@ let draw = (model, tts) =>
       Scene.model(Assets.xbot)
         |> Scene.animate(pose(model, tts))
         |> Scene.rotateY(Angle.degrees(180.0)),
+      // Show the target in world space. This applies the same 180-degree
+      // transform as the model so the marker and IK target stay coincident.
+      Scene.sphere()
+        |> Scene.scale(0.025)
+        |> Scene.emissive(Color.rgb(0.1, 0.95, 1.0))
+        |> Scene.translate(Vec3.make(
+             0.0 - model.headTarget.x,
+             model.headTarget.y,
+             0.0 - model.headTarget.z)),
     ]),
     [
       Light.ambient(Color.rgb(0.25, 0.25, 0.3)),
@@ -112,8 +149,8 @@ let draw = (model, tts) =>
 
 let ui = (model) =>
   Ui.column([
-    Ui.text("Anim.blend: idle / walk / run by speed + Anim.rotate head-look"),
+    Ui.text("Anim.blend: idle / walk / run + Anim.lookAt post-pass"),
     Ui.text(Text.concat("speed: ", Text.fixed(model.speed, 2.0))),
-    Ui.text(Text.concat("head yaw: ", Text.fixed(model.head.yaw, 2.0))),
+    Ui.text(Text.concat("target x: ", Text.fixed(model.headTarget.x, 2.0))),
     Ui.text("keys: 1 idle, 2 walk, 3 run, 0 auto — mouse aims the head"),
   ]) |> Ui.panel(Ui.topLeft())

--- a/functor-prelude/prelude/anim.funi
+++ b/functor-prelude/prelude/anim.funi
@@ -34,3 +34,11 @@ let mask : (List<string>, t) => t
 /// The joint is fully driven by this node; an enclosing mask can still exclude
 /// it.
 let rotate : (string, Angle.t, Angle.t, Angle.t, t) => t
+
+/// Aim one joint's local +Z axis at a model-space target after evaluating the
+/// pose below it.
+///
+/// `maxDeflection` limits the shortest correction from the evaluated pose and
+/// must be between 0 and 180 degrees. `weight` is clamped to `0..1`. The joint
+/// is fully driven by this node; an enclosing mask can still exclude it.
+let lookAt : (string, Vec3.t, Angle.t, float, t) => t

--- a/runtime/functor-runtime-common/src/anim.rs
+++ b/runtime/functor-runtime-common/src/anim.rs
@@ -17,7 +17,9 @@
 //! - `Mask` restricts an expression's influence to the subtrees rooted at
 //!   the named joints (per-finger poses, upper-body-only layers).
 //! - `Rotate` post-multiplies an additive local rotation onto one joint —
-//!   the programmatic per-joint control (head aim, finger curl).
+//!   the programmatic per-joint control (finger curl, authored offsets).
+//! - `LookAt` aims one joint's local +Z axis at a model-space target after
+//!   evaluating the expression below it.
 //!
 //! Evaluation carries a per-joint influence weight so `Mask` composes
 //! through `Blend`/`Add`: a joint no input drives falls back to the bind
@@ -25,7 +27,10 @@
 
 use std::collections::HashMap;
 
-use cgmath::{Euler, InnerSpace, Matrix4, Quaternion, Rad, Rotation, Vector3, Zero};
+use cgmath::{
+    Euler, InnerSpace, Matrix3, Matrix4, One, Quaternion, Rad, Rotation, SquareMatrix, Vector3,
+    Zero,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::model::{JointPose, Model, Pose, Skeleton};
@@ -71,6 +76,16 @@ pub enum AnimExpr {
         joint: String,
         /// XYZ Euler angles in radians, applied in the joint's local frame.
         euler: [f32; 3],
+        expr: Box<AnimExpr>,
+    },
+    /// Aim one joint's local +Z axis at a model-space target after evaluating
+    /// `expr`. The shortest correction is clamped to `max_angle` radians and
+    /// blended by `weight`.
+    LookAt {
+        joint: String,
+        target: [f32; 3],
+        max_angle: f32,
+        weight: f32,
         expr: Box<AnimExpr>,
     },
 }
@@ -222,7 +237,139 @@ fn eval(model: &Model, expr: &AnimExpr, on_warning: &mut dyn FnMut(AnimWarning))
             }
             inner
         }
+        AnimExpr::LookAt {
+            joint,
+            target,
+            max_angle,
+            weight,
+            expr,
+        } => {
+            let mut inner = eval(model, expr, on_warning);
+            match model.skeleton.joint_id_by_name(joint) {
+                Some(joint_id) => {
+                    apply_look_at(
+                        &model.skeleton,
+                        &mut inner,
+                        joint_id,
+                        Vector3::from(*target),
+                        *max_angle,
+                        *weight,
+                    );
+                }
+                None => on_warning(AnimWarning::MissingJoint(joint)),
+            }
+            inner
+        }
     }
+}
+
+/// Resolve one joint exactly as `finalize` would, without allocating a full
+/// pose. Look-at only needs the target joint and its ancestor chain, so this
+/// keeps the post-pass proportional to hierarchy depth.
+fn resolved_joint_pose(
+    skeleton: &Skeleton,
+    pose: &WeightedPose,
+    joint_id: i32,
+) -> Option<JointPose> {
+    match pose.joints.get(&joint_id) {
+        Some((joint, weight)) if *weight >= 1.0 => Some(*joint),
+        Some((joint, weight)) if *weight > 0.0 => {
+            let bind = skeleton.get_joint_bind_pose(joint_id)?;
+            Some(mix_joint(&bind, joint, *weight))
+        }
+        _ => skeleton.get_joint_bind_pose(joint_id),
+    }
+}
+
+struct ResolvedAbsolute {
+    transform: Matrix4<f32>,
+    parent_transform: Matrix4<f32>,
+}
+
+fn resolved_absolute(
+    skeleton: &Skeleton,
+    pose: &WeightedPose,
+    joint_id: i32,
+) -> Option<ResolvedAbsolute> {
+    let local = resolved_joint_pose(skeleton, pose, joint_id)?;
+    let parent_transform = match skeleton.get_joint_parent_id(joint_id) {
+        Some(parent_id) => {
+            let parent = resolved_absolute(skeleton, pose, parent_id)?;
+            parent.transform
+        }
+        None => Matrix4::one(),
+    };
+    Some(ResolvedAbsolute {
+        transform: parent_transform * local.transform(),
+        parent_transform,
+    })
+}
+
+fn scaled_shortest_arc(
+    from: Vector3<f32>,
+    to: Vector3<f32>,
+    rear_pole: Vector3<f32>,
+    max_angle: f32,
+    weight: f32,
+) -> Quaternion<f32> {
+    // At the exact antipode there are infinitely many shortest arcs. Supplying
+    // the joint's current up axis makes that otherwise singular choice stable:
+    // rearward targets turn around local up instead of whichever arbitrary
+    // world axis happens to survive the cross product.
+    let correction = Quaternion::from_arc(from, to, Some(rear_pole));
+    let angle = 2.0 * correction.s.clamp(-1.0, 1.0).acos();
+    if angle <= 1e-6 {
+        return Quaternion::one();
+    }
+    let fraction = (max_angle.max(0.0) / angle).min(1.0) * weight.clamp(0.0, 1.0);
+    Quaternion::one().slerp(correction, fraction)
+}
+
+fn apply_look_at(
+    skeleton: &Skeleton,
+    pose: &mut WeightedPose,
+    joint_id: i32,
+    target: Vector3<f32>,
+    max_angle: f32,
+    weight: f32,
+) {
+    if max_angle <= 0.0 || weight <= 0.0 {
+        return;
+    }
+    let Some(mut joint) = resolved_joint_pose(skeleton, pose, joint_id) else {
+        return;
+    };
+    let Some(absolute) = resolved_absolute(skeleton, pose, joint_id) else {
+        return;
+    };
+    let offset = target - absolute.transform.w.truncate();
+    if offset.magnitude2() <= 1e-12 {
+        return;
+    }
+
+    let parent_linear = Matrix3::from_cols(
+        absolute.parent_transform.x.truncate(),
+        absolute.parent_transform.y.truncate(),
+        absolute.parent_transform.z.truncate(),
+    );
+    let Some(parent_inverse) = parent_linear.invert() else {
+        return;
+    };
+    let desired_in_parent = parent_inverse * offset;
+    if desired_in_parent.magnitude2() <= 1e-12 {
+        return;
+    }
+    let current_in_parent = joint.rotation.rotate_vector(Vector3::unit_z());
+    let rear_pole = joint.rotation.rotate_vector(Vector3::unit_y());
+    let local_correction = scaled_shortest_arc(
+        current_in_parent,
+        desired_in_parent.normalize(),
+        rear_pole,
+        max_angle,
+        weight,
+    );
+    joint.rotation = (local_correction * joint.rotation).normalize();
+    pose.joints.insert(joint_id, (joint, 1.0));
 }
 
 fn full_weight(pose: Pose) -> WeightedPose {
@@ -625,6 +772,132 @@ mod tests {
         let expr = AnimExpr::Rotate {
             joint: "tail".to_string(),
             euler: [0.0, 0.0, 1.0],
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let mut missing = Vec::new();
+        let transforms = skinning_transforms(&model, &expr, &mut |warning| {
+            if let AnimWarning::MissingJoint(name) = warning {
+                missing.push(name.to_string());
+            }
+        });
+        assert_eq!(missing, vec!["tail".to_string()]);
+        assert_eq!(transforms[0], Matrix4::identity());
+    }
+
+    #[test]
+    fn look_at_aims_after_the_parent_pose_has_settled() {
+        let model = chain_model();
+        let expr = AnimExpr::LookAt {
+            joint: "hand".to_string(),
+            target: [0.0, 2.0, 0.0],
+            max_angle: std::f32::consts::PI,
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rotate {
+                joint: "arm".to_string(),
+                euler: [0.0, std::f32::consts::FRAC_PI_2, 0.0],
+                expr: Box::new(AnimExpr::Rest),
+            }),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let forward = transforms[2].z.truncate().normalize();
+        assert!(
+            (forward - Vector3::unit_y()).magnitude() < 1e-5,
+            "forward: {forward:?}"
+        );
+    }
+
+    #[test]
+    fn look_at_clamps_the_correction_and_blends_its_weight() {
+        let model = chain_model();
+        let expr = AnimExpr::LookAt {
+            joint: "hand".to_string(),
+            target: [1.0, 0.0, 0.0],
+            max_angle: 60.0_f32.to_radians(),
+            weight: 0.5,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let forward = transforms[2].z.truncate().normalize();
+        let angle = Vector3::unit_z().dot(forward).clamp(-1.0, 1.0).acos();
+        assert!(
+            (angle - 30.0_f32.to_radians()).abs() < 1e-5,
+            "angle: {} degrees",
+            angle.to_degrees()
+        );
+    }
+
+    #[test]
+    fn look_at_uses_joint_up_as_the_rear_singularity_pole() {
+        let max_angle = 60.0_f32.to_radians();
+        let expected = vec3(-max_angle.sin(), 0.0, max_angle.cos());
+
+        // Tiny floating-point jitter around the exact antipode must not choose
+        // opposite arbitrary axes and make a clamped head snap side-to-side.
+        for x in [-1e-8, 0.0, 1e-8] {
+            let target = vec3(x, 0.0, -1.0).normalize();
+            let correction = scaled_shortest_arc(
+                Vector3::unit_z(),
+                target,
+                Vector3::unit_y(),
+                max_angle,
+                1.0,
+            );
+            let forward = correction.rotate_vector(Vector3::unit_z());
+            assert!(
+                (forward - expected).magnitude() < 1e-5,
+                "target {target:?} produced {forward:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn look_at_aims_through_non_uniform_parent_scale() {
+        let mut builder = SkeletonBuilder::create(vec![Matrix4::identity(); 2]);
+        builder.add_joint(
+            0,
+            0,
+            "root".to_string(),
+            None,
+            Matrix4::from_nonuniform_scale(2.0, 1.0, 0.5),
+        );
+        builder.add_joint(
+            1,
+            1,
+            "head".to_string(),
+            Some(0),
+            Matrix4::from_translation(Vector3::unit_y()),
+        );
+        let model = Model {
+            meshes: vec![],
+            skeleton: builder.build(),
+            animations: vec![],
+        };
+        let expr = AnimExpr::LookAt {
+            joint: "head".to_string(),
+            // The joint is at (0,1,0), so the requested model-space
+            // direction is (1,1,0).
+            target: [1.0, 2.0, 0.0],
+            max_angle: std::f32::consts::PI,
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let forward = transforms[1].z.truncate().normalize();
+        let expected = vec3(1.0, 1.0, 0.0).normalize();
+        assert!(
+            (forward - expected).magnitude() < 1e-5,
+            "forward: {forward:?}"
+        );
+    }
+
+    #[test]
+    fn look_at_on_unknown_joint_warns_and_is_ignored() {
+        let model = chain_model();
+        let expr = AnimExpr::LookAt {
+            joint: "tail".to_string(),
+            target: [0.0, 0.0, 1.0],
+            max_angle: std::f32::consts::FRAC_PI_2,
+            weight: 1.0,
             expr: Box::new(AnimExpr::Rest),
         };
         let mut missing = Vec::new();

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -44,6 +44,8 @@
 //! Camera.toWorldRay(mouse, camera)                         -> Option<{ origin, direction }>
 //!   (top-left logical mouse coordinates through the authored perspective;
 //!    both fields are Vec3 values and direction is normalized)
+//! Anim.lookAt(joint, target, maxDeflection, weight, anim)  -> Anim
+//!   (post-pass aim of local +Z at a model-space Vec3 target)
 //! Frame.create(camera, scene)                               -> Frame
 //! Camera2D.create(width, height)                             -> Camera2D
 //! Camera2D.at(x, y, camera) / Camera2D.zoom(k, camera)       -> Camera2D
@@ -2940,8 +2942,9 @@ one with Asset.model/texture(…) first"
 }
 
 /// The Anim pose algebra — clip sampling, blending, the rest pose, additive
-/// layers, masks, and per-joint rotation. Playheads/weights are explicit in
-/// the values, so the pose stays a pure function of what the game derived.
+/// layers, masks, per-joint rotation, and model-space look-at. Playheads,
+/// targets, and weights are explicit in the values, so the pose stays a pure
+/// function of what the game derived.
 fn register_anim(reg: &mut crate::host_registry::Registry) {
     // A clip sample as a value: the named glTF clip at a playhead in seconds
     // (looping by the clip's duration). The playhead is explicit — derive it
@@ -3059,6 +3062,35 @@ additive local XYZ rotation";
             Ok(FunctorLangAnim(AnimExpr::Rotate {
                 joint,
                 euler: [x.0, y.0, z.0],
+                expr: Box::new(anim.0),
+            }))
+        },
+    );
+    // A pure post-pass over the expression beneath it: aim the joint's local
+    // +Z axis at a model-space target after clips/blends have settled. The
+    // explicit limit keeps arbitrary targets from producing unnatural full
+    // turns; the weight makes the correction blendable.
+    const LOOK_AT: &str = "Anim.lookAt(\"jointName\", target, maxDeflection, weight, anim) — \
+a non-empty joint name, model-space Vec3 target, Angle limit from 0 to 180 degrees, and weight";
+    reg.fn5(
+        "Anim.lookAt",
+        LOOK_AT,
+        |joint: String,
+         target: FunctorLangVec3,
+         max_deflection: FunctorLangAngle,
+         weight: f64,
+         anim: FunctorLangAnim| {
+            let max_deflection: cgmath::Rad<f32> = max_deflection.0.into();
+            if joint.is_empty()
+                || !(0.0..=std::f32::consts::PI).contains(&max_deflection.0)
+            {
+                return Err(format!("usage: {LOOK_AT}"));
+            }
+            Ok(FunctorLangAnim(AnimExpr::LookAt {
+                joint,
+                target: [target.0 .0, target.0 .1, target.0 .2],
+                max_angle: max_deflection.0,
+                weight: weight as f32,
                 expr: Box::new(anim.0),
             }))
         },
@@ -7387,8 +7419,8 @@ Anim.clip(\"walk\", tts)"
     }
 
     // The full pose algebra composes through pipes and lands on the Model
-    // node as nested AnimExpr data: rest |> rotate, masked blends, additive
-    // layers.
+    // node as nested AnimExpr data: rest |> rotate |> lookAt, masked blends,
+    // additive layers.
     #[test]
     fn anim_algebra_composes_and_serializes() {
         let value = eval(
@@ -7396,6 +7428,7 @@ Anim.clip(\"walk\", tts)"
              Scene.model(Asset.model(\"glove.glb\")) |> Scene.animate(\n\
                Anim.rest()\n\
                  |> Anim.rotate(\"finger_index_0_r\", Angle.degrees(45.0), Angle.degrees(0.0), Angle.degrees(0.0))\n\
+                 |> Anim.lookAt(\"finger_index_0_r\", Vec3.make(1.0, 2.0, 3.0), Angle.degrees(80.0), 0.75)\n\
                  |> Anim.mask([\"wrist_r\"])\n\
                  |> Anim.add(Anim.clip(\"wave\", 1.0), 0.5))",
         );
@@ -7420,8 +7453,22 @@ Anim.clip(\"walk\", tts)"
             panic!("expected a Mask base, got {base:?}");
         };
         assert_eq!(joints, &vec!["wrist_r".to_string()]);
+        let AnimExpr::LookAt {
+            joint,
+            target,
+            max_angle,
+            weight,
+            expr,
+        } = &**expr
+        else {
+            panic!("expected a LookAt inside the mask, got {expr:?}");
+        };
+        assert_eq!(joint, "finger_index_0_r");
+        assert_eq!(target, &[1.0, 2.0, 3.0]);
+        assert!((*max_angle - 80.0_f32.to_radians()).abs() < 1e-6);
+        assert!((*weight - 0.75).abs() < 1e-6);
         let AnimExpr::Rotate { joint, euler, expr } = &**expr else {
-            panic!("expected a Rotate inside the mask, got {expr:?}");
+            panic!("expected a Rotate inside LookAt, got {expr:?}");
         };
         assert_eq!(joint, "finger_index_0_r");
         assert!((euler[0] - 45.0_f32.to_radians()).abs() < 1e-6);
@@ -7449,6 +7496,37 @@ Anim.clip(\"walk\", tts)"
             failure.error.message.contains("Angle"),
             "message: {}",
             failure.error.message
+        );
+    }
+
+    #[test]
+    fn anim_look_at_enforces_spatial_and_angle_brands() {
+        for source in [
+            "let main = () => Anim.rest() |> Anim.lookAt(\"head\", { x: 0.0, y: 1.0, z: 2.0 }, Angle.degrees(80.0), 1.0)",
+            "let main = () => Anim.rest() |> Anim.lookAt(\"head\", Vec3.make(0.0, 1.0, 2.0), 1.4, 1.0)",
+        ] {
+            let module =
+                functor_lang::lower(functor_lang::parse(source).unwrap()).unwrap();
+            let failure =
+                functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+                    .err()
+                    .expect("should fail");
+            assert!(
+                failure.error.message.contains("Vec3")
+                    || failure.error.message.contains("Angle"),
+                "message: {}",
+                failure.error.message
+            );
+        }
+    }
+
+    #[test]
+    fn anim_look_at_rejects_an_invalid_deflection_limit() {
+        assert_eq!(
+            fail_message(
+                "let main = () => Anim.rest() |> Anim.lookAt(\"head\", Vec3.make(0.0, 1.0, 2.0), Angle.degrees(181.0), 1.0)"
+            ),
+            "usage: Anim.lookAt(\"jointName\", target, maxDeflection, weight, anim) — a non-empty joint name, model-space Vec3 target, Angle limit from 0 to 180 degrees, and weight"
         );
     }
 

--- a/runtime/functor-runtime-common/src/manifest.rs
+++ b/runtime/functor-runtime-common/src/manifest.rs
@@ -265,10 +265,10 @@ pub fn duplicate_clip_names(clips: &[(String, f32)]) -> Vec<String> {
     duplicate_names(clips.iter().map(|(name, _)| name.as_str()))
 }
 
-/// Joint names appearing more than once in a model. `Anim.rotate` selects the
-/// smallest matching node id while `Anim.mask` selects all matching subtrees;
-/// duplicate nodes are not individually name-addressable, so the generator
-/// emits one field.
+/// Joint names appearing more than once in a model. `Anim.rotate` and
+/// `Anim.lookAt` select the smallest matching node id while `Anim.mask`
+/// selects all matching subtrees; duplicate nodes are not individually
+/// name-addressable, so the generator emits one field.
 pub fn duplicate_joint_names(joints: &[String]) -> Vec<String> {
     duplicate_names(joints.iter().map(String::as_str))
 }

--- a/runtime/functor-runtime-common/src/model/skeleton.rs
+++ b/runtime/functor-runtime-common/src/model/skeleton.rs
@@ -12,6 +12,39 @@ pub struct JointPose {
     pub scale: Vector3<f32>,
 }
 
+impl JointPose {
+    pub(crate) fn from_transform(transform: Matrix4<f32>) -> Self {
+        let translation = transform.w.truncate();
+        let linear = Matrix3::from_cols(
+            transform.x.truncate(),
+            transform.y.truncate(),
+            transform.z.truncate(),
+        );
+        let scale = Vector3::new(
+            linear.x.magnitude(),
+            linear.y.magnitude(),
+            linear.z.magnitude(),
+        );
+        let rotation_matrix = Matrix3::from_cols(
+            linear.x / scale.x,
+            linear.y / scale.y,
+            linear.z / scale.z,
+        );
+
+        Self {
+            translation,
+            rotation: Quaternion::from(rotation_matrix),
+            scale,
+        }
+    }
+
+    pub(crate) fn transform(self) -> Matrix4<f32> {
+        Matrix4::from_translation(self.translation)
+            * Matrix4::from(self.rotation)
+            * Matrix4::from_nonuniform_scale(self.scale.x, self.scale.y, self.scale.z)
+    }
+}
+
 /// A skeleton-shaped set of local joint transforms in TRS form — what clip
 /// sampling produces and blending combines, before being applied back onto a
 /// [`Skeleton`] for skinning. Keyed by joint id (sparse, like `joint_info`).
@@ -60,34 +93,7 @@ impl Skeleton {
     pub fn base_pose(&self) -> Pose {
         let mut joints = HashMap::new();
         for (&joint_index, joint) in &self.joint_info {
-            // Extract translation (last column)
-            let translation = joint.transform.w.truncate();
-
-            // Extract the upper-left 3x3 matrix
-            let m = Matrix3::from_cols(
-                joint.transform.x.truncate(),
-                joint.transform.y.truncate(),
-                joint.transform.z.truncate(),
-            );
-
-            // Extract scale factors
-            let scale_x = m.x.magnitude();
-            let scale_y = m.y.magnitude();
-            let scale_z = m.z.magnitude();
-            let scale = Vector3::new(scale_x, scale_y, scale_z);
-
-            // Normalize the columns to get the rotation matrix, then a quaternion
-            let rotation_matrix = Matrix3::from_cols(m.x / scale_x, m.y / scale_y, m.z / scale_z);
-            let rotation = Quaternion::from(rotation_matrix);
-
-            joints.insert(
-                joint_index,
-                JointPose {
-                    translation,
-                    rotation,
-                    scale,
-                },
-            );
+            joints.insert(joint_index, JointPose::from_transform(joint.transform));
         }
         Pose { joints }
     }
@@ -125,9 +131,7 @@ impl Skeleton {
         let mut new_skeleton = self.clone();
         for (&joint_index, joint) in new_skeleton.joint_info.iter_mut() {
             if let Some(jp) = pose.joints.get(&joint_index) {
-                joint.transform = Matrix4::from_translation(jp.translation)
-                    * Matrix4::from(jp.rotation)
-                    * Matrix4::from_nonuniform_scale(jp.scale.x, jp.scale.y, jp.scale.z);
+                joint.transform = jp.transform();
             }
         }
         new_skeleton.joint_absolute_transform =
@@ -179,6 +183,16 @@ impl Skeleton {
             .get(&idx)
             .map(|m| m.transform)
             .unwrap_or(Matrix4::identity())
+    }
+
+    pub(crate) fn get_joint_parent_id(&self, idx: i32) -> Option<i32> {
+        self.joint_info.get(&idx).and_then(|joint| joint.parent)
+    }
+
+    pub(crate) fn get_joint_bind_pose(&self, idx: i32) -> Option<JointPose> {
+        self.joint_info
+            .get(&idx)
+            .map(|joint| JointPose::from_transform(joint.transform))
     }
 
     pub fn get_joint_absolute_transform(&self, idx: i32) -> Matrix4<f32> {

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -77,6 +77,25 @@ fn camera_world_ray_checks_as_physics_cast_input() {
     );
 }
 
+/// Cursor rays can become model-space targets for the pure animation
+/// post-pass without unpacking the Vec3 at the animation boundary.
+#[test]
+fn camera_world_ray_checks_as_anim_look_at_input() {
+    let diags = check(
+        "let camera = Camera.lookAt(\n\
+           Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0))\n\
+         let aim = (mouse: Input.mouse): Anim.t =>\n\
+           match Camera.toWorldRay(mouse, camera) with\n\
+           | Option.Some(ray) => Anim.rest() |> Anim.lookAt(\n\
+               \"head\", ray.origin |> Vec3.add(ray.direction), Angle.degrees(80.0), 1.0)\n\
+           | Option.None => Anim.rest()",
+    );
+    assert!(
+        diags.is_empty(),
+        "Camera.toWorldRay should feed Anim.lookAt directly: {diags:?}"
+    );
+}
+
 /// Engine-owned `.fun` modules participate in the same typecheck as the host
 /// interfaces they build upon.
 #[test]


### PR DESCRIPTION
## Summary

- add Anim.lookAt as a pure animation post-pass that aims a joint local +Z axis at a model-space target after the inner pose settles
- resolve animated ancestor transforms, non-uniform parent scale, weighted joints, max deflection, and stable rearward targets in the engine
- replace the animation sample manual head Euler math with Camera.toWorldRay plus Anim.lookAt, including the same sample in the web sandbox
- document the Functor Lang surface and teach generated joint-name guidance about look-at consumers

Closes #309

## Stack

This follows the merged screen-to-world picking ray work in #584. It establishes the one-joint IK primitive before the planned two-bone hand reach and draggable target sample.

## Verification

- cargo test -p functor_runtime_common --quiet — 620 unit tests, 12 prelude typechecks
- cargo test -p functor-cli --no-default-features — 85 tests
- npm run check:docs
- npm run build:cli — native and wasm runtimes
- target/release/functor -d examples/animation test
- target/release/functor -d examples/animation build native
- npm run build:lang-wasm
- npm run test:site — all checks passed, including the animation sandbox and visible pointer input
- git diff --check

## Performance

Release frame_bench kept allocations and bytes exactly unchanged from main:

| cells | main min us/frame | change min us/frame | allocs/frame | bytes/frame |
| ---: | ---: | ---: | ---: | ---: |
| 400 | 429.8 | 430.1 | 13,877 | 843,387 |
| 1,600 | 1,697.5 | 1,685.8 | 54,717 | 3,307,227 |
| 3,136 | 3,307.0 | 3,292.6 | 106,973 | 6,460,251 |

The time deltas remain inside run-to-run spread. A post-review run remained in the same band at 434.3 / 1707.2 / 3317.3 us with identical allocation counts.

## Duplication review

The pre-write API index found no existing joint aim solver. The changed implementation has no production clone; the only changed-file jscpd match was intentional missing-joint test setup shared with Anim.rotate.

## Review disposition

- independent reviewer: no findings; visual behavior and specialization both validated
- Codex reviewer: one Medium finding for the 180-degree rear-target ambiguity
- fixed: Anim.lookAt now supplies the settled joint up axis as a deterministic antipodal pole, with a regression test covering floating-point jitter around directly rearward targets
- verification was rerun after the fix
- post-embed visual xreview: both reviewers passed the 24-frame GIF and the two fixed-time stills with no findings; the marker and head move together across opposite target positions

## Visuals

![Anim.lookAt target tracking demo](https://gist.githubusercontent.com/tommy-xr/2395403e46ab0d3f27f170df8f2638b4/raw/functor-anim-look-at-demo.gif)

<sub>Xbot follows the cyan model-space target after locomotion animates its spine; the target is driven by Camera.toWorldRay in pointer mode. Rendered headlessly via --capture-frame / --fixed-time.</sub>

### Still

![Anim.lookAt tracking the cyan model-space target](https://gist.githubusercontent.com/tommy-xr/2395403e46ab0d3f27f170df8f2638b4/raw/functor-anim-look-at-still.png)

### Before → after

Both sides use the same fixed time (2.4 seconds). The updated sample replaces the manual additive Euler rotation with the model-space Anim.lookAt post-pass and makes its target visible.

![Before Anim.rotate and after Anim.lookAt](https://gist.githubusercontent.com/tommy-xr/2395403e46ab0d3f27f170df8f2638b4/raw/functor-anim-look-at-before-after.png)