### PR TITLE
feat(site): stage a one-click platformer hero

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -187,30 +187,6 @@ const regionHash = (frame) =>
       })
   );
 
-// True if any pixel in the lower half of the player canvas is green-dominant
-// (g > 150, r < 100) — the hero's dot-grid lives below the horizon, so a green
-// recolor of the dots shows up here even though the sun/sky dominate the center.
-const lowerHalfGreen = (frame) =>
-  frame.evaluate(
-    () =>
-      new Promise((resolve) => {
-        requestAnimationFrame(() => {
-          const gl = document.getElementById("canvas");
-          const c = document.createElement("canvas");
-          c.width = gl.width;
-          c.height = gl.height;
-          const ctx = c.getContext("2d");
-          ctx.drawImage(gl, 0, 0);
-          const y0 = Math.floor(c.height * 0.5);
-          const d = ctx.getImageData(0, y0, c.width, c.height - y0).data;
-          for (let i = 0; i < d.length; i += 4) {
-            if (d[i] < 100 && d[i + 1] > 150) return resolve(true);
-          }
-          resolve(false);
-        });
-      })
-  );
-
 const playerFrame = (page) => {
   const frame = page.frames().find((f) => f.url().includes("player.html"));
   if (!frame) throw new Error("player iframe not found");
@@ -220,6 +196,18 @@ const playerFrame = (page) => {
 // --- 1. Landing page: the hero scene actually renders. ------------------------
 {
   const page = await browser.newPage({ viewport: { width: 1024, height: 640 } });
+  // Force recurring multi-step render frames while the hero stages. The baked
+  // input script must be scheduled inside the runtime's fixed-step loop; a
+  // parent-page rAF observer cannot reliably see frames 18/19 under this load.
+  await page.addInitScript(() => {
+    if (window !== window.top) return;
+    window.__heroFrameStall = window.setInterval(() => {
+      const until = performance.now() + 55;
+      while (performance.now() < until) {
+        // Deliberately occupy the page thread.
+      }
+    }, 80);
+  });
   const consoleLog = [];
   page.on("console", (m) => consoleLog.push(m.text()));
   await page.goto(BASE);
@@ -227,85 +215,186 @@ const playerFrame = (page) => {
     if (i > 100) throw new Error(`hero never loaded:\n${consoleLog.join("\n")}`);
     await sleep(200);
   }
-  await sleep(600);
-  const pixel = await centerPixel(playerFrame(page));
-  // Anything the hero draws at center (sun, sky, grid) differs from the GL
+  await page.waitForFunction(() => window.__hero?.staged(), null, { timeout: 15000 });
+  await page.evaluate(() => window.clearInterval(window.__heroFrameStall));
+  const heroPlayer = playerFrame(page);
+  const pixel = await centerPixel(heroPlayer);
+  // Anything the platformer draws at center (sky / hills) differs from the GL
   // clear color rgb(26, 51, 77); "not clear color" = the scene rendered.
   const rendered = Math.abs(pixel[0] - 26) + Math.abs(pixel[1] - 51) + Math.abs(pixel[2] - 77) > 30;
   check("landing hero scene renders", rendered, `center = rgb(${pixel})`);
+  const tagline = await page.locator(".hero-sub").textContent();
+  check(
+    "landing hero uses the engine-wide tagline",
+    tagline.trim() === "A free, open-source game engine.",
+    JSON.stringify(tagline.trim())
+  );
 
   // The shared player carries the scrubber into the hero iframe too (hidden
   // until history, but the element is present).
-  const heroHasScrubber = await playerFrame(page).evaluate(
+  const heroHasScrubber = await heroPlayer.evaluate(
     () => !!document.getElementById("scrubber")
   );
   check("landing hero player has the scrubber element", heroHasScrubber);
 
-  // The hero mini-sandbox: a live editor over just the `dot` def.
+  // The hero mini-sandbox: a live editor over just the jump tuning region.
   await page.waitForFunction(
-    () => window.__hero && window.__hero.region().includes("let dot"),
+    () => window.__hero && window.__hero.region().includes("let jumpVelocity"),
     { timeout: 10000 }
   );
   const region = await page.evaluate(() => window.__hero.region());
   check(
-    "hero editor shows only the dot region (not the whole file)",
-    region.includes("let dot") && !region.includes("let init"),
+    "hero editor shows only the jump region (not the whole file)",
+    region.includes("let jumpVelocity") && !region.includes("let init"),
     region.slice(0, 40)
   );
 
-  // A green edit: recolor the dots' emissive to pure green. The scene must
-  // hot-swap with the model preserved (the wave keeps rolling) — no reload.
-  const greenRegion = region.replace(
-    /Scene\.emissive\(Color\.rgb\([^)]*\)\)/,
-    "Scene.emissive(Color.rgb(0.1, 1.0, 0.2))"
+  // The loader has already driven the checked-in input script, paused, and
+  // parked immediately before Up-down. Extrapolation remains OFF so the real
+  // crystal button is the promised one-click reveal.
+  const staged = await heroPlayer.evaluate(() => {
+    const events = window.__scrub.events();
+    const jump = events.find((event) => event.label === "Up down");
+    return {
+      paused: window.__scrub.paused(),
+      frame: window.__scrub.frame(),
+      labels: events.map((event) => event.label),
+      jumpFrame: jump?.frame,
+      preview: window.__scrub.model().preview,
+    };
+  });
+  check(
+    "landing hero bakes the complete jump input into its timeline",
+    ["Right down", "Up down", "Up up", "Right up"].every((label) =>
+      staged.labels.includes(label)
+    ),
+    JSON.stringify(staged)
   );
-  await page.evaluate((s) => window.__hero.setRegion(s), greenRegion);
-  await page.waitForFunction(
-    () =>
-      window.__hero.status().state === "live" &&
-      window.__hero.status().message.includes("model preserved"),
+  check(
+    "landing hero parks two frames before takeoff with extrapolation off",
+    staged.paused &&
+      staged.jumpFrame !== undefined &&
+      staged.frame === staged.jumpFrame - 2 &&
+      staged.preview.enabled === false &&
+      staged.preview.seconds === 0.9 &&
+      staged.preview.rate === 8,
+    JSON.stringify(staged)
+  );
+
+  await heroPlayer.evaluate(() => document.getElementById("scrub-extrapolate").click());
+  await heroPlayer.waitForFunction(() => window.__scrub.model().preview.enabled, {
+    timeout: 3000,
+  });
+  await sleep(500);
+  const strongJumpHash = await regionHash(heroPlayer);
+  check(
+    "one click enables the platformer's extrapolation",
+    await heroPlayer.evaluate(
+      () =>
+        window.__scrub.model().preview.enabled &&
+        window.__scrub.view().previewFrames > 0
+    )
+  );
+
+  // Weakening the jump rebuilds the recorded future under the edited code.
+  // The anchor stays parked; only its extrapolated trajectory changes.
+  const weakRegion = region.replace("let jumpVelocity = 13.0", "let jumpVelocity = 10.0");
+  const reloadsBeforeWeak = await heroPlayer.evaluate(
+    () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
+  );
+  const rangeBeforeWeak = await heroPlayer.evaluate(() => Array.from(window.__scrub.range()));
+  await page.evaluate((s) => window.__hero.setRegion(s), weakRegion);
+  await heroPlayer.waitForFunction(
+    (before) =>
+      window.__scrub.events().filter((event) => event.kind === "reload-ok").length > before,
+    reloadsBeforeWeak,
     { timeout: 8000 }
   );
-  check("hero edit reaches an ok status mentioning model preserved", true);
-  await sleep(500);
-  const heroGreen = await lowerHalfGreen(playerFrame(page));
-  check("hero edit recolors the grid green", heroGreen);
+  await page.waitForFunction(() => window.__hero.status().state === "live", null, {
+    timeout: 8000,
+  });
+  await sleep(700);
+  const weakJumpHash = await regionHash(heroPlayer);
+  check(
+    "editing jumpVelocity redraws the projected trajectory",
+    weakJumpHash !== strongJumpHash,
+    `${strongJumpHash} -> ${weakJumpHash}`
+  );
 
-  // A broken edit (unbalanced paren): error surfaced, old frame keeps drawing.
-  await page.evaluate((s) => window.__hero.setRegion(s), `${greenRegion}\n(`);
+  // A broken edit (unbalanced paren): error surfaced, old preview keeps drawing.
+  await page.evaluate((s) => window.__hero.setRegion(s), `${weakRegion}\n(`);
   await page.waitForFunction(() => window.__hero.status().state === "error", {
     timeout: 8000,
   });
   await sleep(300);
-  const stillPixel = await centerPixel(playerFrame(page));
-  const stillRendered =
-    Math.abs(stillPixel[0] - 26) +
-      Math.abs(stillPixel[1] - 51) +
-      Math.abs(stillPixel[2] - 77) >
-    30;
+  const brokenJumpHash = await regionHash(heroPlayer);
   check(
-    "hero broken edit errors and the scene still renders",
-    stillRendered,
-    `center = rgb(${stillPixel})`
+    "hero broken edit keeps the last good projected trajectory",
+    brokenJumpHash === weakJumpHash,
+    `${weakJumpHash} -> ${brokenJumpHash}`
   );
 
-  // Recover with a good edit; the scrubber keeps recording as it runs.
-  await page.evaluate((s) => window.__hero.setRegion(s), greenRegion);
-  await page.waitForFunction(() => window.__hero.status().state === "live", {
+  // Recover with the original jump. The deliberately paused timeline remains
+  // parked and retains the whole recorded script across both safe reloads.
+  const reloadsBeforeRecovery = await heroPlayer.evaluate(
+    () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
+  );
+  await page.evaluate((s) => window.__hero.setRegion(s), region);
+  await heroPlayer.waitForFunction(
+    (before) =>
+      window.__scrub.events().filter((event) => event.kind === "reload-ok").length > before,
+    reloadsBeforeRecovery,
+    { timeout: 8000 }
+  );
+  await page.waitForFunction(() => window.__hero.status().state === "live", null, {
     timeout: 8000,
   });
-  const heroPlayer = playerFrame(page);
-  await heroPlayer.waitForFunction(
-    () => window.__scrub && window.__scrub.range().length === 2,
-    { timeout: 10000 }
-  );
-  const hr0 = await heroPlayer.evaluate(() => window.__scrub.range());
-  await sleep(500);
-  const hr1 = await heroPlayer.evaluate(() => window.__scrub.range());
+  const recovered = await heroPlayer.evaluate(() => ({
+    paused: window.__scrub.paused(),
+    frame: window.__scrub.frame(),
+    range: Array.from(window.__scrub.range()),
+    previewEnabled: window.__scrub.model().preview.enabled,
+  }));
   check(
-    "hero scrubber still records after edits",
-    hr1[1] > hr0[1],
-    `${hr0} -> ${hr1}`
+    "hero edits preserve the staged paused timeline",
+    recovered.paused &&
+      recovered.frame === staged.frame &&
+      recovered.range[0] === rangeBeforeWeak[0] &&
+      recovered.range[1] >= rangeBeforeWeak[1] &&
+      recovered.previewEnabled,
+    JSON.stringify({ staged, rangeBeforeWeak, recovered })
+  );
+
+  // A rejected scheduler batch is transactional: the valid first edge must
+  // not leak through when a later frame cannot be represented by the runtime.
+  await heroPlayer.evaluate((end) => window.__scrub.seek(end), recovered.range[1]);
+  await heroPlayer.waitForFunction(
+    (end) => window.__scrub.frame() === end,
+    recovered.range[1],
+    { timeout: 8000 }
+  );
+  const beforeRejectedBatch = await heroPlayer.evaluate(() => ({
+    frame: window.__scrub.frame(),
+    inputs: window.__scrub.events().filter((event) => event.kind === "input").length,
+    accepted: window.__scrub.scheduleKeyInputs([
+      { frame: 0, code: 30, isDown: true },
+      { frame: 1e30, code: 30, isDown: false },
+    ]),
+  }));
+  await heroPlayer.evaluate(() => window.__scrub.togglePause());
+  await heroPlayer.waitForFunction(
+    (frame) => window.__scrub.frame() >= frame + 4,
+    beforeRejectedBatch.frame,
+    { timeout: 8000 }
+  );
+  await heroPlayer.evaluate(() => window.__scrub.togglePause());
+  const afterRejectedBatch = await heroPlayer.evaluate(
+    () => window.__scrub.events().filter((event) => event.kind === "input").length
+  );
+  check(
+    "rejected hero input batches enqueue no partial key edges",
+    !beforeRejectedBatch.accepted && afterRejectedBatch === beforeRejectedBatch.inputs,
+    JSON.stringify({ beforeRejectedBatch, afterRejectedBatch })
   );
 
   await page.close();

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -260,10 +260,12 @@ const playerFrame = (page) => {
     // headline: they must sit fully inside the viewport at rest, never
     // needing a scroll to be read.
     const tunableLines = lines.filter((line) =>
-      /🔮|let runSpeed =|let jumpVelocity =|let gravity =/.test(line.textContent)
+      /🔮|let runSpeed =|let jumpVelocity =|let gravity =|let chasmHalf =/.test(
+        line.textContent
+      )
     );
     const tunablesVisible =
-      tunableLines.length === 4 &&
+      tunableLines.length === 5 &&
       tunableLines.every((line) => {
         const rect = line.getBoundingClientRect();
         return rect.top >= viewport.top - 1 && rect.bottom <= viewport.bottom + 1;
@@ -282,13 +284,29 @@ const playerFrame = (page) => {
       region.includes("let runSpeed") &&
       region.includes("let jumpVelocity") &&
       region.includes("let gravity") &&
+      region.includes("let chasmHalf") &&
+      // The DERIVED ground geometry stays outside the editable region: the
+      // drawn platforms and the collided ground must keep deriving from one
+      // chasmHalf, never drift apart under an edit.
+      !region.includes("let leftGroundWidth") &&
       region.includes("let world = (model, tts) =>") &&
       region.includes("Sprite.group") &&
       !region.includes("let init"),
     region.slice(0, 40)
   );
+  const sourceLink = await page.evaluate(() => {
+    const link = document.querySelector(".hero-editor-source");
+    return link && { href: link.getAttribute("href"), title: link.title, text: link.textContent.trim() };
+  });
   check(
-    "hero editor shows the tunables trio uncropped at rest",
+    "hero excerpt label deep-links into the sandbox with this example",
+    sourceLink?.href === "sandbox.html?example=mario" &&
+      sourceLink.text === "examples/mario/game.fun" &&
+      sourceLink.title.length > 0,
+    JSON.stringify(sourceLink)
+  );
+  check(
+    "hero editor shows the tunables uncropped at rest",
     excerptLayout.tunablesVisible,
     JSON.stringify(excerptLayout)
   );
@@ -340,11 +358,7 @@ const playerFrame = (page) => {
   const strongJumpHash = await regionHash(heroPlayer);
   check(
     "one click enables the platformer's extrapolation",
-    await heroPlayer.evaluate(
-      () =>
-        window.__scrub.model().preview.enabled &&
-        window.__scrub.view().previewFrames > 0
-    )
+    await heroPlayer.evaluate(() => window.__scrub.view().previewFrames > 0)
   );
 
   // Push an edited region and wait for the runtime to accept it (a fresh
@@ -389,8 +403,19 @@ const playerFrame = (page) => {
     `${weakJumpHash} -> ${heavyJumpHash}`
   );
 
+  // chasmHalf is the level's one upstream geometry knob: widening it must move
+  // the drawn platforms AND the ground the projection falls through, together.
+  const wideRegion = heavyRegion.replace("let chasmHalf = 3.0", "let chasmHalf = 4.5");
+  await applyHeroRegion(wideRegion);
+  const wideJumpHash = await regionHash(heroPlayer);
+  check(
+    "editing chasmHalf redraws the level and its projection",
+    wideJumpHash !== heavyJumpHash,
+    `${heavyJumpHash} -> ${wideJumpHash}`
+  );
+
   // A broken edit (unbalanced paren): error surfaced, old preview keeps drawing.
-  await page.evaluate((s) => window.__hero.setRegion(s), `${heavyRegion}\n(`);
+  await page.evaluate((s) => window.__hero.setRegion(s), `${wideRegion}\n(`);
   await page.waitForFunction(() => window.__hero.status().state === "error", {
     timeout: 8000,
   });
@@ -398,8 +423,8 @@ const playerFrame = (page) => {
   const brokenJumpHash = await regionHash(heroPlayer);
   check(
     "hero broken edit keeps the last good projected trajectory",
-    brokenJumpHash === heavyJumpHash,
-    `${heavyJumpHash} -> ${brokenJumpHash}`
+    brokenJumpHash === wideJumpHash,
+    `${wideJumpHash} -> ${brokenJumpHash}`
   );
 
   // Recover with the original tunables. The deliberately paused timeline

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -327,7 +327,7 @@ const playerFrame = (page) => {
       staged.jumpFrame !== undefined &&
       staged.frame === staged.jumpFrame - 2 &&
       staged.preview.enabled === false &&
-      staged.preview.seconds === 0.9 &&
+      staged.preview.seconds === 1.3 &&
       staged.preview.rate === 8,
     JSON.stringify(staged)
   );

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -243,10 +243,41 @@ const playerFrame = (page) => {
     { timeout: 10000 }
   );
   const region = await page.evaluate(() => window.__hero.region());
+  const excerptHeading = await page.locator(".hero-editor-heading").textContent();
+  const excerptLayout = await page.evaluate(() => {
+    const scroller = document.querySelector(".hero-editor .cm-scroller");
+    const viewport = document.querySelector(".hero-editor-code").getBoundingClientRect();
+    const lines = [...document.querySelectorAll(".hero-editor .cm-line")];
+    const lastLine = lines.findLast((line) => line.textContent.trim() !== "");
+    const lastLineRect = lastLine.getBoundingClientRect();
+    const statusRect = document.querySelector(".hero-status").getBoundingClientRect();
+    const statusOverlapsLastLine =
+      statusRect.left < lastLineRect.right &&
+      statusRect.right > lastLineRect.left &&
+      statusRect.top < lastLineRect.bottom &&
+      statusRect.bottom > lastLineRect.top;
+    return {
+      verticallyVisible: lastLineRect.bottom <= viewport.bottom + 1,
+      horizontallyVisible: scroller.scrollWidth <= scroller.clientWidth + 1,
+      statusOverlapsLastLine,
+    };
+  });
   check(
-    "hero editor shows only the jump region (not the whole file)",
-    region.includes("let jumpVelocity") && !region.includes("let init"),
+    "hero editor clearly labels a real world-building excerpt",
+    excerptHeading.toLowerCase().includes("live excerpt") &&
+      excerptHeading.includes("examples/mario/game.fun") &&
+      region.includes("let jumpVelocity") &&
+      region.includes("let world = (model, tts) =>") &&
+      region.includes("Sprite.group") &&
+      !region.includes("let init"),
     region.slice(0, 40)
+  );
+  check(
+    "hero editor shows every meaningful excerpt line without overflow",
+    excerptLayout.verticallyVisible &&
+      excerptLayout.horizontallyVisible &&
+      !excerptLayout.statusOverlapsLastLine,
+    JSON.stringify(excerptLayout)
   );
 
   // The loader has already driven the checked-in input script, paused, and

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -237,7 +237,7 @@ const playerFrame = (page) => {
   );
   check("landing hero player has the scrubber element", heroHasScrubber);
 
-  // The hero mini-sandbox: a live editor over just the jump tuning region.
+  // The hero mini-sandbox: a live editor over the whole tunables trio.
   await page.waitForFunction(
     () => window.__hero && window.__hero.region().includes("let jumpVelocity"),
     { timeout: 10000 }
@@ -256,7 +256,20 @@ const playerFrame = (page) => {
       statusRect.right > lastLineRect.left &&
       statusRect.top < lastLineRect.bottom &&
       statusRect.bottom > lastLineRect.top;
+    // The three tunables and their inviting lead comment are the panel's
+    // headline: they must sit fully inside the viewport at rest, never
+    // needing a scroll to be read.
+    const tunableLines = lines.filter((line) =>
+      /🔮|let runSpeed =|let jumpVelocity =|let gravity =/.test(line.textContent)
+    );
+    const tunablesVisible =
+      tunableLines.length === 4 &&
+      tunableLines.every((line) => {
+        const rect = line.getBoundingClientRect();
+        return rect.top >= viewport.top - 1 && rect.bottom <= viewport.bottom + 1;
+      });
     return {
+      tunablesVisible,
       verticallyVisible: lastLineRect.bottom <= viewport.bottom + 1,
       horizontallyVisible: scroller.scrollWidth <= scroller.clientWidth + 1,
       statusOverlapsLastLine,
@@ -266,11 +279,18 @@ const playerFrame = (page) => {
     "hero editor clearly labels a real world-building excerpt",
     excerptHeading.toLowerCase().includes("live excerpt") &&
       excerptHeading.includes("examples/mario/game.fun") &&
+      region.includes("let runSpeed") &&
       region.includes("let jumpVelocity") &&
+      region.includes("let gravity") &&
       region.includes("let world = (model, tts) =>") &&
       region.includes("Sprite.group") &&
       !region.includes("let init"),
     region.slice(0, 40)
+  );
+  check(
+    "hero editor shows the tunables trio uncropped at rest",
+    excerptLayout.tunablesVisible,
+    JSON.stringify(excerptLayout)
   );
   check(
     "hero editor shows every meaningful excerpt line without overflow",
@@ -327,24 +347,31 @@ const playerFrame = (page) => {
     )
   );
 
-  // Weakening the jump rebuilds the recorded future under the edited code.
-  // The anchor stays parked; only its extrapolated trajectory changes.
+  // Push an edited region and wait for the runtime to accept it (a fresh
+  // reload-ok marker) and the panel to report live again.
+  const applyHeroRegion = async (src) => {
+    const reloadsBefore = await heroPlayer.evaluate(
+      () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
+    );
+    await page.evaluate((s) => window.__hero.setRegion(s), src);
+    await heroPlayer.waitForFunction(
+      (before) =>
+        window.__scrub.events().filter((event) => event.kind === "reload-ok").length > before,
+      reloadsBefore,
+      { timeout: 8000 }
+    );
+    await page.waitForFunction(() => window.__hero.status().state === "live", null, {
+      timeout: 8000,
+    });
+    await sleep(700);
+  };
+
+  // Weakening the jump rebuilds the predicted (pink) future under the edited
+  // code. The anchor stays parked, so the recorded (cyan) past is unchanged;
+  // only the extrapolated trajectory ahead of it moves.
   const weakRegion = region.replace("let jumpVelocity = 13.0", "let jumpVelocity = 10.0");
-  const reloadsBeforeWeak = await heroPlayer.evaluate(
-    () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
-  );
   const rangeBeforeWeak = await heroPlayer.evaluate(() => Array.from(window.__scrub.range()));
-  await page.evaluate((s) => window.__hero.setRegion(s), weakRegion);
-  await heroPlayer.waitForFunction(
-    (before) =>
-      window.__scrub.events().filter((event) => event.kind === "reload-ok").length > before,
-    reloadsBeforeWeak,
-    { timeout: 8000 }
-  );
-  await page.waitForFunction(() => window.__hero.status().state === "live", null, {
-    timeout: 8000,
-  });
-  await sleep(700);
+  await applyHeroRegion(weakRegion);
   const weakJumpHash = await regionHash(heroPlayer);
   check(
     "editing jumpVelocity redraws the projected trajectory",
@@ -352,8 +379,18 @@ const playerFrame = (page) => {
     `${strongJumpHash} -> ${weakJumpHash}`
   );
 
+  // gravity is editable in the same region: it must move the projection too.
+  const heavyRegion = weakRegion.replace("let gravity = 30.0", "let gravity = 45.0");
+  await applyHeroRegion(heavyRegion);
+  const heavyJumpHash = await regionHash(heroPlayer);
+  check(
+    "editing gravity redraws the projected trajectory",
+    heavyJumpHash !== weakJumpHash,
+    `${weakJumpHash} -> ${heavyJumpHash}`
+  );
+
   // A broken edit (unbalanced paren): error surfaced, old preview keeps drawing.
-  await page.evaluate((s) => window.__hero.setRegion(s), `${weakRegion}\n(`);
+  await page.evaluate((s) => window.__hero.setRegion(s), `${heavyRegion}\n(`);
   await page.waitForFunction(() => window.__hero.status().state === "error", {
     timeout: 8000,
   });
@@ -361,25 +398,14 @@ const playerFrame = (page) => {
   const brokenJumpHash = await regionHash(heroPlayer);
   check(
     "hero broken edit keeps the last good projected trajectory",
-    brokenJumpHash === weakJumpHash,
-    `${weakJumpHash} -> ${brokenJumpHash}`
+    brokenJumpHash === heavyJumpHash,
+    `${heavyJumpHash} -> ${brokenJumpHash}`
   );
 
-  // Recover with the original jump. The deliberately paused timeline remains
-  // parked and retains the whole recorded script across both safe reloads.
-  const reloadsBeforeRecovery = await heroPlayer.evaluate(
-    () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
-  );
-  await page.evaluate((s) => window.__hero.setRegion(s), region);
-  await heroPlayer.waitForFunction(
-    (before) =>
-      window.__scrub.events().filter((event) => event.kind === "reload-ok").length > before,
-    reloadsBeforeRecovery,
-    { timeout: 8000 }
-  );
-  await page.waitForFunction(() => window.__hero.status().state === "live", null, {
-    timeout: 8000,
-  });
+  // Recover with the original tunables. The deliberately paused timeline
+  // remains parked and retains the whole recorded script across every safe
+  // reload.
+  await applyHeroRegion(region);
   const recovered = await heroPlayer.evaluate(() => ({
     paused: window.__scrub.paused(),
     frame: window.__scrub.frame(),

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -16,9 +16,17 @@
 // --- Tunables (tweak these to change whether the jump clears the chasm) ---
 let runSpeed = 8.0        // horizontal speed while a direction is held
 // <editable>
-// Will the jump clear the chasm?
-// Click 🔮 to preview it, then try 12.0 and 13.0.
+// Tune the jump, then click 🔮 to preview it.
 let jumpVelocity = 13.0
+
+let world = (model, tts) =>
+  Sprite.group([
+    backdrop(),
+    platform(leftGroundX, leftGroundWidth),
+    platform(rightGroundX, rightGroundWidth),
+    character(model, tts),
+  ])
+  |> Sprite.nearest()
 // </editable>
 let gravity = 30.0        // downward acceleration
 
@@ -33,6 +41,10 @@ let groundTop = 0.0       // y of the platform surface the character stands on
 let chasmHalf = 3.0       // gap spans x in [-chasmHalf, chasmHalf] -> width 6.0
 let leftEdge = -11.0      // outer x of the left platform
 let rightEdge = 11.0      // outer x of the right platform
+let leftGroundWidth = -chasmHalf - leftEdge
+let leftGroundX = leftEdge + leftGroundWidth / 2.0
+let rightGroundWidth = rightEdge - chasmHalf
+let rightGroundX = chasmHalf + rightGroundWidth / 2.0
 let startX = -6.0         // character spawn (on the left platform)
 let fallLimit = -2.0      // fall past this (into the chasm) and respawn.
                           // Shallow on purpose: a weak jump that dips into the
@@ -175,16 +187,6 @@ let character = (model, tts) =>
   Sprite.imageRegion(1.6, 1.6, characterRegion(model, tts), Assets.hero_atlas)
     |> faceCharacter(model)
     |> Sprite.move(model.x, model.y + 0.8)
-
-let world = (model, tts) =>
-  Sprite.group([
-    backdrop(),
-    // Left platform: x in [leftEdge, -chasmHalf]; right: [chasmHalf, rightEdge].
-    platform((leftEdge - chasmHalf) / 2.0, -chasmHalf - leftEdge),
-    platform((rightEdge + chasmHalf) / 2.0, rightEdge - chasmHalf),
-    character(model, tts),
-  ])
-  |> Sprite.nearest()
 
 let draw = (model, tts) =>
   Frame.create2D(Camera2D.create(24.0, 13.5), world(model, tts))

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -15,7 +15,11 @@
 
 // --- Tunables (tweak these to change whether the jump clears the chasm) ---
 let runSpeed = 8.0        // horizontal speed while a direction is held
-let jumpVelocity = 13.0   // upward launch speed on jump
+// <editable>
+// Will the jump clear the chasm?
+// Click 🔮 to preview it, then try 12.0 and 13.0.
+let jumpVelocity = 13.0
+// </editable>
 let gravity = 30.0        // downward acceleration
 
 // A jump launched at the edge covers runSpeed * (2*jumpVelocity/gravity)

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -14,10 +14,11 @@
 //   Up / W / Space        — jump (only when grounded)
 
 // --- Tunables (tweak these to change whether the jump clears the chasm) ---
-let runSpeed = 8.0        // horizontal speed while a direction is held
 // <editable>
-// Tune the jump, then click 🔮 to preview it.
-let jumpVelocity = 13.0
+// Tune the jump — speed, launch, gravity. Click 🔮 to preview.
+let runSpeed = 8.0        // horizontal speed while held
+let jumpVelocity = 13.0   // upward launch speed
+let gravity = 30.0        // downward acceleration
 
 let world = (model, tts) =>
   Sprite.group([
@@ -28,13 +29,12 @@ let world = (model, tts) =>
   ])
   |> Sprite.nearest()
 // </editable>
-let gravity = 30.0        // downward acceleration
 
 // A jump launched at the edge covers runSpeed * (2*jumpVelocity/gravity)
 //   = 8 * (2*13/30) = 6.93 units horizontally at the same height it started.
 // The chasm is 6.0 wide (chasmHalf 3.0), so the DEFAULT jump clears it with
-// a small margin — but lowering jumpVelocity (or raising gravity) a little
-// makes the character fall short. That knife-edge is the whole point.
+// a small margin — but lowering jumpVelocity or runSpeed (or raising gravity)
+// a little makes the character fall short. That knife-edge is the whole point.
 
 // --- Level geometry (side view: XY plane, +X right, +Y up) ---
 let groundTop = 0.0       // y of the platform surface the character stands on

--- a/examples/mario/game.fun
+++ b/examples/mario/game.fun
@@ -15,10 +15,11 @@
 
 // --- Tunables (tweak these to change whether the jump clears the chasm) ---
 // <editable>
-// Tune the jump — speed, launch, gravity. Click 🔮 to preview.
+// Tune the jump — speed, launch, gravity, gap — then click 🔮.
 let runSpeed = 8.0        // horizontal speed while held
 let jumpVelocity = 13.0   // upward launch speed
 let gravity = 30.0        // downward acceleration
+let chasmHalf = 3.0       // half the gap — widen it and see
 
 let world = (model, tts) =>
   Sprite.group([
@@ -37,14 +38,21 @@ let world = (model, tts) =>
 // a little makes the character fall short. That knife-edge is the whole point.
 
 // --- Level geometry (side view: XY plane, +X right, +Y up) ---
+// The gap itself (chasmHalf) is a tunable above; it spans
+// x in [-chasmHalf, chasmHalf], so the default gap is 6.0 wide.
 let groundTop = 0.0       // y of the platform surface the character stands on
-let chasmHalf = 3.0       // gap spans x in [-chasmHalf, chasmHalf] -> width 6.0
 let leftEdge = -11.0      // outer x of the left platform
 let rightEdge = 11.0      // outer x of the right platform
+
+// Both platforms derive from the editable chasmHalf — the drawn ground AND
+// the ground the simulation collides with — so widening the gap can never
+// drift the picture out of step with the physics. (Top-level value bindings
+// evaluate in order, so these must follow the edges they read.)
 let leftGroundWidth = -chasmHalf - leftEdge
 let leftGroundX = leftEdge + leftGroundWidth / 2.0
 let rightGroundWidth = rightEdge - chasmHalf
 let rightGroundX = chasmHalf + rightGroundWidth / 2.0
+
 let startX = -6.0         // character spawn (on the left platform)
 let fallLimit = -2.0      // fall past this (into the chasm) and respawn.
                           // Shallow on purpose: a weak jump that dips into the

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -6,6 +6,7 @@ import {
   functor_lang_scene_frame,
   functor_lang_scene_generation,
   functor_lang_scene_range,
+  functor_lang_schedule_key_events,
   functor_lang_seek_scene,
   functor_lang_scrub_seek_result,
   functor_lang_scrub_toggle_pause,
@@ -942,6 +943,33 @@ export function mountScrubber({ hidden = false } = {}) {
     view,
     events: () => state.events,
     selectEvent: (id) => dispatch({ type: "event-selected", id }),
+    // Queue a compact input script against future fixed-step frames. The
+    // runtime applies these edges inside the sub-step loop, so a low-refresh
+    // browser cannot collapse or skip their intended spacing.
+    scheduleKeyInputs: (inputs) => {
+      const baseFrame = functor_lang_scene_frame();
+      if (
+        baseFrame < 0 ||
+        !Array.isArray(inputs) ||
+        inputs.length === 0 ||
+        !inputs.every(
+          ({ frame, code, isDown }) =>
+            Number.isInteger(frame) &&
+            frame >= 0 &&
+            Number.isInteger(code) &&
+            code >= -2147483648 &&
+            code <= 2147483647 &&
+            typeof isDown === "boolean"
+        )
+      ) {
+        return false;
+      }
+      return functor_lang_schedule_key_events(
+        new Float64Array(inputs.map(({ frame }) => baseFrame + 1 + frame)),
+        new Int32Array(inputs.map(({ code }) => code)),
+        new Uint8Array(inputs.map(({ isDown }) => (isDown ? 1 : 0)))
+      );
+    },
     // Accepts the timeline-model preview fields plus `mode` (1 trail /
     // 2 strobe / 3 both; any other index is Off, per `PreviewMode::from_index`).
     // The mode has no chrome — it is seam-only config — so it lives beside the

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -235,7 +235,9 @@ pub fn functor_lang_schedule_key_events(
 
 /// Move the keyboard edges assigned to `frame` into the ordinary page-input
 /// queue immediately before that fixed step. Stale edges are discarded rather
-/// than bunched into a later frame.
+/// than bunched into a later frame. Once queued they are ordinary page input,
+/// so a PINNED frame (paused, or `?fixed-time`) drains and drops them exactly
+/// like everything else — the caller's `drain_input` decides that.
 pub fn queue_scheduled_input_at(frame: u64) -> bool {
     SCHEDULED_INPUT_QUEUE.with(|scheduled| {
         let mut scheduled = scheduled.borrow_mut();
@@ -250,7 +252,13 @@ pub fn queue_scheduled_input_at(frame: u64) -> bool {
         if due.is_empty() {
             return false;
         }
-        INPUT_QUEUE.with(|queue| queue.borrow_mut().extend(due));
+        // Respect the page queue's cap the same way `push_input` does, so a
+        // scheduled batch can never push it past the bound.
+        INPUT_QUEUE.with(|queue| {
+            let mut queue = queue.borrow_mut();
+            let room = INPUT_QUEUE_CAP.saturating_sub(queue.len());
+            queue.extend(due.into_iter().take(room));
+        });
         true
     })
 }

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -165,6 +165,8 @@ use functor_runtime_common::RecordedInput as InputEvent;
 
 thread_local! {
     static INPUT_QUEUE: RefCell<Vec<InputEvent>> = const { RefCell::new(Vec::new()) };
+    static SCHEDULED_INPUT_QUEUE: RefCell<Vec<(u64, InputEvent)>> =
+        const { RefCell::new(Vec::new()) };
 }
 
 /// Far more events than one frame can produce; if the frame loop never starts
@@ -185,6 +187,72 @@ fn push_input(event: InputEvent) {
 #[wasm_bindgen]
 pub fn functor_lang_key_event(code: i32, is_down: bool) {
     push_input(InputEvent::Key { code, is_down });
+}
+
+/// Queue keyboard edges for exact future fixed-step frames. The whole batch is
+/// validated before the queue changes, so a rejected script cannot leave a key
+/// half-pressed. The landing demo uses this to replay its checked-in input
+/// script without depending on browser refresh cadence; ordinary interactive
+/// input keeps using [`functor_lang_key_event`].
+#[wasm_bindgen]
+pub fn functor_lang_schedule_key_events(
+    frames: &[f64],
+    codes: &[i32],
+    is_down: &[u8],
+) -> bool {
+    if frames.is_empty() || frames.len() != codes.len() || frames.len() != is_down.len() {
+        return false;
+    }
+    let mut parsed = Vec::with_capacity(frames.len());
+    for ((frame, code), is_down) in frames.iter().zip(codes).zip(is_down) {
+        if !frame.is_finite()
+            || *frame < 0.0
+            || frame.fract() != 0.0
+            || *frame >= u64::MAX as f64
+            || *is_down > 1
+        {
+            return false;
+        }
+        parsed.push((
+            *frame as u64,
+            InputEvent::Key {
+                code: *code,
+                is_down: *is_down == 1,
+            },
+        ));
+    }
+
+    SCHEDULED_INPUT_QUEUE.with(|queue| {
+        let mut queue = queue.borrow_mut();
+        if parsed.len() > INPUT_QUEUE_CAP.saturating_sub(queue.len()) {
+            return false;
+        }
+        queue.extend(parsed);
+        queue.sort_by_key(|(frame, _)| *frame);
+        true
+    })
+}
+
+/// Move the keyboard edges assigned to `frame` into the ordinary page-input
+/// queue immediately before that fixed step. Stale edges are discarded rather
+/// than bunched into a later frame.
+pub fn queue_scheduled_input_at(frame: u64) -> bool {
+    SCHEDULED_INPUT_QUEUE.with(|scheduled| {
+        let mut scheduled = scheduled.borrow_mut();
+        let first_future = scheduled.partition_point(|(target, _)| *target <= frame);
+        if first_future == 0 {
+            return false;
+        }
+        let due: Vec<InputEvent> = scheduled
+            .drain(..first_future)
+            .filter_map(|(target, event)| (target == frame).then_some(event))
+            .collect();
+        if due.is_empty() {
+            return false;
+        }
+        INPUT_QUEUE.with(|queue| queue.borrow_mut().extend(due));
+        true
+    })
 }
 
 /// Deliver a mouse position in logical CSS pixels for visible-pointer games.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1595,6 +1595,21 @@ async fn run_async() -> Result<(), JsValue> {
             }
 
             for sub in &sub_frames {
+                // Scripted browser demos queue edges against authoritative
+                // fixed-step frames. Admit each edge immediately before its
+                // designated step, even when one rAF drains several steps.
+                let next_scene_frame = game
+                    .current_scene_frame()
+                    .map_or(0, |frame| frame.saturating_add(1));
+                if functor_lang_game::queue_scheduled_input_at(next_scene_frame) {
+                    functor_lang_game::drain_input(
+                        &mut **game,
+                        &mut input_snapshot,
+                        &mut input_edges,
+                        !suspended,
+                        recover_suppressed_releases(&clock),
+                    );
+                }
                 if game.samples_input() {
                     input_edges.apply_to(&mut input_snapshot);
                     game.sampled_input(&input_snapshot);

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1662,8 +1662,12 @@ async fn run_async() -> Result<(), JsValue> {
             // trail/strobe overlays, from ONE shared forward-sim —
             // `frame_preview`, the same step the desktop shell runs. While live,
             // its anchor follows the newest frame; pausing freezes that anchor
-            // instead of enabling the preview. Script inputs are `None`: web has
-            // no --input-script.
+            // instead of enabling the preview. Script inputs are `None`: unlike
+            // the desktop shell's --input-script, the browser's scheduled edges
+            // (`queue_scheduled_input_at`) are a one-shot staging queue, not a
+            // whole-run script, so there is no future schedule to predict —
+            // anything still pending is drained before a pause can freeze an
+            // anchor ahead of it.
             // While a drag-into-the-future catch-up is draining, skip the
             // preview recompute (the anchor moves every frame — a full
             // forward-sim per frame would throttle the catch-up to a crawl);

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -231,7 +231,11 @@ for (const example of EXAMPLES) {
     { source: example.source, output: exampleEntryPath(example.id) },
     ...(example.siblings ?? []),
   ];
-  for (const { source, output } of [...files, ...(example.assets ?? [])]) {
+  for (const { source, output } of [
+    ...files,
+    ...(example.assets ?? []),
+    ...(example.siteFiles ?? []),
+  ]) {
     const slash = output.lastIndexOf("/");
     if (slash >= 0) {
       await mkdir(`${dist}/${output.slice(0, slash)}`, { recursive: true });

--- a/site/index.html
+++ b/site/index.html
@@ -89,7 +89,12 @@
                 <span class="hero-status" data-hero-status></span>
                 Live excerpt
               </span>
-              <code>examples/mario/game.fun</code>
+              <a
+                class="hero-editor-source"
+                href="sandbox.html?example=mario"
+                title="Open in the sandbox"
+                ><code>examples/mario/game.fun</code></a
+              >
             </div>
             <div class="hero-editor-code" data-hero-editor></div>
           </div>

--- a/site/index.html
+++ b/site/index.html
@@ -27,14 +27,15 @@
     <!--@header-->
     <!--/@header-->
 
-    <!-- The demo card IS a functor program: site/examples/hero.fun,
-         interpreted live by the wasm runtime in this iframe. -->
+    <!-- The demo card IS the platformer in examples/mario, interpreted live by
+         the wasm runtime. The landing island records its jump.script behind
+         the loader, then parks immediately before takeoff. -->
     <section class="hero">
       <div class="hero-copy">
         <h1 class="hero-title">FUNCTOR</h1>
         <p class="hero-tagline">Game development from an alternate timeline.</p>
         <p class="hero-sub">
-          A free, open-source 3D game engine.
+          A free, open-source game engine.
         </p>
         <div class="hero-actions">
           <a class="button-primary" href="sandbox.html">▶ Open the sandbox</a>
@@ -72,11 +73,11 @@
           </div>
           <iframe
             class="hero-scene"
-            src="player.html?game=examples%2Fhero.fun"
-            title="live synthwave scene rendered by functor"
+            src="player.html?game=examples%2Fmario.fun&amp;file=examples%2Fmario.fun&amp;file=examples%2Fassets.fun"
+            title="live platformer with time-travel extrapolation rendered by functor"
             allow="pointer-lock"
           ></iframe>
-          <!-- Reserved slot: commit 5 mounts a small editable code panel here. -->
+          <!-- The landing island mounts the jump-velocity editor here. -->
           <div id="hero-editor" class="hero-editor" hidden></div>
         </div>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -77,8 +77,22 @@
             title="live platformer with time-travel extrapolation rendered by functor"
             allow="pointer-lock"
           ></iframe>
-          <!-- The landing island mounts the jump-velocity editor here. -->
-          <div id="hero-editor" class="hero-editor" hidden></div>
+          <!-- The landing island mounts a real excerpt of the running game here. -->
+          <div
+            id="hero-editor"
+            class="hero-editor"
+            aria-label="Live excerpt from examples/mario/game.fun"
+            hidden
+          >
+            <div class="hero-editor-heading">
+              <span class="hero-editor-label">
+                <span class="hero-status" data-hero-status></span>
+                Live excerpt
+              </span>
+              <code>examples/mario/game.fun</code>
+            </div>
+            <div class="hero-editor-code" data-hero-editor></div>
+          </div>
         </div>
       </div>
     </section>

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -143,6 +143,9 @@ export const EXAMPLES: Example[] = [
     assets: [
       { source: "examples/mario/ground.png", output: "ground.png" },
       { source: "examples/mario/hero-atlas.png", output: "hero-atlas.png" },
+      // The landing hero replays this exact desktop verification drive behind
+      // its boot loader, then parks immediately before the jump.
+      { source: "examples/mario/jump.script", output: "examples/mario.jump.script" },
     ],
   },
   // Single-file, and every model is an absolute Babylon CDN URL — the wasm

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -34,6 +34,8 @@ export interface Example {
   siblings?: ExampleCopy[];
   /** Local binary assets the project's `Asset.*` locators resolve to. */
   assets?: ExampleCopy[];
+  /** Extra files copied into the static site, but not uploaded as game assets. */
+  siteFiles?: ExampleCopy[];
   /**
    * Marks a sample that declares a server entry point (the functor.json
    * `entries` shape, like examples/mp) or is otherwise structured for
@@ -143,8 +145,10 @@ export const EXAMPLES: Example[] = [
     assets: [
       { source: "examples/mario/ground.png", output: "ground.png" },
       { source: "examples/mario/hero-atlas.png", output: "hero-atlas.png" },
+    ],
+    siteFiles: [
       // The landing hero replays this exact desktop verification drive behind
-      // its boot loader, then parks immediately before the jump.
+      // its boot loader. It is site orchestration, not a runtime game asset.
       { source: "examples/mario/jump.script", output: "examples/mario.jump.script" },
     ],
   },

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -1,7 +1,8 @@
-// The landing hero's live code panel: a small editor mounted over ONE region
-// of examples/hero.fun (the `dot` def, between `// <editable>` sentinels).
-// Edit the region and the running grid hot-swaps with the model preserved —
-// the wave keeps rolling — then drag the timeline back through the change.
+// The landing hero's live code panel: a small editor mounted over the
+// jumpVelocity region of examples/mario.fun. Behind the boot loader, the page
+// queues the checked-in jump.script at the browser runtime's fixed-step input
+// boundary, waits for its authoritative timeline markers, then pauses and seeks
+// just before takeoff. The visitor's first click on 🔮 reveals the jump.
 //
 // This is the light sibling of sandbox.tsx: it reuses the same editor↔player
 // seam (player-bridge.ts) but a stripped editor (mini-editor.ts — no basicSetup
@@ -29,11 +30,86 @@ interface HeroSeam {
   setRegion(src: string): void;
   region: () => string;
   status: () => HeroStatus;
+  staged: () => boolean;
 }
 
-const HERO_URL = "examples/hero.fun";
+interface ScriptedInput {
+  frame: number;
+  code: number;
+  label: string;
+  isDown: boolean;
+}
+
+interface HeroScrubEvent {
+  frame: number;
+  label: string;
+}
+
+interface HeroScrubSeam {
+  paused(): boolean;
+  frame(): number;
+  seek(frame: number): void;
+  scheduleKeyInputs(inputs: Array<{ frame: number; code: number; isDown: boolean }>): boolean;
+  togglePause(): void;
+  events(): HeroScrubEvent[];
+  setPreview(preview: {
+    enabled?: boolean;
+    seconds?: number;
+    rate?: number;
+    mode?: number;
+  }): void;
+}
+
+type HeroPlayerWindow = Window & { __scrub?: HeroScrubSeam };
+
+const HERO_URL = "examples/mario.fun";
+const JUMP_SCRIPT_URL = "examples/mario.jump.script";
 const OPEN = "// <editable>";
 const CLOSE = "// </editable>";
+const COLD_START_SETTLE_MS = 300;
+const PREVIEW_SECONDS = 0.9;
+const PREVIEW_RATE = 8;
+const PREVIEW_MODE_BOTH = 3;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const nextPaint = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+// The script remains the source of truth for both the deterministic desktop
+// capture and this browser staging pass. The landing demo deliberately accepts
+// only the two controls it needs, so an edited script fails loud instead of
+// silently driving a different game.
+const parseJumpScript = (source: string): ScriptedInput[] => {
+  const keyCodes: Record<string, number> = {
+    Right: 30,
+    Up: 27,
+  };
+  const inputs: ScriptedInput[] = [];
+  for (const [index, raw] of source.split(/\r?\n/).entries()) {
+    const line = raw.split("#", 1)[0].trim();
+    if (!line) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length !== 3) {
+      throw new Error(`${JUMP_SCRIPT_URL}:${index + 1}: expected frame, key, and down|up`);
+    }
+    const [frameText, key, direction] = parts;
+    const scriptFrame = Number(frameText);
+    const code = keyCodes[key];
+    if (!Number.isInteger(scriptFrame) || scriptFrame < 0 || code === undefined) {
+      throw new Error(`${JUMP_SCRIPT_URL}:${index + 1}: unsupported input \`${line}\``);
+    }
+    if (direction !== "down" && direction !== "up") {
+      throw new Error(`${JUMP_SCRIPT_URL}:${index + 1}: expected down|up`);
+    }
+    inputs.push({
+      frame: scriptFrame,
+      code,
+      label: `${key} ${direction}`,
+      isDown: direction === "down",
+    });
+  }
+  if (inputs.length === 0) throw new Error(`${JUMP_SCRIPT_URL}: no scripted inputs`);
+  return inputs.sort((a, b) => a.frame - b.frame);
+};
 
 const frame = document.querySelector<HTMLIFrameElement>(".hero-scene")!;
 const mount = document.getElementById("hero-editor")!;
@@ -68,8 +144,12 @@ const setStatus = (state: HeroState, message = "") => {
 // panel, never leave the loader spinning over a scene that is already running.
 let playerReady = false;
 let editorSettled = false;
+let demoSettled = false;
+let demoSeeded = false;
+let staging = false;
+let scriptedInputs: ScriptedInput[] | null = null;
 const dismissBootLoader = () => {
-  if (!playerReady || !editorSettled) return;
+  if (!playerReady || !editorSettled || !demoSettled) return;
   document.querySelector("[data-fn-boot]")?.classList.add("is-done");
 };
 // Busy until the player's ready handshake: the bridge's onLive (or a
@@ -85,12 +165,100 @@ let region = "";
 
 const fullProgram = () => prefix + region + suffix;
 
+const seedJumpHistory = async (inputs: ScriptedInput[]) => {
+  const player = frame.contentWindow as HeroPlayerWindow | null;
+  const scrub = player?.__scrub;
+  if (!player || !scrub) throw new Error("the platformer timeline did not become ready");
+
+  // Let first-frame compilation and asset setup finish before starting the
+  // script's frame-relative schedule.
+  await delay(COLD_START_SETTLE_MS);
+
+  // Queue the desktop script at the runtime's fixed-step boundary. The runtime
+  // applies every edge immediately before its designated simulation frame, so
+  // low refresh rates and main-thread stalls cannot collapse the jump timing.
+  if (!scrub.scheduleKeyInputs(inputs)) {
+    throw new Error("the platformer rejected the checked-in input script");
+  }
+
+  // The event markers publish separately from the fixed steps. Count paints
+  // rather than wall time so a backgrounded tab simply resumes this wait.
+  let markerPaints = 0;
+  while (
+    markerPaints < 600 &&
+    !inputs.every((input) => scrub.events().some((event) => event.label === input.label))
+  ) {
+    markerPaints += 1;
+    await nextPaint();
+  }
+  const events = scrub.events();
+  if (!inputs.every((input) => events.some((event) => event.label === input.label))) {
+    throw new Error("the platformer did not record every scripted input");
+  }
+  const firstInput = inputs[0];
+  const firstEvent = events.find((event) => event.label === firstInput.label);
+  const preservesFrameOffsets =
+    firstEvent !== undefined &&
+    inputs.every((input) => {
+      const event = events.find((candidate) => candidate.label === input.label);
+      return (
+        event !== undefined &&
+        event.frame - firstEvent.frame === input.frame - firstInput.frame
+      );
+    });
+  if (!preservesFrameOffsets) {
+    throw new Error("the platformer input markers drifted from the checked-in script");
+  }
+
+  if (!scrub.paused()) scrub.togglePause();
+  const pauseDeadline = performance.now() + 3000;
+  while (performance.now() < pauseDeadline && !scrub.paused()) await delay(16);
+  if (!scrub.paused()) throw new Error("the platformer timeline did not pause");
+
+  const jump = events.find((event) => event.label === "Up down");
+  if (!jump) throw new Error("the platformer timeline has no jump marker");
+
+  // Configure, but do not enable, extrapolation. The visible 🔮 button remains
+  // the one click that reveals the complete recorded jump.
+  scrub.setPreview({
+    enabled: false,
+    seconds: PREVIEW_SECONDS,
+    rate: PREVIEW_RATE,
+    mode: PREVIEW_MODE_BOTH,
+  });
+  const anchor = Math.max(0, jump.frame - 2);
+  scrub.seek(anchor);
+  const seekDeadline = performance.now() + 3000;
+  while (performance.now() < seekDeadline && scrub.frame() !== anchor) await delay(16);
+  if (scrub.frame() !== anchor) throw new Error("the platformer timeline did not reach the jump");
+};
+
+const maybeStageDemo = () => {
+  if (staging || demoSettled || !playerReady || !editorSettled || !scriptedInputs) return;
+  staging = true;
+  setStatus("busy", "recording the jump…");
+  void seedJumpHistory(scriptedInputs)
+    .then(() => {
+      demoSeeded = true;
+      setStatus("live", "live — click 🔮 to preview the jump");
+    })
+    .catch((err: unknown) => {
+      setStatus("error", err instanceof Error ? err.message : String(err));
+    })
+    .finally(() => {
+      demoSettled = true;
+      dismissBootLoader();
+    });
+};
+
 const bridge = new PlayerBridge(frame, {
   onReloading: () => setStatus("busy"),
   onLive: () => {
     playerReady = true;
+    if (!demoSettled) setStatus("busy", "recording the jump…");
+    else if (demoSeeded) setStatus("live", "live — click 🔮 to preview the jump");
+    maybeStageDemo();
     dismissBootLoader();
-    setStatus("live", "live");
   },
   onResult: (ok, message) => {
     playerReady = true;
@@ -102,46 +270,53 @@ const bridge = new PlayerBridge(frame, {
 let editor: EditorView | null = null;
 
 const boot = async () => {
-  let source: string;
   try {
-    const response = await fetch(HERO_URL);
-    if (!response.ok) {
-      setStatus("error", `cannot fetch ${HERO_URL}: HTTP ${response.status}`);
-      return; // No editor panel; the scene may still run on its own.
+    const [sourceResponse, scriptResponse] = await Promise.all([
+      fetch(HERO_URL),
+      fetch(JUMP_SCRIPT_URL),
+    ]);
+    if (!sourceResponse.ok) {
+      throw new Error(`cannot fetch ${HERO_URL}: HTTP ${sourceResponse.status}`);
     }
-    source = await response.text();
+    if (!scriptResponse.ok) {
+      throw new Error(`cannot fetch ${JUMP_SCRIPT_URL}: HTTP ${scriptResponse.status}`);
+    }
+    const [source, jumpScript] = await Promise.all([
+      sourceResponse.text(),
+      scriptResponse.text(),
+    ]);
+    scriptedInputs = parseJumpScript(jumpScript);
+
+    const open = source.indexOf(OPEN);
+    const close = source.indexOf(CLOSE, open + OPEN.length);
+    if (open !== -1 && close !== -1) {
+      // Region = everything on the lines strictly between the sentinels; the
+      // sentinels themselves live in prefix/suffix so they never get edited away.
+      const regionStart = source.indexOf("\n", open) + 1;
+      prefix = source.slice(0, regionStart);
+      region = source.slice(regionStart, close);
+      suffix = source.slice(close);
+    } else {
+      // Sentinels missing: fail soft to editing the whole file.
+      prefix = "";
+      region = source;
+      suffix = "";
+    }
+
+    mount.hidden = false;
+    editor = createMiniEditor({
+      parent: mount,
+      doc: region,
+      onChange: (src) => {
+        region = src;
+        bridge.push(fullProgram());
+      },
+    });
   } catch (err) {
-    setStatus("error", `cannot fetch ${HERO_URL}: ${err}`);
+    setStatus("error", err instanceof Error ? err.message : String(err));
+    demoSettled = true;
     return;
   }
-
-  const open = source.indexOf(OPEN);
-  const close = source.indexOf(CLOSE, open + OPEN.length);
-  if (open !== -1 && close !== -1) {
-    // Region = everything on the lines strictly between the sentinels; the
-    // sentinels themselves live in prefix/suffix so they never get edited away.
-    const regionStart = source.indexOf("\n", open) + 1;
-    prefix = source.slice(0, regionStart);
-    region = source.slice(regionStart, close);
-    suffix = source.slice(close);
-  } else {
-    // Sentinels missing: fail soft to editing the whole file.
-    prefix = "";
-    region = source;
-    suffix = "";
-  }
-
-  mount.hidden = false;
-  editor = createMiniEditor({
-    parent: mount,
-    doc: region,
-    onChange: (src) => {
-      region = src;
-      bridge.push(fullProgram());
-    },
-  });
-  // No setStatus here: the dot stays busy until the player announces ready
-  // (bridge onLive) or the first push result comes back.
 };
 
 // Settled means "the card will not change shape again", which every exit path
@@ -150,6 +325,7 @@ const boot = async () => {
 // exhaustive.
 void boot().finally(() => {
   editorSettled = true;
+  maybeStageDemo();
   dismissBootLoader();
 });
 
@@ -167,4 +343,5 @@ void boot().finally(() => {
   },
   region: () => region,
   status: () => ({ ...statusState }),
+  staged: () => demoSeeded,
 };

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -71,7 +71,7 @@ const COLD_START_SETTLE_MS = 300;
 // 1.3s is the shortest forward window that reaches the LANDING: the arc
 // crests and sets the character down on the far platform, so the preview
 // answers "does the jump clear the chasm?" in one glance. 8 strobe copies a
-// second reads as a trajectory — 5 starves it into dots, 12 clumps at takeoff.
+// second reads as a trajectory — 5 reads sparse, 12 clumps copies at takeoff.
 // The backward side is clipped by the run-up (the park sits 42 frames in), so
 // a longer window costs the recorded past nothing.
 const PREVIEW_SECONDS = 1.3;

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -1,8 +1,9 @@
-// The landing hero's live code panel: a small editor mounted over the
-// jumpVelocity region of examples/mario.fun. Behind the boot loader, the page
-// queues the checked-in jump.script at the browser runtime's fixed-step input
-// boundary, waits for its authoritative timeline markers, then pauses and seeks
-// just before takeoff. The visitor's first click on 🔮 reveals the jump.
+// The landing hero's live code panel: a small editor mounted over a real excerpt
+// of examples/mario/game.fun (jump tuning + the world-composition function).
+// Behind the boot loader, the page queues the checked-in jump.script at the
+// browser runtime's fixed-step input boundary, waits for its authoritative
+// timeline markers, then pauses and seeks just before takeoff. The visitor's
+// first click on 🔮 reveals the jump.
 //
 // This is the light sibling of sandbox.tsx: it reuses the same editor↔player
 // seam (player-bridge.ts) but a stripped editor (mini-editor.ts — no basicSetup
@@ -112,15 +113,13 @@ const parseJumpScript = (source: string): ScriptedInput[] => {
 };
 
 const frame = document.querySelector<HTMLIFrameElement>(".hero-scene")!;
-const mount = document.getElementById("hero-editor")!;
-const card = document.querySelector(".hero-card")!;
+const editorShell = document.getElementById("hero-editor")!;
+const mount = editorShell.querySelector<HTMLElement>("[data-hero-editor]")!;
 
-// A small, unobtrusive status dot pinned to the card corner: green when the
+// A small, unobtrusive status dot in the excerpt label: green when the
 // last edit is live, red on a broken edit (the old program keeps running).
 // The full message lives in its tooltip and the __hero.status() seam.
-const dot = document.createElement("div");
-dot.className = "hero-status";
-card.appendChild(dot);
+const dot = document.querySelector<HTMLElement>("[data-hero-status]")!;
 
 let statusState: HeroStatus = { state: "busy", message: "" };
 const setStatus = (state: HeroState, message = "") => {
@@ -131,7 +130,7 @@ const setStatus = (state: HeroState, message = "") => {
 
 // The boot loader (static markup in index.html) evaporates only once the card
 // has BOTH its pixels and its final shape: the player's ready handshake AND a
-// settled editor panel, which grows the card by its own 172px.
+// settled editor panel, which grows the card by its own fixed height.
 //
 // Both conditions, not just the player, because this module is now lazy. At
 // base it was eager, so the panel had always mounted (a same-origin fetch)
@@ -270,6 +269,9 @@ const bridge = new PlayerBridge(frame, {
 let editor: EditorView | null = null;
 
 const boot = async () => {
+  // Establish the card's final successful-path geometry behind the loader.
+  // A fetch/parse failure collapses this to a compact red error header below.
+  editorShell.hidden = false;
   try {
     const [sourceResponse, scriptResponse] = await Promise.all([
       fetch(HERO_URL),
@@ -303,7 +305,6 @@ const boot = async () => {
       suffix = "";
     }
 
-    mount.hidden = false;
     editor = createMiniEditor({
       parent: mount,
       doc: region,
@@ -313,6 +314,7 @@ const boot = async () => {
       },
     });
   } catch (err) {
+    editorShell.classList.add("is-error");
     setStatus("error", err instanceof Error ? err.message : String(err));
     demoSettled = true;
     return;
@@ -320,9 +322,8 @@ const boot = async () => {
 };
 
 // Settled means "the card will not change shape again", which every exit path
-// of boot() reaches — including its failures, where the panel simply never
-// appears. Finalizing here rather than at each `return` is what makes that
-// exhaustive.
+// of boot() reaches — including failures, where only the compact error header
+// remains. Finalizing here rather than at each `return` makes that exhaustive.
 void boot().finally(() => {
   editorSettled = true;
   maybeStageDemo();

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -68,7 +68,13 @@ const JUMP_SCRIPT_URL = "examples/mario.jump.script";
 const OPEN = "// <editable>";
 const CLOSE = "// </editable>";
 const COLD_START_SETTLE_MS = 300;
-const PREVIEW_SECONDS = 0.9;
+// 1.3s is the shortest forward window that reaches the LANDING: the arc
+// crests and sets the character down on the far platform, so the preview
+// answers "does the jump clear the chasm?" in one glance. 8 strobe copies a
+// second reads as a trajectory — 5 starves it into dots, 12 clumps at takeoff.
+// The backward side is clipped by the run-up (the park sits 42 frames in), so
+// a longer window costs the recorded past nothing.
+const PREVIEW_SECONDS = 1.3;
 const PREVIEW_RATE = 8;
 const PREVIEW_MODE_BOTH = 3;
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -304,7 +304,9 @@ a:hover {
    carries the site's shared synthwave theme. */
 .hero-editor {
   border-top: 1px solid var(--line);
-  height: 246px;
+  /* Tall enough for the whole excerpt — the three tunables and their lead
+     comment up top, the world composition below — with no line clipped. */
+  height: 284px;
   overflow: hidden;
   background: #161226;
   display: flex;

--- a/site/styles.css
+++ b/site/styles.css
@@ -299,13 +299,66 @@ a:hover {
   background: #0d0221;
 }
 
-/* The live jump-tuning panel below the scene, inside the card. The mini-editor
+/* A visibly labeled excerpt of the real running game. The label prevents the
+   compact panel reading like a complete source file; the editor beneath it
    carries the site's shared synthwave theme. */
 .hero-editor {
   border-top: 1px solid var(--line);
-  height: 172px;
-  overflow: auto;
+  height: 246px;
+  overflow: hidden;
   background: #161226;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero-editor-heading {
+  flex: 0 0 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  padding: 7px 10px;
+  border-bottom: 1px solid rgba(73, 231, 255, 0.16);
+  background: rgba(13, 2, 33, 0.72);
+  color: var(--cyan);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.hero-editor-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.hero-editor-heading code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-dim);
+  font: inherit;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.hero-editor-code {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.hero-editor.is-error {
+  height: auto;
+}
+
+.hero-editor.is-error .hero-editor-code {
+  display: none;
 }
 
 .hero-editor .cm-editor {
@@ -318,34 +371,29 @@ a:hover {
   line-height: 1.65;
 }
 
-/* A small status dot pinned to the card corner: green live / red on a broken
-   edit. The message lives in its tooltip (title) — calm, not a banner. */
+/* A small status dot in the excerpt label: green live / red on a broken edit.
+   The message lives in its tooltip (title) — calm, not a banner. */
 .hero-status {
-  position: absolute;
-  /* Bottom-left: the top edge belongs to the (top-docked) scrubber, and
-     bottom-right is the mouse-capture chip's corner. Purely an indicator, so it
-     never intercepts clicks. */
-  bottom: 10px;
-  left: 10px;
+  flex: 0 0 auto;
   pointer-events: none;
-  width: 9px;
-  height: 9px;
+  width: 7px;
+  height: 7px;
   border-radius: 999px;
-  background: var(--text-dim);
-  box-shadow: 0 0 0 4px rgba(15, 12, 29, 0.55);
-  z-index: 2;
+  color: var(--text-dim);
+  background: currentColor;
+  box-shadow: 0 0 7px currentColor;
 }
 
 .hero-status[data-state="live"] {
-  background: var(--green);
+  color: var(--green);
 }
 
 .hero-status[data-state="busy"] {
-  background: var(--amber);
+  color: var(--amber);
 }
 
 .hero-status[data-state="error"] {
-  background: var(--red);
+  color: var(--red);
 }
 
 /* Flourish (a): the gradient-clipped wordmark — the one big statement. */

--- a/site/styles.css
+++ b/site/styles.css
@@ -304,9 +304,12 @@ a:hover {
    carries the site's shared synthwave theme. */
 .hero-editor {
   border-top: 1px solid var(--line);
-  /* Tall enough for the whole excerpt — the three tunables and their lead
-     comment up top, the world composition below — with no line clipped. */
-  height: 284px;
+  /* Tall enough for the whole excerpt — the four tunables and their lead
+     comment up top, the world composition below — with no line clipped. The
+     budget is 14 code lines at the shared 11.5px/1.65 editor type; adding a
+     line to the <editable> region means growing this too (the e2e asserts
+     nothing clips). */
+  height: 304px;
   overflow: hidden;
   background: #161226;
   display: flex;
@@ -335,6 +338,22 @@ a:hover {
   align-items: center;
   gap: 6px;
   white-space: nowrap;
+}
+
+/* The file name deep-links into the sandbox with this example loaded. It
+   stays a quiet code label — the global cyan link color would make it compete
+   with the tunables below — and only reads as a link on hover/focus. */
+.hero-editor-source {
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero-editor-source:hover code,
+.hero-editor-source:focus-visible code {
+  color: var(--cyan);
+  text-decoration: underline;
 }
 
 .hero-editor-heading code {

--- a/site/styles.css
+++ b/site/styles.css
@@ -299,8 +299,8 @@ a:hover {
   background: #0d0221;
 }
 
-/* The live code panel below the scene, inside the card (~9 visible lines at
-   the shared editor type below); the mini-editor carries the synthwave theme. */
+/* The live jump-tuning panel below the scene, inside the card. The mini-editor
+   carries the site's shared synthwave theme. */
 .hero-editor {
   border-top: 1px solid var(--line);
   height: 172px;


### PR DESCRIPTION
## Summary

- replace the landing-page neon-grid hero with the Mario-inspired platformer and update the tagline to “A free, open-source game engine.”
- replay the checked-in jump input script at authoritative fixed-step frames, pause two frames before takeoff, and make the existing 🔮 control a one-click jump preview
- expose all four tunables — `runSpeed`, `jumpVelocity`, `gravity`, and `chasmHalf` — in the live editor, so changing any constant the jump math or the level geometry derives from immediately redraws the projected trajectory while preserving the paused timeline
- deep-link the panel's `examples/mario/game.fun` label to the sandbox with the example loaded
- explicitly label the live panel as an excerpt of `examples/mario/game.fun` and include the real `world(model, tts)` composition function
- classify `jump.script` as site-only orchestration rather than a runtime game asset, restoring the two-asset wasm smoke contract
- make browser input-script scheduling transactional and deterministic even when one render frame drains multiple simulation steps

## Visuals

![Platformer hero after one-click jump extrapolation](https://gist.githubusercontent.com/tommy-xr/d52343939ef61d1d88d0e78221d3ce13/raw/after-desktop-preview.png)

<sub>Clicked-preview state under the merged bidirectional extrapolation: the 🔮 control reveals the recorded <b>cyan past</b> — the run-up along the left platform — flowing into the character, and the predicted <b>pink future</b> arcing across the chasm to the landing. The labeled <code>examples/mario/game.fun</code> excerpt shows all four tunables above the world composition, every line uncropped; its file name deep-links into the sandbox.</sub>

### Before → after · desktop

![Desktop homepage before and after](https://gist.githubusercontent.com/tommy-xr/d52343939ef61d1d88d0e78221d3ce13/raw/before-after-desktop.png)

### Before → after · mobile

![Mobile homepage before and after](https://gist.githubusercontent.com/tommy-xr/d52343939ef61d1d88d0e78221d3ce13/raw/before-after-mobile.png)

<sub>Before: isolated <code>origin/main@27a1fd9</code>. After: this branch. Captured headlessly at matched 1440×900 desktop and 390×1000 mobile viewports.</sub>

### Preview-window tuning sweep

![setPreview tuning matrix](https://gist.githubusercontent.com/tommy-xr/d52343939ef61d1d88d0e78221d3ce13/raw/preview-tuning-matrix.png)

<sub>A 9-cell sweep of <code>setPreview</code> under mode 3 (Both): <code>seconds ∈ {0.6, 0.9, 1.3}</code> × <code>rate ∈ {5, 8, 12}</code>, each captured from the same staged park. 0.6 s and 0.9 s both cut the pink arc off in mid-air; 1.3 s carries it through the apex and sets the character down on the far platform — the window that actually answers “does the jump clear the chasm?”. Rate 8 reads as a trajectory: 5 reads sparse and 12 clumps copies at takeoff (the sheet supports the <em>seconds</em> conclusion far more strongly than the rate one — 5 is defensible, just thinner). <b>The branch now commits <code>1.3 s / 8 per second</code> as a first-pass pick — happy to revert to 0.9/8 or take a different cell from the sheet.</b></sub>

## Verification

- `npm run build`
- `npm run check:site`
- `npm run test:runtime-target` — all checks pass
- `wasm-pack build runtime/functor-runtime-web --target=web`
- `./target/release/functor -d examples/mario test`
- `node e2e/site-sandbox.mjs` — **124 checks pass, 0 failures**, including recurring 55 ms main-thread stalls, exact `0/18/19/71` input spacing, one-click preview, live trajectory edits through `jumpVelocity`, `gravity`, and `chasmHalf`, the sandbox deep-link, last-good rendering after a broken edit, timeline preservation, atomic batch rejection, and the 390 px forced-404 fallback
  - the API-reference-search baseline failure this PR previously reported is **gone**: main fixed that assertion in the meantime, so the suite is now fully green

## Frame benchmark

The fixed-step runtime path was measured before (`origin/main@27a1fd9`) and after with the release `frame_bench` harness, back-to-back on an otherwise idle machine (minimum wall time shown). `frame_bench` links `functor_runtime_common`, which this branch does not touch — the change is confined to the web runtime — so parity is expected and confirmed.

| Divisions | Before µs/frame | After µs/frame | Allocs/frame | Bytes/frame |
| ---: | ---: | ---: | ---: | ---: |
| 400 | 433.3 | 433.7 | 13,877 → 13,877 | 843,393 → 843,393 |
| 1,600 | 1,718.5 | 1,713.6 | 54,717 → 54,717 | 3,307,233 → 3,307,233 |
| 3,136 | 3,330.9 | 3,311.8 | 106,973 → 106,973 | 6,460,257 → 6,460,257 |

Allocations and bytes are exactly unchanged; wall-clock movement is within run-to-run noise.

## Rebased onto main

Rebased from `c5f247d` onto `origin/main@27a1fd9`, which merged the bidirectional-extrapolation arc (#599 arrows, #602 ghost-mode + ⚙-popover removal, #608 backward trail) plus the `Camera` → `Camera3D` rename and the stdlib API reference. The reconciliation touched:

- **`runtime/functor-runtime-web/src/lib.rs`** — the only textual conflict. Kept main's un-nested `Effect.preload` block and ported this PR's scheduled-input drain into main's current `for sub in &sub_frames` loop, adapting the call to main's one-argument `recover_suppressed_releases(&clock)`.
- **`runtime/functor-runtime-web/scrubber.js`** — merged cleanly and verified by hand: main's rewritten `setPreview` contract (modes 1 trail / 2 strobe / 3 both) is intact, with `scheduleKeyInputs` inserted beside it.
- **`e2e/site-sandbox.mjs`** — merged without losing coverage from either side; confirmed by diffing main against the merge base rather than assuming. Main's changes since the base (the `Camera3D` renames, the new head-look pointer check, and the API-search fix) are disjoint from this PR's hero section, so no assertion was dropped.
- **Tunables widening** — `runSpeed`, `gravity`, and `chasmHalf` moved inside the `<editable>` sentinels beside `jumpVelocity`, with the four knobs and their inviting lead comment at the top of the panel and `world` below as supporting texture. `chasmHalf` is deliberately the *only* geometry knob exposed: the drawn platforms and the collided ground both derive from it, so widening the gap moves picture and physics together instead of reintroducing the rendered-vs-collision drift an earlier review caught — the derived `leftGround*`/`rightGround*` bindings stay outside the region (and must follow the level edges they read, since top-level value bindings evaluate in order). The panel grew 246 px → 304 px so all fourteen excerpt lines stay uncropped at desktop width, and the e2e suite asserts the tunables are visible at rest, that the derived bindings are *not* editable, and that `gravity` and `chasmHalf` each redraw the projection alongside `jumpVelocity`.
- **Preview retune** — `setPreview` moved from `0.9 s` to `1.3 s` (rate unchanged at 8) on the evidence of the sweep above.
- **Sandbox deep-link** — the excerpt's file label is now an `<a href="sandbox.html?example=mario">` titled “Open in the sandbox”, styled to stay a quiet dim code label that only reads as a link on hover/focus. The visitor's edited region is deliberately *not* carried across: mario is multi-file with binary assets, so the inline `#src` hash would not load it correctly.

## Review findings and dispositions

- **Fixed-step timing:** reviewers reproduced skipped/collapsed input offsets when scheduling from browser animation frames at low refresh rates. Addressed by admitting scheduled edges inside each authoritative fixed sub-step, with a 55 ms stall regression in the browser test.
- **Transactional scheduling:** a reviewer found that scalar calls could enqueue the beginning of a batch before a later invalid edge failed. Addressed with one bulk wasm call that validates the complete batch and available capacity before mutating the queue; the rejection test proves no partial edge is delivered.
- **Broken-edit coverage:** a reviewer noted the original check sampled an unrelated sky pixel. Addressed by hashing the full projected trajectory and requiring byte-identical last-good output after a rejected edit.
- **Asset classification:** the wasm smoke test caught `jump.script` being copied as a runtime asset. Moved it to the site-only orchestration list, restoring the expected two game assets.
- **Shared geometry:** reviewers caught hardcoded rendered platforms drifting from collision geometry. Restored derived left/right ground positions and widths in the real world composition.
- **Editor layout:** the expanded excerpt clipped its final line and the status dot occluded `Sprite.nearest()`. Made every meaningful line overflow-free, moved status into the heading, and captured the result at desktop and mobile widths. The post-rebase widening re-checked this: the lead comment was shortened to stay inside the panel's ~70-column budget, and the height was raised so nothing clips again.
- **Fetch-error indicator:** preserved a compact, visible red error header when the hero excerpt fetch fails, covered by the 390px forced-404 check.
- Final independent re-reviews found no remaining critical, high, or medium correctness issues.

### Post-rebase `/xreview` (Claude + Codex + a dedicated de-dup pass)

Both engines returned **no Critical, High, or Medium findings** against the reconciliation delta, and both independently confirmed the conflict resolution: the drain sits correctly between the preload block and each `tick`, edges clear within the same sub-step iteration, and dropping `sim_running` lost nothing (main's `recover_suppressed_releases` is `!is_fixed_time && is_paused`, and a paused clock yields no sub-frames anyway). Dispositions of the Lows:

- **[AGREED — fixed]** the tuning contact sheet labelled `0.9 s / 8` as “committed” while the branch ships `1.3 s`. Sheet regenerated with the correct cell marked.
- **Fixed:** the comment beside the preview's `None` script inputs still claimed “web has no `--input-script`”, which the new scheduler made false; `queue_scheduled_input_at` did not document that pinned frames drain-and-drop scheduled edges like all other input; moving a scheduled batch into `INPUT_QUEUE` bypassed `INPUT_QUEUE_CAP`; the extrapolation check re-asserted a condition its own `waitForFunction` had just guaranteed; and the rate-5 comment overstated what the sweep shows (5 reads sparse, it is not unusable).
- **Noted, not changed:** `SCHEDULED_INPUT_QUEUE` is not cleared on hot-reload (unreachable here — the batch is fully drained before any edit can land); marker lookup matches on `label` and would alias a script with a repeated key/direction pair (today's four labels are unique); and `PREVIEW_MODE_BOTH` re-pins the seam's existing default (kept as defensive pinning).
- **De-dup pass — out of scope for this rebase:** `parseJumpScript` (site) re-implements desktop's `parse_input_script`, the `{Right: 30, Up: 27}` key codes duplicate the `Key` discriminants across the wasm boundary, and the marker `label` string is re-derived in TS from `input_marker`'s format. All three are real coupling worth collapsing into one shared, script-text-based wasm export — but they are pre-existing PR surface already reviewed and approved, and the fix is a cross-crate refactor rather than part of reconciling the rebase. Filed here so it is visible rather than lost.
