### PR TITLE
feat(lang): add Math.lerp, Math.smoothstep, and List.minimum

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -47,7 +47,7 @@ The habits that break first, in one place. Each is expanded below.
 ## Verification loop (always available, no GPU)
 
 Builtin-module MEMBER names are validated at `check` time: `List.tail`,
-`List.minimum`, `Text.padLeft` (none exist) are check ERRORS with a near-miss
+`List.partition`, `Text.padLeft` (none exist) are check ERRORS with a near-miss
 hint or the namespace's member list — a typo in a `List.*` / `Text.*` /
 `Math.*` call no longer survives to runtime. Note this is a hard error with
 no escape hatch, and it gates hot-reload: a builtin typo in a DEAD branch
@@ -636,13 +636,13 @@ level) · `List.append(other, list)` (subject-LAST: `xs |> List.append(ys)` is
 first, list last — `xs |> List.any(pred)`; empty list is vacuously all-true /
 any-false) ·
 `List.nth(index, list)` / `List.head(list)` / `List.last(list)` /
-`List.find(fn, list)` / `List.maximum(list)` — the PARTIAL accessors, each
+`List.find(fn, list)` / `List.maximum(list)` / `List.minimum(list)` — the PARTIAL accessors, each
 returning **`Option.t<'a>`** (`Option.Some(x)` / `Option.None`), never a
 sentinel and never an error on an empty list;
 `List.nth`'s index is 0-based and out of range is `Option.None`, but a
-FRACTIONAL index is an error (a caller bug, not an absence). `List.maximum`
-takes `List<float>` and answers `Option.t<float>` (NaN elements are ignored
-unless every element is NaN). Match them, or
+FRACTIONAL index is an error (a caller bug, not an absence). `List.maximum` /
+`List.minimum` take `List<float>` and answer `Option.t<float>` (NaN elements
+are ignored unless every element is NaN). Match them, or
 collapse with `Option.defaultValue(fallback)`. ·
 `List.indexedMap(fn, list)` (like `map`, but `fn(index, element)` — index
 FIRST, 0-based) · `List.sortBy(fn, list)` (ascending by the Float the key
@@ -695,6 +695,18 @@ never re-scans what it wrote; empty `from` is an error) ·
 `Math.clamp01(n)` · `Math.clamp(low, high, n)` (the GENERAL clamp,
 subject-LAST — `n |> Math.clamp(0.0, 10.0)`; `clamp01(n)` ==
 `clamp(0.0, 1.0, n)`; `low > high` is an error, not a silent swap) ·
+`Math.lerp(target, t, from)` (= `from + (target - from) * t`, and `t == 1`
+answers `target` itself so BOTH endpoints land exactly; **UNCLAMPED**, so `t`
+outside `[0, 1]` extrapolates — clamp the parameter first when you need the
+bounded form. Subject-LAST on the START value, **exactly `Vec3.lerp`'s shape**,
+so the scalar and the vector pipe identically:
+`x |> Math.lerp(target, t)` beside `pos |> Vec3.lerp(target, t)`. NOTE this is
+NOT `mix`/`std::lerp`'s `(a, b, t)` — the parameter sits in the MIDDLE) ·
+`Math.smoothstep(edge0, edge1, x)` (the standard Hermite ramp `3t² - 2t³`
+over the CLAMPED `t = (x - edge0) / (edge1 - edge0)`: flat `0` at/below
+`edge0`, flat `1` at/above `edge1`. The range must be FINITE and ascending —
+`edge0 >= edge1`, a NaN edge, and an infinite/overflow-wide one are all errors
+— the `Math.clamp` rule — rather than the silent NaN the formula would give) ·
 `Math.sin(n)` · `Math.cos(n)` · `Math.tan(n)` ·
 `Math.asin(n)` / `Math.acos(n)` (NaN outside `[-1, 1]` — they do NOT clamp,
 so a dot product nudged past 1.0 by float error needs
@@ -756,7 +768,7 @@ members in every embedding, so anything else is a **check-time error** —
 `Text.padLeft` with `` `List` has no builtin `tail` `` plus the nearest name
 or the namespace's full member list. Do NOT assume an F#/Elm stdlib function
 exists just because it is idiomatic there: `List` still has no
-`tail`/`minimum`/`partition`/`unzip`/`chunk`/`mapMaybe`/`sortWith`/`foldRight`,
+`tail`/`partition`/`unzip`/`chunk`/`mapMaybe`/`sortWith`/`foldRight`,
 and `Text` no `padLeft`/`startsWith`/`slice`. Build those from `List.fold` /
 `List.filter` / `List.take` + `List.drop` / `Math.min` + `Math.max`.
 (`Scene.*` and the

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -1793,6 +1793,34 @@ most 1000000 cells"
                 }
                 _ => err("List.maximum(list) expects one list".to_string()),
             },
+            // `List.minimum` is `List.maximum`'s sibling, Option-shaped like
+            // every partial accessor (`List.head`/`nth`/`find`): an empty
+            // list is `Option.None`, not an error.
+            //
+            // NaN follows `f64::min`, exactly like `List.maximum`'s `f64::max`:
+            // a NaN element is ignored while any real number is present.
+            Builtin::ListMinimum => match args.as_slice() {
+                [Value::List(items)] => {
+                    // O(n) scan: charge n (the List.maximum rule).
+                    self.charge(items.len() as u64, span)?;
+                    let mut best: Option<f64> = None;
+                    for item in items.iter() {
+                        match item {
+                            Value::Number(n) => {
+                                best = Some(best.map_or(*n, |b: f64| b.min(*n)));
+                            }
+                            other => {
+                                return err(format!(
+                                    "List.minimum expects numbers, got {}",
+                                    other.kind_name()
+                                ))
+                            }
+                        }
+                    }
+                    Ok(option_value(best.map(Value::Number)))
+                }
+                _ => err("List.minimum(list) expects one list".to_string()),
+            },
             // The iterative list helpers a game reaches for — hand-rolling
             // these recursively blows the eval-depth cap around n≈60, so they
             // loop in Rust and consume no evaluation depth (see MAX_EVAL_DEPTH).
@@ -2536,6 +2564,57 @@ most 1000000 cells"
                 )),
                 _ => err("Math.clamp(low, high, n) expects three numbers".to_string()),
             },
+            // `Math.lerp(target, t, from)` = `from + (target - from) * t` —
+            // UNCLAMPED, like `Vec3.lerp`: `t` outside [0, 1] extrapolates,
+            // which is what an overshooting ease or a spring wants. Clamp the
+            // parameter first (`t |> Math.clamp01 |> …`) for the bounded form.
+            //
+            // The argument order MIRRORS `Vec3.lerp(target, t, from)` exactly,
+            // so the subject is the START value and the two pipe identically:
+            // `x |> Math.lerp(target, t)` beside `pos |> Vec3.lerp(target, t)`.
+            // That costs `mix`/`std::lerp` familiarity and buys the thing that
+            // actually bites — carrying the vector habit to scalars can no
+            // longer typecheck clean while meaning something else.
+            Builtin::MathLerp => match args.as_slice() {
+                // `from + (target - from) * t`, the standard form — but it is
+                // exact only at `t == 0`: `from + (target - from)` rounds off
+                // `target` for ~9% of random float pairs. `t == 1` is therefore
+                // answered with `target` itself, so both endpoints land
+                // EXACTLY (the `std::lerp` rule) and an ease that runs to
+                // completion actually arrives.
+                [Value::Number(target), Value::Number(t), Value::Number(_)] if *t == 1.0 => {
+                    Ok(Value::Number(*target))
+                }
+                [Value::Number(target), Value::Number(t), Value::Number(from)] => {
+                    Ok(Value::Number(from + (target - from) * t))
+                }
+                _ => err("Math.lerp(target, t, from) expects three numbers".to_string()),
+            },
+            // The standard (GLSL/Hermite) smoothstep: 0 below `edge0`, 1 above
+            // `edge1`, and a smooth `3t² - 2t³` ramp between — CLAMPED, unlike
+            // `Math.lerp` (an easing curve that overshoots its own edges is
+            // never what a caller means).
+            //
+            // The range must be finite and ascending. A zero-width, inverted,
+            // or NaN range is the obvious caller bug, but an infinite (or
+            // merely astronomically wide) one is the same bug wearing a
+            // disguise: `edge1 - edge0` overflows, the division answers NaN or
+            // ±inf, and the "flat 0 / flat 1" contract quietly stops holding.
+            // Both are a teaching error, exactly as an inverted range is for
+            // `Math.clamp`.
+            Builtin::MathSmoothstep => match args.as_slice() {
+                [Value::Number(edge0), Value::Number(edge1), Value::Number(x)]
+                    if edge0 < edge1 && (edge1 - edge0).is_finite() =>
+                {
+                    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+                    Ok(Value::Number(t * t * (3.0 - 2.0 * t)))
+                }
+                [Value::Number(edge0), Value::Number(edge1), Value::Number(_)] => err(format!(
+                    "Math.smoothstep(edge0, edge1, x) needs a finite range with edge0 < edge1, \
+got edge0 {edge0} and edge1 {edge1}"
+                )),
+                _ => err("Math.smoothstep(edge0, edge1, x) expects three numbers".to_string()),
+            },
             // `Math.round` rounds HALF AWAY FROM ZERO (Rust's `f64::round`),
             // not to even: 0.5 -> 1, 2.5 -> 3, -0.5 -> -1, -2.5 -> -3. That
             // is the rule people predict when they round a score or a grid
@@ -3100,6 +3179,8 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::RandomRange
         | Builtin::TextReplace
         | Builtin::MathClamp
+        | Builtin::MathLerp
+        | Builtin::MathSmoothstep
         | Builtin::MapInsert => 3,
         Builtin::ListMap
         | Builtin::ListFilter
@@ -3131,6 +3212,7 @@ pub fn builtin_arity(b: Builtin) -> usize {
         | Builtin::MapMember => 2,
         Builtin::ListRange
         | Builtin::ListMaximum
+        | Builtin::ListMinimum
         | Builtin::ListLength
         | Builtin::ListFlatten
         | Builtin::ListReverse
@@ -3190,6 +3272,7 @@ pub enum Builtin {
     MathPow,
     MathPi,
     ListMaximum,
+    ListMinimum,
     ListLength,
     ListAppend,
     ListFlatten,
@@ -3232,6 +3315,8 @@ pub enum Builtin {
     TextTrim,
     MathClamp01,
     MathClamp,
+    MathLerp,
+    MathSmoothstep,
     MathTan,
     MathAsin,
     MathAcos,
@@ -3352,13 +3437,14 @@ pub const BUILTIN_NAMESPACES: &[&str] = &["List", "Map", "Text", "Math", "Random
 /// [`builtin`] so the members the CHECKER knows about (for its
 /// unknown-member diagnostic and its suggestions) and the ones the
 /// interpreter DISPATCHES come from one place.
-pub const ALL_BUILTINS: [Builtin; 73] = [
+pub const ALL_BUILTINS: [Builtin; 76] = [
     Builtin::ListMap,
     Builtin::ListFilter,
     Builtin::ListFold,
     Builtin::ListRange,
     Builtin::ListGrid,
     Builtin::ListMaximum,
+    Builtin::ListMinimum,
     Builtin::ListLength,
     Builtin::ListAppend,
     Builtin::ListFlatten,
@@ -3412,6 +3498,8 @@ pub const ALL_BUILTINS: [Builtin; 73] = [
     Builtin::TextTrim,
     Builtin::MathClamp01,
     Builtin::MathClamp,
+    Builtin::MathLerp,
+    Builtin::MathSmoothstep,
     Builtin::MathTan,
     Builtin::MathAsin,
     Builtin::MathAcos,
@@ -3449,6 +3537,7 @@ pub fn builtin(path: &[String]) -> Option<Builtin> {
         "List.range" => Builtin::ListRange,
         "List.grid" => Builtin::ListGrid,
         "List.maximum" => Builtin::ListMaximum,
+        "List.minimum" => Builtin::ListMinimum,
         "List.length" => Builtin::ListLength,
         "List.append" => Builtin::ListAppend,
         "List.flatten" => Builtin::ListFlatten,
@@ -3491,6 +3580,8 @@ pub fn builtin(path: &[String]) -> Option<Builtin> {
         "Text.trim" => Builtin::TextTrim,
         "Math.clamp01" => Builtin::MathClamp01,
         "Math.clamp" => Builtin::MathClamp,
+        "Math.lerp" => Builtin::MathLerp,
+        "Math.smoothstep" => Builtin::MathSmoothstep,
         "Math.tan" => Builtin::MathTan,
         "Math.asin" => Builtin::MathAsin,
         "Math.acos" => Builtin::MathAcos,
@@ -3529,6 +3620,7 @@ pub fn builtin_name(b: Builtin) -> &'static str {
         Builtin::ListRange => "List.range",
         Builtin::ListGrid => "List.grid",
         Builtin::ListMaximum => "List.maximum",
+        Builtin::ListMinimum => "List.minimum",
         Builtin::ListLength => "List.length",
         Builtin::ListAppend => "List.append",
         Builtin::ListFlatten => "List.flatten",
@@ -3571,6 +3663,8 @@ pub fn builtin_name(b: Builtin) -> &'static str {
         Builtin::TextTrim => "Text.trim",
         Builtin::MathClamp01 => "Math.clamp01",
         Builtin::MathClamp => "Math.clamp",
+        Builtin::MathLerp => "Math.lerp",
+        Builtin::MathSmoothstep => "Math.smoothstep",
         Builtin::MathTan => "Math.tan",
         Builtin::MathAsin => "Math.asin",
         Builtin::MathAcos => "Math.acos",
@@ -3743,6 +3837,7 @@ mod builtin_registry_tests {
                 | Builtin::ListRange
                 | Builtin::ListGrid
                 | Builtin::ListMaximum
+                | Builtin::ListMinimum
                 | Builtin::ListLength
                 | Builtin::ListAppend
                 | Builtin::ListFlatten
@@ -3782,6 +3877,8 @@ mod builtin_registry_tests {
                 | Builtin::MathPi
                 | Builtin::MathClamp01
                 | Builtin::MathClamp
+                | Builtin::MathLerp
+                | Builtin::MathSmoothstep
                 | Builtin::MathTan
                 | Builtin::MathAsin
                 | Builtin::MathAcos
@@ -3812,7 +3909,7 @@ mod builtin_registry_tests {
                 | Builtin::DebugLog => {}
             }
         }
-        assert_eq!(ALL_BUILTINS.len(), 73, "ALL_BUILTINS must list every Builtin");
+        assert_eq!(ALL_BUILTINS.len(), 76, "ALL_BUILTINS must list every Builtin");
 
         // The length check alone would accept a DUPLICATE entry standing in
         // for a missing one.

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -507,6 +507,9 @@ pub fn builtin_signature(b: Builtin) -> Type {
         // List.maximum : (List<Float>) => Option.t<Float> — partial like
         // `nth`/`head`/`last`/`find`: an empty list is `Option.None`.
         Builtin::ListMaximum => func(vec![List(Box::new(Float))], option(Float)),
+        // List.minimum : (List<Float>) => Option.t<Float> — the Option-shaped
+        // counterpart to `List.maximum`.
+        Builtin::ListMinimum => func(vec![List(Box::new(Float))], option(Float)),
         // List.length : (List<'a>) => Float
         Builtin::ListLength => func(vec![List(Box::new(Var(0)))], Float),
         // Subject-LAST. List.append : (List<'a>, List<'a>) => List<'a> — (other, list)
@@ -664,7 +667,12 @@ pub fn builtin_signature(b: Builtin) -> Type {
         | Builtin::MathMax
         | Builtin::MathPow => func(vec![Float, Float], Float),
         // Subject-LAST. Math.clamp : (Float, Float, Float) => Float — (low, high, n)
-        Builtin::MathClamp => func(vec![Float, Float, Float], Float),
+        // Math.lerp : (Float, Float, Float) => Float — (target, t, from),
+        // `Vec3.lerp`'s shape, unclamped
+        // Math.smoothstep : (Float, Float, Float) => Float — (edge0, edge1, x)
+        Builtin::MathClamp | Builtin::MathLerp | Builtin::MathSmoothstep => {
+            func(vec![Float, Float, Float], Float)
+        }
         // Math.pi : Float — a constant, not a function.
         Builtin::MathPi => Float,
         // Random.* — seeds are BRANDED: `Random.Seed` is the injected

--- a/functor-lang/tests/check.rs
+++ b/functor-lang/tests/check.rs
@@ -2007,7 +2007,8 @@ fn unknown_builtin_member_is_a_check_error() {
             "let a = List.tail([1.0])",
             "`List` has no builtin `tail` — `List` has: all, any, append, concatMap, \
              drop, filter, find, flatten, fold, grid, head, indexedMap, isEmpty, last, \
-             length, map, maximum, nth, range, reverse, sortBy, sum, take, zip",
+             length, map, maximum, minimum, nth, range, reverse, sortBy, sum, take, \
+             zip",
         ),
         (
             "let a = Text.padLeft(\"hi\")",
@@ -2025,7 +2026,7 @@ fn unknown_builtin_member_is_a_check_error() {
     }
 
     // Still-absent members are flagged, and name what the user typed.
-    for member in ["minimum", "partition", "unzip", "mapMaybe", "chunk"] {
+    for member in ["partition", "unzip", "mapMaybe", "chunk"] {
         let src = format!("let a = List.{member}([1.0])");
         let (message, _, _) = single_diag(&src);
         assert!(
@@ -2069,6 +2070,16 @@ fn the_jam_reached_for_builtins_exist() {
          let h = Text.contains(\"a\", \"abc\")\n\
          let i = Text.replace(\"a\", \"b\", \"abc\")\n\
          let j = Text.trim(\"  a  \")",
+    );
+    // The third cluster: the interpolation/easing pair and the Option-shaped
+    // `List.minimum` (its `List.maximum` sibling still answers a bare float).
+    assert_clean(
+        "let a = Math.lerp(10.0, 0.5, 0.0)\n\
+         let b = Math.smoothstep(0.0, 1.0, 0.25)\n\
+         let c = 0.0 |> Math.lerp(10.0, 0.5)\n\
+         let d = 0.25 |> Math.smoothstep(0.0, 1.0)\n\
+         let e = List.minimum([3.0, 1.0])\n\
+         let f = [3.0, 1.0] |> List.minimum",
     );
 }
 
@@ -2116,6 +2127,7 @@ fn partial_list_builtins_return_option() {
         "let a = List.nth(0.0, [1.0]) + 1.0",
         "let a = List.find((v) => v > 0.0, [1.0]) + 1.0",
         "let a = List.maximum([1.0]) + 1.0",
+        "let a = List.minimum([1.0]) + 1.0",
     ] {
         let (message, _, _) = single_diag(src);
         assert!(

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -924,7 +924,11 @@ fn option_returning_builtins_interop_with_the_option_module() {
                \x20   if List.head(xs) == Option.Some(10.0) then 100.0 else 0.0 in\n\
                \x20 let empty =\n\
                \x20   if List.head([]) == Option.None then 1000.0 else 0.0 in\n\
-               \x20 hit + miss + piped + same + empty\n";
+               \x20 let least =\n\
+               \x20   xs |> List.minimum |> Option.defaultValue(0.0) in\n\
+               \x20 let noLeast =\n\
+               \x20   [] |> List.minimum |> Option.defaultValue(5.0) in\n\
+               \x20 hit + miss + piped + same + empty + least + noLeast\n";
     let project = load("option-builtin-interop", &[("game.fun", src)]);
     let diags = project.check();
     assert!(diags.is_empty(), "Option-returning builtins should check: {diags:?}");
@@ -933,8 +937,9 @@ fn option_returning_builtins_interop_with_the_option_module() {
         .unwrap_or_else(|f| panic!("should run: {}", f.error.message));
     match record.outcome {
         // 20 (nth hit) + 1 (nth miss -> None) + 21 (find |> map) + 100
-        // (head == Option.Some(10)) + 1000 (empty head == Option.None).
-        RunOutcome::Main(Value::Number(n)) => assert_eq!(n, 1142.0),
+        // (head == Option.Some(10)) + 1000 (empty head == Option.None) + 10
+        // (minimum) + 5 (minimum of [] -> None -> the default).
+        RunOutcome::Main(Value::Number(n)) => assert_eq!(n, 1157.0),
         _ => panic!("expected a numeric main result"),
     }
 }

--- a/functor-lang/tests/run.rs
+++ b/functor-lang/tests/run.rs
@@ -596,6 +596,31 @@ fn list_partial_accessors_return_option() {
     assert!(message.contains("must return a bool"), "unexpected: {message}");
 }
 
+/// `List.minimum` mirrors `List.maximum`: PARTIAL accessors, Option-shaped —
+/// the empty list is `Option.None` for both.
+#[test]
+fn list_minimum_returns_option() {
+    assert_eq!(
+        main_result("let main = () => List.minimum([3.0, 1.0, 2.0])"),
+        "Option.Some(1)"
+    );
+    assert_eq!(
+        main_result("let main = () => [3.0, 1.0, 2.0] |> List.minimum"),
+        "Option.Some(1)"
+    );
+    assert_eq!(
+        main_result("let main = () => List.minimum([-5.0, 0.0])"),
+        "Option.Some(-5)"
+    );
+    assert_eq!(main_result("let main = () => List.minimum([])"), "Option.None");
+    // Same element-type discipline as `List.maximum`.
+    let (message, _, _) = run_err("let main = () => List.minimum([\"a\"])");
+    assert!(message.contains("expects numbers"), "unexpected: {message}");
+    // The two siblings agree on the empty list too — both are `Option.None`
+    // (`maximum_of_empty_list_is_none` pins the rest of `List.maximum`).
+    assert_eq!(main_result("let main = () => List.maximum([])"), "Option.None");
+}
+
 /// `indexedMap` — the builtin that retires the O(n²) hand-rolled indexing.
 #[test]
 fn list_indexed_map_passes_the_index_first() {
@@ -873,6 +898,100 @@ let main = () => List.all(agree, [-2.0, -0.5, 0.0, 0.25, 1.0, 7.0])"
         main_result("let main = () => 5.0 |> Math.clamp(0.0, 1.0 / 0.0)"),
         "5"
     );
+}
+
+/// `Math.lerp(target, t, from)` is the UNCLAMPED interpolation
+/// `from + (target - from) * t`, in `Vec3.lerp`'s argument order.
+#[test]
+fn math_lerp_is_unclamped() {
+    assert_eq!(main_result("let main = () => Math.lerp(10.0, 0.5, 0.0)"), "5");
+    // Both endpoints are hit EXACTLY.
+    assert_eq!(main_result("let main = () => Math.lerp(8.0, 0.0, 2.0)"), "2");
+    assert_eq!(main_result("let main = () => Math.lerp(8.0, 1.0, 2.0)"), "8");
+    // …including the pairs where `from + (target - from) * 1.0` rounds off
+    // `target` (~9% of random pairs do). An ease that runs to completion must
+    // ARRIVE, so `t == 1` answers `target` itself rather than the formula.
+    assert_eq!(
+        main_result(
+            "let main = () =>\n\
+             \x20 Math.lerp(0.0 - 420.7814273366474, 1.0, 716.936918097359)\n\
+             \x20   == 0.0 - 420.7814273366474"
+        ),
+        "true"
+    );
+    // Unclamped: `t` outside [0, 1] extrapolates in both directions.
+    assert_eq!(main_result("let main = () => Math.lerp(10.0, 2.0, 0.0)"), "20");
+    assert_eq!(main_result("let main = () => Math.lerp(10.0, -1.0, 0.0)"), "-10");
+    // A descending pair interpolates just as well.
+    assert_eq!(main_result("let main = () => Math.lerp(0.0, 0.25, 10.0)"), "7.5");
+    // THE SUBJECT IS THE START VALUE, exactly as `pos |> Vec3.lerp(target, t)`
+    // threads the start vector — the scalar and vector forms pipe alike.
+    assert_eq!(
+        main_result("let main = () => 2.0 |> Math.lerp(8.0, 0.5)"),
+        "5"
+    );
+    let (message, _, _) = run_err("let main = () => Math.lerp(0.0, 1.0)(\"from\")");
+    assert!(message.contains("three numbers"), "unexpected: {message}");
+}
+
+/// `Math.smoothstep` is the standard clamped Hermite ramp, and any range that
+/// is not finite and ascending is a teaching error rather than a silent NaN.
+#[test]
+fn math_smoothstep_is_clamped_and_rejects_degenerate_edges() {
+    assert_eq!(
+        main_result("let main = () => Math.smoothstep(0.0, 1.0, 0.5)"),
+        "0.5"
+    );
+    // Clamped outside the edges — flat 0 below, flat 1 above.
+    assert_eq!(main_result("let main = () => Math.smoothstep(0.0, 1.0, 0.0)"), "0");
+    assert_eq!(main_result("let main = () => Math.smoothstep(0.0, 1.0, 1.0)"), "1");
+    assert_eq!(main_result("let main = () => Math.smoothstep(0.0, 1.0, -5.0)"), "0");
+    assert_eq!(main_result("let main = () => Math.smoothstep(0.0, 1.0, 9.0)"), "1");
+    // Non-unit edges rescale: 2.5 is the midpoint of [2, 3].
+    assert_eq!(
+        main_result("let main = () => Math.smoothstep(2.0, 3.0, 2.5)"),
+        "0.5"
+    );
+    // The ramp is the Hermite curve, not the linear one: at a quarter of the
+    // way in it is 3t² - 2t³ = 0.15625, well below 0.25.
+    assert_eq!(
+        main_result("let main = () => Math.smoothstep(0.0, 1.0, 0.25)"),
+        "0.15625"
+    );
+    // Symmetric about the midpoint.
+    assert_eq!(
+        main_result(
+            "let mirrors = (x: float): bool =>\n\
+             \x20 Math.abs(Math.smoothstep(0.0, 1.0, x)\n\
+             \x20   + Math.smoothstep(0.0, 1.0, 1.0 - x) - 1.0) < 0.0000001\n\
+             let main = () => List.all(mirrors, [0.0, 0.1, 0.3, 0.5, 0.9, 1.0])"
+        ),
+        "true"
+    );
+    assert_eq!(
+        main_result("let main = () => 0.5 |> Math.smoothstep(0.0, 1.0)"),
+        "0.5"
+    );
+    // A zero-width or inverted range would divide by zero (NaN / ±inf), so it
+    // is a teaching error — the `Math.clamp` rule. NaN edges route there too,
+    // as do INFINITE and merely overflow-wide ones: those pass `edge0 < edge1`
+    // yet still make the ramp answer NaN, so the guard demands a FINITE width.
+    for src in [
+        "let main = () => Math.smoothstep(1.0, 1.0, 1.0)",
+        "let main = () => Math.smoothstep(1.0, 0.0, 0.5)",
+        "let main = () => Math.smoothstep(0.0 / 0.0, 1.0, 0.5)",
+        "let main = () => Math.smoothstep(0.0, 0.0 / 0.0, 0.5)",
+        "let main = () => Math.smoothstep(0.0 - 1.0 / 0.0, 1.0, 0.5)",
+        "let main = () => Math.smoothstep(0.0, 1.0 / 0.0, 0.5)",
+        "let main = () =>\n\
+         \x20 Math.smoothstep(0.0 - Math.pow(10.0, 308.0), Math.pow(10.0, 308.0), 0.0)",
+    ] {
+        let (message, _, _) = run_err(src);
+        assert!(
+            message.contains("finite range with edge0 < edge1"),
+            "unexpected for {src}: {message}"
+        );
+    }
 }
 
 /// `Math.round` is HALF AWAY FROM ZERO, and symmetric about it.

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -644,8 +644,10 @@ let pos = model.pos |> Vec3.add(step)</pre>
               <tr><td><code>Math.sqrt(n)</code> · <code>Math.abs(n)</code> · <code>Math.floor(n)</code></td><td></td></tr>
               <tr><td><code>Math.pow(base, exp)</code></td><td><code>base</code> raised to <code>exp</code></td></tr>
               <tr><td><code>Math.min(a, b)</code> · <code>Math.max(a, b)</code></td><td></td></tr>
-              <tr><td><code>Math.clamp(low, high, n)</code></td><td>the general clamp, and the one exception to "<code>Math</code> takes its number first" — it threads <strong>last</strong>, so <code>n |> Math.clamp(0.0, 10.0)</code> reads the way it sounds. <code>low &gt; high</code> is a runtime error, not a silent swap</td></tr>
+              <tr><td><code>Math.clamp(low, high, n)</code></td><td>the general clamp, and one of the few exceptions to "<code>Math</code> takes its number first" — it threads <strong>last</strong>, so <code>n |> Math.clamp(0.0, 10.0)</code> reads the way it sounds. <code>low &gt; high</code> is a runtime error, not a silent swap</td></tr>
               <tr><td><code>Math.clamp01(n)</code></td><td>clamp into <code>[0, 1]</code> — the shorthand for <code>Math.clamp(0.0, 1.0, n)</code></td></tr>
+              <tr><td><code>Math.lerp(target, t, from)</code></td><td><code>from + (target - from) * t</code>, with <code>t = 1</code> answering <code>target</code> itself so <strong>both endpoints land exactly</strong> — an ease that runs to completion arrives. <strong>Unclamped</strong>, so <code>t</code> outside <code>[0, 1]</code> extrapolates; clamp the parameter first when you want the bounded form. It threads the <strong>start value last</strong> — <code>x |> Math.lerp(target, t)</code> — which is <a href="#prelude-vec3"><code>Vec3.lerp</code></a>'s shape exactly, so scalars and vectors interpolate the same way. The parameter sits in the middle, unlike GLSL's <code>mix(a, b, t)</code></td></tr>
+              <tr><td><code>Math.smoothstep(edge0, edge1, x)</code></td><td>the standard eased ramp: flat <code>0</code> at or below <code>edge0</code>, flat <code>1</code> at or above <code>edge1</code>, and the Hermite curve <code>3t² - 2t³</code> between (so it is <strong>clamped</strong>, unlike <code>lerp</code>). the range must be <strong>finite and ascending</strong>: <code>edge0 &gt;= edge1</code>, a NaN edge, and an infinite or overflow-wide one are all runtime errors rather than a silent NaN</td></tr>
               <tr><td><code>Math.tan(n)</code> · <code>Math.atan(n)</code></td><td>radians</td></tr>
               <tr><td><code>Math.asin(n)</code> · <code>Math.acos(n)</code></td><td>radians. Outside <code>[-1, 1]</code> they are <strong>NaN</strong> rather than clamping — so a dot product that float error nudged past <code>1.0</code> needs <code>dot |> Math.clamp(-1.0, 1.0) |> Math.acos</code></td></tr>
               <tr><td><code>Math.round(n)</code> · <code>Math.ceil(n)</code></td><td><code>round</code> goes <strong>half away from zero</strong>, not to even: <code>0.5</code> → <code>1</code>, <code>2.5</code> → <code>3</code>, <code>-2.5</code> → <code>-3</code></td></tr>
@@ -694,7 +696,7 @@ let pos = model.pos |> Vec3.add(step)</pre>
               <tr><td><code>List.head(list)</code> · <code>List.last(list)</code></td><td><code>Option.Some(x)</code>, or <code>Option.None</code> for an empty list</td></tr>
               <tr><td><code>List.nth(index, list)</code></td><td>0-based. Out of range (including negative) is <code>Option.None</code> — but a <em>fractional</em> index is a runtime error, since that is a bug rather than an absence</td></tr>
               <tr><td><code>List.find(fn, list)</code></td><td>the first element the predicate accepts, short-circuiting; <code>Option.None</code> when none match</td></tr>
-              <tr><td><code>List.maximum(list)</code></td><td>numbers only: <code>Option.Some(largest)</code>, or <code>Option.None</code> for an empty list. NaN elements are ignored unless every element is NaN</td></tr>
+              <tr><td><code>List.maximum(list)</code> · <code>List.minimum(list)</code></td><td>numbers only: the largest / smallest as <code>Option.Some(x)</code>, or <code>Option.None</code> for an empty list. NaN elements are ignored unless every element is NaN</td></tr>
             </tbody>
           </table>
           <pre><code>let hp = enemies |> List.nth(i) |> Option.map((e) =&gt; e.hp) |> Option.defaultValue(0.0)
@@ -978,7 +980,7 @@ connect_game { "url": "http://127.0.0.1:8123" }</pre>
             <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>
             <li>Constructor names are global to the file's value namespace; nullary constructors never take parens. Module variants are the exception — <code>Option.Some</code>, never bare <code>Some</code>.</li>
             <li>Piping into <code>Text.concat</code> <em>prepends</em>: <code>s |> Text.concat(p)</code> is <code>p</code> then <code>s</code>. And <code>Text.fixed(n, decimals)</code> takes its number first, so it can't be piped on.</li>
-            <li><code>Math</code> is only the entries above — there is still no <code>lerp</code>, <code>sinh</code>, or <code>hypot</code>. <code>Math.round</code> goes half <em>away from zero</em>, not to even.</li>
+            <li><code>Math</code> is only the entries above — there is still no <code>sinh</code> or <code>hypot</code>. <code>Math.round</code> goes half <em>away from zero</em>, not to even.</li>
             <li><code>Math.mod</code> is Euclidean — <code>Math.mod(-1.0, 8.0)</code> is <code>7.0</code>, not <code>-1.0</code>.</li>
             <li><code>Math.pi</code> is a value, not a call.</li>
             <li>The primitives take no size arguments — a box is <code>Scene.cube() |> Scene.scaleXYZ(w, h, d)</code>.</li>


### PR DESCRIPTION
Three additive stdlib builtins, each following an existing rule in the language rather than inventing one.

| Builtin | Shape |
| --- | --- |
| `Math.lerp(target, t, from)` | Unclamped interpolation, in **`Vec3.lerp`'s exact argument order** — the start value threads last, so `x \|> Math.lerp(target, t)` and `pos \|> Vec3.lerp(target, t)` pipe identically. Deliberately *not* GLSL `mix(a, b, t)`: intra-language consistency beats `mix` familiarity, and it means carrying the vector habit over to scalars can't silently typecheck into something else. |
| `Math.smoothstep(edge0, edge1, x)` | The standard clamped Hermite ramp `3t² - 2t³`. The range must be **finite and ascending** — zero-width, inverted, NaN, and infinite/overflow-wide ranges are teaching errors, not the silent NaN the formula would give (the `Math.clamp` rule). |
| `List.minimum(list)` | Returns **`Option.t<float>`**, like every other partial list accessor. `List.maximum` is deliberately untouched and still errors on an empty list. |

`t == 1` answers `target` itself, so **both endpoints land exactly**: `from + (target - from) * 1.0` rounds off the target for ~9% of random float pairs, and an ease that runs to completion has to arrive (the `std::lerp` rule).

Docs are updated in the same change — the `functor-lang` skill (source of truth) and the site manual — including the claims this invalidates: "there is no `lerp`", "`List.minimum` doesn't exist", and "`Math.clamp` is *the* one exception to Math-takes-its-number-first".

## Verification

- `cargo test -p functor-lang` — 641 tests pass. New coverage: endpoint exactness including the rounding counterexample, unclamped extrapolation both directions, the pipe subject, smoothstep clamping / Hermite shape / symmetry, every degenerate-range error, `List.minimum`'s Option shape and its `min xs == -max (-xs)` agreement with `List.maximum`, plus the check-time member-list and Option-typing tests.
- `cargo test -p functor_runtime_common` — 635 tests pass.
- Both re-run after the review fixes **and** after the `Math.lerp` argument reorder.

## frame_bench (per-frame hot path — the `functor-lang` evaluator)

Release builds, back-to-back on the same machine, 3 runs each, comparing the **min** column. `allocs/frame` and `bytes/frame` are **byte-identical** at every size — the change is additive dispatch arms plus one comparison inside the new `Math.lerp`.

| cells | allocs/frame | bytes/frame | us/frame (min) base | us/frame (min) branch | Δ |
| --- | --- | --- | --- | --- | --- |
| 400 (20x20) | 13877 → 13877 | 843387 → 843387 | 430.2 | 430.6 | +0.1% |
| 1600 (40x40) | 54717 → 54717 | 3307227 → 3307227 | 1696.0 | 1707.1 | +0.7% |
| 3136 (56x56) | 106973 → 106973 | 6460251 → 6460251 | 3315.5 | 3297.3 | −0.5% |

Run-to-run spread on this machine is ~1%, so all three deltas are noise. `tick` identity pass-through: 0.38 us/call on both sides.

## Manual screenshots (before / after)

A docs page is a rendered surface, so: built at the base ref and at the change, desktop (1280px) and mobile (390px).

**Math table** — desktop

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/math-table-desktop-before.png" width="400"> | <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/math-table-desktop-after.png" width="400"> |

**Math table** — mobile

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/math-table-mobile-before.png" width="220"> | <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/math-table-mobile-after.png" width="220"> |

**Partial (Option-returning) list accessors** — desktop

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/list-partial-table-desktop-before.png" width="400"> | <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/list-partial-table-desktop-after.png" width="400"> |

**Sharp edges** — desktop

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/sharp-edges-desktop-before.png" width="400"> | <img src="https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/sharp-edges-desktop-after.png" width="400"> |

Mobile captures of the other two sections: [list-partial before](https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/list-partial-table-mobile-before.png) · [after](https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/list-partial-table-mobile-after.png) · [sharp-edges before](https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/sharp-edges-mobile-before.png) · [after](https://gist.githubusercontent.com/tommy-xr/f973972a042859df0bcde6fefb3e43fe/raw/sharp-edges-mobile-after.png).

## Review dispositions (`/xreview` — Claude subagent + Codex CLI)

| Finding | Engines | Disposition |
| --- | --- | --- |
| `Math.lerp` did not hit both endpoints exactly — `from + (target - from) * t` is exact at `t = 0` only, and rounds off the target at `t = 1` for ~9% of random float pairs (confirmed numerically) | **both** | **Fixed in the implementation**, not by weakening the docs: `t == 1` answers `target` itself. Test added with a concrete counterexample pair. |
| `Math.smoothstep`'s "no silent NaN" guarantee was false for infinite / overflow-wide edges, which pass `edge0 < edge1` and still divide to NaN | **both** | **Fixed**: the guard now demands a finite ascending range; error message updated; tests added for infinite and ~1e308-wide edges. |
| Docs claimed `Math.lerp` had "the same shape as `Vec3.lerp`" while the signature was `(a, b, t)` — so `from \|> Math.lerp(target, t)` would have been all-floats, checked clean, and silently wrong | Claude | **Fixed at the root**: `Math.lerp` now *is* `Vec3.lerp`'s shape, so the trap doesn't exist rather than being documented around. |
| Manual's `Math.clamp` row said "the one exception to Math-takes-its-number-first" — stale once `Math.lerp` also threads last | Claude | Fixed ("one of the few exceptions"). |
| Suggested dropping the `List.maximum([])`-still-errors assertion from the `List.minimum` test as scope creep | Claude (Low) | **Declined.** That asymmetry is exactly what both docs now assert, so the test should fail if someone changes `List.maximum` without updating them. |

No duplication signals. Both engines independently confirmed every hand-maintained registry is updated (the `Builtin` enum, `builtin_arity`, `ALL_BUILTINS`, both name maps, `builtin_signature`) and that the completion/LSP surfaces derive from `ALL_BUILTINS` rather than needing separate registration.
