### PR TITLE
feat(web): net egress/ingress on the embedder seam

### DIFF
--- a/runtime/functor-runtime-common/src/net/embedder.rs
+++ b/runtime/functor-runtime-common/src/net/embedder.rs
@@ -13,10 +13,14 @@
 //!  { "kind": "error",        "key": "ws://…", "conn": 1, "message": "…" }]
 //! ```
 //!
-//! It is deliberately NOT `NetEvent`: the push methods carry the routing `key`
-//! beside the event and take a message as text, so a serialized `NetEvent`
-//! would be missing the key and would put a `Message` payload on the wire as a
-//! byte array.
+//! The two directions of the seam use different shapes ON PURPOSE. Egress is
+//! the drained [`ConnCommand`](super::ConnCommand) JSON verbatim — the already
+//! versioned logic↔shell protocol type, so the embedder consumes exactly what
+//! every other host consumes (byte payloads included; an embedder that wants
+//! text decodes UTF-8 once). Ingress cannot be `NetEvent` or a mirrored
+//! `ConnCommand`: its job is to feed the four `net_push_*` producer methods,
+//! which take the routing `key` beside each event and a message as TEXT — so
+//! this type mirrors those signatures one-for-one instead.
 
 use serde::Deserialize;
 

--- a/runtime/functor-runtime-common/src/net/embedder.rs
+++ b/runtime/functor-runtime-common/src/net/embedder.rs
@@ -1,0 +1,132 @@
+//! Inbound events delivered by an *embedding page* rather than by a socket.
+//!
+//! The web runtime can route its networking to the page that embeds it (the
+//! "embedder" transport — see `runtime/functor-runtime-web/src/lib.rs`): it
+//! posts its drained [`ConnCommand`](super::ConnCommand)s outward and the
+//! embedder posts events back in. This is the wire shape of that return path,
+//! mirroring the four `net_push_*` producer methods one-for-one:
+//!
+//! ```json
+//! [{ "kind": "connected",    "key": "ws://…", "conn": 1 },
+//!  { "kind": "message",      "key": "ws://…", "conn": 1, "text": "…" },
+//!  { "kind": "disconnected", "key": "ws://…", "conn": 1 },
+//!  { "kind": "error",        "key": "ws://…", "conn": 1, "message": "…" }]
+//! ```
+//!
+//! It is deliberately NOT `NetEvent`: the push methods carry the routing `key`
+//! beside the event and take a message as text, so a serialized `NetEvent`
+//! would be missing the key and would put a `Message` payload on the wire as a
+//! byte array.
+
+use serde::Deserialize;
+
+/// One inbound network event handed to the runtime by its embedder.
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum DeliveredEvent {
+    /// The connection identified by `key` became usable as `conn`.
+    Connected { key: String, conn: i32 },
+    /// Text arrived on `conn`.
+    Message { key: String, conn: i32, text: String },
+    /// `conn` closed.
+    Disconnected { key: String, conn: i32 },
+    /// A transport-level error on `conn`; the connection is considered dead.
+    Error {
+        key: String,
+        conn: i32,
+        message: String,
+    },
+}
+
+impl DeliveredEvent {
+    /// The connection this event is about.
+    pub fn conn(&self) -> i32 {
+        match *self {
+            DeliveredEvent::Connected { conn, .. }
+            | DeliveredEvent::Message { conn, .. }
+            | DeliveredEvent::Disconnected { conn, .. }
+            | DeliveredEvent::Error { conn, .. } => conn,
+        }
+    }
+}
+
+/// Parse an embedder delivery (a JSON array of the events above). The error is
+/// a teaching string the host logs — a malformed delivery is dropped, never
+/// fatal.
+///
+/// A negative `conn` is rejected rather than pushed: the `net_push_*` methods
+/// take an `i32` but the id is a `u64` [`ConnectionId`](super::ConnectionId)
+/// on the other side of the prelude, so `-1` would reach the game as
+/// `18446744073709551615`. [xreview]
+pub fn parse_delivered_events(json: &str) -> Result<Vec<DeliveredEvent>, String> {
+    let events: Vec<DeliveredEvent> = serde_json::from_str(json).map_err(|e| {
+        format!(
+            "{e} — expected a JSON array of \
+             {{\"kind\":\"connected\"|\"message\"|\"disconnected\"|\"error\", \
+             \"key\":…, \"conn\":…}}"
+        )
+    })?;
+    if let Some(bad) = events.iter().find(|e| e.conn() < 0) {
+        return Err(format!("negative connection id {}", bad.conn()));
+    }
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_every_event_kind() {
+        let json = r#"[
+            { "kind": "connected", "key": "ws://x/", "conn": 1 },
+            { "kind": "message", "key": "ws://x/", "conn": 1, "text": "hi" },
+            { "kind": "disconnected", "key": "ws://x/", "conn": 1 },
+            { "kind": "error", "key": "ws://x/", "conn": 2, "message": "boom" }
+        ]"#;
+        assert_eq!(
+            parse_delivered_events(json).unwrap(),
+            vec![
+                DeliveredEvent::Connected {
+                    key: "ws://x/".into(),
+                    conn: 1
+                },
+                DeliveredEvent::Message {
+                    key: "ws://x/".into(),
+                    conn: 1,
+                    text: "hi".into()
+                },
+                DeliveredEvent::Disconnected {
+                    key: "ws://x/".into(),
+                    conn: 1
+                },
+                DeliveredEvent::Error {
+                    key: "ws://x/".into(),
+                    conn: 2,
+                    message: "boom".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn an_empty_delivery_is_valid() {
+        assert_eq!(parse_delivered_events("[]").unwrap(), vec![]);
+    }
+
+    #[test]
+    fn malformed_deliveries_are_errors_not_panics() {
+        // Not an array, an unknown kind, and a missing field.
+        assert!(parse_delivered_events("{}").is_err());
+        assert!(parse_delivered_events(r#"[{"kind":"nope","key":"k","conn":1}]"#).is_err());
+        assert!(parse_delivered_events(r#"[{"kind":"connected","key":"k"}]"#).is_err());
+    }
+
+    #[test]
+    fn a_negative_conn_is_rejected() {
+        // It would reach the game as u64::MAX through the prelude's cast.
+        let err = parse_delivered_events(r#"[{"kind":"connected","key":"k","conn":-1}]"#)
+            .unwrap_err();
+        assert!(err.contains("negative connection id"), "{err}");
+    }
+}

--- a/runtime/functor-runtime-common/src/net/mod.rs
+++ b/runtime/functor-runtime-common/src/net/mod.rs
@@ -10,11 +10,13 @@
 //! identical whether they run over a real network or the virtual one.
 
 mod connection;
+mod embedder;
 mod inbox;
 mod registry;
 mod virtual_net;
 
 pub use connection::*;
+pub use embedder::*;
 pub use inbox::*;
 pub use registry::*;
 pub use virtual_net::*;

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -12,7 +12,9 @@ use functor_runtime_common::asset::{AssetCache, AssetLoader};
 use functor_runtime_common::functor_lang_game_embedded::FunctorLangEmbeddedGame;
 use functor_runtime_common::geometry::Geometry;
 use functor_runtime_common::io::load_bytes_async;
-use functor_runtime_common::net::{ConnCommand, HttpMethod, NetCommand};
+use functor_runtime_common::net::{
+    parse_delivered_events, ConnCommand, DeliveredEvent, HttpMethod, NetCommand,
+};
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::texture::{
     RuntimeTexture, Texture2D, TextureData, TextureFormat, TextureOptions, PNG,
@@ -160,6 +162,54 @@ fn functor_lang_entry_prefix() -> String {
         .ok()
         .and_then(|v| v.as_string())
         .unwrap_or_default()
+}
+
+/// Where the runtime's networking goes. Three routings exist: the in-process
+/// netsim (`sim::is_running()`, which short-circuits everything before this
+/// choice is even reached), real browser WebSockets, and the *embedder* — the
+/// page hosting this runtime.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NetTransport {
+    /// `window.__functorNetTransport` absent or `"websocket"`: open real sockets.
+    WebSocket,
+    /// `window.__functorNetTransport === "embedder"`: post the drained
+    /// [`ConnCommand`]s to the embedding page and take events back from it
+    /// through [`functor_lang_net_deliver`]. No socket is opened.
+    Embedder,
+}
+
+/// Read the boot global once (it selects a routing for the page's lifetime, so
+/// re-reading it per frame would only invite a mid-run flip). The CLI's dev
+/// index page deliberately does NOT set it — there is no coordinator behind
+/// `functor run wasm`, so it defaults to WebSocket there; the site's
+/// `player.html` sets it from `?net=embedder`.
+fn net_transport() -> NetTransport {
+    thread_local! {
+        static TRANSPORT: Cell<Option<NetTransport>> = const { Cell::new(None) };
+    }
+    TRANSPORT.with(|cached| {
+        if let Some(transport) = cached.get() {
+            return transport;
+        }
+        let value = js_sys::Reflect::get(&window(), &JsValue::from_str("__functorNetTransport"))
+            .ok()
+            .and_then(|v| v.as_string());
+        let transport = match value.as_deref() {
+            Some("embedder") => NetTransport::Embedder,
+            None | Some("websocket") => NetTransport::WebSocket,
+            Some(other) => {
+                web_sys::console::warn_1(
+                    &format!(
+                        "[net] unknown window.__functorNetTransport={other}; using websockets"
+                    )
+                    .into(),
+                );
+                NetTransport::WebSocket
+            }
+        };
+        cached.set(Some(transport));
+        transport
+    })
 }
 
 /// The project's full file list (entry FIRST, then siblings), as the CLI's Functor Lang
@@ -917,11 +967,16 @@ struct WsClient {
     next_id: u64,
 }
 
-/// Drain the game's queued connection commands and perform them with browser
-/// WebSockets; socket events are pushed back into the game from the handlers.
+/// Drain the game's queued connection commands and perform them: with browser
+/// WebSockets (socket events are pushed back into the game from the handlers),
+/// or — under [`NetTransport::Embedder`] — by handing them to the embedding page.
 fn dispatch_conn_commands(game: &dyn GameProducer, state: &Rc<RefCell<WsClient>>) {
     let json = game.net_drain_conn_commands();
     if json == "[]" {
+        return;
+    }
+    if net_transport() == NetTransport::Embedder {
+        post_conn_commands_to_embedder(&json);
         return;
     }
     let commands: Vec<ConnCommand> = match serde_json::from_str(&json) {
@@ -959,6 +1014,98 @@ fn dispatch_conn_commands(game: &dyn GameProducer, state: &Rc<RefCell<WsClient>>
             }
         }
     }
+}
+
+/// Embedder egress: hand the drained commands (verbatim, as the JSON array the
+/// producer serialized) to the hosting page as
+/// `{ type: "functor-net-commands", commands: [...] }`. Unlike the WebSocket
+/// path, `Listen` is NOT refused here — a browser can't bind a socket, but the
+/// embedder can honour a listen however it likes, so every command goes out.
+///
+/// A top-level page has no embedder to route to; warn once and drop, the way
+/// the WebSocket path warns about `Sub.listen`.
+///
+/// The commands go out with our OWN origin as the target, so egress and ingress
+/// (which only accepts same-origin deliveries) enforce the same boundary — the
+/// player is deliberately embeddable, and every `Send` payload and `Connect`
+/// URL is in here. [xreview]
+///
+/// Idempotency is the embedder's to keep: `Connect`/`Listen` are idempotent by
+/// key (see `net::connection`), and unlike `ws_connect` this path holds no
+/// connection table to dedupe against — a re-declare (every hot reload emits
+/// one) is forwarded verbatim.
+fn post_conn_commands_to_embedder(json: &str) {
+    let parent = window().parent().ok().flatten();
+    let Some(parent) = parent.filter(|p| p != &window()) else {
+        thread_local! {
+            static WARNED: Cell<bool> = const { Cell::new(false) };
+        }
+        if !WARNED.replace(true) {
+            web_sys::console::warn_1(
+                &"[net] embedder transport with no embedding page; net commands are dropped".into(),
+            );
+        }
+        return;
+    };
+    let commands = match js_sys::JSON::parse(json) {
+        Ok(value) => value,
+        Err(_) => {
+            web_sys::console::error_1(&"[net] bad conn commands json".into());
+            return;
+        }
+    };
+    let message = Object::new();
+    let _ = js_sys::Reflect::set(
+        &message,
+        &JsValue::from_str("type"),
+        &JsValue::from_str("functor-net-commands"),
+    );
+    let _ = js_sys::Reflect::set(&message, &JsValue::from_str("commands"), &commands);
+    let origin = window().location().origin().unwrap_or_default();
+    let _ = parent.post_message(&message, &origin);
+}
+
+/// Embedder ingress: the counterpart of [`post_conn_commands_to_embedder`] —
+/// the embedding page delivers inbound network events as a JSON array (see
+/// [`DeliveredEvent`]), and each one lands on the live producer exactly as a
+/// socket handler's push would. Malformed JSON logs once and is dropped.
+///
+/// Only under [`NetTransport::Embedder`]: the transport gate belongs at the
+/// seam, not in one of its callers. Otherwise a page running real WebSockets
+/// could have events injected against a live socket's connection id (the id
+/// spaces are the same). [xreview]
+#[wasm_bindgen]
+pub fn functor_lang_net_deliver(events_json: &str) {
+    if net_transport() != NetTransport::Embedder {
+        web_sys::console::error_1(
+            &"[net] functor_lang_net_deliver requires window.__functorNetTransport = \"embedder\""
+                .into(),
+        );
+        return;
+    }
+    let events = match parse_delivered_events(events_json) {
+        Ok(events) => events,
+        Err(e) => {
+            web_sys::console::error_1(&format!("[net] bad net delivery: {e}").into());
+            return;
+        }
+    };
+    // One borrow for the whole batch: a mid-frame collision drops the delivery
+    // with a single log rather than one per event.
+    with_live_game(|g| {
+        for event in events {
+            match event {
+                DeliveredEvent::Connected { key, conn } => g.net_push_connected(key, conn),
+                DeliveredEvent::Message { key, conn, text } => {
+                    g.net_push_conn_message(key, conn, text)
+                }
+                DeliveredEvent::Disconnected { key, conn } => g.net_push_disconnected(key, conn),
+                DeliveredEvent::Error { key, conn, message } => {
+                    g.net_push_conn_error(key, conn, message)
+                }
+            }
+        }
+    });
 }
 
 fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {

--- a/site/player.html
+++ b/site/player.html
@@ -150,6 +150,7 @@
         functor_lang_inspector_trace_gen,
         functor_lang_set_source,
         functor_lang_set_project,
+        functor_lang_net_deliver,
         functor_lang_viewer_detached,
         functor_lang_viewer_look,
         functor_lang_viewer_move,
@@ -220,6 +221,18 @@
         } else {
           console.warn(`[player] invalid ?prefix=${prefix} (not an identifier); booting the unprefixed contract`);
         }
+      }
+      // ?net=embedder: route the game's networking to the HOSTING page instead
+      // of opening browser WebSockets — the runtime posts
+      // `functor-net-commands` outward and takes `functor-net-deliver` back
+      // (see the message listener below). Must be set before init(); absent (or
+      // anything else, which warns) leaves the default WebSocket transport.
+      const net = params.get("net");
+      const embedderNet = net === "embedder";
+      if (embedderNet) {
+        window.__functorNetTransport = "embedder";
+      } else if (net !== null) {
+        console.warn(`[player] unknown ?net=${net}; using the default websocket transport`);
       }
       if (!inlineProject) {
         window.__functorLangGamePath = src
@@ -660,6 +673,7 @@
       };
 
       const pushQueue = [];
+      const netQueue = []; // embedder net events that arrived before the producer
       let booted = false; // inline: has the first valid project kicked off boot()?
       let wasmReady = false;
 
@@ -674,6 +688,19 @@
           if (wasmReady && functor_lang_is_running()) {
             window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
           }
+          return;
+        }
+        // Embedder networking: inbound events from the hosting page, handed
+        // straight to the runtime. Same-origin only (the panes are same-origin
+        // iframes) — this injects data the game treats as its network.
+        // Deliveries that beat the producer are QUEUED, not dropped, like the
+        // source pushes below: `Connected` is never retransmitted, so losing
+        // one leaves the game waiting forever on a connection it already has.
+        if (data.type === "functor-net-deliver") {
+          if (!embedderNet || event.origin !== window.location.origin) return;
+          const events = data.events ?? [];
+          if (wasmReady && functor_lang_is_running()) functor_lang_net_deliver(JSON.stringify(events));
+          else netQueue.push(...events);
           return;
         }
         if (data.type !== "functor-lang-set-source" && data.type !== "functor-lang-set-project") return;
@@ -718,6 +745,9 @@
           window.parent.postMessage({ type: "functor-lang-preview-ready" }, "*");
         }
         while (pushQueue.length) applyPush(pushQueue.shift());
+        if (netQueue.length) {
+          functor_lang_net_deliver(JSON.stringify(netQueue.splice(0)));
+        }
       };
 
       const boot = () => init().then(() => {


### PR DESCRIPTION
PR 1 of the **coordinator transport arc** (multiplayer-IDE design doc, Addendum 4): the wasm web runtime gains a third network routing mode — **embedder** — beside real-WebSocket and the in-process sim. In embedder mode the runtime opens no sockets; it hands drained net traffic to the embedding page and accepts deliveries back. This is the seam the sandbox's host-page coordinator (next PR) drives; panes become transport endpoints for real.

**Mode selection** is host-declared, never guessed: the boot global `window.__functorNetTransport` (`"embedder"`, else websocket; unknown values warn and fall back), set by `site/player.html` from `?net=embedder`. A pane must not infer embedder from being iframed — a parent without a coordinator would swallow packets silently, so the parent that actually routes says so. The CLI dev server page keeps the websocket default (no coordinator there); exported bundles are unaffected.

**Egress**: `{ type: "functor-net-commands", commands: [...] }` posted to `window.parent`, same-origin targeted (not `*`). The `commands` array is the producer's drained `ConnCommand` JSON verbatim — the already-versioned protocol type, no parallel shape. `Sub.listen` is **not** refused in embedder mode (the coordinator will honor it — browsers can't listen, so this is what finally makes a server role in a pane possible). A top-level page in embedder mode warns once and drops.

**Ingress**: new export `functor_lang_net_deliver(events_json)` — a JSON array of `{kind: connected|message|disconnected|error, key, conn, ...}` mirroring the four `net_push_*` producer methods one-for-one (`DeliveredEvent` + `parse_delivered_events` in `functor-runtime-common/src/net/embedder.rs`; `NetEvent` deliberately not reused — it lacks the routing key and carries byte payloads where the push methods take text). The export is gated on embedder mode (conn-id space is shared with live sockets — an ungated export would let forged events land on a real connection); `player.html` relays parent `functor-net-deliver` messages same-origin-only and queues deliveries that arrive before the producer is up.

Existing paths untouched: the websocket branch is byte-identical, and the in-process sim still short-circuits both directions.

**Cross-engine review (Codex + Claude, reviewed independently in sequence), dispositioned:**
- Applied [AGREED — both engines found these independently]: egress targets own origin instead of `"*"` (would broadcast Connect URLs/payloads to any cross-origin embedder, with no upside since ingress is same-origin anyway); the deliver export gated on embedder mode (conn-id space shared with live sockets).
- Applied (single-engine or implementer hardening, each proof-covered): pre-producer deliveries queued (flushed on ready); negative `conn` rejected at parse (an unchecked `-1 as u64` would otherwise become a giant conn id downstream); `Serialize`/`Clone` dropped from the ingress DTO; one `with_live_game` per delivered batch.
- Fixed after the second review: the `embedder.rs` module doc justified the ingress shape with an argument the verbatim egress contradicted — rationale rewritten (egress stays verbatim `ConnCommand` because it is the versioned protocol type; ingress mirrors the push methods; the shapes differ on purpose).
- Considered and not taken, with rationale: reshaping egress into a hand-written text-payload command type (revisit if the coordinator wants it; today it decodes UTF-8 in one place); per-element lenient parsing (one teaching error and drop, by design); `Connect` dedupe by key (coordinator state — documented as the embedder's obligation on `post_conn_commands_to_embedder`, lands with the coordinator PR).

**Verification:** functor_runtime_common 627+12 tests green (5 new ingress-parse tests: all four kinds, empty batch, malformed shapes, negative conn); wasm target check clean; `--features=strict` desktop build clean; wasm bundle + site rebuilt; `npm run test:site` ALL CHECKS PASSED; Playwright proofs — (1) embedder round-trip: `examples/mp`'s client under `?net=embedder` posts `Connect` to the parent, a `connected` delivery back yields the client's first `Send` (`Protocol.Move`) on the wire, zero page errors; (2) websocket regression: without the param the WS still opens and zero net-command messages are posted; (3) early delivery honored via the queue. All re-run after review fixes.

Next in the stack: the sandbox host coordinator (perfect links, `Connect` routed by listen-name, `net=embedder` passed unconditionally for every pane) → remove `functor-netsim` → impairment + packet log → barrier stepping → input inversion → whole-environment seek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
