### PR TITLE
feat(lsp): inline-module aware completion, hover, and folding

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -434,6 +434,12 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   module renames it (`step` → `Server.step`), which the rebinder treats
   like any rename: the stored closure keeps its OLD body and prints a loud
   `[functor-lang]` warning.
+- **In the editor**: completion follows the CURSOR into a block — inside
+  `module Server { … }` the module's own names are offered bare (shadowing
+  the file's, which stay visible), `Utils.` offers the nested module `Grid`,
+  `Utils.Grid.` offers its members, and inside the declaring file a block is
+  referenced bare (`Grid.`). Hover shows the canonical name
+  (`Server.step : …`), and each `module` block is a folding range.
 
 ### Interface files (`.funi`)
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -658,8 +658,21 @@ snapshots — no GPU, fully agent-verifiable.
       canonicalization, shadowing (values and record types), opens
       (local + cross-file, collision + cycle), each collision, file-level
       cycle attribution, and cross-reload rebind.
-      Follow-ups: LSP completion/goto for inline modules, and a
-      `functor.json` `entries` form that names them as roles.
+      Follow-ups: a `functor.json` `entries` form that names them as roles.
+      **Part 7 — module-aware editor tooling — done:** the cursor's
+      namespace is now span-based (the `module` block it sits in, from the
+      project's `inline_modules` index), so bare completion inside a block
+      offers the module's own names — shadowing the file's — alongside the
+      file's top level; `Utils.` offers the nested module `Grid` (not the
+      member `Grid.cell`) and `Utils.Grid.` its members; inside the
+      declaring file a block is referenced bare (`Grid.`). Hover, goto,
+      code lenses, inlay hints, doc comments, and `expect` status already
+      key off canonical names/spans and are pinned by tests. `module`
+      blocks are the one construct the LSP emits FOLDING RANGES for
+      (indentation folding is the client's default), and the VSCode
+      grammar highlights the `module` keyword. *Verify:* completion,
+      goto, hover, codelens, inlay, and docs unit tests, plus an
+      end-to-end LSP test for in-block completion scope + folding.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/functor-lang/examples/inline_modules.ast
+++ b/functor-lang/examples/inline_modules.ast
@@ -233,6 +233,7 @@ Program {
                     ),
                 ],
                 span: 97..110,
+                block: 97..393,
             },
         ),
         Module(
@@ -325,6 +326,7 @@ Program {
                     ),
                 ],
                 span: 395..408,
+                block: 395..576,
             },
         ),
         Let(

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -38,6 +38,10 @@ pub struct ModuleDecl {
     /// The `module Name` header span (not the whole block) — the span
     /// collision errors point at.
     pub span: Span,
+    /// The WHOLE block, `module` through the closing `}` — what editor
+    /// tooling folds and what decides which module the cursor is in
+    /// (see `functor_lang::project::InlineModule`).
+    pub block: Span,
 }
 
 /// `expect <expr>` — an inline test: a bool expression evaluated by test

--- a/functor-lang/src/codelens.rs
+++ b/functor-lang/src/codelens.rs
@@ -100,4 +100,17 @@ mod tests {
         // `b`'s lens anchors at the start of its `let`, on line 2.
         assert_eq!(&src[lenses[1].span.start..lenses[1].span.start + 5], "let b");
     }
+
+    // PR 2. A def inside an inline `module` gets its own lens, titled with the
+    // canonical name and anchored at its (indented) `let`.
+    #[test]
+    fn a_def_inside_a_module_gets_a_qualified_lens() {
+        let src = "module Server {\n  let step = (d: float) => d\n}\n";
+        let module = crate::lower(crate::parse(src).unwrap()).unwrap();
+        let (_, types) = check_with_types(&module);
+        let lenses = signatures(&module, &types);
+        assert_eq!(lenses.len(), 1);
+        assert_eq!(lenses[0].title, "Server.step : (float) => float");
+        assert_eq!(lenses[0].span.start, src.find("let step").unwrap());
+    }
 }

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -80,10 +80,12 @@ const KEYWORDS: [&str; 12] = [
 /// `project` (possibly a stale last-good load). The two span spaces never mix.
 ///
 /// `current_module` is the open FILE's module (`Game`, `Utils`);
-/// `inline_module` is the `module Name { … }` block the cursor sits inside,
-/// if any (the caller finds it with
-/// [`Project::inline_module_at`](crate::project::Project::inline_module_at)) —
-/// its members are visible bare and SHADOW the file's, mirroring `lower`'s
+/// `inline_module` is the CANONICAL PATH
+/// ([`InlineModule::path`](crate::project::InlineModule::path) — `Server` in
+/// the entry, `Utils.Grid` elsewhere) of the `module Name { … }` block the
+/// cursor sits inside, if any; the caller finds it with
+/// [`Project::inline_module_at`](crate::project::Project::inline_module_at).
+/// Its members are visible bare and SHADOW the file's, mirroring `lower`'s
 /// resolution order.
 pub fn complete(
     project: &Project,
@@ -92,7 +94,14 @@ pub fn complete(
     live_text: &str,
     offset: usize,
 ) -> Vec<CompletionItem> {
-    let scopes = scope_namespaces(project, current_module, inline_module);
+    // The namespaces the cursor sees, MOST SPECIFIC FIRST: the inline `module`
+    // block it sits in, then the file's own (`lower`'s resolution order — a
+    // module's own names shadow the file's).
+    let scopes: Vec<String> = inline_module
+        .into_iter()
+        .chain(Some(current_module))
+        .map(str::to_string)
+        .collect();
     match context_at(live_text, offset) {
         Context::None => Vec::new(),
         Context::Member {
@@ -117,33 +126,6 @@ pub fn complete(
             let fresh = fresh_offset(project, current_module, live_text, offset);
             top_level_candidates(project, current_module, &scopes, &partial, fresh)
         }
-    }
-}
-
-/// The canonical namespaces the cursor sees, MOST SPECIFIC FIRST: the inline
-/// `module` block it sits in, then the file's own. Matches `lower`'s
-/// resolution order (a module's own names shadow the file's).
-fn scope_namespaces(
-    project: &Project,
-    current_module: &str,
-    inline_module: Option<&str>,
-) -> Vec<String> {
-    let mut scopes = Vec::new();
-    if let Some(name) = inline_module {
-        scopes.push(canonical_module(&project.entry, current_module, name));
-    }
-    scopes.push(current_module.to_string());
-    scopes
-}
-
-/// The canonical prefix an inline module's members carry: bare in the ENTRY
-/// file (`Server.step`), file-qualified elsewhere (`Utils.Grid.cell`) —
-/// `lower::Lowerer::canonical_prefix`'s rule.
-fn canonical_module(entry: &str, file: &str, inline: &str) -> String {
-    if file == entry {
-        inline.to_string()
-    } else {
-        format!("{file}.{inline}")
     }
 }
 
@@ -403,10 +385,6 @@ fn member_candidates(
     fresh: Option<usize>,
 ) -> Vec<CompletionItem> {
     let module = &project.module;
-    let prefix = format!("{}.", canonical_qualifier(project, current_module, qualifier));
-    // Namespaces one level BELOW the qualifier — an inline module of it, seen
-    // through its members' canonical names (`Utils.Grid.cell` under `Utils.`).
-    let mut nested: BTreeSet<String> = BTreeSet::new();
     // Lazy: only checked now that a context matched (defs need the checker's
     // types for their details). The check is on `project` (last-good), never
     // on the live buffer.
@@ -416,30 +394,41 @@ fn member_candidates(
     // top-level lets BEFORE sibling/builtin modules (see `crate::lower`'s
     // resolution order), so `List.x` on a record-typed binder named `List` is
     // a field access, not a builtin call. When the buffer is fresh and the
-    // qualifier is a single segment that names a value, answer as that value:
-    // a declared record offers its fields, anything else offers nothing
-    // (field access on a non-record has no members). Chained `a.b.` stays
-    // empty — the chained-member boundary.
-    if !qualifier.contains('.') {
-        if let Some(offset) = fresh {
-            if let Some(ty) = qualifier_type(project, scopes, qualifier, offset, &types) {
-                return finish(record_fields_of(project, &ty), partial);
-            }
+    // qualifier's HEAD names a value, answer as that value: a single segment
+    // over a declared record offers its fields, anything else offers nothing
+    // (field access on a non-record has no members, and a chained `a.b.` is
+    // the chained-member boundary — never a namespace's members).
+    let head = qualifier.split_once('.').map_or(qualifier, |(head, _)| head);
+    if let Some(offset) = fresh {
+        if let Some(ty) = qualifier_type(project, scopes, head, offset, &types) {
+            let fields = if qualifier.contains('.') {
+                Vec::new()
+            } else {
+                record_fields_of(project, &ty)
+            };
+            return finish(fields, partial);
         }
     }
 
+    // The namespace the written qualifier names HERE, as a canonical prefix.
+    // `None` means it names none (an entry-file `module Server` written bare
+    // from a sibling, where the spelling is `Game.Server`) — no candidates.
+    let Some(canonical) = canonical_qualifier(project, current_module, qualifier) else {
+        return Vec::new();
+    };
+    let prefix = format!("{canonical}.");
     let mut items = Vec::new();
 
     // Host-provided values (`Scene.cube : () => Scene.t`).
     for sig in &module.signatures {
-        if let Some(label) = member_of(&sig.name, &prefix, &mut nested) {
+        if let Some(label) = direct_member(&sig.name, &prefix) {
             let kind = if sig.ty.name == "=>" {
                 CompletionKind::Function
             } else {
                 CompletionKind::Value
             };
             items.push(CompletionItem {
-                label,
+                label: label.to_string(),
                 detail: Some(format!("{} : {}", sig.name, type_name_text(&sig.ty))),
                 kind,
             });
@@ -448,10 +437,10 @@ fn member_candidates(
 
     // Sibling/user-module defs (detail from the checker, hover-identical).
     for def in &module.defs {
-        if let Some(label) = member_of(&def.name, &prefix, &mut nested) {
+        if let Some(label) = direct_member(&def.name, &prefix) {
             let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
             items.push(CompletionItem {
-                label,
+                label: label.to_string(),
                 detail: Some(format!("{} : {ty}", def.name)),
                 kind: value_kind(&ty),
             });
@@ -463,9 +452,9 @@ fn member_candidates(
         if let TypeBody::Variants(decls) = &ty.body {
             let ret = ctor_return(ty);
             for variant in decls {
-                if let Some(label) = member_of(&variant.name, &prefix, &mut nested) {
+                if let Some(label) = direct_member(&variant.name, &prefix) {
                     items.push(CompletionItem {
-                        label,
+                        label: label.to_string(),
                         detail: Some(ctor_detail(variant, &ret)),
                         kind: CompletionKind::Constructor,
                     });
@@ -478,70 +467,82 @@ fn member_candidates(
     // functions, but a constant like `Math.pi` is a plain value.
     for &b in &BUILTINS {
         let name = builtin_name(b);
-        if let Some(label) = member_of(name, &prefix, &mut nested) {
+        if let Some(label) = direct_member(name, &prefix) {
             items.push(CompletionItem {
-                label,
+                label: label.to_string(),
                 detail: Some(format!("{name} : {}", builtin_signature(b))),
                 kind: value_kind(&builtin_signature(b)),
             });
         }
     }
 
-    // The qualifier's own inline modules (`Utils.` offers `Grid`). A type-only
-    // block contributes no member above, so index them directly too.
+    // The namespaces nested under the qualifier (`Utils.` offers `Grid`).
+    // Inline modules are their only source: no builtin or `.funi` name has a
+    // second dot, so a member's own name can never imply one.
     for inline in &project.inline_modules {
         if let Some(segment) = inline.path.strip_prefix(&prefix) {
-            nested.insert(segment.to_string());
+            items.push(CompletionItem {
+                label: segment.to_string(),
+                detail: None,
+                kind: CompletionKind::Module,
+            });
         }
-    }
-    for name in nested {
-        items.push(CompletionItem {
-            label: name,
-            detail: None,
-            kind: CompletionKind::Module,
-        });
     }
 
     finish(items, partial)
 }
 
-/// `name` (a canonical dotted name) as a DIRECT member of `prefix`, or `None`
-/// when it is not under `prefix` at all or belongs to a namespace nested below
-/// it — `Utils.Grid.cell` is not a member `Grid.cell` of `Utils`, it records
-/// `Grid` in `nested` (finding 9 of PR 1's review).
-fn member_of(name: &str, prefix: &str, nested: &mut BTreeSet<String>) -> Option<String> {
+/// `name` (a canonical dotted name) as a DIRECT member of `prefix`: `None`
+/// when it is not under `prefix`, or when it belongs to a namespace nested
+/// below it — `Utils.Grid.cell` is not a member `Grid.cell` of `Utils`
+/// (finding 9 of PR 1's review); the nested `Grid` is offered separately.
+fn direct_member<'a>(name: &'a str, prefix: &str) -> Option<&'a str> {
     let rest = name.strip_prefix(prefix)?;
-    match rest.split_once('.') {
-        Some((segment, _)) => {
-            nested.insert(segment.to_string());
-            None
-        }
-        None => Some(rest.to_string()),
-    }
+    (!rest.contains('.')).then_some(rest)
 }
 
-/// The canonical prefix a WRITTEN qualifier names. An inline module of the
-/// current file is referenced by its bare name there (`Grid` inside
-/// `utils.fun` → `Utils.Grid`); everything else — a sibling (`Utils`), a
-/// sibling's inline module (`Utils.Grid`), a builtin namespace (`Scene`), and
-/// the entry file's own inline modules (already canonically bare) — is the
-/// qualifier as written. Mirrors `lower::Lowerer::resolve_module_prefix`.
-fn canonical_qualifier(project: &Project, current_module: &str, qualifier: &str) -> String {
+/// The canonical prefix a WRITTEN qualifier names HERE, or `None` when it
+/// names no namespace reachable from `current_module`. Mirrors
+/// `lower::Lowerer::resolve_module_prefix` + `canonical_prefix`:
+///
+/// - one of this FILE's inline modules, referenced by its bare name there
+///   (`Grid` inside `utils.fun` → `Utils.Grid`);
+/// - an entry-qualified path, which canonicalizes with the entry stripped
+///   (`Game.Server` → `Server`, the same members the entry file writes bare);
+/// - an entry-file inline module written bare from ANOTHER file — not
+///   reachable (`Server.step` there is an unknown external): `None`;
+/// - anything else — a sibling (`Utils`), a sibling's inline module
+///   (`Utils.Grid`), a builtin namespace (`Scene`) — as written.
+fn canonical_qualifier(
+    project: &Project,
+    current_module: &str,
+    qualifier: &str,
+) -> Option<String> {
     let (head, rest) = match qualifier.split_once('.') {
         Some((head, rest)) => (head, Some(rest)),
         None => (qualifier, None),
     };
-    let Some(inline) = project
-        .inline_modules
-        .iter()
-        .find(|inline| inline.file == current_module && inline.name == head)
-    else {
-        return qualifier.to_string();
+    let inline_of = |file: &str| {
+        project
+            .inline_modules
+            .iter()
+            .find(|inline| inline.file == file && inline.name == head)
     };
-    match rest {
-        Some(rest) => format!("{}.{rest}", inline.path),
-        None => inline.path.clone(),
+    if let Some(inline) = inline_of(current_module) {
+        return Some(match rest {
+            Some(rest) => format!("{}.{rest}", inline.path),
+            None => inline.path.clone(),
+        });
     }
+    if head == project.entry {
+        // `Game.` alone would strip to the empty prefix (every canonical name
+        // "under" it) — out of scope; only `Game.Something` canonicalizes.
+        return rest.map(str::to_string);
+    }
+    if inline_of(&project.entry).is_some() {
+        return None;
+    }
+    Some(qualifier.to_string())
 }
 
 /// The fields of a declared record type, or empty. Only a [`Type::Record`]
@@ -690,11 +691,17 @@ fn top_level_candidates(
     for &b in &BUILTINS {
         module_segment(builtin_name(b), &mut modules);
     }
-    // This file's own inline modules, referenced bare here (`Grid` inside
-    // `utils.fun`, whose members canonicalize as `Utils.Grid.*`).
+    // Inline modules are bare only inside their DECLARING file. The entry's
+    // land in `modules` above (its members are canonically bare, so `Server`
+    // is their first segment) — drop those from every other file, where the
+    // spelling is `Game.Server` and a bare `Server.step` is an unknown
+    // external. A sibling's (`Utils.Grid.cell` → segment `Utils`) are the
+    // mirror case: add them back inside `utils.fun`.
     for inline in &project.inline_modules {
         if inline.file == current_module {
             modules.insert(inline.name.clone());
+        } else if inline.file == *entry {
+            modules.remove(&inline.name);
         }
     }
     modules.remove(current_module);
@@ -1707,6 +1714,69 @@ mod tests {
         // At the file's top level the file's own binding wins.
         let outside = complete(&project, "Game", None, "let x = ", "let x = ".len());
         assert_eq!(find(&outside, "value").detail.as_deref(), Some("value : float"));
+    }
+
+    // In a SIBLING file the cursor's block is passed as its canonical path
+    // (`Utils.Grid`), and its members are offered bare there.
+    #[test]
+    fn bare_completion_inside_a_siblings_module_body() {
+        let project = modules_project();
+        let items = complete(
+            &project,
+            "Utils",
+            Some("Utils.Grid"),
+            "let x = ",
+            "let x = ".len(),
+        );
+        assert_eq!(
+            find(&items, "cell").detail.as_deref(),
+            Some("Utils.Grid.cell : (float) => float")
+        );
+        assert_eq!(find(&items, "version").detail.as_deref(), Some("Utils.version : float"));
+    }
+
+    // [xreview] The ENTRY's inline modules are bare only in the entry file:
+    // from a sibling, `Server.step` is an unknown external, so neither the
+    // name nor its members may be offered there.
+    #[test]
+    fn an_entry_inline_module_is_not_bare_in_a_sibling() {
+        let project = modules_project();
+        let top = complete(&project, "Utils", None, "let x = ", "let x = ".len());
+        assert!(!has(&top, "Server"), "{:?}", labels(&top));
+        let live = "let x = Server.";
+        let items = complete(&project, "Utils", None, live, live.len());
+        assert!(items.is_empty(), "{:?}", labels(&items));
+    }
+
+    // …the spelling that DOES resolve there is the entry-qualified one, whose
+    // canonical members are bare (`Game.Server.step` → `Server.step`).
+    #[test]
+    fn an_entry_inline_module_completes_entry_qualified() {
+        let project = modules_project();
+        let live = "let x = Game.Server.";
+        let items = complete(&project, "Utils", None, live, live.len());
+        assert_eq!(
+            find(&items, "step").detail.as_deref(),
+            Some("Server.step : (Server.Cmd) => float")
+        );
+        assert_eq!(find(&items, "Spawn").kind, CompletionKind::Constructor);
+    }
+
+    // [xreview] A value shadows a MULTI-segment namespace too: with a binder
+    // named `Utils` in scope, `Utils.Grid.` is field access on it (the
+    // chained-member boundary), not the sibling's inline module.
+    #[test]
+    fn a_value_shadows_a_nested_namespace_qualifier() {
+        let src = "let f = (Utils) => Utils.Grid.";
+        // The cached project holds this buffer minus the trailing `.` — the
+        // one edit the member freshness gate accepts.
+        let cached = "let f = (Utils) => Utils.Grid";
+        let project = project_of(
+            &[("game.fun", cached), ("utils.fun", MODULES_SIBLING)],
+            &[],
+        );
+        let items = complete(&project, "Game", None, src, src.len());
+        assert!(items.is_empty(), "{:?}", labels(&items));
     }
 
     // The scope-aware layer follows the cursor into a module body: a lambda

--- a/functor-lang/src/complete.rs
+++ b/functor-lang/src/complete.rs
@@ -25,7 +25,13 @@
 //! other stale or broken buffer skips both layers and falls back to the
 //! textual-only answer — the low-confidence rule, in its simplest honest form.
 //!
-//! Non-goals: chained members (`a.b.`), type-position members (`Scene.t` /
+//! Inline `module` blocks are namespaces too: the cursor's block (the caller
+//! passes it — see [`complete`]) contributes its own names bare and shadows
+//! the file's, `Utils.` offers the inline modules nested under it, and
+//! `Utils.Grid.` offers that block's members.
+//!
+//! Non-goals: chained members off a VALUE (`pos.origin.`), type-position
+//! members (`Scene.t` /
 //! `Pieces.Shape` in annotations), `open`ed modules' exports offered bare (the
 //! merged module does not retain `open` metadata), and expression receivers
 //! (`foo().`). Each testable one is pinned as an empty result by a boundary
@@ -72,12 +78,21 @@ const KEYWORDS: [&str; 12] = [
 /// OFFSET CONTRACT: `offset` is LOCAL to `live_text` (the live buffer), NOT
 /// project-wide. Context comes purely from `live_text`; candidates purely from
 /// `project` (possibly a stale last-good load). The two span spaces never mix.
+///
+/// `current_module` is the open FILE's module (`Game`, `Utils`);
+/// `inline_module` is the `module Name { … }` block the cursor sits inside,
+/// if any (the caller finds it with
+/// [`Project::inline_module_at`](crate::project::Project::inline_module_at)) —
+/// its members are visible bare and SHADOW the file's, mirroring `lower`'s
+/// resolution order.
 pub fn complete(
     project: &Project,
     current_module: &str,
+    inline_module: Option<&str>,
     live_text: &str,
     offset: usize,
 ) -> Vec<CompletionItem> {
+    let scopes = scope_namespaces(project, current_module, inline_module);
     match context_at(live_text, offset) {
         Context::None => Vec::new(),
         Context::Member {
@@ -89,12 +104,46 @@ pub fn complete(
             // the buffer that is exactly the cached text plus the `.partial`
             // tail being typed (see [`member_fresh_offset`]).
             let fresh = member_fresh_offset(project, current_module, live_text, dot, offset);
-            member_candidates(project, current_module, &qualifier, &partial, fresh)
+            member_candidates(
+                project,
+                current_module,
+                &scopes,
+                &qualifier,
+                &partial,
+                fresh,
+            )
         }
         Context::TopLevel { partial } => {
             let fresh = fresh_offset(project, current_module, live_text, offset);
-            top_level_candidates(project, current_module, &partial, fresh)
+            top_level_candidates(project, current_module, &scopes, &partial, fresh)
         }
+    }
+}
+
+/// The canonical namespaces the cursor sees, MOST SPECIFIC FIRST: the inline
+/// `module` block it sits in, then the file's own. Matches `lower`'s
+/// resolution order (a module's own names shadow the file's).
+fn scope_namespaces(
+    project: &Project,
+    current_module: &str,
+    inline_module: Option<&str>,
+) -> Vec<String> {
+    let mut scopes = Vec::new();
+    if let Some(name) = inline_module {
+        scopes.push(canonical_module(&project.entry, current_module, name));
+    }
+    scopes.push(current_module.to_string());
+    scopes
+}
+
+/// The canonical prefix an inline module's members carry: bare in the ENTRY
+/// file (`Server.step`), file-qualified elsewhere (`Utils.Grid.cell`) —
+/// `lower::Lowerer::canonical_prefix`'s rule.
+fn canonical_module(entry: &str, file: &str, inline: &str) -> String {
+    if file == entry {
+        inline.to_string()
+    } else {
+        format!("{file}.{inline}")
     }
 }
 
@@ -309,8 +358,8 @@ fn lex_completion_prefix(prefix: &str) -> Option<Vec<Token>> {
 
 /// The dotted qualifier ending at `tokens[end]` (an `Ident`): walk back over an
 /// `Ident (Dot Ident)*` chain so `a.b.` yields `"a.b"`. A multi-segment
-/// qualifier matches no module in v1 (its candidates come back empty — the
-/// chained-member boundary).
+/// qualifier names a nested namespace (`Utils.Grid.`); one that names no
+/// module comes back empty — the chained-member boundary.
 fn qualifier_chain(tokens: &[Token], end: usize) -> String {
     let mut names = Vec::new();
     let mut i = end;
@@ -343,16 +392,21 @@ fn is_keyword(kind: &TokenKind) -> bool {
 }
 
 /// Candidates for `Qualifier.partial`: the module's `.funi` signatures, its
-/// sibling defs, its ADT constructors, and the builtins in its namespace.
+/// sibling defs, its ADT constructors, the builtins in its namespace, and its
+/// nested inline modules (`Utils.` offers `Grid`).
 fn member_candidates(
     project: &Project,
     current_module: &str,
+    scopes: &[String],
     qualifier: &str,
     partial: &str,
     fresh: Option<usize>,
 ) -> Vec<CompletionItem> {
     let module = &project.module;
-    let prefix = format!("{qualifier}.");
+    let prefix = format!("{}.", canonical_qualifier(project, current_module, qualifier));
+    // Namespaces one level BELOW the qualifier — an inline module of it, seen
+    // through its members' canonical names (`Utils.Grid.cell` under `Utils.`).
+    let mut nested: BTreeSet<String> = BTreeSet::new();
     // Lazy: only checked now that a context matched (defs need the checker's
     // types for their details). The check is on `project` (last-good), never
     // on the live buffer.
@@ -368,7 +422,7 @@ fn member_candidates(
     // empty — the chained-member boundary.
     if !qualifier.contains('.') {
         if let Some(offset) = fresh {
-            if let Some(ty) = qualifier_type(project, current_module, qualifier, offset, &types) {
+            if let Some(ty) = qualifier_type(project, scopes, qualifier, offset, &types) {
                 return finish(record_fields_of(project, &ty), partial);
             }
         }
@@ -378,14 +432,14 @@ fn member_candidates(
 
     // Host-provided values (`Scene.cube : () => Scene.t`).
     for sig in &module.signatures {
-        if let Some(label) = sig.name.strip_prefix(&prefix) {
+        if let Some(label) = member_of(&sig.name, &prefix, &mut nested) {
             let kind = if sig.ty.name == "=>" {
                 CompletionKind::Function
             } else {
                 CompletionKind::Value
             };
             items.push(CompletionItem {
-                label: label.to_string(),
+                label,
                 detail: Some(format!("{} : {}", sig.name, type_name_text(&sig.ty))),
                 kind,
             });
@@ -394,10 +448,10 @@ fn member_candidates(
 
     // Sibling/user-module defs (detail from the checker, hover-identical).
     for def in &module.defs {
-        if let Some(label) = def.name.strip_prefix(&prefix) {
+        if let Some(label) = member_of(&def.name, &prefix, &mut nested) {
             let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
             items.push(CompletionItem {
-                label: label.to_string(),
+                label,
                 detail: Some(format!("{} : {ty}", def.name)),
                 kind: value_kind(&ty),
             });
@@ -409,9 +463,9 @@ fn member_candidates(
         if let TypeBody::Variants(decls) = &ty.body {
             let ret = ctor_return(ty);
             for variant in decls {
-                if let Some(label) = variant.name.strip_prefix(&prefix) {
+                if let Some(label) = member_of(&variant.name, &prefix, &mut nested) {
                     items.push(CompletionItem {
-                        label: label.to_string(),
+                        label,
                         detail: Some(ctor_detail(variant, &ret)),
                         kind: CompletionKind::Constructor,
                     });
@@ -424,16 +478,70 @@ fn member_candidates(
     // functions, but a constant like `Math.pi` is a plain value.
     for &b in &BUILTINS {
         let name = builtin_name(b);
-        if let Some(label) = name.strip_prefix(&prefix) {
+        if let Some(label) = member_of(name, &prefix, &mut nested) {
             items.push(CompletionItem {
-                label: label.to_string(),
+                label,
                 detail: Some(format!("{name} : {}", builtin_signature(b))),
                 kind: value_kind(&builtin_signature(b)),
             });
         }
     }
 
+    // The qualifier's own inline modules (`Utils.` offers `Grid`). A type-only
+    // block contributes no member above, so index them directly too.
+    for inline in &project.inline_modules {
+        if let Some(segment) = inline.path.strip_prefix(&prefix) {
+            nested.insert(segment.to_string());
+        }
+    }
+    for name in nested {
+        items.push(CompletionItem {
+            label: name,
+            detail: None,
+            kind: CompletionKind::Module,
+        });
+    }
+
     finish(items, partial)
+}
+
+/// `name` (a canonical dotted name) as a DIRECT member of `prefix`, or `None`
+/// when it is not under `prefix` at all or belongs to a namespace nested below
+/// it — `Utils.Grid.cell` is not a member `Grid.cell` of `Utils`, it records
+/// `Grid` in `nested` (finding 9 of PR 1's review).
+fn member_of(name: &str, prefix: &str, nested: &mut BTreeSet<String>) -> Option<String> {
+    let rest = name.strip_prefix(prefix)?;
+    match rest.split_once('.') {
+        Some((segment, _)) => {
+            nested.insert(segment.to_string());
+            None
+        }
+        None => Some(rest.to_string()),
+    }
+}
+
+/// The canonical prefix a WRITTEN qualifier names. An inline module of the
+/// current file is referenced by its bare name there (`Grid` inside
+/// `utils.fun` → `Utils.Grid`); everything else — a sibling (`Utils`), a
+/// sibling's inline module (`Utils.Grid`), a builtin namespace (`Scene`), and
+/// the entry file's own inline modules (already canonically bare) — is the
+/// qualifier as written. Mirrors `lower::Lowerer::resolve_module_prefix`.
+fn canonical_qualifier(project: &Project, current_module: &str, qualifier: &str) -> String {
+    let (head, rest) = match qualifier.split_once('.') {
+        Some((head, rest)) => (head, Some(rest)),
+        None => (qualifier, None),
+    };
+    let Some(inline) = project
+        .inline_modules
+        .iter()
+        .find(|inline| inline.file == current_module && inline.name == head)
+    else {
+        return qualifier.to_string();
+    };
+    match rest {
+        Some(rest) => format!("{}.{rest}", inline.path),
+        None => inline.path.clone(),
+    }
 }
 
 /// The fields of a declared record type, or empty. Only a [`Type::Record`]
@@ -462,19 +570,19 @@ fn record_fields_of(project: &Project, ty: &Type) -> Vec<CompletionItem> {
 }
 
 /// The checked type of a single-segment member qualifier at `offset`, when it
-/// names a VALUE: a binder in scope (innermost wins), else an own-module def
-/// (bare for the entry, `Module.name` for a sibling). A binding that exists
-/// but has no checked type is `Unknown` (it still shadows — the caller must
-/// not fall through to namespace members). `None` only when no value binding
-/// has that name.
+/// names a VALUE: a binder in scope (innermost wins), else a def of one of the
+/// cursor's namespaces (`scopes`, most specific first — an inline module's own
+/// def shadows the file's). A binding that exists but has no checked type is
+/// `Unknown` (it still shadows — the caller must not fall through to namespace
+/// members). `None` only when no value binding has that name.
 fn qualifier_type(
     project: &Project,
-    current_module: &str,
+    scopes: &[String],
     qualifier: &str,
     offset: usize,
     types: &ExprTypes,
 ) -> Option<Type> {
-    if let Some(def) = enclosing_def(project, current_module, offset) {
+    if let Some(def) = enclosing_def(project, scopes, offset) {
         if let Some((_, binding, _)) = binders_in_scope(&def.value, offset)
             .into_iter()
             .find(|(name, _, _)| name == qualifier)
@@ -482,24 +590,29 @@ fn qualifier_type(
             return Some(types.binding(binding).cloned().unwrap_or(Type::Unknown));
         }
     }
-    let canonical = if current_module == project.entry {
-        qualifier.to_string()
-    } else {
-        format!("{current_module}.{qualifier}")
-    };
-    let def = project
-        .module
-        .defs
-        .iter()
-        .find(|def| def.name == canonical)?;
+    let def = scopes.iter().find_map(|scope| {
+        let canonical = qualified(scope, &project.entry, qualifier);
+        project.module.defs.iter().find(|def| def.name == canonical)
+    })?;
     Some(types.expr(def.value.id).cloned().unwrap_or(Type::Unknown))
 }
 
-/// Candidates at a top-level position: keywords, the current module's own
-/// defs and constructors (bare), and the visible module names.
+/// A member's canonical name in `scope`: bare in the entry file (whose
+/// members carry no prefix), `Scope.name` everywhere else.
+fn qualified(scope: &str, entry: &str, name: &str) -> String {
+    if scope == entry {
+        name.to_string()
+    } else {
+        format!("{scope}.{name}")
+    }
+}
+
+/// Candidates at a top-level position: keywords, the names visible bare in the
+/// cursor's namespaces (`scopes`, most specific first), and the module names.
 fn top_level_candidates(
     project: &Project,
     current_module: &str,
+    scopes: &[String],
     partial: &str,
     fresh: Option<usize>,
 ) -> Vec<CompletionItem> {
@@ -512,7 +625,7 @@ fn top_level_candidates(
     // keywords/globals below so `finish`'s stable sort + dedup lets an inner
     // binder shadow a same-named global (locals appear first, dedup keeps them).
     if let Some(offset) = fresh {
-        if let Some(def) = enclosing_def(project, current_module, offset) {
+        if let Some(def) = enclosing_def(project, scopes, offset) {
             for (name, binding, mutable) in binders_in_scope(&def.value, offset) {
                 items.push(binder_item(&name, binding, mutable, &types));
             }
@@ -527,30 +640,31 @@ fn top_level_candidates(
         });
     }
 
-    // This module's own defs, referenced bare in source. (Entry defs are
-    // already bare; a sibling's are `Module.name` — the same strip either way.)
-    for def in &module.defs {
-        if owning_module(&def.name, entry) == current_module {
-            let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
-            items.push(CompletionItem {
-                label: bare_name(&def.name).to_string(),
-                detail: Some(format!("{} : {ty}", def.name)),
-                kind: value_kind(&ty),
-            });
+    // The defs and constructors referenced bare here, namespace by namespace —
+    // an inline `module`'s own first, then the enclosing file's, so `finish`'s
+    // dedup keeps the shadowing one (`lower`'s resolution order).
+    for scope in scopes {
+        for def in &module.defs {
+            if owning_module(&def.name, entry) == scope {
+                let ty = types.expr(def.value.id).cloned().unwrap_or(Type::Unknown);
+                items.push(CompletionItem {
+                    label: bare_name(&def.name).to_string(),
+                    detail: Some(format!("{} : {ty}", def.name)),
+                    kind: value_kind(&ty),
+                });
+            }
         }
-    }
-
-    // This module's own constructors, also bare.
-    for ty in &module.types {
-        if let TypeBody::Variants(decls) = &ty.body {
-            let ret = ctor_return(ty);
-            for variant in decls {
-                if owning_module(&variant.name, entry) == current_module {
-                    items.push(CompletionItem {
-                        label: bare_name(&variant.name).to_string(),
-                        detail: Some(ctor_detail(variant, &ret)),
-                        kind: CompletionKind::Constructor,
-                    });
+        for ty in &module.types {
+            if let TypeBody::Variants(decls) = &ty.body {
+                let ret = ctor_return(ty);
+                for variant in decls {
+                    if owning_module(&variant.name, entry) == scope {
+                        items.push(CompletionItem {
+                            label: bare_name(&variant.name).to_string(),
+                            detail: Some(ctor_detail(variant, &ret)),
+                            kind: CompletionKind::Constructor,
+                        });
+                    }
                 }
             }
         }
@@ -575,6 +689,13 @@ fn top_level_candidates(
     }
     for &b in &BUILTINS {
         module_segment(builtin_name(b), &mut modules);
+    }
+    // This file's own inline modules, referenced bare here (`Grid` inside
+    // `utils.fun`, whose members canonicalize as `Utils.Grid.*`).
+    for inline in &project.inline_modules {
+        if inline.file == current_module {
+            modules.insert(inline.name.clone());
+        }
     }
     modules.remove(current_module);
     for name in modules {
@@ -626,12 +747,15 @@ fn value_kind(ty: &Type) -> CompletionKind {
 }
 
 /// The top-level def whose span contains project-wide `offset` and whose name
-/// belongs to `current_module` (the file being edited) — the def whose value
-/// expression the scope-aware walk explores. Ends are inclusive so a cursor at
-/// the very end of the def (the common completion position) still matches.
-fn enclosing_def<'a>(project: &'a Project, current_module: &str, offset: usize) -> Option<&'a Def> {
+/// belongs to one of the cursor's namespaces (`scopes` — the file being edited
+/// and, inside a `module` block, that block) — the def whose value expression
+/// the scope-aware walk explores. Ends are inclusive so a cursor at the very
+/// end of the def (the common completion position) still matches.
+fn enclosing_def<'a>(project: &'a Project, scopes: &[String], offset: usize) -> Option<&'a Def> {
     project.module.defs.iter().find(|def| {
-        owning_module(&def.name, &project.entry) == current_module
+        scopes
+            .iter()
+            .any(|scope| owning_module(&def.name, &project.entry) == scope)
             && scope_contains(def.span, offset)
     })
 }
@@ -741,16 +865,17 @@ fn binder_item(name: &str, binding: BindingId, mutable: bool, types: &ExprTypes)
     }
 }
 
-/// The module a canonical name belongs to: the segment before its first `.`,
-/// or the entry (whose members are bare).
+/// The module a canonical name belongs to: everything before its LAST `.`
+/// (`Utils.clamp` → `Utils`, `Utils.Grid.cell` → the inline module
+/// `Utils.Grid`), or the entry (whose members are bare).
 fn owning_module<'a>(name: &'a str, entry: &'a str) -> &'a str {
-    name.split_once('.').map_or(entry, |(module, _)| module)
+    name.rsplit_once('.').map_or(entry, |(module, _)| module)
 }
 
 /// A canonical name stripped of its module qualifier (`Utils.clamp` →
-/// `clamp`; a bare name is unchanged).
+/// `clamp`, `Utils.Grid.cell` → `cell`; a bare name is unchanged).
 fn bare_name(name: &str) -> &str {
-    name.split_once('.').map_or(name, |(_, member)| member)
+    name.rsplit_once('.').map_or(name, |(_, member)| member)
 }
 
 /// Record `name`'s module qualifier (its first dotted segment), if any.
@@ -803,7 +928,7 @@ mod tests {
     /// seam.
     fn game(project_src: &str, prelude: &[(&str, &str)], live: &str) -> Vec<CompletionItem> {
         let project = project_of(&[("game.fun", project_src)], prelude);
-        complete(&project, "Game", live, live.len())
+        complete(&project, "Game", None, live, live.len())
     }
 
     /// Complete in module `Game` at byte `offset` inside `src`, with the entry
@@ -811,7 +936,7 @@ mod tests {
     /// scope-aware layers (locals, record fields) run.
     fn fresh(src: &str, prelude: &[(&str, &str)], offset: usize) -> Vec<CompletionItem> {
         let project = project_of(&[("game.fun", src)], prelude);
-        complete(&project, "Game", src, offset)
+        complete(&project, "Game", None, src, offset)
     }
 
     fn labels(items: &[CompletionItem]) -> Vec<String> {
@@ -941,7 +1066,7 @@ mod tests {
             &[],
         );
         let live = "let s = Utils.";
-        let items = complete(&project, "Game", live, live.len());
+        let items = complete(&project, "Game", None, live, live.len());
         assert_eq!(
             items,
             vec![
@@ -974,7 +1099,7 @@ mod tests {
             &[],
         );
         let live = "let s = Pieces.";
-        let items = complete(&project, "Game", live, live.len());
+        let items = complete(&project, "Game", None, live, live.len());
         assert_eq!(labels(&items), ["Circle", "Point", "count"]);
         assert_eq!(find(&items, "Circle").kind, CompletionKind::Constructor);
         assert_eq!(
@@ -1000,7 +1125,7 @@ mod tests {
             )],
             &[],
         );
-        let items = complete(&entry, "Game", "let x = ", "let x = ".len());
+        let items = complete(&entry, "Game", None, "let x = ", "let x = ".len());
         assert!(has(&items, "Left"));
         assert!(has(&items, "Right"));
         assert_eq!(find(&items, "Left").kind, CompletionKind::Constructor);
@@ -1012,7 +1137,7 @@ mod tests {
             ],
             &[],
         );
-        let items = complete(&sibling, "Pieces", "let x = ", "let x = ".len());
+        let items = complete(&sibling, "Pieces", None, "let x = ", "let x = ".len());
         assert!(
             has(&items, "Circle"),
             "own ctor bare in {:?}",
@@ -1037,7 +1162,7 @@ mod tests {
             &[("Scene", SCENE)],
         );
         let live = "let x = ";
-        let items = complete(&project, "Game", live, live.len());
+        let items = complete(&project, "Game", None, live, live.len());
         assert_eq!(find(&items, "let").kind, CompletionKind::Keyword);
         assert!(has(&items, "main"), "own def bare in {:?}", labels(&items));
         assert_eq!(find(&items, "Utils").kind, CompletionKind::Module);
@@ -1064,7 +1189,7 @@ mod tests {
             &[("Scene", SCENE)],
         );
         let live = "let y = ";
-        let items = complete(&project, "Utils", live, live.len());
+        let items = complete(&project, "Utils", None, live, live.len());
         assert!(has(&items, "clamp"), "own def bare in {:?}", labels(&items));
         assert!(has(&items, "Scene"));
         assert!(!has(&items, "Utils"), "own module offered to itself");
@@ -1148,7 +1273,7 @@ mod tests {
         let project = project_of(&[("game.fun", src)], &[]);
 
         // Inside `f`'s body: `score` is offered, typed from its annotation.
-        let in_f = complete(&project, "Game", src, src.find("=> score").unwrap() + 8);
+        let in_f = complete(&project, "Game", None, src, src.find("=> score").unwrap() + 8);
         assert_eq!(
             find(&in_f, "score").detail.as_deref(),
             Some("score : float")
@@ -1156,7 +1281,7 @@ mod tests {
         assert_eq!(find(&in_f, "score").kind, CompletionKind::Value);
 
         // Inside `g`'s body (end of buffer): `g`'s own param, but NOT `score`.
-        let in_g = complete(&project, "Game", src, src.len());
+        let in_g = complete(&project, "Game", None, src, src.len());
         assert!(has(&in_g, "yy"), "g's own param: {:?}", labels(&in_g));
         assert!(!has(&in_g, "score"), "outer param leaked into a later def");
     }
@@ -1170,7 +1295,7 @@ mod tests {
         let project = project_of(&[("game.fun", src)], &[]);
 
         // In the Circle arm (after the body reference `rad`): `rad`, not `side`.
-        let in_circle = complete(&project, "Game", src, src.find("rad |").unwrap() + 3);
+        let in_circle = complete(&project, "Game", None, src, src.find("rad |").unwrap() + 3);
         assert_eq!(
             find(&in_circle, "rad").detail.as_deref(),
             Some("rad : float")
@@ -1178,7 +1303,7 @@ mod tests {
         assert!(!has(&in_circle, "side"), "other arm's binder leaked");
 
         // In the Square arm (end of buffer): `side`, not `rad`.
-        let in_square = complete(&project, "Game", src, src.len());
+        let in_square = complete(&project, "Game", None, src, src.len());
         assert!(
             has(&in_square, "side"),
             "arm binder: {:?}",
@@ -1195,11 +1320,11 @@ mod tests {
         let project = project_of(&[("game.fun", src)], &[]);
 
         // In the `in` body (end, partial `y`): the `let` binder `y` is offered.
-        let in_body = complete(&project, "Game", src, src.len());
+        let in_body = complete(&project, "Game", None, src, src.len());
         assert_eq!(find(&in_body, "y").detail.as_deref(), Some("y : float"));
 
         // In `y`'s value (`x + 1.0`, empty partial): `x` is in scope, `y` NOT.
-        let in_value = complete(&project, "Game", src, src.find("let y = ").unwrap() + 8);
+        let in_value = complete(&project, "Game", None, src, src.find("let y = ").unwrap() + 8);
         assert!(
             has(&in_value, "x"),
             "param in the value: {:?}",
@@ -1234,13 +1359,13 @@ mod tests {
         let src = "type Vec2 = { x: float, y: float }\nlet len = (v: Vec2) => v";
         let project = project_of(&[("game.fun", src)], &[]);
         let live = format!("{src}.");
-        let items = complete(&project, "Game", &live, live.len());
+        let items = complete(&project, "Game", None, &live, live.len());
         assert_eq!(labels(&items), ["x", "y"]);
         assert_eq!(find(&items, "x").kind, CompletionKind::Field);
 
         // And with a partial being typed after the dot: `.y` filters to `y`.
         let live = format!("{src}.y");
-        let items = complete(&project, "Game", &live, live.len());
+        let items = complete(&project, "Game", None, &live, live.len());
         assert_eq!(labels(&items), ["y"]);
     }
 
@@ -1252,7 +1377,7 @@ mod tests {
         let project = project_of(&[("game.fun", src)], &[]);
         let dot = src.find("v +").unwrap() + 1;
         let live = format!("{}.{}", &src[..dot], &src[dot..]);
-        let items = complete(&project, "Game", &live, dot + 1); // cursor after the dot
+        let items = complete(&project, "Game", None, &live, dot + 1); // cursor after the dot
         assert_eq!(labels(&items), ["x"]);
     }
 
@@ -1270,7 +1395,7 @@ mod tests {
         let src = "let Scene = 1.0\nlet f = () => Scene";
         let project = project_of(&[("game.fun", src)], &[("Scene", SCENE)]);
         let live = format!("{src}.");
-        let items = complete(&project, "Game", &live, live.len());
+        let items = complete(&project, "Game", None, &live, live.len());
         assert!(
             items.is_empty(),
             "prelude members leaked past a def: {:?}",
@@ -1314,14 +1439,14 @@ mod tests {
         // partial: the gate is closed, so the param local `v` is suppressed,
         // while the v1 keywords/modules still answer.
         let stale_top = "type Vec2 = { x: float, y: float }\nlet len = (v: Vec2) => ";
-        let top = complete(&project, "Game", stale_top, stale_top.len());
+        let top = complete(&project, "Game", None, stale_top, stale_top.len());
         assert!(!has(&top, "v"), "a local leaked through a stale buffer");
         assert!(has(&top, "let"), "v1 keyword still offered");
         assert!(has(&top, "Scene"), "v1 module still offered");
 
         // A stale member buffer `v.`: record fields must not resolve.
         let stale_v = "type Vec2 = { x: float, y: float }\nlet len = (v: Vec2) => v.";
-        let member = complete(&project, "Game", stale_v, stale_v.len());
+        let member = complete(&project, "Game", None, stale_v, stale_v.len());
         assert!(
             member.is_empty(),
             "record fields resolved stale: {:?}",
@@ -1329,7 +1454,7 @@ mod tests {
         );
 
         // …but a v1 prelude member (no freshness needed) still answers.
-        let scene = complete(&project, "Game", "let s = Scene.", "let s = Scene.".len());
+        let scene = complete(&project, "Game", None, "let s = Scene.", "let s = Scene.".len());
         assert!(has(&scene, "cube"), "v1 prelude member still works");
     }
 
@@ -1340,7 +1465,7 @@ mod tests {
     fn sibling_file_locals_use_base_translation() {
         let utils = "let g = (val: float) => val";
         let project = project_of(&[("game.fun", STUB), ("utils.fun", utils)], &[]);
-        let items = complete(&project, "Utils", utils, utils.len());
+        let items = complete(&project, "Utils", None, utils, utils.len());
         assert!(has(&items, "val"), "sibling local: {:?}", labels(&items));
         assert_eq!(find(&items, "val").detail.as_deref(), Some("val : float"));
     }
@@ -1358,7 +1483,7 @@ mod tests {
             &[],
         );
         let offset = src.find("v.").unwrap() + 2; // after the dot
-        let items = complete(&project, "Game", src, offset);
+        let items = complete(&project, "Game", None, src, offset);
         assert_eq!(labels(&items), ["x", "y"]);
         assert_eq!(find(&items, "x").kind, CompletionKind::Field);
         assert_eq!(find(&items, "x").detail.as_deref(), Some("x : float"));
@@ -1377,7 +1502,7 @@ mod tests {
     #[test]
     fn empty_buffer_offers_top_level() {
         let project = project_of(&[("game.fun", STUB)], &[]);
-        let items = complete(&project, "Game", "", 0);
+        let items = complete(&project, "Game", None, "", 0);
         assert!(has(&items, "let"));
     }
 
@@ -1461,7 +1586,7 @@ mod tests {
             &[],
         );
         let live = "let s = Pieces.";
-        let items = complete(&project, "Game", live, live.len());
+        let items = complete(&project, "Game", None, live, live.len());
         assert_eq!(
             find(&items, "Full").detail.as_deref(),
             Some("Pieces.Full : ('a) => Box<'a>")
@@ -1477,5 +1602,121 @@ mod tests {
     fn full_keyword_still_offered() {
         let items = game(STUB, &[], "let");
         assert!(has(&items, "let"));
+    }
+
+    // --- Inline `module` blocks (PR 2) ---
+
+    /// An entry file with a `module Server` block (canonically BARE members)
+    /// and a sibling `utils.fun` with a `module Grid` block (`Utils.Grid.*`).
+    const MODULES_ENTRY: &str = "let speed = 4.0\n\
+                                 module Server {\n\
+                                 \x20 type Cmd = | Spawn(id: float)\n\
+                                 \x20 let step = (c: Cmd) => 1.0\n\
+                                 }\n";
+    const MODULES_SIBLING: &str = "let version = 3.0\n\
+                                   module Grid {\n\
+                                   \x20 let cell = (x: float) => x\n\
+                                   }\n";
+
+    fn modules_project() -> Project {
+        project_of(
+            &[("game.fun", MODULES_ENTRY), ("utils.fun", MODULES_SIBLING)],
+            &[],
+        )
+    }
+
+    // An entry-file inline module completes by its bare name (its members
+    // canonicalize bare, so this is the ordinary member path).
+    #[test]
+    fn entry_inline_module_members_complete() {
+        let project = modules_project();
+        let live = "let x = Server.";
+        let items = complete(&project, "Game", None, live, live.len());
+        assert_eq!(find(&items, "step").detail.as_deref(), Some("Server.step : (Server.Cmd) => float"));
+        assert_eq!(find(&items, "Spawn").kind, CompletionKind::Constructor);
+    }
+
+    // Finding 9 of PR 1's review: `Utils.` used to offer the MEMBER
+    // `Grid.cell`. It offers the nested module `Grid` instead.
+    #[test]
+    fn a_files_inline_module_is_a_nested_namespace_not_a_member() {
+        let project = modules_project();
+        let live = "let x = Utils.";
+        let items = complete(&project, "Game", None, live, live.len());
+        assert!(!has(&items, "Grid.cell"), "{:?}", labels(&items));
+        assert!(has(&items, "version"));
+        assert_eq!(find(&items, "Grid").kind, CompletionKind::Module);
+    }
+
+    // …and the multi-segment qualifier completes that module's members.
+    #[test]
+    fn members_of_a_siblings_inline_module_complete() {
+        let project = modules_project();
+        let live = "let x = Utils.Grid.";
+        let items = complete(&project, "Game", None, live, live.len());
+        assert_eq!(
+            find(&items, "cell").detail.as_deref(),
+            Some("Utils.Grid.cell : (float) => float")
+        );
+    }
+
+    // Inside the declaring file, an inline module is referenced BARE — both as
+    // a top-level candidate and as a qualifier resolving to `Utils.Grid`.
+    #[test]
+    fn inline_module_is_bare_inside_its_own_file() {
+        let project = modules_project();
+        let top = complete(&project, "Utils", None, "let x = ", "let x = ".len());
+        assert_eq!(find(&top, "Grid").kind, CompletionKind::Module);
+
+        let live = "let x = Grid.";
+        let items = complete(&project, "Utils", None, live, live.len());
+        assert_eq!(labels(&items), ["cell"]);
+    }
+
+    // The cursor INSIDE a `module` block: its own names are visible bare,
+    // alongside the enclosing file's top level.
+    #[test]
+    fn bare_completion_inside_a_module_body_sees_both_namespaces() {
+        let project = modules_project();
+        let items = complete(&project, "Game", Some("Server"), "let x = ", "let x = ".len());
+        assert_eq!(
+            find(&items, "step").detail.as_deref(),
+            Some("Server.step : (Server.Cmd) => float")
+        );
+        assert_eq!(find(&items, "Spawn").kind, CompletionKind::Constructor);
+        // The file's top level, visible from inside the module.
+        assert_eq!(find(&items, "speed").detail.as_deref(), Some("speed : float"));
+    }
+
+    // A module's own name SHADOWS a same-named one at the file's top level —
+    // the module's is the one offered (lowering's resolution order).
+    #[test]
+    fn a_modules_own_name_shadows_the_files() {
+        let project = project_of(
+            &[(
+                "game.fun",
+                "let value = 1.0\nmodule Server {\n  let value = 2.0\n}\n",
+            )],
+            &[],
+        );
+        let inside = complete(&project, "Game", Some("Server"), "let x = ", "let x = ".len());
+        assert_eq!(
+            find(&inside, "value").detail.as_deref(),
+            Some("Server.value : float")
+        );
+        // At the file's top level the file's own binding wins.
+        let outside = complete(&project, "Game", None, "let x = ", "let x = ".len());
+        assert_eq!(find(&outside, "value").detail.as_deref(), Some("value : float"));
+    }
+
+    // The scope-aware layer follows the cursor into a module body: a lambda
+    // param of a def declared INSIDE the block is offered there.
+    #[test]
+    fn locals_inside_a_module_body_are_offered() {
+        let src = "module Server {\n  let step = (delta: float) => delta\n}\n";
+        let project = project_of(&[("game.fun", src)], &[]);
+        let offset = src.find("=> delta").unwrap() + 3;
+        let items = complete(&project, "Game", Some("Server"), src, offset);
+        assert_eq!(find(&items, "delta").detail.as_deref(), Some("delta : float"));
     }
 }

--- a/functor-lang/src/docs.rs
+++ b/functor-lang/src/docs.rs
@@ -185,6 +185,29 @@ mod tests {
         );
     }
 
+    /// A comment block above an INDENTED def inside an inline `module`
+    /// attaches to it — the walk is line-based, so the block's indentation is
+    /// immaterial.
+    #[test]
+    fn a_def_inside_a_module_attaches_its_comment_block() {
+        let src = "module Server {\n  \
+                   // Advance the world by one command.\n  \
+                   let step = (d: float) => d\n\
+                   }\n";
+        let project =
+            load_single_source("game", src).unwrap_or_else(|e| panic!("loads: {}", e.render()));
+        let step = project
+            .module
+            .defs
+            .iter()
+            .find(|d| d.name == "Server.step")
+            .expect("Server.step def");
+        assert_eq!(
+            doc_comment(&project.sources, step.span).as_deref(),
+            Some("Advance the world by one command.")
+        );
+    }
+
     #[test]
     fn source_only_extraction_understands_explicit_doc_comments() {
         let src = "/// Make a widget.\nlet make : () => t\n";

--- a/functor-lang/src/goto.rs
+++ b/functor-lang/src/goto.rs
@@ -459,4 +459,33 @@ mod tests {
         let module = crate::lower(crate::parse(src).unwrap()).unwrap();
         assert!(definition_span(&module, src.len()).is_none());
     }
+
+    // --- Inline `module` blocks (PR 2) ---
+
+    // Every kind of reference into a `module Server { … }` block resolves to
+    // its declaration: the flat canonical name (`Server.step`) is what the IR
+    // carries, so the name index needs no module awareness.
+    #[test]
+    fn references_into_an_inline_module_resolve() {
+        let src = "module Server {\n  \
+                   type Cmd = | Spawn(id: float)\n  \
+                   let step = (c: Cmd) => 1.0\n\
+                   }\n\
+                   let go = () => Server.step(Server.Spawn(1.0))\n";
+        assert_eq!(def_at(src, "Server.step("), Some("let step = "));
+        assert_eq!(def_at(src, "Server.Spawn(1.0"), Some("Spawn(id: float)"));
+        // The annotation inside the block, on the module's own type.
+        assert_eq!(def_at(src, "Cmd)"), Some("type Cmd = | Spawn(id: float)"));
+    }
+
+    // A def INSIDE a module referring to the enclosing file's top level (the
+    // lowering scope rule) still jumps to the file-level binding.
+    #[test]
+    fn a_module_member_jumps_to_a_file_level_definition() {
+        let src = "let speed = 4.0\n\
+                   module Server {\n  \
+                   let step = () => speed\n\
+                   }\n";
+        assert_eq!(def_at(src, "speed\n}"), Some("let speed = "));
+    }
 }

--- a/functor-lang/src/hover.rs
+++ b/functor-lang/src/hover.rs
@@ -387,4 +387,22 @@ mod review_tests {
         let src = "let f = (x: float) => let mut a = x in a := a + 1.0; a";
         assert_eq!(hover_at(src, "mut a ="), "mut a : float");
     }
+
+    // PR 2. A member of an inline `module` hovers with its CANONICAL
+    // qualified name, both at the reference and at the declaration.
+    #[test]
+    fn inline_module_members_hover_qualified() {
+        let src = "module Server {\n  \
+                   let step = (delta: float) => delta\n\
+                   }\n\
+                   let go = () => Server.step(1.0)\n";
+        assert_eq!(
+            hover_at(src, "Server.step(1.0"),
+            "Server.step : (float) => float"
+        );
+        assert_eq!(
+            hover_at(src, "let step ="),
+            "Server.step : (float) => float"
+        );
+    }
 }

--- a/functor-lang/src/inlay.rs
+++ b/functor-lang/src/inlay.rs
@@ -146,4 +146,15 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].1, ": Map<string, 'a>");
     }
+
+    // PR 2. A param of a def inside an inline `module` is hinted like any
+    // other — the hints are per-def, and a module's defs are ordinary defs.
+    #[test]
+    fn infers_a_param_inside_an_inline_module() {
+        let src = "module Server {\n  let step = (d) => d + 1.0\n}\n";
+        let got = hints(src);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].1, ": float");
+        assert_eq!(got[0].0, src.find("(d)").unwrap() + 2);
+    }
 }

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -290,11 +290,12 @@ the top level of the file"
                 _ => return self.error("`let`, `type`, `expect`, or `}` inside a module"),
             }
         }
-        self.bump();
+        let close = self.bump();
         Ok(ModuleDecl {
             name,
             items,
             span: kw.span.to(name_span),
+            block: kw.span.to(close.span),
         })
     }
 

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -172,6 +172,9 @@ pub struct Project {
     pub sources: SourceMap,
     /// The entry file's module name (`game.fun` → `Game`).
     pub entry: String,
+    /// Every inline `module` block of the project's files, in file order —
+    /// the editor tooling's index (which module the cursor is in, folding).
+    pub inline_modules: Vec<InlineModule>,
     /// Per-module record-literal visibility (own + `open`ed types) —
     /// [`Project::check`] hands it to the checker so a bare literal never
     /// resolves against an unrelated sibling's type.
@@ -193,6 +196,29 @@ impl Project {
     pub fn check_with_types(&self) -> (Vec<CheckError>, crate::types::ExprTypes) {
         crate::types::check_with_scopes_and_types(&self.module, &self.scopes)
     }
+
+    /// The inline `module` block containing project-wide `offset`, if any —
+    /// the cursor's namespace for `functor_lang::complete` (blocks never
+    /// nest, so at most one matches).
+    pub fn inline_module_at(&self, offset: usize) -> Option<&InlineModule> {
+        self.inline_modules
+            .iter()
+            .find(|module| module.span.start <= offset && offset < module.span.end)
+    }
+}
+
+/// One `module Name { … }` block, indexed for editor tooling.
+pub struct InlineModule {
+    /// The declared name — how the block is referenced inside its own file
+    /// (`Grid`).
+    pub name: String,
+    /// The declaring file's module (`Utils`).
+    pub file: String,
+    /// The canonical prefix its members carry: bare in the ENTRY file
+    /// (`Server.step`), file-qualified elsewhere (`Utils.Grid.cell`).
+    pub path: String,
+    /// The whole block, `module` through `}`, in the project-wide span space.
+    pub span: crate::Span,
 }
 
 /// One file of a project, with its base offset in the project-wide span
@@ -702,6 +728,7 @@ fn link(files: Vec<SourceFile>) -> Result<Project, ProjectError> {
     // Inline `module` blocks are keyed by their full path (`Utils.Grid`);
     // a file's own top-level exports never include them.
     let mut exports: HashMap<String, Exports> = HashMap::new();
+    let mut inline_modules: Vec<InlineModule> = Vec::new();
     let file_modules: HashSet<&str> = files.iter().map(|f| f.module.as_str()).collect();
     for (index, (file, program)) in files.iter().zip(&programs).enumerate() {
         exports.insert(file.module.clone(), exports_of(&program.items));
@@ -744,6 +771,18 @@ rename it"
                 ));
             }
             exports.insert(format!("{}.{name}", file.module), exports_of(&decl.items));
+            inline_modules.push(InlineModule {
+                name: decl.name.clone(),
+                file: file.module.clone(),
+                // The entry file's members canonicalize BARE (`lower`'s
+                // rule), so its inline modules keep only their own segment.
+                path: if file.module == entry {
+                    decl.name.clone()
+                } else {
+                    format!("{}.{name}", file.module)
+                },
+                span: decl.block,
+            });
         }
     }
     let exports = exports;
@@ -889,6 +928,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         module: merged,
         sources: SourceMap { files },
         entry,
+        inline_modules,
         scopes,
     })
 }

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -232,6 +232,7 @@ fn run(
                         "hoverProvider": true,
                         "definitionProvider": true,
                         "inlayHintProvider": true,
+                        "foldingRangeProvider": true,
                         "codeLensProvider": { "resolveProvider": false },
                         "completionProvider": { "triggerCharacters": ["."] },
                         "executeCommandProvider": {
@@ -315,6 +316,18 @@ fn run(
                 write_message(
                     writer,
                     &json!({ "jsonrpc": "2.0", "id": id, "result": Value::Array(hints) }),
+                );
+            }
+            ("textDocument/foldingRange", Some(id)) => {
+                let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
+                let result = documents
+                    .contains_key(uri)
+                    .then(|| folding_ranges(uri, &documents))
+                    .flatten()
+                    .unwrap_or_else(|| json!([]));
+                write_message(
+                    writer,
+                    &json!({ "jsonrpc": "2.0", "id": id, "result": result }),
                 );
             }
             ("textDocument/codeLens", Some(id)) => {
@@ -1112,12 +1125,40 @@ fn inlay_hints(uri: &str, documents: &HashMap<String, String>, range: &Value) ->
     Some(Value::Array(hints))
 }
 
+/// Answer a folding-range request: one collapsible region per inline
+/// `module Name { … }` block in the open file. (Indentation-based folding is
+/// the client's own default and needs no server ranges; a `module` block is
+/// the one construct whose extent only the parser knows.)
+fn folding_ranges(uri: &str, documents: &HashMap<String, String>) -> Option<Value> {
+    let project = load_project(uri, documents)?;
+    let file = project.sources.file_by_path(&uri_to_path(uri)?)?;
+    let line_of = |offset: usize| lsp_position(&file.src, offset - file.base)["line"].clone();
+    let ranges: Vec<Value> = project
+        .inline_modules
+        .iter()
+        .filter(|module| owns(file, module.span.start))
+        .filter_map(|module| {
+            let (start, end) = (line_of(module.span.start), line_of(module.span.end - 1));
+            // A one-line block has nothing to fold.
+            (start != end).then(|| json!({
+                "startLine": start,
+                "endLine": end,
+                "kind": "region",
+            }))
+        })
+        .collect();
+    Some(Value::Array(ranges))
+}
+
 /// Answer a completion request. Unlike hover/definition, the offset stays
 /// **local** to the live buffer (no `file.base +`): `functor_lang::complete`
 /// derives context textually from that buffer, while candidates come from the
 /// (possibly stale) last-good `project`. `current_module` is the open file's
 /// module (a sibling's own defs are referenced bare), falling back to the
-/// project entry.
+/// project entry, and the cursor's inline `module` block (if any) is the
+/// namespace nested inside it — found by SPAN, since one file holds several.
+/// Like the candidates, the block comes from the cached project: a stale cache
+/// can name the previous block, which the same low-confidence rule tolerates.
 fn completion(
     project: &functor_lang::project::Project,
     uri: &str,
@@ -1126,15 +1167,18 @@ fn completion(
 ) -> Option<Value> {
     let text = documents.get(uri)?;
     let offset = position_to_offset(text, position)?;
-    let current_module = uri_to_path(uri)
-        .and_then(|path| {
-            project
-                .sources
-                .file_by_path(&path)
-                .map(|file| file.module.clone())
-        })
-        .unwrap_or_else(|| project.entry.clone());
-    let items = functor_lang::complete::complete(project, &current_module, text, offset);
+    let file = uri_to_path(uri).and_then(|path| project.sources.file_by_path(&path));
+    let current_module = file.map_or_else(|| project.entry.clone(), |file| file.module.clone());
+    let inline = file
+        .and_then(|file| project.inline_module_at(file.base + offset))
+        .map(|module| module.name.clone());
+    let items = functor_lang::complete::complete(
+        project,
+        &current_module,
+        inline.as_deref(),
+        text,
+        offset,
+    );
     if items.is_empty() {
         return None;
     }

--- a/tools/functor-lang-lsp/src/main.rs
+++ b/tools/functor-lang-lsp/src/main.rs
@@ -320,10 +320,13 @@ fn run(
             }
             ("textDocument/foldingRange", Some(id)) => {
                 let uri = params["textDocument"]["uri"].as_str().unwrap_or("");
-                let result = documents
-                    .contains_key(uri)
-                    .then(|| folding_ranges(uri, &documents))
-                    .flatten()
+                // From the last-good load (like completion): no reparse on a
+                // request the client re-issues after every edit, and a
+                // momentarily broken buffer keeps its folds instead of
+                // popping every block open.
+                let result = projects
+                    .get(uri)
+                    .and_then(|project| folding_ranges(project, uri))
                     .unwrap_or_else(|| json!([]));
                 write_message(
                     writer,
@@ -1129,8 +1132,10 @@ fn inlay_hints(uri: &str, documents: &HashMap<String, String>, range: &Value) ->
 /// `module Name { … }` block in the open file. (Indentation-based folding is
 /// the client's own default and needs no server ranges; a `module` block is
 /// the one construct whose extent only the parser knows.)
-fn folding_ranges(uri: &str, documents: &HashMap<String, String>) -> Option<Value> {
-    let project = load_project(uri, documents)?;
+fn folding_ranges(
+    project: &functor_lang::project::Project,
+    uri: &str,
+) -> Option<Value> {
     let file = project.sources.file_by_path(&uri_to_path(uri)?)?;
     let line_of = |offset: usize| lsp_position(&file.src, offset - file.base)["line"].clone();
     let ranges: Vec<Value> = project
@@ -1170,8 +1175,14 @@ fn completion(
     let file = uri_to_path(uri).and_then(|path| project.sources.file_by_path(&path));
     let current_module = file.map_or_else(|| project.entry.clone(), |file| file.module.clone());
     let inline = file
-        .and_then(|file| project.inline_module_at(file.base + offset))
-        .map(|module| module.name.clone());
+        .and_then(|file| {
+            // A stale cache can put the live offset past this file's range —
+            // never adopt another file's block.
+            project
+                .inline_module_at(file.base + offset)
+                .filter(|module| module.file == file.module)
+        })
+        .map(|module| module.path.clone());
     let items = functor_lang::complete::complete(
         project,
         &current_module,

--- a/tools/functor-lang-lsp/tests/completion.rs
+++ b/tools/functor-lang-lsp/tests/completion.rs
@@ -40,7 +40,7 @@ fn find<'a>(
 fn real_prelude_scene_member_completion() {
     let project = project();
     let live = "let s = Scene.";
-    let items = complete(&project, "Game", live, live.len());
+    let items = complete(&project, "Game", None, live, live.len());
     let names = labels(&items);
     for member in ["cube", "sphere", "group"] {
         assert!(
@@ -58,7 +58,7 @@ fn real_prelude_scene_member_completion() {
 fn real_prelude_partial_member_filters() {
     let project = project();
     let live = "let s = Scene.cu";
-    let items = complete(&project, "Game", live, live.len());
+    let items = complete(&project, "Game", None, live, live.len());
     assert_eq!(labels(&items), ["cube"]);
 }
 
@@ -66,7 +66,7 @@ fn real_prelude_partial_member_filters() {
 fn bundled_animator_member_completion() {
     let project = project();
     let live = "let pose = Animator.";
-    let items = complete(&project, "Game", live, live.len());
+    let items = complete(&project, "Game", None, live, live.len());
     let names = labels(&items);
     for member in ["start", "play", "pose"] {
         assert!(

--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -628,6 +628,75 @@ fn scope_aware_completion_over_real_stdio() {
     server.child.wait().expect("wait for exit");
 }
 
+/// Inline modules over the real binary: the cursor's `module` block decides
+/// the completion namespace (span-based, so the SECOND block in the file wins
+/// where it should), and the same blocks come back as folding ranges.
+#[test]
+fn inline_modules_drive_completion_scope_and_folding() {
+    // Two blocks: `describe` is visible bare only inside `Client`, and the
+    // file's `speed` is visible inside both.
+    const TEXT: &str = "let speed = 4.0\n\
+                        module Server {\n  \
+                        let step = (d: float) => d\n\
+                        }\n\
+                        module Client {\n  \
+                        let describe = () => speed\n\
+                        }\n";
+    let mut server = Server::spawn();
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "capabilities": {} },
+    }));
+    let capabilities = server.recv()["result"]["capabilities"].clone();
+    assert_eq!(capabilities["foldingRangeProvider"], json!(true));
+    server.send(json!({ "jsonrpc": "2.0", "method": "initialized", "params": {} }));
+    server.send(json!({
+        "jsonrpc": "2.0", "method": "textDocument/didOpen",
+        "params": { "textDocument": {
+            "uri": URI, "languageId": "functor-lang", "version": 1, "text": TEXT,
+        } },
+    }));
+    server.recv(); // publishDiagnostics (clean)
+
+    // Completion at the end of `Client`'s body line (line 5): the block's own
+    // `describe` and the file's `speed`, but NOT `Server`'s `step`.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 2, "method": "textDocument/completion",
+        "params": {
+            "textDocument": { "uri": URI },
+            "position": { "line": 5, "character": 23 },
+        },
+    }));
+    let result = server.recv()["result"].clone();
+    let labels: Vec<String> = result
+        .as_array()
+        .expect("completion array")
+        .iter()
+        .map(|item| item["label"].as_str().unwrap_or("").to_string())
+        .collect();
+    assert!(labels.contains(&"describe".to_string()), "{result}");
+    assert!(labels.contains(&"speed".to_string()), "{result}");
+    assert!(!labels.contains(&"step".to_string()), "{result}");
+
+    // Folding: one region per block, `module` line → closing-brace line.
+    server.send(json!({
+        "jsonrpc": "2.0", "id": 3, "method": "textDocument/foldingRange",
+        "params": { "textDocument": { "uri": URI } },
+    }));
+    let result = server.recv()["result"].clone();
+    assert_eq!(
+        result,
+        json!([
+            { "startLine": 1, "endLine": 3, "kind": "region" },
+            { "startLine": 4, "endLine": 6, "kind": "region" },
+        ]),
+    );
+
+    server.send(json!({ "jsonrpc": "2.0", "id": 9, "method": "shutdown" }));
+    server.recv();
+    server.send(json!({ "jsonrpc": "2.0", "method": "exit" }));
+    server.child.wait().expect("wait for exit");
+}
+
 /// The VSCode extension's grammar and manifests must at least be valid JSON
 /// (visual verification happens in the editor — see tools/functor-lang-vscode/README).
 /// The highlighting sample must also be a valid Functor Lang module, so it stays in

--- a/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
+++ b/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
@@ -100,7 +100,7 @@
     },
     "keyword": {
       "name": "keyword.control.functor",
-      "match": "\\b(let|type)\\b"
+      "match": "\\b(let|type|module)\\b"
     },
     "boolean": {
       "name": "constant.language.boolean.functor",

--- a/tools/functor-lang-vscode/test/sample.fun
+++ b/tools/functor-lang-vscode/test/sample.fun
@@ -35,6 +35,15 @@ let report = (scores) =>
     |> List.map((s) => Text.concat("score: ", Text.fromFloat(s)))
     |> Text.toBullets
 
+// An inline module: a named namespace inside the file.
+module Server {
+  type Cmd = | Spawn(id: float) | Despawn(id: float)
+  let step = (c: Cmd): float =>
+    match c with
+    | Spawn(id) => id
+    | Despawn(id) => -id
+}
+
 let main = () =>
   report([
     12.0,

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -340,15 +340,17 @@ fn complete_impl(sources: Vec<(PathBuf, String)>, active: &Path, offset: usize) 
         let Some(project) = borrow.as_ref() else {
             return empty_completion();
         };
-        // Complete in the active file's module scope; a file the cached
+        // Complete in the active file's module scope — plus the inline
+        // `module` block the cursor sits in, found by span. A file the cached
         // project doesn't know (just created, buffer still broken) falls back
         // to the entry module.
-        let module = project
-            .sources
-            .file_by_path(active)
-            .map(|file| file.module.clone())
-            .unwrap_or_else(|| project.entry.clone());
-        let items = functor_lang::complete::complete(project, &module, &live, byte);
+        let file = project.sources.file_by_path(active);
+        let module = file.map_or_else(|| project.entry.clone(), |file| file.module.clone());
+        let inline = file
+            .and_then(|file| project.inline_module_at(file.base + byte))
+            .map(|module| module.name.clone());
+        let items =
+            functor_lang::complete::complete(project, &module, inline.as_deref(), &live, byte);
         completion_json(&items)
     })
 }

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -347,8 +347,14 @@ fn complete_impl(sources: Vec<(PathBuf, String)>, active: &Path, offset: usize) 
         let file = project.sources.file_by_path(active);
         let module = file.map_or_else(|| project.entry.clone(), |file| file.module.clone());
         let inline = file
-            .and_then(|file| project.inline_module_at(file.base + byte))
-            .map(|module| module.name.clone());
+            .and_then(|file| {
+                // A stale cache can put the live offset past this file's
+                // range — never adopt another file's block.
+                project
+                    .inline_module_at(file.base + byte)
+                    .filter(|module| module.file == file.module)
+            })
+            .map(|module| module.path.clone());
         let items =
             functor_lang::complete::complete(project, &module, inline.as_deref(), &live, byte);
         completion_json(&items)


### PR DESCRIPTION
**PR 2 of a 3-PR stack**, based on #590 (`feat/inline-modules`). PR 3 is the
`functor.json` entries form that names inline modules as roles.

PR 1 left the editor tooling compiling but module-unaware. This makes it
first-class: the cursor's **namespace is now span-based**, so a
`module Server { … }` block is a real scope for completion, and `module` blocks
fold.

## What changed

**Cursor-position current module.** "Current module" is no longer a function of
the file. The LSP finds the block the cursor sits in by SPAN and passes its
canonical path to `complete` (`Server` in the entry, `Utils.Grid` elsewhere);
the wasm editor (`tools/functor-lang-wasm`) does the same.

**Completion** (`functor-lang/src/complete.rs`):

- **Finding 9 of PR 1's review is fixed** — `Utils.` offered the member
  `Grid.cell`; it now offers the nested **module** `Grid`, and `Utils.Grid.`
  offers `cell`. `owning_module` / `bare_name` moved to `rsplit_once`, matching
  PR 1's `types.rs` change.
- Bare completion inside a block follows PR 1's resolution order: locals → the
  module's own names → the file's top level → builtins. The module's names
  **shadow** the file's (pushed first; `finish`'s stable sort + dedup keeps
  them). `open`ed names offered bare stays the pre-existing documented non-goal
  (the merged module keeps no `open` metadata) — see dispositions.
- Qualifier resolution mirrors `lower::resolve_module_prefix` +
  `canonical_prefix`: a block is bare inside its declaring file (`Grid.` in
  `utils.fun`), entry-qualified from elsewhere (`Game.Server.` → the bare
  canonical `Server.*`), and an entry block written bare in a sibling
  (`Server.` — an unknown external there) offers nothing.

**Folding.** The LSP had no `foldingRangeProvider`; it now advertises one and
emits a `region` per `module` block. Indentation folding is the client's own
default — a block's extent is the one thing only the parser knows. Ranges come
from the last-good cache (like completion): no reparse on a per-keystroke
request, and a momentarily broken buffer keeps its folds.

**Hover / goto / codelens / inlay / docs / expects** already key off canonical
names and spans, so they worked — they are now *pinned by tests*: goto into a
block (def, ctor, annotation) and out of one to a file-level def; hover showing
the canonical `Server.step : …`; a lens titled `Server.step : …` anchored at the
indented `let`; an inlay hint on a param inside a block; a doc comment above an
indented def.

**VSCode extension:** the TextMate grammar highlights `module` (it knew only
`let|type`), and `test/sample.fun` gains a block so the grammar sample keeps
exercising every construct.

## Language-crate seams (called out per the brief)

Two, both tooling-facing; no parser/lower/checker semantics changed.

1. `ast::ModuleDecl` gains **`block: Span`** — the whole `module … }` block.
   PR 1's `span` is the header only (what collision errors point at), which
   cannot answer "is the cursor inside this block?" or "what do I fold?".
2. `project::Project` gains **`inline_modules: Vec<InlineModule>`** (name, file,
   canonical path, block span) plus **`inline_module_at(offset)`**, collected in
   `link()` where the blocks are already walked for exports. This is also the
   natural place for PR 3's role lookup.

The `inline_modules.ast` golden absorbs the new field (`UPDATE_GOLDENS=1`).

## Verification

- `cargo test -p functor-lang` — **11/11 suites green** (138 lib, 163 check, 131
  project, 83 …), including the new completion / goto / hover / codelens /
  inlay / docs tests.
- `cargo test -p functor-lang-lsp` — green except
  **`prelude_gives_host_calls_real_types`, which fails identically on the base
  ref** (verified by stashing): it expects the old `Scene.cube` doc text
  "Primitive geometry." while the prelude now says "Create a unit cube centered
  at the origin." Pre-existing, unrelated, left alone.
- `cargo test -p functor_runtime_common` — **613 + 11 green**.
- `cargo check -p functor-lang-wasm -p functor-docgen` green;
  `cargo clippy -p functor-lang -p functor-lang-lsp` adds **no new warnings**
  (2 + 3, all pre-existing and outside these hunks).
- New end-to-end LSP test (`tests/e2e.rs`) drives the real binary: two blocks in
  one file — completion inside the SECOND sees its own names and the file's but
  not the first's, and `textDocument/foldingRange` returns both regions.

Not perf-sensitive (LSP/editor paths only, nothing per-frame), so no
`frame_bench` run. No visual surface changed.

## xreview dispositions

Two independent reviewers (Claude subagent + Codex CLI). Everything
Critical/High is **fixed**, in commit `ba241ef`.

| # | Finding | Engine | Disposition |
| --- | --- | --- | --- |
| 1 | **High** — a sibling file offered the ENTRY's inline modules bare (`Server` in the module list, `Server.` completing its members), but `Server.step` there is an unknown external — completion led to a *runtime* failure with no diagnostic | Claude | **Fixed.** The module list drops entry-file block names outside the entry, and `canonical_qualifier` returns `None` for that spelling (no candidates). Test: `an_entry_inline_module_is_not_bare_in_a_sibling`. |
| 2 | **Medium** — `Game.Server.`, the spelling that *does* resolve from a sibling, completed to nothing (prefix `Game.Server.` vs the canonical bare `Server.*`) | Claude | **Fixed.** `canonical_qualifier` strips the entry prefix, mirroring `lower::canonical_prefix`. Test: `an_entry_inline_module_completes_entry_qualified`. |
| 3 | **Medium** — the LIVE-buffer offset is added to the CACHED `file.base` and searched across ALL files' spans, so a stale cache could select another file's block (two files may each declare `module Grid`) | **[AGREED]** Claude + Codex | **Fixed** for the cross-file half: both call sites now `.filter(|m| m.file == file.module)`. The *same-file* staleness is **accepted by design** — gating it on freshness would drop module scope exactly while you type a partial (the buffer is stale by definition then), the module already documents this low-confidence rule, and the blast radius is a neighbouring block's names in one popup. |
| 4 | **Medium** — multi-segment qualifiers bypassed value shadowing: with a binder named `Utils` in scope, `Utils.Grid.` offered the real module's members | Codex | **Fixed.** The value check now runs on the qualifier's HEAD for every qualifier; a chain over a value answers empty (the chained-member boundary). Test: `a_value_shadows_a_nested_namespace_qualifier`, verified failing without the fix. |
| 5 | **Medium** (simplicity) — `member_of`'s `&mut BTreeSet` out-parameter was dead: inline modules are the only source of a nested segment (no builtin or `.funi` name has two dots — verified), and they are already enumerated from the index | Claude | **Fixed.** Replaced by `direct_member(name, prefix) -> Option<&str>`; the threaded set and four `String` allocs are gone. |
| 6 | **Low** — `folding_ranges` re-parsed and re-linked the whole project (prelude included) on a request VSCode issues after every edit; a broken buffer collapsed to `[]`, popping folds open | Claude | **Fixed.** Sourced from the last-good `projects` cache, like completion. |
| 7 | **Medium** — bare completion inside a block omits file-level `open` exports, so the offered scope does not fully mirror lowering | Codex | **Won't fix here.** Pre-existing and explicitly a v1 non-goal in `complete.rs`'s module docs ("`open`ed modules' exports offered bare — the merged module does not retain `open` metadata"); not specific to inline modules, and it needs a new per-file `open` index in `Project`. Out of scope. |
| — | `canonical_module` duplicated the entry-bare rule a third time | Claude | **Fixed** as part of #3: `complete` now takes the block's canonical `path`, so the helper is deleted. |

Both engines independently confirmed clean: the `rsplit_once` move for
three-segment names, the shadowing order (stable sort + `dedup_by` keeps the
first-pushed), the `block` span being exclusive-of-`}`+1 so `end - 1` lands on
the brace, folding's `owns` guard, and minimality (no hunk outside the stated
goal).

## Docs

`.claude/skills/functor-lang/SKILL.md` gains an "In the editor" bullet under
inline modules; `docs/functor-lang.md` records this as B8 **Part 7** and drops
the LSP follow-up PR 1 recorded.
