### PR TITLE
feat(anim): add two-bone reach IK

### DIFF
--- a/cli/src/commands/import.rs
+++ b/cli/src/commands/import.rs
@@ -15,7 +15,7 @@
 //!
 //! `file = module`, so games write `Scene.model(Assets.xbot)` and
 //! `Anim.clip(Assets.xbotClips.walk.name, tts)`, or pass
-//! `Assets.xbotJoints.mixamorig_Head` to `Anim.rotate` / `Anim.lookAt` /
+//! `Assets.xbotJoints.mixamorig_Head` to `Anim.rotate` / `Anim.lookAt` / `Anim.reach` /
 //! `Anim.mask` — a typo is a check-time error instead of a silent fallback.
 //! The file is meant to be CHECKED IN (it typechecks without the binary assets,
 //! which are fetched, not committed); `run`/`build` call [`ensure_fresh`] to
@@ -529,7 +529,7 @@ fn vetted_joints(file: &str, joints: Vec<String>) -> Vec<String> {
         if !dups.is_empty() {
             emit(Event::Warning {
                 message: format!(
-                    "{file}: duplicate joint name(s) {} — Anim.rotate/Anim.lookAt/Anim.mask resolve \
+                    "{file}: duplicate joint name(s) {} — Anim.rotate/Anim.lookAt/Anim.reach/Anim.mask resolve \
 by name (rotation/look-at: smallest id; mask: all matching subtrees), so one constant \
 per name is generated",
                     dups.join(", ")

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -165,6 +165,41 @@ const centerPixel = (frame) =>
       })
   );
 
+// Locate the animation sample's emissive cyan reach target in framebuffer
+// coordinates. Reading pixels lets the drag test click what was actually
+// rendered instead of relying on a camera/layout-specific hardcoded point.
+const cyanCentroid = (frame) =>
+  frame.evaluate(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          const gl = document.getElementById("canvas");
+          const c = document.createElement("canvas");
+          c.width = gl.width;
+          c.height = gl.height;
+          const ctx = c.getContext("2d");
+          ctx.drawImage(gl, 0, 0);
+          const { data } = ctx.getImageData(0, 0, c.width, c.height);
+          let count = 0;
+          let sumX = 0;
+          let sumY = 0;
+          for (let y = 0; y < c.height; y += 1) {
+            for (let x = 0; x < c.width; x += 1) {
+              const i = (y * c.width + x) * 4;
+              if (data[i] < 110 && data[i + 1] > 155 && data[i + 2] > 155) {
+                count += 1;
+                sumX += x;
+                sumY += y;
+              }
+            }
+          }
+          resolve(count > 12
+            ? { x: sumX / count, y: sumY / count, count, width: c.width, height: c.height }
+            : null);
+        });
+      })
+  );
+
 // Hash a 32×32 downscale of the whole player canvas (drawn in a rAF callback so
 // it reads the just-rendered buffer). Two equal hashes ~300ms apart = the frame
 // is frozen; a change = it's animating.
@@ -1004,29 +1039,92 @@ for (const example of examples) {
     check(`example '${example}' loads live and ticks cleanly`, errors.length === 0, errors.join("\n"));
     if (example === "animation") {
       const player = playerFrame(page);
+      const source = await page.evaluate(() => window.__sandbox.getSource());
       check(
-        "head-look example keeps an absolute visible pointer",
+        "sandbox promotes the stacked reach sample source",
+        source.includes("Anim.reach(") && source.includes("Camera3D.toWorldRay("),
+        source.slice(0, 240)
+      );
+      check(
+        "stacked IK example keeps an absolute visible pointer",
         player.url().includes("cursor=visible"),
         player.url()
       );
-      await player.evaluate(() => {
+      const before = await cyanCentroid(player);
+      check(
+        "stacked IK example renders its cyan draggable target",
+        before !== null,
+        JSON.stringify(before)
+      );
+      const dragBridge = before === null
+        ? {
+            beforeFrame: await player.evaluate(() => window.__scrub.frame()),
+            pressConsumed: false,
+            destinationX: 0,
+            destinationY: 0,
+          }
+        : await player.evaluate((marker) => {
         const rect = document.getElementById("canvas").getBoundingClientRect();
-        window.dispatchEvent(new MouseEvent("mousemove", {
-          clientX: rect.left + rect.width * 0.9,
-          clientY: rect.top + rect.height * 0.25,
+        const canvas = document.getElementById("canvas");
+        const clientX = rect.left + marker.x * rect.width / marker.width;
+        const clientY = rect.top + marker.y * rect.height / marker.height;
+        const destinationX = marker.x < marker.width / 2
+          ? Math.max(20, marker.x - 110)
+          : Math.min(marker.width - 20, marker.x + 110);
+        const destinationY = Math.max(20, marker.y - 70);
+        const destinationClientX =
+          rect.left + destinationX * rect.width / marker.width;
+        const destinationClientY =
+          rect.top + destinationY * rect.height / marker.height;
+        canvas.dispatchEvent(new MouseEvent("mousemove", {
+          clientX,
+          clientY,
+          bubbles: true,
         }));
-      });
+        const press = new MouseEvent("mousedown", {
+          button: 0,
+          clientX,
+          clientY,
+          bubbles: true,
+          cancelable: true,
+        });
+        canvas.dispatchEvent(press);
+        // Move before the next sampled step. The sample must pick at the
+        // event-time press point, not this final snapshot point.
+        canvas.dispatchEvent(new MouseEvent("mousemove", {
+          clientX: destinationClientX,
+          clientY: destinationClientY,
+          bubbles: true,
+        }));
+        return {
+          beforeFrame: window.__scrub.frame(),
+          pressConsumed: press.defaultPrevented,
+          destinationX,
+          destinationY,
+        };
+        }, before);
       await player.waitForFunction(
-        () => window.__scrub.events().some((event) => event.kind === "mouse-move"),
+        (beforeFrame) => window.__scrub.frame() >= beforeFrame + 2,
+        dragBridge.beforeFrame,
         { timeout: 3000 }
       );
-      const mouseMove = await player.evaluate(() =>
-        window.__scrub.events().findLast((event) => event.kind === "mouse-move")
-      );
+      const after = await cyanCentroid(player);
+      await player.evaluate(() => {
+        window.dispatchEvent(new MouseEvent("mouseup", {
+          button: 0,
+          bubbles: true,
+        }));
+      });
+      const afterDragFrame = await player.evaluate(() => window.__scrub.frame());
+      const markerTravel = before && after
+        ? Math.hypot(after.x - before.x, after.y - before.y)
+        : 0;
       check(
-        "visible pointer movement reaches the head-look runtime",
-        mouseMove?.label.startsWith("mouse move ("),
-        JSON.stringify(mouseMove)
+        "visible pointer drag moves the rendered reach target",
+        dragBridge.pressConsumed
+          && afterDragFrame >= dragBridge.beforeFrame + 2
+          && markerTravel > 25,
+        JSON.stringify({ before, after, markerTravel, ...dragBridge, afterDragFrame })
       );
     }
   } catch {

--- a/examples/animation/game.fun
+++ b/examples/animation/game.fun
@@ -1,16 +1,22 @@
-// Locomotion blending + model-space head look — the `Scene.animate` /
-// `Anim.blend` / `Anim.lookAt` demo.
+// Locomotion blending + stacked head-look and two-bone arm reach.
 //
-// Xbot's idle/walk/run clips are mixed by a single speed parameter
-// (0 = idle, 0.5 = walk, 1 = run — a 1D blend space), and the head joint is
-// aimed at a model-space point after the blend has animated its whole parent
-// chain. The playheads, weights, and target are derived here, in game code,
-// from `tts` and the model — the engine owns no animation clock or hidden IK
-// state, so scrubbing time-travel replays the exact pose.
+// Xbot's idle/walk/run clips are mixed by a single speed parameter, then pure
+// animation post-passes aim the head and solve both direct arm chains after the
+// animated spine has settled. The cyan and pink model-space targets can be
+// dragged with the visible pointer; Camera3D.toWorldRay supplies the pick plane.
+// Every target, playhead, and weight is plain frame data, so time travel and
+// replay reproduce the exact pose.
 //
-// Keys: 1 = idle, 2 = walk, 3 = run, 0 = auto-cycle (default). Speed eases
-// toward the target, so clip transitions crossfade smoothly. Move the mouse
-// to make the head follow the pointer (the auto mode sweeps it until then).
+// Keys: 1 = idle, 2 = walk, 3 = run, 0 = auto-cycle (default).
+
+type Drag =
+  | NotDragging
+  | DragLeft
+  | DragRight
+
+type Target = { x: float, y: float, z: float }
+
+let target3 = (x: float, y: float, z: float): Target => { x: x, y: y, z: z }
 
 let camera =
   Camera3D.lookAt(Vec3.make(0.0, 1.4, -3.2), Vec3.make(0.0, 0.9, 0.0))
@@ -19,8 +25,16 @@ let init = {
   speed: 0.0,
   target: 0.0,
   auto: true,
-  headTarget: { x: 0.0, y: 1.55, z: 1.2 },
-  pointerDrivesHead: false,
+  leftTarget: target3(0.52, 1.24, 0.28),
+  rightTarget: target3(-0.52, 1.24, 0.28),
+  manualLeft: false,
+  manualRight: false,
+  dragging: NotDragging,
+  pointerX: 0.0,
+  pointerY: 0.0,
+  pressX: 0.0,
+  pressY: 0.0,
+  pressPending: false,
 }
 
 let input = (model, key, isDown) =>
@@ -31,11 +45,26 @@ let input = (model, key, isDown) =>
     | Key.Num1 => { model with target: 0.0, auto: false }
     | Key.Num2 => { model with target: 0.5, auto: false }
     | Key.Num3 => { model with target: 1.0, auto: false }
-    | Key.Num0 => { model with auto: true, pointerDrivesHead: false }
+    | Key.Num0 => { model with auto: true }
     | _ => model
 
-// Pick a point on a plane between the camera and Xbot, then undo the model's
-// 180-degree scene rotation: Anim.lookAt targets live in model space because
+// Mouse-button callbacks do not carry coordinates, so retain the preceding
+// event-time mouse position. sampledInput can then distinguish a quick
+// press/move/release whose final snapshot position is no longer over the
+// sphere that was actually clicked.
+let mouseMove = (model, x, y) =>
+  { model with pointerX: x, pointerY: y }
+
+let mouseButton = (model, button, isDown) =>
+  if button == Mouse.Left && isDown then
+    { model with
+        pressX: model.pointerX,
+        pressY: model.pointerY,
+        pressPending: true }
+  else model
+
+// Both targets live on one vertical interaction plane in front of Xbot.
+// Undo the model's 180-degree scene rotation after intersecting the world ray:
 // the animation evaluator intentionally knows nothing about Scene transforms.
 let pointerTarget = (mouse: Input.mouse) =>
   match Camera3D.toWorldRay(mouse, camera) with
@@ -45,65 +74,93 @@ let pointerTarget = (mouse: Input.mouse) =>
     match dz > 0.0001 with
     | false => Option.None
     | true =>
-      let distance = ((0.0 - 1.2) - Vec3.z(ray.origin)) / dz in
+      let worldPlaneZ = 0.0 - 0.28 in
+      let distance = (worldPlaneZ - Vec3.z(ray.origin)) / dz in
       let worldTarget =
         ray.origin |> Vec3.add(ray.direction |> Vec3.scale(distance)) in
-      Option.Some({
-        x: 0.0 - Vec3.x(worldTarget),
-        y: Vec3.y(worldTarget),
-        z: 0.0 - Vec3.z(worldTarget),
-      })
+      Option.Some(target3(
+        0.0 - Vec3.x(worldTarget),
+        Vec3.y(worldTarget),
+        0.0 - Vec3.z(worldTarget)))
 
+let distance2D = (a: Target, b: Target) =>
+  let dx = a.x - b.x in
+  let dy = a.y - b.y in
+  Math.sqrt(dx * dx + dy * dy)
+
+let pickRadius = 0.16
+
+let pickTarget = (pointer: Target, left: Target, right: Target) =>
+  let leftDistance = distance2D(pointer, left) in
+  let rightDistance = distance2D(pointer, right) in
+  if leftDistance <= pickRadius && leftDistance <= rightDistance then DragLeft
+  else if rightDistance <= pickRadius then DragRight
+  else NotDragging
+
+// Press edges choose a target, the held level drags it, and release ends the
+// drag. The raw hook above preserves the event-time press coordinate; the
+// sampled snapshot remains the deterministic source of held/released state.
 let sampledInput = (model, snapshot: Input.snapshot) =>
-  match model.pointerDrivesHead with
-  | false => model
-  | true =>
+  let pressed = model.pressPending || snapshot.mouse.pressed.left in
+  let pressMouse =
+    if model.pressPending then
+      { snapshot.mouse with x: model.pressX, y: model.pressY }
+    else snapshot.mouse in
+  let selected =
+    if pressed then
+      match pointerTarget(pressMouse) with
+      | Option.Some(pointer) =>
+        pickTarget(pointer, model.leftTarget, model.rightTarget)
+      | Option.None => NotDragging
+    else model.dragging in
+  let moved =
     match pointerTarget(snapshot.mouse) with
     | Option.None => model
-    | Option.Some(target) => { model with headTarget: target }
-
-// The edge handler only switches control modes. sampledInput owns the actual
-// ray conversion so the target is sampled deterministically at fixed steps.
-let mouseMove = (model, x, y) =>
-  { model with pointerDrivesHead: true }
+    | Option.Some(pointer) =>
+      match selected with
+      | DragLeft =>
+        { model with leftTarget: pointer, manualLeft: true }
+      | DragRight =>
+        { model with rightTarget: pointer, manualRight: true }
+      | NotDragging => model in
+  { moved with
+      dragging:
+        if snapshot.mouse.buttons.left then selected else NotDragging,
+      pressPending: false }
 
 let tick = (model, dt, tts) =>
-  // Auto mode sweeps the target through idle -> walk -> run and back.
+  // Auto mode sweeps the locomotion blend through idle -> walk -> run and back.
   let target =
-    (match model.auto with
-     | true => (1.0 - Math.cos(tts * 0.6)) * 0.5
-     | false => model.target) in
+    if model.auto then (1.0 - Math.cos(tts * 0.6)) * 0.5
+    else model.target in
   let rate = Math.clamp01(dt * 4.0) in
-  // Until the pointer takes over, sweep a point in front of the character so
-  // the engine-side look-at remains obvious in a hands-off preview.
-  let headTarget =
-    (match model.pointerDrivesHead with
-     | true => model.headTarget
-     | false => {
-         x: Math.sin(tts * 0.9) * 0.9,
-         y: 1.55 + Math.sin(tts * 1.7) * 0.22,
-         z: 1.2,
-       }) in
+  // Each hand target idles independently until the user drags it.
+  let leftTarget =
+    if model.manualLeft then model.leftTarget
+    else target3(
+      0.52 + Math.sin(tts * 0.8) * 0.08,
+      1.24 + Math.sin(tts * 1.1) * 0.12,
+      0.28) in
+  let rightTarget =
+    if model.manualRight then model.rightTarget
+    else target3(
+      -0.52 + Math.sin(tts * 0.9 + 2.0) * 0.08,
+      1.24 + Math.sin(tts * 1.3 + 1.0) * 0.12,
+      0.28) in
   { model with
       speed: model.speed + (target - model.speed) * rate,
-      headTarget: headTarget }
+      leftTarget: leftTarget,
+      rightTarget: rightTarget }
 
 let absF = (x: float): float =>
-  match x < 0.0 with
-  | true => 0.0 - x
-  | false => x
+  if x < 0.0 then 0.0 - x else x
 
-// The 1D blend space: each clip's weight peaks at its point on the speed
-// axis (idle at 0, walk at 0.5, run at 1) and fades linearly to its
-// neighbors. Anim.blend normalizes, so adjacent weights crossfade.
+// The 1D blend space: each clip's weight peaks at its point on the speed axis
+// and fades linearly to its neighbors. Anim.blend normalizes the weights.
 let idleWeight = (s: float): float => Math.clamp01(1.0 - s * 2.0)
 let walkWeight = (s: float): float => Math.clamp01(1.0 - absF(s - 0.5) * 2.0)
 let runWeight = (s: float): float => Math.clamp01(s * 2.0 - 1.0)
 
-// Clip names come from the generated `assets.fun` (`functor import`) — a typo
-// in a typed constant is a check-time error, not a silent bind pose. The
-// model itself is the branded `Assets.xbot` (`Asset.model`), so its
-// reference is typo-proof too.
 let locomotion = (s: float, tts: float): Anim.t =>
   Anim.blend([
     (Anim.clip(Assets.xbotClips.idle.name, tts), idleWeight(s)),
@@ -111,16 +168,45 @@ let locomotion = (s: float, tts: float): Anim.t =>
     (Anim.clip(Assets.xbotClips.run.name, tts), runWeight(s)),
   ])
 
-// The full pose: solve the head after locomotion has animated its spine.
-// local +Z is Xbot's authored facing axis; the explicit limit keeps targets
-// behind the character from producing a full turn.
+let focusTarget = (model, tts) =>
+  match model.dragging with
+  | DragLeft => model.leftTarget
+  | DragRight => model.rightTarget
+  | NotDragging =>
+    if Math.sin(tts * 0.7) >= 0.0 then model.leftTarget else model.rightTarget
+
+// The whole stack: locomotion settles the spine, lookAt follows one sphere,
+// then each sibling arm chain reaches its own target. The evaluated locomotion
+// pose supplies each elbow's bend side.
 let pose = (model, tts) =>
+  let focus = focusTarget(model, tts) in
   locomotion(model.speed, tts)
     |> Anim.lookAt(
          Assets.xbotJoints.mixamorig_Head,
-         Vec3.make(model.headTarget.x, model.headTarget.y, model.headTarget.z),
-         Angle.degrees(75.0),
+         Vec3.make(focus.x, focus.y, focus.z),
+         Angle.degrees(65.0),
+         0.8)
+    |> Anim.reach(
+         Assets.xbotJoints.mixamorig_LeftArm,
+         Assets.xbotJoints.mixamorig_LeftForeArm,
+         Assets.xbotJoints.mixamorig_LeftHand,
+         Vec3.make(model.leftTarget.x, model.leftTarget.y, model.leftTarget.z),
          1.0)
+    |> Anim.reach(
+         Assets.xbotJoints.mixamorig_RightArm,
+         Assets.xbotJoints.mixamorig_RightForeArm,
+         Assets.xbotJoints.mixamorig_RightHand,
+         Vec3.make(model.rightTarget.x, model.rightTarget.y, model.rightTarget.z),
+         1.0)
+
+let modelToWorld = (target) =>
+  Vec3.make(0.0 - target.x, target.y, 0.0 - target.z)
+
+let targetMarker = (target, color, selected) =>
+  Scene.sphere()
+    |> Scene.scale(if selected then 0.09 else 0.075)
+    |> Scene.emissive(color)
+    |> Scene.translate(modelToWorld(target))
 
 let draw = (model, tts) =>
   Frame.createLit(
@@ -132,25 +218,40 @@ let draw = (model, tts) =>
       Scene.model(Assets.xbot)
         |> Scene.animate(pose(model, tts))
         |> Scene.rotateY(Angle.degrees(180.0)),
-      // Show the target in world space. This applies the same 180-degree
-      // transform as the model so the marker and IK target stay coincident.
-      Scene.sphere()
-        |> Scene.scale(0.025)
-        |> Scene.emissive(Color.rgb(0.1, 0.95, 1.0))
-        |> Scene.translate(Vec3.make(
-             0.0 - model.headTarget.x,
-             model.headTarget.y,
-             0.0 - model.headTarget.z)),
+      targetMarker(
+        model.leftTarget,
+        Color.rgb(0.1, 0.95, 1.0),
+        model.dragging == DragLeft),
+      targetMarker(
+        model.rightTarget,
+        Color.rgb(1.0, 0.2, 0.65),
+        model.dragging == DragRight),
     ]),
     [
       Light.ambient(Color.rgb(0.25, 0.25, 0.3)),
-      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 0.96, 0.88), 1.0) |> Light.castShadows,
+      Light.directional(Vec3.make(-0.5, -1.0, 0.4), Color.rgb(1.0, 0.96, 0.88), 1.0)
+        |> Light.castShadows,
     ])
 
 let ui = (model) =>
   Ui.column([
-    Ui.text("Anim.blend: idle / walk / run + Anim.lookAt post-pass"),
+    Ui.text("Anim.lookAt + Anim.reach over the locomotion blend"),
     Ui.text(Text.concat("speed: ", Text.fixed(model.speed, 2.0))),
-    Ui.text(Text.concat("target x: ", Text.fixed(model.headTarget.x, 2.0))),
-    Ui.text("keys: 1 idle, 2 walk, 3 run, 0 auto — mouse aims the head"),
+    Ui.text("drag the cyan / pink spheres — each hand follows its target"),
+    Ui.text("keys: 1 idle, 2 walk, 3 run, 0 auto"),
   ]) |> Ui.panel(Ui.topLeft())
+
+expect pickTarget(
+  target3(0.50, 1.24, 0.28),
+  target3(0.52, 1.24, 0.28),
+  target3(-0.52, 1.24, 0.28)) == DragLeft
+
+expect pickTarget(
+  target3(-0.50, 1.24, 0.28),
+  target3(0.52, 1.24, 0.28),
+  target3(-0.52, 1.24, 0.28)) == DragRight
+
+expect pickTarget(
+  target3(0.0, 0.4, 0.28),
+  target3(0.52, 1.24, 0.28),
+  target3(-0.52, 1.24, 0.28)) == NotDragging

--- a/functor-prelude/prelude/anim.funi
+++ b/functor-prelude/prelude/anim.funi
@@ -55,3 +55,11 @@ let rotate : (string, Angle.t, Angle.t, Angle.t, t) => t
 /// is fully driven by this node, exactly as with `Anim.rotate`; an enclosing
 /// mask can still exclude it.
 let lookAt : (string, Vec3.t, Angle.t, float, t) => t
+
+/// Reach a model-space target with a direct two-bone joint chain.
+///
+/// `root`, `middle`, and `end` must name direct parent/child joints, such as an
+/// upper arm, forearm, and hand. Unreachable targets clamp to the chain's
+/// nearest extension. The evaluated pose below supplies the elbow bend side,
+/// `root` must have uniform scale, and `weight` is clamped to `0..1`.
+let reach : (string, string, string, Vec3.t, float, t) => t

--- a/runtime/functor-runtime-common/src/anim.rs
+++ b/runtime/functor-runtime-common/src/anim.rs
@@ -20,6 +20,8 @@
 //!   the programmatic per-joint control (finger curl, authored offsets).
 //! - `LookAt` aims one joint's local +Z axis at a model-space target after
 //!   evaluating the expression below it.
+//! - `Reach` rotates a direct two-bone chain so its end joint approaches a
+//!   model-space target, preserving the evaluated pose's elbow bend side.
 //!
 //! Evaluation carries a per-joint influence weight so `Mask` composes
 //! through `Blend`/`Add`: a joint no input drives falls back to the bind
@@ -29,7 +31,7 @@ use std::collections::HashMap;
 
 use cgmath::{
     Euler, InnerSpace, Matrix3, Matrix4, One, Quaternion, Rad, Rotation, SquareMatrix, Vector3,
-    Zero,
+    Vector4, Zero,
 };
 use serde::{Deserialize, Serialize};
 
@@ -88,6 +90,18 @@ pub enum AnimExpr {
         weight: f32,
         expr: Box<AnimExpr>,
     },
+    /// Rotate a direct `root -> middle -> end` chain so the end joint reaches
+    /// a model-space target after evaluating `expr`. Unreachable targets clamp
+    /// to the chain's nearest possible extension; the evaluated middle joint
+    /// supplies the bend side.
+    Reach {
+        root: String,
+        middle: String,
+        end: String,
+        target: [f32; 3],
+        weight: f32,
+        expr: Box<AnimExpr>,
+    },
 }
 
 /// A missing reference discovered during evaluation — the caller surfaces
@@ -97,6 +111,14 @@ pub enum AnimExpr {
 pub enum AnimWarning<'a> {
     MissingClip(&'a str),
     MissingJoint(&'a str),
+    InvalidChain {
+        root: &'a str,
+        middle: &'a str,
+        end: &'a str,
+    },
+    NonUniformRootScale {
+        root: &'a str,
+    },
 }
 
 /// A pose with a per-joint influence weight in `[0, 1]` — how `Mask`
@@ -260,6 +282,48 @@ fn eval(model: &Model, expr: &AnimExpr, on_warning: &mut dyn FnMut(AnimWarning))
             }
             inner
         }
+        AnimExpr::Reach {
+            root,
+            middle,
+            end,
+            target,
+            weight,
+            expr,
+        } => {
+            let mut inner = eval(model, expr, on_warning);
+            let root_id = model.skeleton.joint_id_by_name(root);
+            let middle_id = model.skeleton.joint_id_by_name(middle);
+            let end_id = model.skeleton.joint_id_by_name(end);
+            for (name, id) in [
+                (root.as_str(), root_id),
+                (middle.as_str(), middle_id),
+                (end.as_str(), end_id),
+            ] {
+                if id.is_none() {
+                    on_warning(AnimWarning::MissingJoint(name));
+                }
+            }
+            if let (Some(root_id), Some(middle_id), Some(end_id)) = (root_id, middle_id, end_id) {
+                match apply_reach(
+                    &model.skeleton,
+                    &mut inner,
+                    root_id,
+                    middle_id,
+                    end_id,
+                    Vector3::from(*target),
+                    *weight,
+                ) {
+                    Ok(()) => {}
+                    Err(ReachFailure::InvalidChain) => {
+                        on_warning(AnimWarning::InvalidChain { root, middle, end });
+                    }
+                    Err(ReachFailure::NonUniformRootScale) => {
+                        on_warning(AnimWarning::NonUniformRootScale { root });
+                    }
+                }
+            }
+            inner
+        }
     }
 }
 
@@ -370,6 +434,253 @@ fn apply_look_at(
     );
     joint.rotation = (local_correction * joint.rotation).normalize();
     pose.joints.insert(joint_id, (joint, 1.0));
+}
+
+/// A deterministic direction perpendicular to `axis`, preferring `hint`
+/// when it already carries a useful bend side.
+fn perpendicular(axis: Vector3<f32>, hint: Vector3<f32>) -> Vector3<f32> {
+    let hint = normalized_f64(hint).unwrap_or_else(Vector3::zero);
+    let projected = hint - axis * hint.dot(axis);
+    if let Some(direction) = normalized_f64(projected) {
+        return direction;
+    }
+    let basis = if axis.x.abs() <= axis.y.abs() && axis.x.abs() <= axis.z.abs() {
+        Vector3::unit_x()
+    } else if axis.y.abs() <= axis.z.abs() {
+        Vector3::unit_y()
+    } else {
+        Vector3::unit_z()
+    };
+    normalized_f64(basis - axis * basis.dot(axis)).unwrap_or_else(Vector3::unit_x)
+}
+
+fn transform_point(transform: Matrix4<f32>, point: Vector3<f32>) -> Option<Vector3<f32>> {
+    let transformed = transform * Vector4::new(point.x, point.y, point.z, 1.0);
+    if transformed.w.abs() <= 1e-12 {
+        None
+    } else {
+        Some(transformed.truncate() / transformed.w)
+    }
+}
+
+fn length_f64(vector: Vector3<f32>) -> f64 {
+    let x = f64::from(vector.x);
+    let y = f64::from(vector.y);
+    let z = f64::from(vector.z);
+    (x * x + y * y + z * z).sqrt()
+}
+
+fn normalized_f64(vector: Vector3<f32>) -> Option<Vector3<f32>> {
+    let length = length_f64(vector);
+    if !length.is_finite() || length <= 1e-12 {
+        return None;
+    }
+    Some(Vector3::new(
+        (f64::from(vector.x) / length) as f32,
+        (f64::from(vector.y) / length) as f32,
+        (f64::from(vector.z) / length) as f32,
+    ))
+}
+
+/// Rotate one joint so the model-space segment below it turns from `current`
+/// toward `desired`. Converting both vectors through the settled parent
+/// transform keeps the local correction correct under animated ancestors.
+fn rotate_segment_toward(
+    skeleton: &Skeleton,
+    pose: &mut WeightedPose,
+    joint_id: i32,
+    current: Vector3<f32>,
+    desired: Vector3<f32>,
+    bend_normal: Vector3<f32>,
+    weight: f32,
+) -> bool {
+    let Some(mut joint) = resolved_joint_pose(skeleton, pose, joint_id) else {
+        return false;
+    };
+    let Some(absolute) = resolved_absolute(skeleton, pose, joint_id) else {
+        return false;
+    };
+    let parent_linear = Matrix3::from_cols(
+        absolute.parent_transform.x.truncate(),
+        absolute.parent_transform.y.truncate(),
+        absolute.parent_transform.z.truncate(),
+    );
+    let Some(parent_inverse) = parent_linear.invert() else {
+        return false;
+    };
+    let from = parent_inverse * current;
+    let to = parent_inverse * desired;
+    let Some(from) = normalized_f64(from) else {
+        return false;
+    };
+    let Some(to) = normalized_f64(to) else {
+        return false;
+    };
+    let pole = perpendicular(from, parent_inverse * bend_normal);
+    let correction = Quaternion::from_arc(from, to, Some(pole));
+    let correction = Quaternion::one().slerp(correction, weight.clamp(0.0, 1.0));
+    joint.rotation = (correction * joint.rotation).normalize();
+    pose.joints.insert(joint_id, (joint, 1.0));
+    true
+}
+
+/// Analytic two-bone reach over a direct `root -> middle -> end` chain.
+///
+/// The law of cosines chooses the desired middle position. The middle joint
+/// from the evaluated pose acts as the pole point, which preserves the
+/// authored/animated elbow side without adding hidden state or another API
+/// parameter. Each local correction is derived after its parent has settled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReachFailure {
+    InvalidChain,
+    NonUniformRootScale,
+}
+
+fn apply_reach(
+    skeleton: &Skeleton,
+    pose: &mut WeightedPose,
+    root_id: i32,
+    middle_id: i32,
+    end_id: i32,
+    target: Vector3<f32>,
+    weight: f32,
+) -> Result<(), ReachFailure> {
+    if skeleton.get_joint_parent_id(middle_id) != Some(root_id)
+        || skeleton.get_joint_parent_id(end_id) != Some(middle_id)
+    {
+        return Err(ReachFailure::InvalidChain);
+    }
+    if weight <= 0.0 {
+        return Ok(());
+    }
+    let Some(root_joint) = resolved_joint_pose(skeleton, pose, root_id) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let scale = root_joint.scale.map(f32::abs);
+    let largest_scale = scale.x.max(scale.y).max(scale.z);
+    let smallest_scale = scale.x.min(scale.y).min(scale.z);
+    if largest_scale - smallest_scale > largest_scale * 1e-4 {
+        return Err(ReachFailure::NonUniformRootScale);
+    }
+
+    let Some(root_absolute) = resolved_absolute(skeleton, pose, root_id) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(middle_absolute) = resolved_absolute(skeleton, pose, middle_id) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(end_absolute) = resolved_absolute(skeleton, pose, end_id) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(model_to_solve) = root_absolute.parent_transform.invert() else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let solve_to_model = root_absolute.parent_transform;
+    let Some(root) = transform_point(model_to_solve, root_absolute.transform.w.truncate()) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(middle) = transform_point(model_to_solve, middle_absolute.transform.w.truncate())
+    else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(end) = transform_point(model_to_solve, end_absolute.transform.w.truncate()) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(target) = transform_point(model_to_solve, target) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let upper = middle - root;
+    let lower = end - middle;
+    let upper_length = length_f64(upper);
+    let lower_length = length_f64(lower);
+    if upper_length <= 1e-6 || lower_length <= 1e-6 {
+        return Err(ReachFailure::InvalidChain);
+    }
+
+    let target_offset = target - root;
+    let target_distance = length_f64(target_offset);
+    let current_offset = end - root;
+    let target_direction = if target_distance > 1e-6 {
+        normalized_f64(target_offset).ok_or(ReachFailure::InvalidChain)?
+    } else if let Some(direction) = normalized_f64(current_offset) {
+        direction
+    } else {
+        normalized_f64(upper).ok_or(ReachFailure::InvalidChain)?
+    };
+    let maximum = upper_length + lower_length;
+    let minimum = (upper_length - lower_length).abs().max(maximum * 1e-5);
+    let distance = target_distance.clamp(minimum, maximum);
+
+    // Use the evaluated middle joint as the pole point. Its projection onto
+    // the plane normal to the target direction says which side the elbow was
+    // already on; a straight pose gets a deterministic model-axis fallback.
+    let bend_direction = perpendicular(target_direction, upper);
+    let along = (upper_length * upper_length - lower_length * lower_length + distance * distance)
+        / (2.0 * distance);
+    let height = (upper_length * upper_length - along * along)
+        .max(0.0)
+        .sqrt();
+    let desired_middle =
+        root + target_direction * along as f32 + bend_direction * height as f32;
+    let desired_end = root + target_direction * distance as f32;
+    let Some(root_model) = transform_point(solve_to_model, root) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(desired_middle_model) = transform_point(solve_to_model, desired_middle) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(desired_end_model) = transform_point(solve_to_model, desired_end) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let desired_upper = desired_middle_model - root_model;
+    let desired_lower = desired_end_model - desired_middle_model;
+    let desired_upper_direction =
+        normalized_f64(desired_upper).ok_or(ReachFailure::InvalidChain)?;
+    let desired_lower_direction =
+        normalized_f64(desired_lower).ok_or(ReachFailure::InvalidChain)?;
+    let bend_normal = desired_upper_direction.cross(desired_lower_direction);
+    let bend_normal = if let Some(direction) = normalized_f64(bend_normal) {
+        direction
+    } else {
+        normalized_f64(target_direction.cross(bend_direction))
+            .ok_or(ReachFailure::InvalidChain)?
+    };
+
+    if !rotate_segment_toward(
+        skeleton,
+        pose,
+        root_id,
+        middle_absolute.transform.w.truncate() - root_absolute.transform.w.truncate(),
+        desired_upper,
+        bend_normal,
+        weight,
+    ) {
+        return Err(ReachFailure::InvalidChain);
+    }
+
+    // Root rotation moved both descendants. Resolve the settled second
+    // segment before computing the middle-joint correction.
+    let Some(middle_after) = resolved_absolute(skeleton, pose, middle_id) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let Some(end_after) = resolved_absolute(skeleton, pose, end_id) else {
+        return Err(ReachFailure::InvalidChain);
+    };
+    let middle_after = middle_after.transform.w.truncate();
+    let lower_after = end_after.transform.w.truncate() - middle_after;
+    if rotate_segment_toward(
+        skeleton,
+        pose,
+        middle_id,
+        lower_after,
+        desired_end_model - middle_after,
+        bend_normal,
+        weight,
+    ) {
+        Ok(())
+    } else {
+        Err(ReachFailure::InvalidChain)
+    }
 }
 
 fn full_weight(pose: Pose) -> WeightedPose {
@@ -578,6 +889,32 @@ mod tests {
                 duration: 2.0,
                 channels: vec![channel(0), channel(1), channel(2)],
             }],
+        }
+    }
+
+    /// A direct two-bone chain with unit segments along +X:
+    /// upper(root at origin) -> lower(at x=1) -> end(at x=2).
+    fn reach_model() -> Model {
+        let mut builder = SkeletonBuilder::create(vec![Matrix4::identity(); 3]);
+        builder.add_joint(0, 0, "upper".to_string(), None, Matrix4::identity());
+        builder.add_joint(
+            1,
+            1,
+            "lower".to_string(),
+            Some(0),
+            Matrix4::from_translation(Vector3::unit_x()),
+        );
+        builder.add_joint(
+            2,
+            2,
+            "end".to_string(),
+            Some(1),
+            Matrix4::from_translation(Vector3::unit_x()),
+        );
+        Model {
+            meshes: vec![],
+            skeleton: builder.build(),
+            animations: vec![],
         }
     }
 
@@ -908,6 +1245,360 @@ mod tests {
         });
         assert_eq!(missing, vec!["tail".to_string()]);
         assert_eq!(transforms[0], Matrix4::identity());
+    }
+
+    #[test]
+    fn reach_places_the_end_joint_at_a_reachable_target() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [0.0, 2.0_f32.sqrt(), 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let root = joint_translation(&transforms, 0);
+        let middle = joint_translation(&transforms, 1);
+        let end = joint_translation(&transforms, 2);
+        let target = vec3(0.0, 2.0_f32.sqrt(), 0.0);
+        assert!((end - target).magnitude() < 1e-5, "end: {end:?}");
+        assert!(((middle - root).magnitude() - 1.0).abs() < 1e-5);
+        assert!(((end - middle).magnitude() - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn reach_clamps_an_unreachable_target_to_full_extension() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [5.0, 0.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        assert!((joint_translation(&transforms, 2) - vec3(2.0, 0.0, 0.0)).magnitude() < 1e-5);
+    }
+
+    #[test]
+    fn reach_clamps_a_large_finite_target_without_overflow() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [0.0, 1e30, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let end = joint_translation(&transforms, 2);
+        assert!((end - vec3(0.0, 2.0, 0.0)).magnitude() < 1e-5, "end: {end:?}");
+    }
+
+    #[test]
+    fn reach_folds_safely_when_the_target_is_at_the_root() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [0.0, 0.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        assert!(transforms.iter().all(|transform| {
+            [
+                transform.x.x,
+                transform.x.y,
+                transform.x.z,
+                transform.x.w,
+                transform.y.x,
+                transform.y.y,
+                transform.y.z,
+                transform.y.w,
+                transform.z.x,
+                transform.z.y,
+                transform.z.z,
+                transform.z.w,
+                transform.w.x,
+                transform.w.y,
+                transform.w.z,
+                transform.w.w,
+            ]
+            .into_iter()
+            .all(f32::is_finite)
+        }));
+        assert!(joint_translation(&transforms, 2).magnitude() < 3e-5);
+    }
+
+    #[test]
+    fn reach_solves_through_non_uniform_parent_scale() {
+        let mut builder = SkeletonBuilder::create(vec![Matrix4::identity(); 4]);
+        builder.add_joint(
+            0,
+            0,
+            "scaled-parent".to_string(),
+            None,
+            Matrix4::from_nonuniform_scale(2.0, 1.0, 0.5),
+        );
+        builder.add_joint(1, 1, "upper".to_string(), Some(0), Matrix4::identity());
+        builder.add_joint(
+            2,
+            2,
+            "lower".to_string(),
+            Some(1),
+            Matrix4::from_translation(Vector3::unit_x()),
+        );
+        builder.add_joint(
+            3,
+            3,
+            "end".to_string(),
+            Some(2),
+            Matrix4::from_translation(Vector3::unit_x()),
+        );
+        let model = Model {
+            meshes: vec![],
+            skeleton: builder.build(),
+            animations: vec![],
+        };
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            // In the scaled parent's local solve space this is (1, 1, 0),
+            // a reachable target for two unit segments.
+            target: [2.0, 1.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let end = joint_translation(&transforms, 3);
+        assert!(
+            (end - vec3(2.0, 1.0, 0.0)).magnitude() < 1e-5,
+            "end: {end:?}"
+        );
+    }
+
+    #[test]
+    fn reach_warns_for_non_uniform_root_scale_and_is_ignored() {
+        let mut builder = SkeletonBuilder::create(vec![Matrix4::identity(); 3]);
+        builder.add_joint(
+            0,
+            0,
+            "upper".to_string(),
+            None,
+            Matrix4::from_nonuniform_scale(2.0, 1.0, 0.5),
+        );
+        builder.add_joint(
+            1,
+            1,
+            "lower".to_string(),
+            Some(0),
+            Matrix4::from_translation(Vector3::unit_x()),
+        );
+        builder.add_joint(
+            2,
+            2,
+            "end".to_string(),
+            Some(1),
+            Matrix4::from_translation(Vector3::unit_x()),
+        );
+        let model = Model {
+            meshes: vec![],
+            skeleton: builder.build(),
+            animations: vec![],
+        };
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [0.0, 2.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let rest = skinning_transforms(&model, &AnimExpr::Rest, &mut no_warning);
+        let mut warnings = Vec::new();
+        let reached = skinning_transforms(&model, &expr, &mut |warning| {
+            if let AnimWarning::NonUniformRootScale { root } = warning {
+                warnings.push(root.to_string());
+            }
+        });
+        assert_eq!(warnings, vec!["upper"]);
+        assert_eq!(reached, rest);
+    }
+
+    #[test]
+    fn reach_warns_for_small_non_uniform_root_scale_and_is_ignored() {
+        let mut builder = SkeletonBuilder::create(vec![Matrix4::identity(); 3]);
+        builder.add_joint(
+            0,
+            0,
+            "upper".to_string(),
+            None,
+            Matrix4::from_nonuniform_scale(0.00009, 0.00001, 0.00001),
+        );
+        builder.add_joint(
+            1,
+            1,
+            "lower".to_string(),
+            Some(0),
+            Matrix4::from_translation(vec3(10000.0, 0.0, 0.0)),
+        );
+        builder.add_joint(
+            2,
+            2,
+            "end".to_string(),
+            Some(1),
+            Matrix4::from_translation(vec3(10000.0, 0.0, 0.0)),
+        );
+        let model = Model {
+            meshes: vec![],
+            skeleton: builder.build(),
+            animations: vec![],
+        };
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [0.0, 1.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let rest = skinning_transforms(&model, &AnimExpr::Rest, &mut no_warning);
+        let mut warnings = Vec::new();
+        let reached = skinning_transforms(&model, &expr, &mut |warning| {
+            if let AnimWarning::NonUniformRootScale { root } = warning {
+                warnings.push(root.to_string());
+            }
+        });
+        assert_eq!(warnings, vec!["upper"]);
+        assert_eq!(reached, rest);
+    }
+
+    #[test]
+    fn reach_normalizes_large_finite_bone_vectors_without_overflow() {
+        let mut builder = SkeletonBuilder::create(vec![Matrix4::identity(); 3]);
+        builder.add_joint(0, 0, "upper".to_string(), None, Matrix4::identity());
+        builder.add_joint(
+            1,
+            1,
+            "lower".to_string(),
+            Some(0),
+            Matrix4::from_translation(vec3(1e30, 1e30, 0.0)),
+        );
+        builder.add_joint(
+            2,
+            2,
+            "end".to_string(),
+            Some(1),
+            Matrix4::from_translation(vec3(1e30, 0.0, 0.0)),
+        );
+        let model = Model {
+            meshes: vec![],
+            skeleton: builder.build(),
+            animations: vec![],
+        };
+        let target = vec3(0.0, 1e30, 0.0);
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: target.into(),
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let end = joint_translation(&transforms, 2);
+        assert!(
+            length_f64(end - target) / 1e30 < 1e-5,
+            "target: {target:?}, end: {end:?}"
+        );
+    }
+
+    #[test]
+    fn reach_preserves_the_evaluated_bend_side() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [1.0, 1.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        let middle = joint_translation(&transforms, 1);
+        let end = joint_translation(&transforms, 2);
+        // The rest pose's elbow starts on +X, so it remains on that side of
+        // the root->target line instead of choosing the mirrored solution.
+        assert!(middle.x > middle.y, "middle: {middle:?}");
+        assert!((end - vec3(1.0, 1.0, 0.0)).magnitude() < 1e-5);
+    }
+
+    #[test]
+    fn reach_zero_weight_leaves_the_pose_unchanged() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "end".to_string(),
+            target: [0.0, 2.0, 0.0],
+            weight: 0.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let transforms = skinning_transforms(&model, &expr, &mut no_warning);
+        assert_eq!(joint_translation(&transforms, 1), vec3(1.0, 0.0, 0.0));
+        assert_eq!(joint_translation(&transforms, 2), vec3(2.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn reach_warns_for_a_non_direct_chain_and_is_ignored() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "end".to_string(),
+            end: "lower".to_string(),
+            target: [0.0, 1.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let mut invalid = Vec::new();
+        let transforms = skinning_transforms(&model, &expr, &mut |warning| {
+            if let AnimWarning::InvalidChain { root, middle, end } = warning {
+                invalid.push((root.to_string(), middle.to_string(), end.to_string()));
+            }
+        });
+        assert_eq!(
+            invalid,
+            vec![("upper".to_string(), "end".to_string(), "lower".to_string())]
+        );
+        assert_eq!(joint_translation(&transforms, 2), vec3(2.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn reach_warns_for_each_missing_joint_and_is_ignored() {
+        let model = reach_model();
+        let expr = AnimExpr::Reach {
+            root: "shoulder".to_string(),
+            middle: "elbow".to_string(),
+            end: "hand".to_string(),
+            target: [0.0, 1.0, 0.0],
+            weight: 1.0,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let mut missing = Vec::new();
+        let transforms = skinning_transforms(&model, &expr, &mut |warning| {
+            if let AnimWarning::MissingJoint(name) = warning {
+                missing.push(name.to_string());
+            }
+        });
+        assert_eq!(missing, vec!["shoulder", "elbow", "hand"]);
+        assert_eq!(joint_translation(&transforms, 2), vec3(2.0, 0.0, 0.0));
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -46,6 +46,8 @@
 //!    both fields are Vec3 values and direction is normalized)
 //! Anim.lookAt(joint, target, maxDeflection, weight, anim)  -> Anim
 //!   (post-pass aim of local +Z at a model-space Vec3 target)
+//! Anim.reach(root, middle, end, target, weight, anim)      -> Anim
+//!   (post-pass two-bone reach preserving the evaluated bend side)
 //! Frame.create(camera, scene)                               -> Frame
 //! Camera2D.create(width, height)                             -> Camera2D
 //! Camera2D.at(x, y, camera) / Camera2D.zoom(k, camera)       -> Camera2D
@@ -3032,9 +3034,9 @@ one with Asset.model/texture(…) first"
 }
 
 /// The Anim pose algebra — clip sampling, blending, the rest pose, additive
-/// layers, masks, per-joint rotation, and model-space look-at. Playheads,
-/// targets, and weights are explicit in the values, so the pose stays a pure
-/// function of what the game derived.
+/// layers, masks, per-joint rotation, model-space look-at, and two-bone reach.
+/// Playheads, targets, and weights are explicit in the values, so the pose
+/// stays a pure function of what the game derived.
 fn register_anim(reg: &mut crate::host_registry::Registry) {
     // A clip sample as a value: the named glTF clip at a playhead in seconds
     // (looping by the clip's duration). The playhead is explicit — derive it
@@ -3180,6 +3182,40 @@ a non-empty joint name, model-space Vec3 target, Angle limit from 0 to 180 degre
                 joint,
                 target: [target.0 .0, target.0 .1, target.0 .2],
                 max_angle: max_deflection.0,
+                weight: weight as f32,
+                expr: Box::new(anim.0),
+            }))
+        },
+    );
+    // A pure two-bone IK post-pass: solve a direct root -> middle -> end
+    // chain toward a model-space target after the expression below has
+    // settled. The evaluated middle position supplies the bend side.
+    const REACH: &str = "Anim.reach(\"rootJoint\", \"middleJoint\", \"endJoint\", target, \
+weight, anim) — three distinct non-empty joint names forming a direct two-bone chain \
+with uniform root scale, a model-space Vec3 target, and weight";
+    reg.fn6(
+        "Anim.reach",
+        REACH,
+        |root: String,
+         middle: String,
+         end: String,
+         target: FunctorLangVec3,
+         weight: f64,
+         anim: FunctorLangAnim| {
+            if root.is_empty()
+                || middle.is_empty()
+                || end.is_empty()
+                || root == middle
+                || root == end
+                || middle == end
+            {
+                return Err(format!("usage: {REACH}"));
+            }
+            Ok(FunctorLangAnim(AnimExpr::Reach {
+                root,
+                middle,
+                end,
+                target: [target.0 .0, target.0 .1, target.0 .2],
                 weight: weight as f32,
                 expr: Box::new(anim.0),
             }))
@@ -7955,8 +7991,8 @@ Anim.clip(\"walk\", tts)"
     }
 
     // The full pose algebra composes through pipes and lands on the Model
-    // node as nested AnimExpr data: rest |> rotate |> lookAt, masked blends,
-    // additive layers.
+    // node as nested AnimExpr data: rest |> rotate |> lookAt |> reach,
+    // masked blends, additive layers.
     #[test]
     fn anim_algebra_composes_and_serializes() {
         let value = eval(
@@ -7965,6 +8001,7 @@ Anim.clip(\"walk\", tts)"
                Anim.rest()\n\
                  |> Anim.rotate(\"finger_index_0_r\", Angle.degrees(45.0), Angle.degrees(0.0), Angle.degrees(0.0))\n\
                  |> Anim.lookAt(\"finger_index_0_r\", Vec3.make(1.0, 2.0, 3.0), Angle.degrees(80.0), 0.75)\n\
+                 |> Anim.reach(\"arm_r\", \"forearm_r\", \"wrist_r\", Vec3.make(3.0, 2.0, 1.0), 0.6)\n\
                  |> Anim.mask([\"wrist_r\"])\n\
                  |> Anim.add(Anim.clip(\"wave\", 1.0), 0.5))",
         );
@@ -7989,6 +8026,22 @@ Anim.clip(\"walk\", tts)"
             panic!("expected a Mask base, got {base:?}");
         };
         assert_eq!(joints, &vec!["wrist_r".to_string()]);
+        let AnimExpr::Reach {
+            root,
+            middle,
+            end,
+            target,
+            weight,
+            expr,
+        } = &**expr
+        else {
+            panic!("expected a Reach inside the mask, got {expr:?}");
+        };
+        assert_eq!(root, "arm_r");
+        assert_eq!(middle, "forearm_r");
+        assert_eq!(end, "wrist_r");
+        assert_eq!(target, &[3.0, 2.0, 1.0]);
+        assert!((*weight - 0.6).abs() < 1e-6);
         let AnimExpr::LookAt {
             joint,
             target,
@@ -8063,6 +8116,22 @@ Anim.clip(\"walk\", tts)"
                 "let main = () => Anim.rest() |> Anim.lookAt(\"head\", Vec3.make(0.0, 1.0, 2.0), Angle.degrees(181.0), 1.0)"
             ),
             "usage: Anim.lookAt(\"jointName\", target, maxDeflection, weight, anim) — a non-empty joint name, model-space Vec3 target, Angle limit from 0 to 180 degrees, and weight"
+        );
+    }
+
+    #[test]
+    fn anim_reach_enforces_spatial_brand_and_distinct_joint_names() {
+        let bare_target = fail_message(
+            "let main = () => Anim.rest() |> Anim.reach(\"arm\", \"forearm\", \"hand\", { x: 0.0, y: 1.0, z: 2.0 }, 1.0)"
+        );
+        assert!(bare_target.contains("Vec3"), "message: {bare_target}");
+
+        let duplicate_name = fail_message(
+            "let main = () => Anim.rest() |> Anim.reach(\"arm\", \"arm\", \"hand\", Vec3.make(0.0, 1.0, 2.0), 1.0)"
+        );
+        assert!(
+            duplicate_name.contains("three distinct non-empty joint names"),
+            "message: {duplicate_name}"
         );
     }
 

--- a/runtime/functor-runtime-common/src/manifest.rs
+++ b/runtime/functor-runtime-common/src/manifest.rs
@@ -265,10 +265,10 @@ pub fn duplicate_clip_names(clips: &[(String, f32)]) -> Vec<String> {
     duplicate_names(clips.iter().map(|(name, _)| name.as_str()))
 }
 
-/// Joint names appearing more than once in a model. `Anim.rotate` and
-/// `Anim.lookAt` select the smallest matching node id while `Anim.mask`
-/// selects all matching subtrees; duplicate nodes are not individually
-/// name-addressable, so the generator emits one field.
+/// Joint names appearing more than once in a model. `Anim.rotate`,
+/// `Anim.lookAt`, and `Anim.reach` select the smallest matching node id while
+/// `Anim.mask` selects all matching subtrees; duplicate nodes are not
+/// individually name-addressable, so the generator emits one field.
 pub fn duplicate_joint_names(joints: &[String]) -> Vec<String> {
     duplicate_names(joints.iter().map(String::as_str))
 }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -71,6 +71,9 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v11: the `AnimExpr::Reach` two-bone IK variant nested in
+/// `ModelDescription.animation`.
+///
 /// v10: logical mouse surface extent — `InputSnapshot.mouse.surface_width` /
 /// `surface_height`, defaulted when decoding older samples.
 ///
@@ -103,7 +106,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 10;
+pub const PROTOCOL_VERSION: u32 = 11;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -600,7 +603,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 10);
+        assert_eq!(PROTOCOL_VERSION, 11);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -627,7 +630,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 10);
+        assert_eq!(PROTOCOL_VERSION, 11);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],
@@ -640,6 +643,28 @@ mod tests {
             r#"{"Geometry":{"ConvexPolygon":{"points":[[0.0,0.0],[2.0,0.0],[1.0,1.5]]}}}"#
         );
         let back: SceneObject = serde_json::from_str(&json).expect("deserialize polygon geometry");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    #[test]
+    fn two_bone_reach_animation_wire_is_pinned() {
+        use crate::anim::AnimExpr;
+
+        assert_eq!(PROTOCOL_VERSION, 11);
+        let reach = AnimExpr::Reach {
+            root: "upper".to_string(),
+            middle: "lower".to_string(),
+            end: "hand".to_string(),
+            target: [1.0, 2.0, 3.0],
+            weight: 0.75,
+            expr: Box::new(AnimExpr::Rest),
+        };
+        let json = serde_json::to_string(&reach).expect("serialize two-bone reach");
+        assert_eq!(
+            json,
+            r#"{"Reach":{"root":"upper","middle":"lower","end":"hand","target":[1.0,2.0,3.0],"weight":0.75,"expr":"Rest"}}"#
+        );
+        let back: AnimExpr = serde_json::from_str(&json).expect("deserialize two-bone reach");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }
 

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1235,27 +1235,45 @@ impl Scene3D {
                                     &hydrated_model,
                                     expr,
                                     &mut |warning| {
-                                        let (kind, name, hint) = match warning {
+                                        let (key, message) = match warning {
                                             crate::anim::AnimWarning::MissingClip(name) => (
-                                                "clip",
-                                                name,
-                                                "rendering the bind pose (functor inspect \
-lists a model's clips)",
+                                                format!("anim-clip:{str}:{name}"),
+                                                format!(
+                                                    "[anim] model \"{str}\" has no clip \
+named \"{name}\" — rendering the bind pose (functor inspect lists a model's clips)"
+                                                ),
                                             ),
                                             crate::anim::AnimWarning::MissingJoint(name) => (
-                                                "joint",
-                                                name,
-                                                "ignoring it (functor inspect lists a \
-model's joints)",
+                                                format!("anim-joint:{str}:{name}"),
+                                                format!(
+                                                    "[anim] model \"{str}\" has no joint \
+named \"{name}\" — ignoring it (functor inspect lists a model's joints)"
+                                                ),
+                                            ),
+                                            crate::anim::AnimWarning::InvalidChain {
+                                                root,
+                                                middle,
+                                                end,
+                                            } => (
+                                                format!("anim-chain:{str}:{root}:{middle}:{end}"),
+                                                format!(
+                                                    "[anim] model \"{str}\" joints \
+\"{root}\" -> \"{middle}\" -> \"{end}\" are not a direct, non-degenerate \
+two-bone chain — ignoring Anim.reach"
+                                            ),
+                                            ),
+                                            crate::anim::AnimWarning::NonUniformRootScale {
+                                                root,
+                                            } => (
+                                                format!("anim-reach-scale:{str}:{root}"),
+                                                format!(
+                                                    "[anim] model \"{str}\" root joint \
+\"{root}\" has non-uniform scale — Anim.reach requires uniform root scale, \
+so the reach is ignored"
+                                                ),
                                             ),
                                         };
-                                        scene_context.warn_once(
-                                            &format!("anim-{kind}:{str}:{name}"),
-                                            &format!(
-                                                "[anim] model \"{str}\" has no {kind} \
-named \"{name}\" — {hint}"
-                                            ),
-                                        );
+                                        scene_context.warn_once(&key, &message);
                                     },
                                 ),
                                 // Zero-config default: the first clip

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -102,6 +102,25 @@ fn camera_world_ray_checks_as_anim_look_at_input() {
     );
 }
 
+/// The same cursor-derived model-space Vec3 can drive the stacked two-bone
+/// post-pass without unpacking or weakening its brand.
+#[test]
+fn camera_world_ray_checks_as_anim_reach_input() {
+    let diags = check(
+        "let camera = Camera3D.lookAt(\n\
+           Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0))\n\
+         let reach = (mouse: Input.mouse): Anim.t =>\n\
+           match Camera3D.toWorldRay(mouse, camera) with\n\
+           | Option.Some(ray) => Anim.rest() |> Anim.reach(\n\
+               \"upper\", \"lower\", \"hand\", ray.origin |> Vec3.add(ray.direction), 1.0)\n\
+           | Option.None => Anim.rest()",
+    );
+    assert!(
+        diags.is_empty(),
+        "Camera3D.toWorldRay should feed Anim.reach directly: {diags:?}"
+    );
+}
+
 /// Engine-owned `.fun` modules participate in the same typecheck as the host
 /// interfaces they build upon.
 #[test]

--- a/site/examples/animation/assets.fun
+++ b/site/examples/animation/assets.fun
@@ -20,8 +20,20 @@ let xbotClips: XbotClips = {
 
 type XbotJoints = {
   mixamorig_Head: string,
+  mixamorig_LeftArm: string,
+  mixamorig_LeftForeArm: string,
+  mixamorig_LeftHand: string,
+  mixamorig_RightArm: string,
+  mixamorig_RightForeArm: string,
+  mixamorig_RightHand: string,
 }
 
 let xbotJoints: XbotJoints = {
   mixamorig_Head: "mixamorig:Head",
+  mixamorig_LeftArm: "mixamorig:LeftArm",
+  mixamorig_LeftForeArm: "mixamorig:LeftForeArm",
+  mixamorig_LeftHand: "mixamorig:LeftHand",
+  mixamorig_RightArm: "mixamorig:RightArm",
+  mixamorig_RightForeArm: "mixamorig:RightForeArm",
+  mixamorig_RightHand: "mixamorig:RightHand",
 }

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 304));
+        assert_eq!(count(ApiGroup::Engine), (27, 305));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
## Stack

Stacked on #586 (`feat/anim-look-at`). Review this PR against that branch; the diff contains only the two-bone IK and interactive reach sample.

Part of #306.

## Summary

- add typed, pure `Anim.reach(root, middle, end, target, weight, anim)` two-bone IK with direct-chain validation, unreachable-target clamping, evaluated-pose bend preservation, and explicit warnings for unsupported root scale
- build on `Anim.lookAt` in the animation example: Xbot locomotes while its head follows one of two moving targets and both hands reach toward the cyan/pink spheres
- make both spheres draggable with a visible pointer via `Camera.toWorldRay`, deterministic sampled mouse edges, and event-time press-coordinate latching
- promote the complete animation example to the site sandbox, including its generated CDN joint manifest and a rendered-interaction browser test
- bump the animation protocol to v11 and pin the exact `Reach` wire representation

## Verification

- `npm run build:cli`
- `cargo test -q -p functor_runtime_common` (634 unit + 13 integration tests)
- `cargo test -q -p functor-cli` (100 passed, 1 ignored)
- `./target/release/functor -d examples/animation test` (3/3)
- `npm run check:docs`
- `npm run test:site`
- `git diff --check`

## Performance

Stack-relative release `frame_bench` comparison against `feat/anim-look-at`:

| Cells | Parent min | This PR min | Allocs/frame | Bytes/frame |
| ---: | ---: | ---: | ---: | ---: |
| 400 | 437.5 us | 439.7 us | 13,877 = | 843,387 -> 844,491 |
| 1,600 | 1,711.8 us | 1,719.9 us | 54,717 = | 3,307,227 -> 3,308,331 |
| 3,136 | 3,333.2 us | 3,345.9 us | 106,973 = | 6,460,251 -> 6,461,355 |

Allocation counts are exactly unchanged. The fixed +1,104 bytes/frame is the new typed `Anim` module member carried through module cloning (~0.13% in the smallest case); timings are within the observed run-to-run noise.

## Review disposition

Two independent adversarial review passes are clean. Findings from the first passes were fixed and covered: non-uniform root scale, relative scale tolerance on tiny rigs, overflow-safe finite-vector math, event-time click coordinates, rendered-motion E2E validation, and the protocol version/wire pin.

The duplicate index found no existing two-bone solver, and the token scan found no production clone. The optional semantic scan could not download its model because DNS was unavailable; existing pose-resolution and look-at helpers were reused where applicable.

Post-embed visual xreview: both independent reviewers found no visual or wiring defects. The 24-frame GIF and fixed-time stills show both wrists staying on their moving targets while the head switches focus; verdict: ship.

## Visuals

![Anim.reach two-bone IK demo](https://gist.githubusercontent.com/tommy-xr/d3e15fa7e914a917921ef6505729a6ff/raw/functor-two-bone-reach-demo.gif)

<sub>Xbot’s head and both hands track cyan/pink model-space targets after locomotion; dragging uses Camera.toWorldRay and deterministic mouse transitions. Rendered headlessly via --capture-frame / --fixed-time.</sub>

### Still

![Xbot reaching both hands toward model-space targets](https://gist.githubusercontent.com/tommy-xr/d3e15fa7e914a917921ef6505729a6ff/raw/functor-two-bone-reach-still.png)

### Before → after

Both sides use the same fixed time (2.4 seconds) and compare this stacked PR directly with its parent branch. The new Anim.reach post-passes solve both arm chains after locomotion and head look-at.

![Parent head look-at and this PR two-hand reach](https://gist.githubusercontent.com/tommy-xr/d3e15fa7e914a917921ef6505729a6ff/raw/functor-two-bone-reach-before-after.png)