### PR TITLE
fix(lang): teaching errors for <- assignment, qualified constructors, and nested match

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -32,7 +32,8 @@ The habits that break first, in one place. Each is expanded below.
   the first one included. Arm bodies are full expressions, so a nested
   `match` must be parenthesized.
 - **Nullary constructors take no parens** (`Point`, never `Point()`), and
-  constructors resolve bare — `Shape.Circle` is an unknown external.
+  constructors resolve bare — type-qualifying one (`Shape.Circle`) is a load
+  error telling you to write `Circle`.
 - **Local bindings are `let … in`** inside a body; top-level defs are
   mutually visible.
 - **File = module**: every sibling `.fun` in the entry's directory loads with
@@ -472,8 +473,10 @@ that's what `functor test` is for.
   builtin/prelude function therefore takes its "subject" (list, scene) LAST.
   Because `|>` is syntax, `x |> f(a)` lowers directly to the saturated `f(a, x)`
   (never a partial `f(a)`), so scene/list pipes allocate nothing.
-- **`:=` not `<-`** — `<-` is reserved for future do-block binds.
-  Assignment must be followed by `;` and a continuation expression.
+- **`:=` not `<-`** — `<-` is reserved for future do-block binds. Writing
+  `acc <- acc + 1.0;` is a parse error naming `:=` (it would otherwise lex as
+  the comparison `acc < (-acc + 1.0)`). Assignment must be followed by `;`
+  and a continuation expression.
 - **`mut` is non-capturable**: a lambda may not read or assign an enclosing
   `mut` binding (lowering error). Params, globals, and plain `let`s are
   immutable. No top-level `let mut`.
@@ -492,10 +495,15 @@ that's what `functor test` is for.
   non-finite numbers.
 - **Greedy match arms**: arm bodies are full expressions, so a nested
   `match` inside an arm consumes the following `|` arms as its own —
-  parenthesize the inner match (F#/OCaml convention). The leading `|` is
+  parenthesize the inner match (F#/OCaml convention). The checker catches
+  this: the swallowed arms report as `` `Y` is not a constructor of `B` ``
+  with a hint naming the enclosing match (beside the outer match's now
+  non-exhaustive error). The leading `|` is
   required before every arm and every variant alternative, first included.
 - **Constructors resolve bare and live in the VALUE namespace**: `Circle(2.0)`
-  works anywhere (`Shape.Circle` does NOT — it stays an unknown external),
+  works anywhere (`Shape.Circle` does NOT — TYPE-qualifying a constructor is
+  a load error pointing at the bare form; MODULE-qualifying one is fine,
+  `Utils.Circle`),
   which is why ctor names must be unique ACROSS all variant types in the
   module, and `let Circle = …` alongside a ctor `Circle` is a
   duplicate-definition error. An (uppercase) param may still shadow a ctor;

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -52,8 +52,10 @@
 //! - `first` names a top-level `let` → [`ExprKind::Global`]; remaining
 //!   segments likewise become field access.
 //! - `first` names a declared variant constructor → [`ExprKind::Ctor`]
-//!   (the `Type.Ctor` qualified form is deliberately NOT supported — a
-//!   qualified name whose head is a type name stays an unknown external).
+//!   (the `Type.Ctor` qualified form is deliberately NOT supported — naming
+//!   a type's own constructor through it is an error teaching the bare
+//!   form, since it could otherwise only fail as an unknown external at run
+//!   time).
 //! - `first` names an `open`ed module's def or constructor → the qualified
 //!   [`ExprKind::Global`] / [`ExprKind::Ctor`].
 //! - `first` names a sibling module → resolve `rest[0]` against its exports
@@ -180,6 +182,7 @@ fn lower_module(
     // variant types too.
     let mut globals = HashSet::new();
     let mut ctors: HashMap<String, usize> = HashMap::new();
+    let mut ctor_types: HashMap<String, String> = HashMap::new();
     let mut type_names = HashSet::new();
     for item in &program.items {
         match item {
@@ -246,6 +249,7 @@ namespace)",
                             });
                         }
                         ctors.insert(variant.name.clone(), variant.fields.len());
+                        ctor_types.insert(variant.name.clone(), decl.name.clone());
                     }
                 }
             }
@@ -371,6 +375,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
         globals,
         ctors,
         types: type_names,
+        ctor_types,
         project,
         open_values,
         open_types,
@@ -481,6 +486,10 @@ struct Lowerer<'p> {
     ctors: HashMap<String, usize>,
     /// This module's own declared type names (bare).
     types: HashSet<String>,
+    /// This module's own constructors → the variant type that declares them.
+    /// Only used to teach the `Shape.Circle` mistake (constructors resolve
+    /// bare); resolution itself never consults it.
+    ctor_types: HashMap<String, String>,
     /// The project context, when lowering as part of one (B8 modules).
     project: Option<&'p ProjectEnv<'p>>,
     /// Names brought into scope by `open`s (collision-free by pass 1b).
@@ -1175,11 +1184,25 @@ impl Lowerer<'_> {
                 (kind, 2)
             }
             None if segments.len() > 1 => {
+                // `Shape.Circle(2.0)` — TYPE-qualifying a constructor. It is
+                // not a module reference, so it would otherwise fall through
+                // to the host seam and die at run time as an unknown
+                // external. Constructors resolve bare.
+                if self.ctor_types.get(&segments[1]) == Some(first) {
+                    return Err(LowerError {
+                        message: format!(
+                            "`{}` is a constructor of the type `{first}`, not a member of a \
+module — constructors resolve bare: write `{}`",
+                            segments[1], segments[1]
+                        ),
+                        span,
+                    });
+                }
                 return Ok(Expr {
                     id: self.expr_id(),
                     kind: ExprKind::External(segments),
                     span,
-                })
+                });
             }
             None => {
                 let hint = if self

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -623,11 +623,25 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             TokenKind::If => self.if_expr(),
             TokenKind::Ident(_) if self.nth_kind(1) == &TokenKind::ColonEq => self.assign(),
             _ => {
+                let start = self.pos;
                 let expr = self.pipeline();
                 // A stray `:=` after a non-name expression would otherwise
                 // surface as a baffling error at the enclosing context.
                 if expr.is_ok() && self.peek_kind() == &TokenKind::ColonEq {
                     self.error("nothing (assignment targets must be a bare `let mut` name)")
+                } else if expr.is_ok() && self.peek_kind() == &TokenKind::Semi {
+                    // `acc <- acc + 1.0;` lexes as the comparison
+                    // `acc < (-acc + 1.0)`, which parses fine and only dies at
+                    // the `;` — far from the mistake. Teach it here.
+                    match self.arrow_assign(start) {
+                        Some(span) => Err(ParseError {
+                            message: "assignment is `:=`, not `<-` (`<-` is reserved for future \
+do-binds)"
+                                .to_string(),
+                            span,
+                        }),
+                        None => expr,
+                    }
                 } else {
                     expr
                 }
@@ -635,6 +649,34 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
         };
         self.depth -= 1;
         result
+    }
+
+    /// Did the expression starting at `start` open with `name<-` — an F#-style
+    /// assignment? The lexer has no `<-` token, so it arrives as `<` then `-`
+    /// and the whole thing parses as a comparison against a negation; only the
+    /// caller's trailing `;` reveals that an assignment was meant. Both halves
+    /// of the tell are required, and the pair must be ADJACENT in the source,
+    /// so a real `a < -b` comparison (and `a <- b` with no `;` after it) is
+    /// untouched. Returns the `<-` span.
+    fn arrow_assign(&self, start: usize) -> Option<Span> {
+        // `acc := a <-1.0;` is a legitimate assignment whose VALUE happens to
+        // look like this — never teach `:=` at someone already writing it.
+        if start > 0 && self.tokens[start - 1].kind == TokenKind::ColonEq {
+            return None;
+        }
+        let name = self.tokens.get(start)?;
+        let lt = self.tokens.get(start + 1)?;
+        let minus = self.tokens.get(start + 2)?;
+        let adjacent = lt.span.end == minus.span.start;
+        if matches!(name.kind, TokenKind::Ident(_))
+            && lt.kind == TokenKind::Lt
+            && minus.kind == TokenKind::Minus
+            && adjacent
+        {
+            Some(lt.span.to(minus.span))
+        } else {
+            None
+        }
     }
 
     /// `let [mut] name = value in body` — expression-level binding.

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -89,6 +89,7 @@ fn parse_impl(src: &str, base: usize, interface: bool) -> Result<Program, ParseE
         pos: 0,
         depth: 0,
         interface,
+        in_assign_value: 0,
     }
     .program()
 }
@@ -107,6 +108,14 @@ struct Parser {
     depth: usize,
     /// Parsing a `.funi` interface file: `let` is a bodyless signature.
     interface: bool,
+    /// Nesting depth inside an assignment's VALUE (`acc := <here>; rest`).
+    /// A `;` is produced by nothing but `assign`, so while this is non-zero
+    /// the `;` an expression ends at may be an enclosing assignment's rather
+    /// than a mistyped `<-`'s — see [`Parser::arrow_assign`], which then
+    /// stays quiet. Deliberately conservative: a genuine `<-` nested inside
+    /// an assignment value keeps the old (worse) error instead of risking a
+    /// wrong one on valid code.
+    in_assign_value: u32,
 }
 
 impl Parser {
@@ -659,9 +668,12 @@ do-binds)"
     /// so a real `a < -b` comparison (and `a <- b` with no `;` after it) is
     /// untouched. Returns the `<-` span.
     fn arrow_assign(&self, start: usize) -> Option<Span> {
-        // `acc := a <-1.0;` is a legitimate assignment whose VALUE happens to
-        // look like this — never teach `:=` at someone already writing it.
-        if start > 0 && self.tokens[start - 1].kind == TokenKind::ColonEq {
+        // The `;` we are standing on may be the terminator of an ENCLOSING
+        // assignment, in which case this expression is that assignment's
+        // value (possibly several `let … in` / `if` levels down) and the
+        // comparison is exactly what was meant. Someone already writing `:=`
+        // is never taught `:=`.
+        if self.in_assign_value > 0 {
             return None;
         }
         let name = self.tokens.get(start)?;
@@ -742,7 +754,12 @@ do-binds)"
     fn assign(&mut self) -> Result<Expr, ParseError> {
         let (name, name_span) = self.expect_ident("a name")?;
         self.expect(TokenKind::ColonEq, "`:=`")?;
-        let value = self.expr()?;
+        // The value's `;` terminator is this assignment's, at whatever depth
+        // the value's tail expression ends — see `arrow_assign`.
+        self.in_assign_value += 1;
+        let value = self.expr();
+        self.in_assign_value -= 1;
+        let value = value?;
         self.expect(
             TokenKind::Semi,
             "`;` (an assignment carries its continuation)",

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -774,6 +774,7 @@ fn check_impl(
         partials: HashMap::new(),
         def_param_names: HashMap::new(),
         ctor_param_names: HashMap::new(),
+        match_scrutinees: Vec::new(),
     };
 
     // Record type names first (nominal references may be forward), then
@@ -1133,6 +1134,12 @@ struct Checker<'s> {
     def_param_names: HashMap<String, Vec<String>>,
     /// Constructor name → its field names, in order (same purpose).
     ctor_param_names: HashMap<String, Vec<String>>,
+    /// Scrutinee types of the `match`es currently being checked, outermost
+    /// first (the innermost is the one whose arms are being checked). Purely
+    /// a diagnostic side channel: it turns "`Y` is not a constructor of `B`"
+    /// into the greedy-arm hint when `Y` belongs to an ENCLOSING match's
+    /// scrutinee — the nested-match-ate-the-following-arms mistake.
+    match_scrutinees: Vec<Type>,
 }
 
 /// An under-applied call's provenance: enough to say `` `shift` is applied to
@@ -2387,6 +2394,9 @@ missing {missing}. Did you forget an argument?"
         let mut list_exact: Vec<usize> = Vec::new();
         let mut list_tail_mins: Vec<usize> = Vec::new();
         let mut result: Option<Type> = None;
+        // Enclosing-match context for the greedy-arm hint (see
+        // `match_scrutinees`); popped below, after the arms are checked.
+        self.match_scrutinees.push(scrutinee_ty.clone());
         for arm in arms {
             // Arms after a catch-all are unreachable at runtime — they are
             // still CHECKED (garbage draws diagnostics) but must not
@@ -2435,6 +2445,7 @@ missing {missing}. Did you forget an argument?"
                 Some(prev) => self.join_arms(prev, body_ty, arm.body.span, "match arms"),
             });
         }
+        self.match_scrutinees.pop();
         // Exhaustiveness fires only where the scrutinee's type is known —
         // RE-ZONKED: the arms' patterns may have just SOLVED it (the
         // stale-zonk hole both engines found: an inferred-scrutinee match
@@ -2572,6 +2583,31 @@ a catch-all arm (`_` or a name)"
         }
     }
 
+    /// The greedy-arm hint for a ctor pattern that belongs to `type_name`
+    /// while the match it sits in scrutinizes something else. When an
+    /// ENCLOSING match's scrutinee IS `type_name`, the arm was almost
+    /// certainly meant for that outer match and was swallowed by a nested
+    /// `match` in the arm above it (arm bodies are full expressions). Empty
+    /// otherwise, so an ordinary wrong-constructor mistake reads unchanged.
+    fn greedy_arm_hint(&self, type_name: &str) -> String {
+        // The LAST entry is the match being checked right now; only the ones
+        // enclosing it can have had an arm stolen.
+        let enclosing = self.match_scrutinees.split_last().map(|(_, rest)| rest);
+        let stolen = enclosing.is_some_and(|tys| {
+            tys.iter()
+                .any(|ty| matches!(self.zonk(ty), Type::Variant(name, _) if name == type_name))
+        });
+        if stolen {
+            format!(
+                " — did you mean to parenthesize the inner `match`? arm bodies are full \
+expressions, so a nested `match` swallows the arms that follow it (this one reads as an arm of \
+the inner match, not of the `{type_name}` match around it)"
+            )
+        } else {
+            String::new()
+        }
+    }
+
     /// Check one pattern against the scrutinee's type and record its
     /// variables' binding types (a bare variable binds the scrutinee's type;
     /// constructor sub-patterns bind the declared field types).
@@ -2679,9 +2715,10 @@ value is {scrutinee} — it can never match",
                     let mut field_tys = field_tys;
                     match scrutinee {
                         Type::Variant(s, _) if *s != type_name => {
+                            let hint = self.greedy_arm_hint(&type_name);
                             self.diag(
                                 pattern.span,
-                                format!("`{name}` is not a constructor of `{s}`"),
+                                format!("`{name}` is not a constructor of `{s}`{hint}"),
                             );
                         }
                         Type::Variant(_, targs) => {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -83,7 +83,7 @@ use crate::ir::{
 };
 use crate::span::Span;
 use crate::CheckError;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 #[derive(Clone, PartialEq)]
@@ -1138,8 +1138,10 @@ struct Checker<'s> {
     /// first (the innermost is the one whose arms are being checked). Purely
     /// a diagnostic side channel: it turns "`Y` is not a constructor of `B`"
     /// into the greedy-arm hint when `Y` belongs to an ENCLOSING match's
-    /// scrutinee — the nested-match-ate-the-following-arms mistake.
-    match_scrutinees: Vec<Type>,
+    /// scrutinee — the nested-match-ate-the-following-arms mistake. Each
+    /// entry is that match's scrutinee type plus the ctor names it already
+    /// has arms for (an arm it still has cannot have been stolen).
+    match_scrutinees: Vec<(Type, HashSet<String>)>,
 }
 
 /// An under-applied call's provenance: enough to say `` `shift` is applied to
@@ -2395,8 +2397,17 @@ missing {missing}. Did you forget an argument?"
         let mut list_tail_mins: Vec<usize> = Vec::new();
         let mut result: Option<Type> = None;
         // Enclosing-match context for the greedy-arm hint (see
-        // `match_scrutinees`); popped below, after the arms are checked.
-        self.match_scrutinees.push(scrutinee_ty.clone());
+        // `match_scrutinees`); popped below, after the arms are checked. The
+        // ctor names THIS match already has arms for come along: an arm it
+        // still has was not stolen from it. [BOTH engines — review]
+        let own_ctors: HashSet<String> = arms
+            .iter()
+            .filter_map(|arm| match &arm.pattern.kind {
+                PatternKind::Ctor { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect();
+        self.match_scrutinees.push((scrutinee_ty.clone(), own_ctors));
         for arm in arms {
             // Arms after a catch-all are unreachable at runtime — they are
             // still CHECKED (garbage draws diagnostics) but must not
@@ -2583,19 +2594,23 @@ a catch-all arm (`_` or a name)"
         }
     }
 
-    /// The greedy-arm hint for a ctor pattern that belongs to `type_name`
-    /// while the match it sits in scrutinizes something else. When an
-    /// ENCLOSING match's scrutinee IS `type_name`, the arm was almost
-    /// certainly meant for that outer match and was swallowed by a nested
-    /// `match` in the arm above it (arm bodies are full expressions). Empty
-    /// otherwise, so an ordinary wrong-constructor mistake reads unchanged.
-    fn greedy_arm_hint(&self, type_name: &str) -> String {
+    /// The greedy-arm hint for a ctor pattern `name` that belongs to
+    /// `type_name` while the match it sits in scrutinizes something else.
+    /// When an ENCLOSING match scrutinizes `type_name` and has NO arm for
+    /// `name`, the arm was almost certainly meant for that outer match and
+    /// was swallowed by a nested `match` in the arm above it (arm bodies are
+    /// full expressions). Empty otherwise — an ordinary wrong-constructor
+    /// mistake, including one inside a properly parenthesized inner match
+    /// whose outer already handles `name`, reads unchanged. [BOTH engines]
+    fn greedy_arm_hint(&self, name: &str, type_name: &str) -> String {
         // The LAST entry is the match being checked right now; only the ones
         // enclosing it can have had an arm stolen.
         let enclosing = self.match_scrutinees.split_last().map(|(_, rest)| rest);
-        let stolen = enclosing.is_some_and(|tys| {
-            tys.iter()
-                .any(|ty| matches!(self.zonk(ty), Type::Variant(name, _) if name == type_name))
+        let stolen = enclosing.is_some_and(|entries| {
+            entries.iter().any(|(ty, arm_ctors)| {
+                !arm_ctors.contains(name)
+                    && matches!(self.zonk(ty), Type::Variant(n, _) if n == type_name)
+            })
         });
         if stolen {
             format!(
@@ -2715,7 +2730,7 @@ value is {scrutinee} — it can never match",
                     let mut field_tys = field_tys;
                     match scrutinee {
                         Type::Variant(s, _) if *s != type_name => {
-                            let hint = self.greedy_arm_hint(&type_name);
+                            let hint = self.greedy_arm_hint(name, &type_name);
                             self.diag(
                                 pattern.span,
                                 format!("`{name}` is not a constructor of `{s}`{hint}"),

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -932,6 +932,26 @@ fn nested_match_swallowing_arms_teaches_parenthesizing() {
     );
 }
 
+/// An already-parenthesized inner match whose OUTER match still has that
+/// arm swallowed nothing — it is an ordinary typo, and advising parens
+/// would be wrong. [BOTH engines — review]
+#[test]
+fn parenthesized_inner_match_gets_no_greedy_hint() {
+    let (message, _, _) = single_diag(
+        "type A = | X | Y\n\
+         type B = | P | Q\n\
+         let f = (a: A, b: B): string =>\n\
+         \x20 match a with\n\
+         \x20 | X =>\n\
+         \x20   (match b with\n\
+         \x20    | P => \"xp\"\n\
+         \x20    | Y => \"typo\"\n\
+         \x20    | Q => \"xq\")\n\
+         \x20 | Y => \"y\"\n",
+    );
+    assert_eq!(message, "`Y` is not a constructor of `B`");
+}
+
 /// …and an ordinary foreign constructor — including one inside a nested
 /// match that no enclosing scrutinee explains — keeps the bare message.
 #[test]

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -899,6 +899,59 @@ fn error_foreign_ctor_in_a_match() {
     assert_eq!((line, col), (3, 45));
 }
 
+/// The greedy-arm trap: a nested `match` in an arm swallows the arms that
+/// follow it, so the OUTER match loses them (non-exhaustive) and they arrive
+/// at the INNER one as foreign constructors. The two diagnostics are
+/// connected — the foreign-ctor one names the real cause.
+#[test]
+fn nested_match_swallowing_arms_teaches_parenthesizing() {
+    let diags = check_src(
+        "type A = | X | Y\n\
+         type B = | P | Q\n\
+         let f = (a: A, b: B): string =>\n\
+         \x20 match a with\n\
+         \x20 | X =>\n\
+         \x20   match b with\n\
+         \x20   | P => \"xp\"\n\
+         \x20   | Q => \"xq\"\n\
+         \x20 | Y => \"y\"\n",
+    );
+    assert_eq!(diags.len(), 2, "got {diags:?}");
+    assert_eq!(diags[0].0, "match on `A` is not exhaustive: missing `Y`");
+    assert!(
+        diags[1]
+            .0
+            .starts_with("`Y` is not a constructor of `B` — did you mean to parenthesize"),
+        "got: {}",
+        diags[1].0
+    );
+    assert!(
+        diags[1].0.contains("`A` match around it"),
+        "the hint names the enclosing match's type; got: {}",
+        diags[1].0
+    );
+}
+
+/// …and an ordinary foreign constructor — including one inside a nested
+/// match that no enclosing scrutinee explains — keeps the bare message.
+#[test]
+fn foreign_ctor_without_an_enclosing_match_has_no_hint() {
+    let (message, _, _) = single_diag(
+        "type A = | X | Y\n\
+         type B = | P | Q\n\
+         type C = | R\n\
+         let f = (a: A, b: B): string =>\n\
+         \x20 match a with\n\
+         \x20 | X =>\n\
+         \x20   (match b with\n\
+         \x20    | P => \"xp\"\n\
+         \x20    | Q => \"xq\"\n\
+         \x20    | R => \"r\")\n\
+         \x20 | Y => \"y\"\n",
+    );
+    assert_eq!(message, "`R` is not a constructor of `B`");
+}
+
 /// A constructor pattern against a known non-variant scrutinee.
 #[test]
 fn error_ctor_pattern_against_a_float() {

--- a/functor-lang/tests/ir.rs
+++ b/functor-lang/tests/ir.rs
@@ -327,16 +327,37 @@ fn error_ctor_collides_with_let() {
 
 /// …but `type Shape` itself stays in the type namespace: a `let Shape` is
 /// fine, and `Shape.Circle` is deliberately NOT a constructor reference
-/// (only bare `Circle` is) — it stays an unknown external.
+/// (only bare `Circle` is). It used to fall through to the host seam and die
+/// at RUN time as `unknown external `Shape.Circle``; now the resolver names
+/// the mistake.
 #[test]
-fn qualified_ctor_form_is_not_supported() {
-    let module = lower_src("type Shape = | Circle(r: float)\nlet f = () => Shape.Circle(1.0)");
+fn qualified_ctor_form_teaches_the_bare_form() {
+    let (message, line, col) =
+        lower_err("type Shape = | Circle(r: float)\nlet f = () => Shape.Circle(1.0)");
+    assert_eq!(
+        message,
+        "`Circle` is a constructor of the type `Shape`, not a member of a module — \
+constructors resolve bare: write `Circle`"
+    );
+    assert_eq!((line, col), (2, 15));
+}
+
+/// The teaching error is keyed to the ctor's OWN type, so an unrelated
+/// qualified name (a host external, or another type's constructor) still
+/// lowers to the gradual external seam.
+#[test]
+fn unrelated_qualified_names_stay_external() {
+    let module = lower_src(
+        "type Shape = | Circle(r: float)\n\
+         type Blob = | Splat\n\
+         let f = () => Blob.Circle(1.0)",
+    );
     let (_, body) = lambda_body(&module, 0);
     let ExprKind::Call { callee, .. } = &body.kind else {
         panic!("expected a call, got {body:?}");
     };
     assert!(
-        matches!(&callee.kind, ExprKind::External(path) if path == &["Shape", "Circle"]),
+        matches!(&callee.kind, ExprKind::External(path) if path == &["Blob", "Circle"]),
         "expected an external, got {callee:?}"
     );
 }

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -275,6 +275,33 @@ fn assignment_to_field_is_a_targeted_error() {
     );
 }
 
+/// `acc <- acc + 1.0;` lexes as `acc < (-acc + 1.0)`, parses as a comparison,
+/// and used to die at the `;` with a top-level "expected `let`…" error far
+/// from the mistake. It teaches `:=` at the `<-` instead.
+#[test]
+fn arrow_assignment_teaches_colon_eq() {
+    let (message, line, col) =
+        parse_err("let f = (a) =>\n  let mut acc = a in\n  acc <- acc + 1.0;\n  acc");
+    assert!(
+        message.contains("assignment is `:=`, not `<-`"),
+        "got: {message}"
+    );
+    assert_eq!((line, col), (3, 7));
+}
+
+/// The teaching error must not eat a real comparison-with-negation, whether
+/// or not the source spaces it out — and `:=` assignments whose VALUE has
+/// that shape stay assignments.
+#[test]
+fn comparison_with_negation_still_parses() {
+    assert!(functor_lang::parse("let lt = (a, b) => a < -b").is_ok());
+    assert!(functor_lang::parse("let lt = (a, b) => a <-b").is_ok());
+    assert!(functor_lang::parse(
+        "let f = (a) =>\n  let mut acc = 0.0 in\n  acc := a <-1.0;\n  acc"
+    )
+    .is_ok());
+}
+
 // --- Variant declarations + match (B5 part 1) ---
 
 /// Both `type` bodies parse; the variant form allows nullary constructors

--- a/functor-lang/tests/parser.rs
+++ b/functor-lang/tests/parser.rs
@@ -300,6 +300,17 @@ fn comparison_with_negation_still_parses() {
         "let f = (a) =>\n  let mut acc = 0.0 in\n  acc := a <-1.0;\n  acc"
     )
     .is_ok());
+    // …including where the comparison ends an assignment value SEVERAL
+    // levels down, so the `;` it stops at is the assignment's, not a
+    // mistyped `<-`'s. [BOTH engines — review]
+    assert!(functor_lang::parse(
+        "let f = (a) =>\n  let mut acc = 0.0 in\n  acc := let y = 1.0 in a <-y;\n  acc"
+    )
+    .is_ok());
+    assert!(functor_lang::parse(
+        "let f = (a) =>\n  let mut acc = 0.0 in\n  acc := if a > 0.0 then a <-1.0 else true;\n  acc"
+    )
+    .is_ok());
 }
 
 // --- Variant declarations + match (B5 part 1) ---

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -332,7 +332,9 @@ let area = (s: Shape): float =>
           </p>
           <p>
             <strong>Arms are greedy:</strong> a nested <code>match</code> inside an arm consumes
-            the following <code>|</code> arms as its own — parenthesize the inner match.
+            the following <code>|</code> arms as its own — parenthesize the inner match. The
+            checker diagnoses it for you: a swallowed arm reports as "not a constructor of" the
+            inner scrutinee, with a hint pointing back at the outer match.
           </p>
 
           <h3>The conditional</h3>
@@ -962,7 +964,6 @@ connect_game { "url": "http://127.0.0.1:8123" }</pre>
             <li><code>if</code> is an expression: both branches are required, and chains use <code>else if</code> rather than <code>elif</code>.</li>
             <li>Captured game mouse input defaults on when captured hooks exist. <code>"mouseCapture":false</code> opts out; <code>"cursor":"visible"</code> selects absolute pointer input instead. Held buttons are force-released on focus loss.</li>
             <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>
-            <li>A nested <code>match</code> inside an arm eats the following arms — parenthesize it.</li>
             <li>Constructor names are global to the file's value namespace; nullary constructors never take parens. Module variants are the exception — <code>Option.Some</code>, never bare <code>Some</code>.</li>
             <li>Piping into <code>Text.concat</code> <em>prepends</em>: <code>s |> Text.concat(p)</code> is <code>p</code> then <code>s</code>. And <code>Text.fixed(n, decimals)</code> takes its number first, so it can't be piped on.</li>
             <li><code>Math</code> is only the entries above — there is still no <code>lerp</code>, <code>sinh</code>, or <code>hypot</code>. <code>Math.round</code> goes half <em>away from zero</em>, not to even.</li>


### PR DESCRIPTION
Three non-breaking teaching errors in the `functor-lang` crate. Each one replaces a diagnostic that pointed far away from (or lied about) the actual mistake.

## 1. `<-` assignment → teaches `:=` (parser)

`acc <- acc + 1.0;` lexes as the comparison `acc < (-acc + 1.0)`, parses fine, and only fell over at the `;` with a useless `expected 'let', 'type', 'open', or 'expect' at top level, found ';'`.

```
p.fun:3:7: error: assignment is `:=`, not `<-` (`<-` is reserved for future do-binds)
```

The tell is *both* an adjacent `<` `-` pair opening the expression **and** the trailing `;` (a `;` is produced by nothing but `assign`, so an expression standing on one is already a parse error). Suppressed inside an assignment's own value at any nesting, so `acc := let y = 1.0 in a <-y;` stays a comparison.

## 2. Type-qualified constructor → teaches the bare form (resolver)

`Shape.Circle(2.0)` used to fall through to the host-external seam and die at RUN time as `unknown external 'Shape.Circle'`.

```
p.fun:10:18: error: `Circle` is a constructor of the type `Shape`, not a member of a
module — constructors resolve bare: write `Circle`
```

It fires only when the qualifier is a type declared in this module **and** the member is one of *that type's* constructors. Module qualification is untouched: `Util.Wrapped(1.0)`, `Option.Some(3.0)`, `Result.Ok(4.0)` all still resolve, and an unrelated qualified name still lowers to the gradual external seam.

## 3. Nested match → connects the two diagnostics (checker)

A nested `match` in an arm swallows the arms that follow it. The checker already emitted both halves of the story without connecting them; now the swallowed arm points back at the outer match:

```
p.fun:10:3: error: match on `A` is not exhaustive: missing `Y`
p.fun:15:5: error: `Y` is not a constructor of `B` — did you mean to parenthesize the
inner `match`? arm bodies are full expressions, so a nested `match` swallows the arms
that follow it (this one reads as an arm of the inner match, not of the `A` match around it)
```

The hint requires the stray ctor to belong to an enclosing match's scrutinee **and** that enclosing match to have no arm for it already — so an ordinary wrong-constructor typo, including one inside a correctly parenthesized inner match, reads exactly as before.

## Docs

Fix 3 retires sharp-edge bullet #6 in the manual ("A nested `match` inside an arm eats the following arms — parenthesize it") — the checker now diagnoses it directly, and the rule stays documented inline in the language section, which now says so. The `functor-lang` skill's stale wording is updated: type-qualifying a ctor is a load error (not "an unknown external"), `<-` is a parse error naming `:=`, and the greedy-arm rule notes the checker catches it.

### Manual — sharp edges, before / after (desktop 1280px)

| before | after |
| --- | --- |
| ![sharp edges before](https://gist.githubusercontent.com/tommy-xr/23f14b51a51e2bef50c341033edc6d5a/raw/sharp-edges-before-desktop.png) | ![sharp edges after](https://gist.githubusercontent.com/tommy-xr/23f14b51a51e2bef50c341033edc6d5a/raw/sharp-edges-after-desktop.png) |

Mobile (420px): [before](https://gist.githubusercontent.com/tommy-xr/23f14b51a51e2bef50c341033edc6d5a/raw/sharp-edges-before-mobile.png) · [after](https://gist.githubusercontent.com/tommy-xr/23f14b51a51e2bef50c341033edc6d5a/raw/sharp-edges-after-mobile.png) — same single-bullet delta, no layout change.

### Manual — "Arms are greedy" paragraph, before / after

![greedy arms before](https://gist.githubusercontent.com/tommy-xr/23f14b51a51e2bef50c341033edc6d5a/raw/greedy-arms-before.png)
![greedy arms after](https://gist.githubusercontent.com/tommy-xr/23f14b51a51e2bef50c341033edc6d5a/raw/greedy-arms-after.png)

<sub>Captured headlessly with Playwright/chromium at 1280px and 420px, rendering `site/manual/index.html` at the base ref and at this branch. `npm run site:build` had a pre-existing `generate-icons.mjs` `ERR_MODULE_NOT_FOUND` on main — `npm install` fixed that, but the full site build then requires the wasm web-runtime bundle (`wasm-pack build runtime/functor-runtime-web`), so these shots render the page source against the shipped `site/styles.css` rather than `site/dist`. Only the build-time header injection is absent; the sharp-edges list and the language section render as shipped.</sub>

## Verification

- `cargo test -p functor-lang` — all suites pass (121 + 166 + 33 + 38 + 58 + 63 + 20 + 15 + 130). No golden regeneration was needed (no snapshot changed).
- New tests: `arrow_assignment_teaches_colon_eq`, `comparison_with_negation_still_parses` (spaced, unspaced, and three assignment-value nestings) in `tests/parser.rs`; `qualified_ctor_form_teaches_the_bare_form`, `unrelated_qualified_names_stay_external` in `tests/ir.rs`; `nested_match_swallowing_arms_teaches_parenthesizing`, `parenthesized_inner_match_gets_no_greedy_hint`, `foreign_ctor_without_an_enclosing_match_has_no_hint` in `tests/check.rs`.
- Empirical probes via `cargo run -q -p functor-lang -- check|run <probe.fun>` in scratch dirs outside `examples/` (file = module), showing each new message — the three transcripts above are those runs.
- **No false positives**, probed: `a < -b` and `a <-b` both parse; `acc := a <-1.0;`, `acc := let y = 1.0 in a <-y;` and `acc := match … | true => a <-1.0 …;` all parse and run; `Util.Wrapped`, `Option.Some`, `Result.Ok`, `Util.unwrap` all resolve and evaluate; the parenthesized nested match and a third-type stray ctor draw no hint.
- Repo sweep: no `.fun` file in the repo uses `<-` outside comments, and no type-qualified constructor exists (`Msg.Tick` is a comment; `Protocol.*` / `Shapes.*` / `World.*` / `Option.*` are module qualification).

## Review dispositions (`/xreview` — Claude subagent + Codex CLI)

| # | Finding | Engines | Disposition |
| --- | --- | --- | --- |
| 1 | The `<-` heuristic rejected a valid comparison ending an assignment value at depth (`acc := let y = 1.0 in a <-y;`) — the `start-1 == :=` token guard only covered the direct value. | **BOTH** (Codex High, Claude Medium) | **Fixed** — replaced by an explicit `in_assign_value` counter incremented around `assign()`'s value parse, so the whole value at any nesting is exempt. Two regression tests. Deliberately conservative: a genuine `<-` inside an assignment value keeps the old error rather than risking a wrong one. |
| 2 | The greedy-arm hint fired on an already-parenthesized inner match, advising parens that were already there. | **BOTH** (Claude Medium, Codex Medium) | **Fixed** — each match now records the ctor names it has arms for; the hint requires the enclosing match to *lack* that arm (an arm it still has cannot have been stolen). Regression test `parenthesized_inner_match_gets_no_greedy_hint`. |
| 3 | The symmetric pattern-position mistake (`| Shape.Circle(r) =>`) still says `unknown module 'Shape'`, which is false — `Shape` is a declared type. | Claude (Low) | **Deferred** — out of this PR's scope (expression position only, as specified). Worth a follow-up routing `resolve_pattern_ctor` through the same `ctor_types` check. |
| 4 | Keep the manual's greedy-match bullet; the checker's hint is a heuristic, not a guarantee. | Claude (Low) | **Declined** — retiring the bullet is the requested change, the rule remains documented inline in the language section (now noting the checker diagnoses it), and after fix #2 the hint's precondition is precise. |
| 5 | The `ctor_types` map may be unnecessary — `types.contains(first) && ctors.contains_key(member)` would do. | Claude (Low) | **Declined** — the map keeps the error precise (it names the owning type and fires only for *that* type's constructors, per the spec), and keeps `Blob.Circle` on the gradual external seam rather than claiming a relationship that does not exist. |
| — | No duplication signals; `check_match`'s push/pop is balanced with no early return between them; the stale-zonk case is handled (`greedy_arm_hint` re-zonks); the new lowering error cannot fire on previously-valid programs (the module branch runs first — verified with a local `type Key` shadow against the prelude `Key` module). | Claude (verified negatives) | Noted. |

Verification was re-run after the fixes (full `cargo test -p functor-lang`, plus all probes).

## Not covered

No perf work: this is parse/lower/check-time only (no per-frame hot path), so no `frame_bench` run. No device/GPU surface touched.
