### PR TITLE
feat(site): host net coordinator — perfect links between panes

### DIFF
--- a/e2e/fixtures/net-host.html
+++ b/e2e/fixtures/net-host.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>net coordinator host — examples/mp across panes</title>
+    <style>
+      body { margin: 0; background: #12071f; color: #d8d0e8; font: 13px monospace; }
+      .row { display: flex; gap: 4px; padding: 4px; }
+      iframe { width: 320px; height: 200px; border: 1px solid #402a5a; }
+    </style>
+  </head>
+  <body>
+    <!--
+      The e2e host for the net coordinator (driven by e2e/net-coordinator.mjs).
+
+      It is the smallest possible embodiment of what site/src/mp-panes.ts does:
+      mount N `player.html?net=embedder` panes, hand them all to ONE
+      NetCoordinator, and let them talk. The panes here run examples/mp — a
+      SERVER entry and two CLIENT entries over a shared protocol.fun — which
+      the sandbox cannot yet express (it has no server-pane UI; that is a later
+      PR). Copied into site/dist by the driver, next to the coordinator bundle
+      and a copy of examples/mp.
+    -->
+    <div class="row" id="panes"></div>
+    <script type="module">
+      import { NetCoordinator } from "./net-coordinator.js";
+
+      // Entry FIRST, then siblings — the ?file= contract (file = module).
+      const SIBLINGS = [
+        "examples/mp/protocol.fun",
+        "examples/mp/view.fun",
+        "examples/mp/client.fun",
+        "examples/mp/server.fun",
+      ];
+
+      const net = new NetCoordinator();
+      const traces = new Map();
+      const consoleLines = [];
+      const frames = new Map();
+
+      const mount = (id, entry) => {
+        const frame = document.createElement("iframe");
+        frame.title = id;
+        const params = new URLSearchParams({ game: entry, scrubber: "hidden", net: "embedder" });
+        params.append("file", entry);
+        for (const sibling of SIBLINGS) {
+          if (sibling !== entry) params.append("file", sibling);
+        }
+        frames.set(id, frame);
+        net.addPane(id, frame);
+        document.getElementById("panes").appendChild(frame);
+        frame.src = `player.html?${params}`;
+      };
+
+      // The panes' relays: the paused inspector trace (how the driver reads a
+      // pane's model) and forwarded console lines (so a runtime error is
+      // visible rather than silent).
+      window.addEventListener("message", (event) => {
+        if (event.origin !== window.location.origin) return;
+        const paneId = [...frames].find(([, f]) => f.contentWindow === event.source)?.[0];
+        if (!paneId) return;
+        const data = event.data;
+        if (data?.type === "functor-inspector-trace") traces.set(paneId, data.trace);
+        if (data?.type === "functor-lang-console") {
+          consoleLines.push(`[${paneId}] ${data.level}: ${data.message}`);
+        }
+      });
+
+      // One server, two clients — so a client's view must include the OTHER
+      // client's player for propagation to be proved.
+      mount("server", "examples/mp/server.fun");
+      mount("client 1", "examples/mp/client.fun");
+      mount("client 2", "examples/mp/client.fun");
+
+      window.__netHost = {
+        packets: () => net.packets().map((p) => ({ ...p })),
+        console: () => consoleLines.slice(),
+        frame: (id) => frames.get(id)?.contentWindow?.__scrub?.frame() ?? null,
+        // Pausing makes each pane publish its inspector trace, which is how a
+        // host page can read a pane's live model at all.
+        pause: (id) => {
+          const seam = frames.get(id)?.contentWindow?.__scrub;
+          if (!seam || seam.paused()) return false;
+          seam.togglePause();
+          return true;
+        },
+        resume: (id) => {
+          const seam = frames.get(id)?.contentWindow?.__scrub;
+          if (!seam || !seam.paused()) return false;
+          seam.togglePause();
+          return true;
+        },
+        trace: (id) => traces.get(id) ?? null,
+        // The pane's live model, rendered by the interpreter: the paused
+        // trace replays each entry point, and every one of them binds the
+        // model as `m`.
+        model: (id) => {
+          const trace = traces.get(id);
+          const invocations = trace?.invocations ?? [];
+          const inv = invocations.find((i) => i.entry === "draw") ?? invocations[0];
+          return inv?.bindings?.find((b) => b.name === "m")?.value ?? null;
+        },
+        // Pane teardown: a reloaded pane is a new game, and the coordinator
+        // must close what the old document had open.
+        reload: (id) => frames.get(id)?.contentWindow?.location.reload(),
+        key: (id, code, down = true) => {
+          const win = frames.get(id)?.contentWindow;
+          if (!win) return false;
+          win.dispatchEvent(new win.KeyboardEvent(down ? "keydown" : "keyup", { code }));
+          return true;
+        },
+      };
+    </script>
+  </body>
+</html>

--- a/e2e/net-coordinator.mjs
+++ b/e2e/net-coordinator.mjs
@@ -1,0 +1,250 @@
+// Net-coordinator e2e: a WHOLE multiplayer session across player IFRAMES —
+// one authoritative server pane and two client panes, routed by the host page's
+// coordinator (site/src/net-coordinator.ts) over the embedder seam, with NO
+// sockets and no server process.
+//
+// This is the pane-shaped sibling of e2e/wasm-sim.mjs. That test runs the same
+// project (examples/mp) through the IN-PROCESS netsim inside one page; this one
+// runs it the way the sandbox will: three independent `player.html?net=embedder`
+// runtimes, each with its own model and its own render loop, whose packets cross
+// the postMessage boundary and are routed by the host.
+//
+// It asserts:
+//
+//   1. every pane boots and ticks (a dead pane would make the rest vacuous);
+//   2. the coordinator routes the connect handshake — both clients get
+//      `connected`, and so does the server, twice;
+//   3. traffic flows BOTH ways (client -> server Move, server -> client
+//      Snapshot broadcasts);
+//   4. the server's model tracks two players, and each client's world contains
+//      BOTH players — i.e. client 1's state reached client 2 through the server;
+//   5. input propagates: a keydown in client 1 produces a client-1 -> server
+//      packet that client 2 does not produce.
+//
+// A pane's model is read through its PAUSED inspector trace: pausing makes the
+// player relay `functor-inspector-trace`, whose replayed bindings carry the
+// live values (there is no model-json export on the web runtime).
+//
+// Run manually (needs the web-runtime wasm bundle):
+//
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/net-coordinator.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { cp, mkdir, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+import esbuild from "esbuild";
+
+const PORT = Number(process.env.FUNCTOR_NET_PORT ?? 8124);
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DIST = `${ROOT}site/dist`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+const check = (ok, what, detail = "") => {
+  console.log(`${ok ? "  ok" : "FAIL"}  ${what}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+// Build the site, then add the three things this host page needs that the
+// site itself does not ship: the coordinator as a standalone ES module, a copy
+// of examples/mp (not one of the sandbox's examples), and the host page.
+const build = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+await esbuild.build({
+  entryPoints: [`${ROOT}site/src/net-coordinator.ts`],
+  outfile: `${DIST}/net-coordinator.js`,
+  bundle: true,
+  format: "esm",
+  logLevel: "warning",
+});
+await mkdir(`${DIST}/examples/mp`, { recursive: true });
+for (const file of ["server.fun", "client.fun", "protocol.fun", "view.fun"]) {
+  await cp(`${ROOT}examples/mp/${file}`, `${DIST}/examples/mp/${file}`);
+}
+await cp(`${ROOT}e2e/fixtures/net-host.html`, `${DIST}/net-host.html`);
+
+try {
+  await fetch(BASE);
+  console.error(`port ${PORT} is already in use — kill the process on it first`);
+  process.exit(1);
+} catch {
+  // Nothing listening: good.
+}
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+process.on("exit", () => server.kill());
+for (let i = 0; ; i++) {
+  try {
+    await fetch(BASE);
+    break;
+  } catch {
+    if (i > 50) throw new Error("site server never came up");
+    await sleep(200);
+  }
+}
+
+const PANES = ["server", "client 1", "client 2"];
+
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+  await page.goto(`${BASE}/net-host.html`);
+
+  // 1. Every pane boots and ticks.
+  const framesAt = () => page.evaluate((ids) => ids.map((id) => window.__netHost.frame(id)), PANES);
+  for (let i = 0; i < 100; i++) {
+    const frames = await framesAt();
+    if (frames.every((f) => typeof f === "number" && f > 2)) break;
+    await sleep(200);
+  }
+  const first = await framesAt();
+  await sleep(1500);
+  const second = await framesAt();
+  check(
+    first.every((f) => typeof f === "number") && second.every((f, i) => f > first[i]),
+    "all three panes boot and tick",
+    `${JSON.stringify(first)} -> ${JSON.stringify(second)}`
+  );
+
+  const packets = await page.evaluate(() => window.__netHost.packets());
+  const of = (kind) => packets.filter((p) => p.kind === kind);
+
+  // 2. The connect handshake reached both ends.
+  const connected = of("connected");
+  check(
+    connected.filter((p) => p.to === "client 1").length === 1 &&
+      connected.filter((p) => p.to === "client 2").length === 1 &&
+      connected.filter((p) => p.to === "server").length === 2,
+    "the coordinator routed both connects to both ends",
+    connected.map((p) => `${p.from}->${p.to}#${p.conn}`).join(" ")
+  );
+  check(
+    of("error").length === 0,
+    "no connect was refused",
+    JSON.stringify(of("error").map((p) => p.to))
+  );
+
+  // 3. Traffic in both directions.
+  const messages = of("message");
+  const toClients = messages.filter((p) => p.from === "server");
+  const toServer = messages.filter((p) => p.to === "server");
+  check(
+    toClients.length > 10 && toClients.every((p) => p.size > 0),
+    "the server broadcasts snapshots to the clients",
+    `${toClients.length} packets`
+  );
+  check(
+    toServer.length >= 2,
+    "the clients send to the server",
+    `${toServer.length} packets from ${[...new Set(toServer.map((p) => p.from))].join(", ")}`
+  );
+
+  // 5a. Input path: `w` in client 1 sends a Move — and only from client 1.
+  // The server then integrates that player's z, which is what 5b reads back
+  // out of the OTHER client's world.
+  const sendsFrom = (id, log) => log.filter((p) => p.kind === "message" && p.from === id).length;
+  const before = { c1: sendsFrom("client 1", packets), c2: sendsFrom("client 2", packets) };
+  await page.evaluate(() => window.__netHost.key("client 1", "KeyW", true));
+  await sleep(600);
+  const afterLog = await page.evaluate(() => window.__netHost.packets());
+  const after = { c1: sendsFrom("client 1", afterLog), c2: sendsFrom("client 2", afterLog) };
+  check(
+    after.c1 > before.c1 && after.c2 === before.c2,
+    "a keydown in client 1 sends to the server, and only from client 1",
+    `client 1 ${before.c1}->${after.c1}, client 2 ${before.c2}->${after.c2}`
+  );
+
+  // 4. Model state, read from each pane's paused inspector trace.
+  await page.evaluate((ids) => ids.forEach((id) => window.__netHost.pause(id)), PANES);
+  await sleep(1200);
+  const models = await page.evaluate(
+    (ids) => Object.fromEntries(ids.map((id) => [id, window.__netHost.model(id)])),
+    PANES
+  );
+  if (process.env.FUNCTOR_NET_DUMP) {
+    await writeFile("/tmp/net-models.json", JSON.stringify(models, null, 2));
+  }
+  check(
+    PANES.every((id) => typeof models[id] === "string"),
+    "every pane's paused model is readable",
+    JSON.stringify(models["client 1"])
+  );
+  check(
+    models["client 1"].includes('status: "in-world"') &&
+      models["client 2"].includes('status: "in-world"'),
+    "both clients joined the server's world",
+    `${models["client 1"]}`
+  );
+  check(
+    (models["server"].match(/cid: /g) ?? []).length === 2,
+    "the server tracks both players",
+    models["server"]
+  );
+  // 5b. Cross-client propagation. Each client's world must hold BOTH rows,
+  // and the row for the player that pressed `w` (pid 0, spawned at z = -1.8)
+  // must have moved in z in the OTHER client's copy — client 1's input
+  // reached client 2 through the server.
+  const rowsOf = (text) =>
+    [...text.matchAll(/\{ pid: (-?[\d.]+), x: (-?[\d.]+), z: (-?[\d.]+) \}/g)].map((m) => ({
+      pid: Number(m[1]),
+      x: Number(m[2]),
+      z: Number(m[3]),
+    }));
+  const worlds = { 1: rowsOf(models["client 1"]), 2: rowsOf(models["client 2"]) };
+  check(
+    worlds[1].length === 2 && worlds[2].length === 2,
+    "each client's world contains both players",
+    `client 1: ${worlds[1].length} rows, client 2: ${worlds[2].length} rows`
+  );
+  const moved = worlds[2].find((r) => r.pid === 0);
+  const untouched = worlds[2].find((r) => r.pid === 1);
+  check(
+    !!moved && moved.z > -1.8 && !!untouched && untouched.z === 0,
+    "client 1's `w` moved its player in CLIENT 2's world (client -> server -> client)",
+    JSON.stringify(worlds[2])
+  );
+
+  // 6. Teardown: reloading a pane closes its connection at BOTH ends — proved
+  // in the SERVER's model, not just in the packet log. After client 2 reloads,
+  // its reboot rejoins as a third player id; the server must hold TWO players
+  // (the old one dropped) with a `pid: 2` among them. A disconnect that was
+  // logged but never delivered would leave three.
+  const connOfClient2 = connected.find((p) => p.to === "client 2")?.conn;
+  await page.evaluate(() => ["server", "client 2"].forEach((id) => window.__netHost.resume(id)));
+  await page.evaluate(() => window.__netHost.reload("client 2"));
+  await sleep(4000);
+  const closedLog = await page.evaluate(() => window.__netHost.packets());
+  const dropped = closedLog.filter((p) => p.kind === "disconnected" && p.conn === connOfClient2);
+  check(
+    dropped.length === 2 && new Set(dropped.map((p) => p.to)).size === 2,
+    "reloading a pane routes a disconnect to both ends of its connection",
+    dropped.map((p) => `${p.to}#${p.conn}`).join(" ")
+  );
+  await page.evaluate(() => window.__netHost.pause("server"));
+  await sleep(1200);
+  const rejoined = await page.evaluate(() => window.__netHost.model("server"));
+  check(
+    (rejoined.match(/cid: /g) ?? []).length === 2 && rejoined.includes("pid: 2"),
+    "the server dropped the reloaded pane's player and accepted its rejoin",
+    rejoined
+  );
+
+  const lines = await page.evaluate(() => window.__netHost.console());
+  const errors = lines.filter((l) => l.includes("error:"));
+  check(errors.length === 0, "no pane reported a runtime error", errors.slice(0, 3).join(" | "));
+  check(pageErrors.length === 0, "the host page threw nothing", pageErrors.slice(0, 3).join(" | "));
+} finally {
+  await browser.close();
+  server.kill();
+}
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "site:build": "npm run generate:icons && node site/build.mjs",
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
+    "test:net-coordinator": "node e2e/net-coordinator.mjs",
     "test:detached-camera": "node e2e/detached-camera.mjs",
     "test:ide": "node e2e/ide-project.mjs",
     "test:ide-page": "node e2e/ide-page.mjs",

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -34,6 +34,7 @@ import { PlayerBridge } from "./player-bridge.js";
 import { asPlayerMessage } from "./protocol.js";
 import type { StatusBar } from "./status-bar-store.js";
 import type { PillState } from "./components/StatusPill.js";
+import { NetCoordinator } from "./net-coordinator.js";
 
 /** The shared scrubber's `window.__scrub` seam (runtime/functor-runtime-web/scrubber.js). */
 interface ScrubSeam {
@@ -309,6 +310,14 @@ export function initMultiplayerPanes({
   const debugGameUi = debugDrawer.querySelector("#mp-debug-game-ui") as HTMLInputElement;
   const debugReset = debugDrawer.querySelector("#mp-debug-reset") as HTMLButtonElement;
 
+  // Every pane's networking routes through ONE coordinator (net-coordinator.ts):
+  // the panes boot `?net=embedder`, post their conn commands to this page, and
+  // it routes them between panes on perfect links. This module owns it because
+  // it owns every pane — including pane 1, the page's own #player — so no pane
+  // can be created outside its view. It is inert for a game that declares no
+  // `Sub.connect`/`Sub.listen`: those panes never post a command.
+  const net = new NetCoordinator();
+
   const panes: Pane[] = [];
   const makePane = (index: number, iframe: HTMLIFrameElement): Pane => {
     const color = PLAYER_COLORS[index % PLAYER_COLORS.length];
@@ -364,6 +373,7 @@ export function initMultiplayerPanes({
     shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", () => focusPane(index));
     tab.addEventListener("click", () => focusPane(index));
     buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement, pane.scope.signal);
+    net.addPane(`client ${index + 1}`, iframe, pane.scope.signal);
     panes.push(pane);
     return pane;
   };
@@ -1184,6 +1194,7 @@ export function initMultiplayerPanes({
     count: () => panes.length,
     destroy() {
       cancelAnimationFrame(raf);
+      net.destroy();
       moduleScope.abort();
       while (mirrors.length) removeMirror();
     },

--- a/site/src/net-coordinator.ts
+++ b/site/src/net-coordinator.ts
@@ -1,0 +1,436 @@
+// The HOST-PAGE net coordinator: it routes game packets between player iframes,
+// so a "server" pane and N "client" panes can talk to each other entirely
+// inside one browser page — no sockets, no server process.
+//
+// Each pane boots `player.html?net=embedder`, which routes the runtime's
+// networking to its embedder (runtime/functor-runtime-web/src/lib.rs): the pane
+// posts its drained `ConnCommand`s outward as
+//
+//     { type: "functor-net-commands", commands: [ …ConnCommand… ] }
+//
+// and takes inbound events back as
+//
+//     { type: "functor-net-deliver", events: [ …DeliveredEvent… ] }
+//
+// This module is the thing in between. Its routing model deliberately MIRRORS
+// the in-process netsim (`runtime/functor-netsim/src/lib.rs`), so a session that
+// runs in panes and the same session run headlessly agree on semantics:
+//
+//   • a listener registry keyed by AUTHORITY (host:port, scheme and path
+//     ignored), so a client url "ws://127.0.0.1:9001/play" matches a server
+//     bind "127.0.0.1:9001" — `authority()` there, `authorityOf` here;
+//   • one connection id per PAIR, shared by both ends (netsim uses the
+//     `VirtualNet` id the same way), so a send from either end routes to the
+//     other by looking up the same row;
+//   • both ends are told `connected` — the client under its connect key, the
+//     accepting server under its LISTEN key — because that key is how each
+//     side's runtime routes the event back to the right `Sub.connect` /
+//     `Sub.listen` tagger;
+//   • FIFO per pane: deliveries queue in arrival order and flush as one batch.
+//
+// PERFECT LINKS ONLY. Everything a link profile would add — latency, jitter,
+// loss, partitions — is deliberately absent, and so is the step barrier: a
+// routed packet is delivered on the host's NEXT rAF, not on the receiving
+// pane's next fixed step. Impairment and the barrier are later PRs; when the
+// barrier lands, `flush()` becomes step-time delivery and `Packet.tick` stops
+// being null.
+//
+// The packet log records from day one even though nothing renders it yet: the
+// coordinator is the only place that sees every packet, so it owns the log the
+// later packet-log rail reads.
+
+/** The commands a pane's runtime emits (`functor_runtime_common::net::ConnCommand`,
+ * serialized by serde's default externally-tagged representation). */
+type ConnCommand =
+  | { Connect: { key: string; url: string } }
+  | { Listen: { key: string; addr: string } }
+  | { Send: { conn: number; payload: number[] } }
+  | { CloseConn: { conn: number } }
+  | { CloseKey: { key: string } };
+
+/** One inbound event handed back to a pane
+ * (`functor_runtime_common::net::DeliveredEvent`). The wire is TEXT here: a
+ * `Send`'s payload bytes are UTF-8 decoded on the way through, matching what a
+ * real WebSocket hands the runtime. */
+type DeliveredEvent =
+  | { kind: "connected"; key: string; conn: number }
+  | { kind: "message"; key: string; conn: number; text: string }
+  | { kind: "disconnected"; key: string; conn: number }
+  | { kind: "error"; key: string; conn: number; message: string };
+
+/** One routed packet, as the (not yet rendered) packet-log rail will read it. */
+export interface Packet {
+  /** The step it belongs to — always null until the barrier lands (see above). */
+  tick: number | null;
+  /** Pane id the packet originated from. */
+  from: string;
+  /** Pane id it was delivered to. */
+  to: string;
+  conn: number;
+  kind: DeliveredEvent["kind"];
+  /** Payload bytes for a message; 0 for the lifecycle kinds. */
+  size: number;
+}
+
+/** Newest entries win: an hour-long session must not grow without bound. The
+ * trim runs in blocks so it is not an O(n) memmove per packet at the cap. */
+const PACKET_LOG_CAP = 10_000;
+const PACKET_LOG_SLACK = 1_000;
+
+/**
+ * How long a `Connect` with no listener waits for its server pane before it
+ * errors.
+ *
+ * It cannot fail fast: a pane's runtime reconciles `Sub.connect` against its
+ * DECLARED keys, so a key that has been emitted once is never re-emitted
+ * (functor_lang_producer::reconcile_connections). An error delivered to a
+ * client that booted a few hundred ms before its server pane would therefore
+ * be permanent, and so would one delivered while the server pane is RELOADING
+ * (which is why `close` re-queues the client end — see there). Panes race by
+ * construction here; netsim, being lockstep, has no such window and errors
+ * immediately. The window is generous because a cold pane boot is a wasm
+ * fetch + compile, and the cost of being wrong is a dead session.
+ */
+const CONNECT_GRACE_MS = 15_000;
+
+/** Hot path: one decoder for every `Send` that crosses the coordinator. */
+const DECODER = new TextDecoder();
+
+/** The authority (host:port) of an endpoint, ignoring scheme and path — the
+ * exact rule netsim's `authority()` applies, so both agree on what matches. */
+const authorityOf = (endpoint: string): string => {
+  const afterScheme = endpoint.split("://").at(-1) ?? endpoint;
+  return afterScheme.split("/")[0] ?? afterScheme;
+};
+
+interface Pane {
+  id: string;
+  frame: HTMLIFrameElement;
+  /** Events queued for this pane, flushed in order on the next host rAF. */
+  outbox: DeliveredEvent[];
+  /** Everything this pane registered outside the coordinator's own scope
+   * (the iframe `load` hook and the current document's `pagehide`). */
+  scope: AbortController;
+}
+
+/** One end of a connection: the pane, and the key ITS runtime routes by. */
+interface Side {
+  pane: string;
+  key: string;
+}
+
+interface Conn {
+  client: Side;
+  server: Side;
+}
+
+interface PendingConnect {
+  pane: string;
+  key: string;
+  since: number;
+}
+
+export class NetCoordinator {
+  private readonly panes = new Map<string, Pane>();
+  /** authority -> the listening side (pane + its listen key). */
+  private readonly listeners = new Map<string, Side>();
+  /** Shared connection id -> its two ends. Ids start at 1: 0 is the "no
+   * connection" id an unroutable-connect error carries (as in netsim). */
+  private readonly conns = new Map<number, Conn>();
+  private readonly pending: PendingConnect[] = [];
+  private readonly log: Packet[] = [];
+  private nextConn = 1;
+  private raf = 0;
+  private readonly abort = new AbortController();
+
+  constructor() {
+    window.addEventListener("message", (event) => this.onMessage(event), {
+      signal: this.abort.signal,
+    });
+    const loop = () => {
+      this.flush();
+      this.raf = requestAnimationFrame(loop);
+    };
+    this.raf = requestAnimationFrame(loop);
+  }
+
+  /**
+   * Register a pane. `id` is the routing identity in the packet log, so it
+   * should be the label the UI shows ("client 2", "server").
+   *
+   * A pane that navigates (reload, or a new `src` for another example) is a
+   * NEW game with a new model, so whatever the previous document had open is
+   * closed. That happens on the outgoing document's `pagehide` rather than on
+   * the incoming one's `load`: `contentWindow` survives the navigation, and
+   * player.html arms its delivery listener BEFORE `load` fires, so resetting
+   * only on `load` leaves a window in which a queued event is posted into the
+   * replacement — which queues it and hands the fresh game a connection id
+   * that belongs to a dead one. `load` re-arms the hook for the next
+   * navigation (and covers the first document, which has none).
+   *
+   * `signal` (mp-panes' per-pane `AbortController`) removes the pane entirely.
+   */
+  addPane(id: string, frame: HTMLIFrameElement, signal?: AbortSignal): void {
+    const scope = new AbortController();
+    this.panes.set(id, { id, frame, outbox: [], scope });
+    const armUnload = () => {
+      frame.contentWindow?.addEventListener("pagehide", () => this.resetPane(id), {
+        once: true,
+        signal: scope.signal,
+      });
+    };
+    frame.addEventListener(
+      "load",
+      () => {
+        this.resetPane(id);
+        armUnload();
+      },
+      { signal: scope.signal }
+    );
+    armUnload();
+    signal?.addEventListener("abort", () => this.removePane(id), { once: true });
+  }
+
+  /** Drop a pane and close every connection it held (both ends notified). */
+  removePane(id: string): void {
+    this.resetPane(id);
+    this.panes.get(id)?.scope.abort();
+    this.panes.delete(id);
+  }
+
+  /** Every packet routed so far, oldest first (capped at the last 10k). */
+  packets(): readonly Packet[] {
+    return this.log;
+  }
+
+  destroy(): void {
+    cancelAnimationFrame(this.raf);
+    this.abort.abort();
+    for (const pane of this.panes.values()) pane.scope.abort();
+    this.panes.clear();
+    this.listeners.clear();
+    this.conns.clear();
+    this.pending.length = 0;
+  }
+
+  // ------------------------------------------------------------------ ingress
+
+  private onMessage(event: MessageEvent): void {
+    // Same-origin panes only: these commands carry game payloads, and a
+    // delivery is data the receiving game trusts as its network.
+    if (event.origin !== window.location.origin) return;
+    const data = event.data as { type?: unknown; commands?: unknown } | null;
+    if (typeof data !== "object" || data === null) return;
+    if (data.type !== "functor-net-commands") return;
+    // `source` is null for a discarded window — and so is a detached iframe's
+    // `contentWindow`, so the two would otherwise "match".
+    if (!event.source) return;
+    const pane = [...this.panes.values()].find((p) => p.frame.contentWindow === event.source);
+    if (!pane) return;
+    if (!Array.isArray(data.commands)) return;
+    for (const command of data.commands as ConnCommand[]) this.perform(pane, command);
+  }
+
+  private perform(pane: Pane, command: ConnCommand): void {
+    if ("Listen" in command) {
+      // Idempotent by authority, like every host treats `Listen` (a hot reload
+      // re-declares it every time). The newest declaration wins.
+      this.listeners.set(authorityOf(command.Listen.key), {
+        pane: pane.id,
+        key: command.Listen.key,
+      });
+      // A client that connected before this pane booted is waiting on it.
+      this.retryPending();
+      return;
+    }
+    if ("Connect" in command) {
+      const { key } = command.Connect;
+      // Idempotent by key: a re-declare while the connection is already up
+      // must not open a second one.
+      if (this.connFor(pane.id, key) !== null) return;
+      if (this.pending.some((p) => p.pane === pane.id && p.key === key)) return;
+      if (!this.open(pane.id, key)) {
+        this.pending.push({ pane: pane.id, key, since: performance.now() });
+      }
+      return;
+    }
+    if ("Send" in command) {
+      const { conn, payload } = command.Send;
+      // A send on a connection this pane is not an end of (a closed one, or a
+      // stale id a model carried across a reload/rewind) is DROPPED, not
+      // misrouted — `VirtualNet::send` refuses the same case via `peer_of`.
+      const peer = this.peerOf(conn, pane.id);
+      if (!peer) return;
+      const text = DECODER.decode(Uint8Array.from(payload));
+      this.deliver(pane.id, peer, { kind: "message", key: peer.key, conn, text }, payload.length);
+      return;
+    }
+    if ("CloseConn" in command) {
+      // Same ownership rule: only an end of a connection may close it.
+      if (this.peerOf(command.CloseConn.conn, pane.id)) this.close(command.CloseConn.conn, pane.id);
+      return;
+    }
+    if ("CloseKey" in command) {
+      const { key } = command.CloseKey;
+      const listener = this.listeners.get(authorityOf(key));
+      if (listener?.pane === pane.id && listener.key === key) {
+        this.listeners.delete(authorityOf(key));
+      }
+      for (const [id, row] of [...this.conns]) {
+        if (
+          (row.client.pane === pane.id && row.client.key === key) ||
+          (row.server.pane === pane.id && row.server.key === key)
+        ) {
+          this.close(id, pane.id);
+        }
+      }
+      this.dropPending((p) => p.pane === pane.id && p.key === key);
+    }
+  }
+
+  // ------------------------------------------------------------------ routing
+
+  /** Resolve a client key to its listening pane and wire the pair up. Returns
+   * false when nobody is listening on that authority (the caller waits).
+   *
+   * KNOWN, inherited from `VirtualNet` (whose `peer_of` has the same
+   * degeneracy): a pane that both listens on and connects to its OWN authority
+   * — a host that also plays — gets both ends of one row, so its own sends
+   * come back under the server key. Real per-end id spaces are the fix, and
+   * belong with the PR that introduces a host-and-play pane. */
+  private open(paneId: string, key: string): boolean {
+    const server = this.listeners.get(authorityOf(key));
+    if (!server || !this.panes.has(server.pane)) return false;
+    const conn = this.nextConn++;
+    this.conns.set(conn, { client: { pane: paneId, key }, server: { ...server } });
+    // BOTH ends learn about the connection, each under its own routing key —
+    // the client under the url it connected to, the server under its bind.
+    // Each is logged as coming FROM its peer, so the log reads as traffic
+    // between two panes rather than as a pane talking to itself.
+    this.deliver(server.pane, { pane: paneId, key }, { kind: "connected", key, conn }, 0);
+    this.deliver(paneId, server, { kind: "connected", key: server.key, conn }, 0);
+    return true;
+  }
+
+  private close(conn: number, byPane: string): void {
+    const row = this.conns.get(conn);
+    if (!row) return;
+    this.conns.delete(conn);
+    for (const side of [row.client, row.server]) {
+      this.deliver(byPane, side, { kind: "disconnected", key: side.key, conn }, 0);
+    }
+    // A client whose peer went away (the server pane reloaded, or closed the
+    // connection) can never ask again: its runtime only emits `Connect` for a
+    // key it has not already declared, and a `disconnected` does not clear
+    // that. So the coordinator re-queues the client end on its behalf, and the
+    // server's next `Listen` re-opens it. Without this, reloading the server
+    // pane kills every client for the rest of the session.
+    if (
+      byPane !== row.client.pane &&
+      this.panes.has(row.client.pane) &&
+      !this.pending.some((p) => p.pane === row.client.pane && p.key === row.client.key)
+    ) {
+      this.pending.push({ ...row.client, since: performance.now() });
+    }
+  }
+
+  /** The peer end of `conn` as seen from `paneId`, or null when that pane is
+   * not on the connection (or it does not exist). */
+  private peerOf(conn: number, paneId: string): Side | null {
+    const row = this.conns.get(conn);
+    if (!row) return null;
+    if (row.client.pane === paneId) return row.server;
+    if (row.server.pane === paneId) return row.client;
+    return null;
+  }
+
+  /** The live connection this pane holds for `key`, if any. */
+  private connFor(paneId: string, key: string): number | null {
+    for (const [id, row] of this.conns) {
+      if (row.client.pane === paneId && row.client.key === key) return id;
+    }
+    return null;
+  }
+
+  private deliver(from: string, to: Side, event: DeliveredEvent, size: number): void {
+    const pane = this.panes.get(to.pane);
+    if (!pane) return;
+    pane.outbox.push(event);
+    this.log.push({ tick: null, from, to: to.pane, conn: event.conn, kind: event.kind, size });
+    if (this.log.length > PACKET_LOG_CAP + PACKET_LOG_SLACK) {
+      this.log.splice(0, this.log.length - PACKET_LOG_CAP);
+    }
+  }
+
+  /** Close everything a pane owns without deregistering the pane itself. */
+  private resetPane(id: string): void {
+    for (const [conn, row] of [...this.conns]) {
+      if (row.client.pane === id || row.server.pane === id) this.close(conn, id);
+    }
+    for (const [authority, side] of [...this.listeners]) {
+      if (side.pane === id) this.listeners.delete(authority);
+    }
+    this.dropPending((p) => p.pane === id);
+    const pane = this.panes.get(id);
+    if (pane) pane.outbox.length = 0;
+  }
+
+  private dropPending(match: (p: PendingConnect) => boolean): void {
+    for (let i = this.pending.length - 1; i >= 0; i--) {
+      if (match(this.pending[i])) this.pending.splice(i, 1);
+    }
+  }
+
+  /** Retry connects whose listener hadn't booted yet; give up after the grace
+   * window with a teaching error on the CALLER's key.
+   *
+   * In ARRIVAL order, so connection ids (and therefore the server's player
+   * order) follow the order the clients asked, not the reverse. */
+  private retryPending(): void {
+    const now = performance.now();
+    const requests = this.pending.splice(0);
+    for (const request of requests) {
+      // Expiry first: a listener that appears after the window has passed must
+      // not silently revive a request already deemed dead (rAF is throttled in
+      // a background tab, so "the window passed" and "we noticed" differ).
+      if (now - request.since > CONNECT_GRACE_MS) {
+        this.deliver(
+          request.pane,
+          { pane: request.pane, key: request.key },
+          {
+            kind: "error",
+            key: request.key,
+            conn: 0,
+            message:
+              `no pane is listening on ${authorityOf(request.key)} — a pane must ` +
+              `declare Sub.listen("${authorityOf(request.key)}", …) before a client can connect`,
+          },
+          0
+        );
+        continue;
+      }
+      // Still routable? Otherwise keep waiting.
+      if (!this.open(request.pane, request.key)) this.pending.push(request);
+    }
+  }
+
+  // ------------------------------------------------------------------- egress
+
+  /**
+   * One batch per pane, in arrival order. This is the "perfect link": a packet
+   * routed during frame N is delivered at the start of the host's frame N+1,
+   * with no impairment applied. The barrier PR moves this to the receiving
+   * pane's step boundary.
+   */
+  private flush(): void {
+    this.retryPending();
+    for (const pane of this.panes.values()) {
+      if (pane.outbox.length === 0) continue;
+      const events = pane.outbox.splice(0);
+      pane.frame.contentWindow?.postMessage(
+        { type: "functor-net-deliver", events },
+        window.location.origin
+      );
+    }
+  }
+}

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -359,7 +359,11 @@ const loadInline = (b64u: string) => {
   // loader derives module `Main` for a non-identifier entry label.
   // scrubber=hidden: the page's chrono bar is the transport UI; the player
   // mounts the __scrub seam with no bar of its own.
-  const params = new URLSearchParams({ src: b64u, scrubber: "hidden" });
+  // net=embedder, UNCONDITIONALLY: this host always routes pane networking
+  // through its own coordinator (net-coordinator.ts) rather than letting a
+  // pane open browser sockets. A program that declares no `Sub.connect`/
+  // `Sub.listen` posts nothing, so the declaration costs it nothing.
+  const params = new URLSearchParams({ src: b64u, scrubber: "hidden", net: "embedder" });
   if (pageMouseCapture === false) params.set("mouseCapture", "false");
   if (pageCursorPolicy) params.set("cursor", pageCursorPolicy);
   frame.src = `player.html?${params}`;
@@ -408,7 +412,8 @@ const loadExample = async (id: string) => {
   // switching examples resets state; the ready announcement re-arms pushes.
   setDoc(source, siblings, assets);
   setStatus("busy", "◌ loading…");
-  const params = new URLSearchParams({ game: url, scrubber: "hidden" });
+  // scrubber=hidden / net=embedder: as in loadInline above.
+  const params = new URLSearchParams({ game: url, scrubber: "hidden", net: "embedder" });
   const cursorPolicy = example?.cursor ?? pageCursorPolicy;
   const mouseCapture = cursorPolicy
     ? null


### PR DESCRIPTION
PR 2 of the **coordinator transport arc** (stacked on #591): the sandbox host page becomes the network. A `NetCoordinator` in `mp-panes` routes game packets between player iframes over #591's embedder seam — perfect links only (delivery on the next host rAF; impairment, the packet-log rail, and barrier stepping are later PRs). After this PR, a server role can `Sub.listen` inside a pane and client panes `Connect`/`Send` to it, entirely in-page: the first real multi-pane multiplayer session in the sandbox architecture.

**Routing model** mirrors the in-process netsim's semantics so the two never disagree: a listener registry keyed by authority (`authorityOf` byte-equivalent to netsim's `authority()`), **one connection id per pair shared by both ends** (netsim's model), FIFO per-pane delivery, one batch per pane per host rAF. Every routed packet is recorded into the coordinator's in-memory log (`{from, to, conn, kind, size}`, capped) from day one — the log is the architecture; drawing it on the chrono rail is a later PR.

**Behavioral decisions** (commented in-file):
- **Pending connects wait for their listener** (15s grace) instead of erroring immediately — the runtime's `reconcile_connections` emits `Connect` once per key and never retries, so a client pane that boots before its server pane must not be permanently dead.
- **Peer-close re-queues the client end**, so reloading the server pane doesn't kill every client; the reloaded server's `Listen` re-resolves them.
- **Pane teardown on `pagehide`**, not `load` — closes the race where an event queued for the outgoing document lands in its replacement.
- The sandbox passes **`net=embedder` unconditionally for every pane** (decision recorded in the design doc): the host that routes declares the transport; non-networked games drain nothing and are unaffected (the whole existing site suite runs this way and passes).

No wasm/runtime changes; netsim untouched (its removal is the next PR); `protocol.ts` untouched — the net messages are a pane↔host seam, not the editor↔player protocol.

**Proof — committed e2e, not a one-off**: `e2e/net-coordinator.mjs` + `e2e/fixtures/net-host.html` (`npm run test:net-coordinator`) mounts `examples/mp` as one server + two client panes and asserts 14 checks end-to-end: both connects routed to both ends, server snapshots broadcast (200+ packets), a keydown in client 1 reaching client 2's world **through** the server, pane reload routing disconnects to both ends, the server dropping and re-accepting the reloaded player, zero pane or host errors. Pane models are read through the paused-inspector trace relay.

**Cross-engine review (Claude + Codex), all Critical/High/Medium fixed and re-verified:** connection ownership checks (any pane could previously send on another pane's conn — ids are predictable), the cross-document delivery race (→ `pagehide` teardown), pending-connect retry order made FIFO, expiry checked before open, per-pane listener controllers stored and aborted on removal, and the teardown e2e assertion strengthened to observe the surviving peer's state rather than log insertion.

**Verification:** `tsc -p site --noEmit` (strict) clean; site rebuilt from scratch; `npm run test:site` ALL CHECKS PASSED; `npm run test:net-coordinator` 14/14. Re-verified twice: once after a mid-run disk-full incident (every step re-run from scratch post-recovery), and again after rebasing onto main's `Camera`→`Camera3D` rename (wasm bundle rebuilt at the rebased state, both browser suites re-run).

Next in the stack: remove `functor-netsim` (the coordinator supersedes its routing; seek-test intent carries forward) → binary payloads → impairment + packet log on the rail → barrier stepping → input inversion → whole-environment seek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
