### PR TITLE
feat(time-travel): oriented arrow marks in extrapolation trails

### DIFF
--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -326,7 +326,7 @@ works for any scene under a fixed camera.
 
 The scene-diff trail/strobe modes follow the same rule for both render families:
 they traverse `Frame.scene` and every anchor `Frame.sprite_layers` scene, then
-draw dots or faded copies back into the matching tree. Sprite layers match by
+draw trail marks or faded copies back into the matching tree. Sprite layers match by
 declaration index and nodes by structural path. A future layer-count change
 truncates every 2D track rather than cross-wiring it; same-count layer reordering
 remains a positional-identity limitation until layers have stable ids. Sprite

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -3,7 +3,8 @@
 //! WORLD transform changes across the sequence ("movers") and render their
 //! future two ways:
 //!
-//! - a **trail** of dots tracing each mover's path (the clean-lines view), and
+//! - a **trail** of arrowheads tracing each mover's path, each pointing along
+//!   the local direction of travel (the clean-lines view), and
 //! - a **scene-space strobe**: real-geometry copies of each mover at its future
 //!   poses, color- or alpha-faded by age (the chronophotography view). Unlike the
 //!   screen-space `--ghost` compositor — which averages N whole frames, pinning
@@ -25,15 +26,35 @@
 
 use std::collections::BTreeMap;
 
-use cgmath::{vec4, InnerSpace, Matrix4, SquareMatrix, Vector3, Vector4};
+use cgmath::{vec4, Deg, InnerSpace, Matrix4, Rad, SquareMatrix, Vector3, Vector4};
 
 use crate::protocol::GameProducer;
 use crate::{
-    Camera2D, Frame, MaterialDescription, RecordedInput, Scene3D, SceneObject, SpriteLayer,
+    Camera2D, Frame, MaterialDescription, RecordedInput, Scene3D, SceneObject, Shape, SpriteLayer,
 };
 
 const TRAIL_RADIUS_3D: f32 = 0.07;
 const TRAIL_REFERENCE_HEIGHT_2D: f32 = 13.5;
+
+/// The arrowhead outline in its own XY space, pointing along +X: tip, then the
+/// two base corners. Every mark shares these exact points and carries its
+/// placement in the transform, so all of them draw from ONE cached polygon mesh
+/// (`PolygonMesh` keys on point count and skips re-upload when the points
+/// match).
+const ARROW_POINTS: [[f32; 2]; 3] = [[1.0, 0.0], [-0.5, 0.6], [-0.5, -0.6]];
+
+/// World size of one arrowhead per unit of trail radius: an arrow 1.5 units
+/// long in [`ARROW_POINTS`] space becomes ~3.3 radii long and ~2.6 wide, about
+/// the visual weight of the sphere it replaces.
+const ARROW_SCALE: f32 = 2.2;
+
+/// Minimum local displacement, as a fraction of the mark radius, for a heading
+/// to be meaningful. Below it the mover is effectively stationary at this
+/// sample (a ball at the apex of its arc, a paused entity) and would point
+/// somewhere arbitrary, so the mark falls back to the direction-free dot.
+/// Relative to the radius so it scales with the 2D camera the same way the
+/// marks do.
+const HEADING_EPS_RADII: f32 = 0.25;
 
 /// One step of a node path: (child index, sibling count). Node identity across
 /// frames = the path of these segments from the root. Including the sibling
@@ -137,7 +158,7 @@ fn anchor_leaves(scene: &Scene3D) -> BTreeMap<Vec<PathSeg>, AnchorLeaf> {
 /// each sampled frame — index 0 = the anchor, truncated at the first structural
 /// mismatch or teleport. `translated` distinguishes movers whose world POSITION
 /// changes from pure in-place spinners (rotation/scale only): the strobe
-/// depicts both, but a dotted trail of a spinner would just pile dots on one
+/// depicts both, but a trail of a spinner would just pile marks on one
 /// spot, so the trail consumer skips them.
 pub struct MoverTrack {
     pub leaf: SceneObject,
@@ -315,23 +336,95 @@ fn sampled_mover_tracks<'a>(
     tracks
 }
 
-/// A single dim emissive marker at a world position. The renderer applies a
-/// node's `xform` on `Group`/`Geometry` but NOT on `Material` (the prelude only
-/// ever puts transforms on Groups), so the world translation goes on an
-/// enclosing Group — the size lives on the geometry leaf.
-fn trail_dot(p: Vector3<f32>, radius: f32) -> Scene3D {
-    let sphere = Scene3D::sphere().transform(Matrix4::from_scale(radius));
+/// Which space a trail is drawn in — the marks are the same arrowhead, but a
+/// sprite layer is viewed straight down -Z, so its mark must stay in the XY
+/// plane, while a 3D mark has to read from any camera angle.
+#[derive(Clone, Copy)]
+enum TrailSpace {
+    Scene3D,
+    Sprite2D,
+}
+
+/// The emissive cyan wrapper every trail mark shares. The renderer applies a
+/// node's `xform` on `Group`/`Geometry` but NOT on `Material`, so placement
+/// goes on the enclosing Group and the mark's own shape on the leaves.
+fn trail_mark(marks: Vec<Scene3D>, place: Matrix4<f32>) -> Scene3D {
     let material = Scene3D {
-        obj: SceneObject::Material(
-            MaterialDescription::emissive(0.25, 0.85, 1.0, 1.0),
-            vec![sphere],
-        ),
+        obj: SceneObject::Material(MaterialDescription::emissive(0.25, 0.85, 1.0, 1.0), marks),
         xform: Matrix4::identity(),
     };
     Scene3D {
         obj: SceneObject::Group(vec![material]),
-        xform: Matrix4::from_translation(p),
+        xform: place,
     }
+}
+
+/// A single dim emissive marker at a world position — the direction-free
+/// fallback for a sample with no meaningful heading.
+fn trail_dot(p: Vector3<f32>, radius: f32) -> Scene3D {
+    let sphere = Scene3D::sphere().transform(Matrix4::from_scale(radius));
+    trail_mark(vec![sphere], Matrix4::from_translation(p))
+}
+
+/// Rotation taking +X onto the unit vector `dir`, with an arbitrary (but
+/// stable) roll: the arrowhead is symmetric about its axis, so only the axis
+/// matters. The helper axis avoids the degenerate cross product when `dir` is
+/// near +Y.
+fn heading_rotation(dir: Vector3<f32>) -> Matrix4<f32> {
+    let helper = if dir.y.abs() < 0.9 {
+        Vector3::new(0.0, 1.0, 0.0)
+    } else {
+        Vector3::new(0.0, 0.0, 1.0)
+    };
+    let x = dir;
+    let z = x.cross(helper).normalize();
+    let y = z.cross(x);
+    Matrix4::from_cols(x.extend(0.0), y.extend(0.0), z.extend(0.0), vec4(0.0, 0.0, 0.0, 1.0))
+}
+
+/// A marker pointing along `dir` (which the caller has established is longer
+/// than the heading threshold). In 3D the arrowhead is two flat heads crossed
+/// at 90° about the direction of travel, so it reads as an arrow from any
+/// camera angle instead of vanishing edge-on; a sprite layer is viewed from one
+/// fixed side, so one flat head in the XY plane is exactly right there.
+fn trail_arrow(p: Vector3<f32>, dir: Vector3<f32>, radius: f32, space: TrailSpace) -> Scene3D {
+    let head = Scene3D {
+        obj: SceneObject::Geometry(Shape::ConvexPolygon {
+            points: ARROW_POINTS.to_vec(),
+        }),
+        xform: Matrix4::identity(),
+    };
+    let (heads, rotation) = match space {
+        TrailSpace::Scene3D => (
+            vec![
+                head.clone(),
+                head.transform(Matrix4::from_angle_x(Deg(90.0))),
+            ],
+            heading_rotation(dir.normalize()),
+        ),
+        // Motion is in the layer's XY plane; spin the head about Z so it always
+        // faces the 2D camera.
+        TrailSpace::Sprite2D => (
+            vec![head],
+            Matrix4::from_angle_z(Rad(dir.y.atan2(dir.x))),
+        ),
+    };
+    trail_mark(
+        heads,
+        Matrix4::from_translation(p) * rotation * Matrix4::from_scale(radius * ARROW_SCALE),
+    )
+}
+
+/// The local direction of travel at sample `i`: the segment between its
+/// neighbors (central difference) where both exist, and the one-sided segment
+/// at each end of the track. `None` when the displacement is too small to be a
+/// heading — see [`HEADING_EPS_RADII`].
+fn heading_at(worlds: &[Matrix4<f32>], i: usize, radius: f32) -> Option<Vector3<f32>> {
+    let before = if i > 0 { &worlds[i - 1] } else { &worlds[i] };
+    let after = worlds.get(i + 1).unwrap_or(&worlds[i]);
+    let dir = world_pos(after) - world_pos(before);
+    let eps = radius * HEADING_EPS_RADII;
+    (dir.magnitude() > eps).then_some(dir)
 }
 
 /// The 1-based future-sample index the strobe's `c`-th copy stands on, for a
@@ -346,16 +439,17 @@ fn trail_from_tracks(
     tracks: &[MoverTrack],
     strobe: Option<&StrobeOptions>,
     radius: f32,
+    space: TrailSpace,
 ) -> Option<Scene3D> {
-    let mut dots = Vec::new();
+    let mut marks = Vec::new();
     for track in tracks {
         // A pure in-place spinner has a track (for the strobe) but no path to
-        // dot — its dots would all land on one spot.
+        // mark — its marks would all land on one spot.
         if !track.translated {
             continue;
         }
         // Off-cadence with the strobe: skip the samples where a copy stands,
-        // so dots fill the gaps BETWEEN copies instead of hiding under them.
+        // so marks fill the gaps BETWEEN copies instead of hiding under them.
         let n_future = track.worlds.len() - 1;
         let skip: Vec<usize> = match strobe {
             Some(s) if n_future > 0 && s.copies > 0 => {
@@ -368,23 +462,33 @@ fn trail_from_tracks(
             if skip.contains(&i) {
                 continue;
             }
-            dots.push(trail_dot(world_pos(w), radius));
+            let p = world_pos(w);
+            marks.push(match heading_at(&track.worlds, i, radius) {
+                Some(dir) => trail_arrow(p, dir, radius, space),
+                None => trail_dot(p, radius),
+            });
         }
     }
-    if dots.is_empty() {
+    if marks.is_empty() {
         None
     } else {
         Some(Scene3D {
-            obj: SceneObject::Group(dots),
+            obj: SceneObject::Group(marks),
             xform: Matrix4::identity(),
         })
     }
 }
 
-/// Build a dotted-trail scene from a scene sequence. Returns `None` when
-/// nothing moved. (The trail consumer of [`mover_tracks`].)
+/// Build a trail scene of direction-of-travel arrowheads from a scene
+/// sequence. Returns `None` when nothing moved. (The trail consumer of
+/// [`mover_tracks`].)
 pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<Scene3D> {
-    trail_from_tracks(&mover_tracks(scenes, eps, max_step), None, TRAIL_RADIUS_3D)
+    trail_from_tracks(
+        &mover_tracks(scenes, eps, max_step),
+        None,
+        TRAIL_RADIUS_3D,
+        TrailSpace::Scene3D,
+    )
 }
 
 /// Scene-space strobe options.
@@ -522,7 +626,7 @@ enum StrobeFade {
 
 /// One strobe copy: the mover's leaf at a future world pose, shaded by its
 /// (age-faded) material. Transforms go on a Group / the leaf itself — never on
-/// a Material node, which the renderer ignores (see [`trail_dot`]).
+/// a Material node, which the renderer ignores (see [`trail_mark`]).
 fn strobe_copy(
     leaf: &SceneObject,
     material: Option<&MaterialDescription>,
@@ -746,7 +850,7 @@ pub struct PreviewOptions {
     pub eps: f32,
     /// Teleport threshold: cut a track at a per-sample jump beyond this.
     pub max_step: f32,
-    /// Emit the dotted trail?
+    /// Emit the arrowhead trail?
     pub trail: bool,
     /// Emit the scene-space strobe?
     pub strobe: Option<StrobeOptions>,
@@ -798,7 +902,7 @@ impl FramePreview {
         self.scene.is_empty() && self.sprite_layers.iter().all(SceneOverlays::is_empty)
     }
 
-    /// Add only dotted trails to `frame`. The screen-space ghost compositor
+    /// Add only trails to `frame`. The screen-space ghost compositor
     /// uses this so trails remain solid across every averaged future frame.
     /// Sprite trails get their own layer with the anchor camera, preventing a
     /// panning future camera from smearing the marker path.
@@ -866,7 +970,12 @@ fn scene_overlays(
     SceneOverlays {
         trail: if opts.trail {
             // When the strobe draws too, the trail stays off its cadence.
-            trail_from_tracks(&tracks, opts.strobe.as_ref(), trail_radius)
+            trail_from_tracks(
+                &tracks,
+                opts.strobe.as_ref(),
+                trail_radius,
+                TrailSpace::Scene3D,
+            )
         } else {
             None
         },
@@ -884,7 +993,12 @@ fn sprite_scene_overlays(
 ) -> SceneOverlays {
     let trail = if opts.trail {
         let tracks = mover_tracks(scenes, opts.eps, opts.max_step);
-        trail_from_tracks(&tracks, opts.strobe.as_ref(), trail_radius)
+        trail_from_tracks(
+            &tracks,
+            opts.strobe.as_ref(),
+            trail_radius,
+            TrailSpace::Sprite2D,
+        )
     } else {
         None
     };
@@ -1296,6 +1410,133 @@ mod tests {
         }
     }
 
+    // The marks of a trail, in track order.
+    fn marks(trail: &Scene3D) -> Vec<Scene3D> {
+        match &trail.obj {
+            SceneObject::Group(marks) => marks.clone(),
+            _ => panic!("expected a group of trail marks"),
+        }
+    }
+
+    // A mark's leaf shapes, under its Group -> Material wrapper.
+    fn mark_shapes(mark: &Scene3D) -> Vec<Shape> {
+        match &mark.obj {
+            SceneObject::Group(children) => match &children[0].obj {
+                SceneObject::Material(_, leaves) => leaves
+                    .iter()
+                    .map(|leaf| match &leaf.obj {
+                        SceneObject::Geometry(shape) => shape.clone(),
+                        other => panic!("expected a geometry leaf, got {other:?}"),
+                    })
+                    .collect(),
+                other => panic!("expected a material wrapper, got {other:?}"),
+            },
+            other => panic!("expected a placed mark group, got {other:?}"),
+        }
+    }
+
+    // Where a mark's own +X (the arrowhead's tip direction) points in world space.
+    fn mark_heading(mark: &Scene3D) -> Vector3<f32> {
+        mark.xform.x.truncate().normalize()
+    }
+
+    fn assert_close(actual: Vector3<f32>, expected: Vector3<f32>) {
+        assert!(
+            (actual - expected).magnitude() < 1e-4,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn marks_point_along_the_local_direction_of_travel() {
+        // A mover running down +X, then one running down +Z: every mark's tip
+        // direction follows the track, and each 3D mark is the crossed pair of
+        // arrowheads (readable from any camera angle).
+        let along_x: Vec<Scene3D> = (0..=3).map(|i| frame(i as f32, 0.0)).collect();
+        let refs: Vec<&Scene3D> = along_x.iter().collect();
+        let trail = trajectory_trail(&refs, 0.05, 3.0).expect("a trail");
+        let along_x_marks = marks(&trail);
+        assert_eq!(along_x_marks.len(), 4);
+        for mark in &along_x_marks {
+            assert_close(mark_heading(mark), vec3(1.0, 0.0, 0.0));
+            assert_eq!(
+                mark_shapes(mark).len(),
+                2,
+                "a 3D arrowhead is two crossed heads"
+            );
+            assert!(matches!(
+                mark_shapes(mark)[0],
+                Shape::ConvexPolygon { .. }
+            ));
+        }
+
+        let along_z = |z: f32| Scene3D {
+            obj: SceneObject::Group(vec![
+                Scene3D::sphere().transform(Matrix4::from_translation(vec3(0.0, 0.0, z)))
+            ]),
+            xform: Matrix4::identity(),
+        };
+        let frames = [along_z(0.0), along_z(1.0), along_z(2.0)];
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let trail = trajectory_trail(&refs, 0.05, 3.0).expect("a trail");
+        for mark in marks(&trail) {
+            assert_close(mark_heading(&mark), vec3(0.0, 0.0, 1.0));
+        }
+    }
+
+    #[test]
+    fn a_near_stationary_sample_falls_back_to_a_dot() {
+        // The mover advances once and then rests: the moving samples get
+        // arrowheads, the resting ones have no heading and stay dots.
+        let frames: Vec<Scene3D> = [0.0, 1.0, 1.0, 1.0]
+            .iter()
+            .map(|x| frame(*x, 0.0))
+            .collect();
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let trail = trajectory_trail(&refs, 0.05, 3.0).expect("a trail");
+        let stepped = marks(&trail);
+        assert_eq!(stepped.len(), 4);
+        assert!(matches!(mark_shapes(&stepped[0])[0], Shape::ConvexPolygon { .. }));
+        assert!(matches!(mark_shapes(&stepped[1])[0], Shape::ConvexPolygon { .. }));
+        for resting in &stepped[2..] {
+            let shapes = mark_shapes(resting);
+            assert_eq!(shapes.len(), 1);
+            assert!(
+                matches!(shapes[0], Shape::Sphere),
+                "a heading-less sample keeps the dot form, got {:?}",
+                shapes[0]
+            );
+        }
+    }
+
+    #[test]
+    fn sprite_marks_stay_flat_in_the_layers_plane() {
+        // A 2D mover heading up (+Y): its mark points that way and keeps facing
+        // the layer camera (its own +Z stays +Z) — an out-of-plane 3D basis
+        // would turn the arrowhead edge-on and invisible.
+        let sprite_at = |x: f32, y: f32| {
+            let mut rendered = Frame::new(Camera::default(), Scene3D::cube());
+            rendered.sprite_layers.push(SpriteLayer {
+                camera: Camera2D::new(24.0, 13.5),
+                scene: frame(x, y),
+            });
+            rendered
+        };
+        let frames: Vec<Frame> = (0..=2).map(|i| sprite_at(0.0, i as f32)).collect();
+        let futures: Vec<&Frame> = frames.iter().skip(1).collect();
+        let preview = preview_from_frames(&frames[0], &futures, &preview_options(true, false));
+        let trail = preview.sprite_layers[0].trail.as_ref().expect("a trail");
+        for mark in marks(trail) {
+            assert_close(mark_heading(&mark), vec3(0.0, 1.0, 0.0));
+            assert_close(mark.xform.z.truncate().normalize(), vec3(0.0, 0.0, 1.0));
+            assert_eq!(
+                mark_shapes(&mark).len(),
+                1,
+                "a sprite mark is one flat arrowhead"
+            );
+        }
+    }
+
     #[test]
     fn nothing_moving_yields_no_trail() {
         let s = frame(1.0, 1.0);
@@ -1438,7 +1679,7 @@ mod tests {
             copies: 2,
             ..Default::default()
         };
-        let trail = trail_from_tracks(&tracks, Some(&opts), TRAIL_RADIUS_3D).expect("a trail");
+        let trail = trail_from_tracks(&tracks, Some(&opts), TRAIL_RADIUS_3D, TrailSpace::Scene3D).expect("a trail");
         match trail.obj {
             SceneObject::Group(dots) => {
                 assert_eq!(dots.len(), 3, "anchor + the two non-copy samples")
@@ -1465,7 +1706,7 @@ mod tests {
         assert!(!tracks[0].translated);
         assert!(strobe_overlay(&tracks, &StrobeOptions::default()).is_some());
         assert!(
-            trail_from_tracks(&tracks, None, TRAIL_RADIUS_3D).is_none(),
+            trail_from_tracks(&tracks, None, TRAIL_RADIUS_3D, TrailSpace::Scene3D).is_none(),
             "no dots for pure rotation"
         );
     }

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -26,7 +26,7 @@
 
 use std::collections::BTreeMap;
 
-use cgmath::{vec4, Deg, InnerSpace, Matrix4, Rad, SquareMatrix, Vector3, Vector4};
+use cgmath::{vec4, Deg, InnerSpace, Matrix4, Quaternion, Rad, SquareMatrix, Vector3, Vector4};
 
 use crate::protocol::GameProducer;
 use crate::{
@@ -36,17 +36,31 @@ use crate::{
 const TRAIL_RADIUS_3D: f32 = 0.07;
 const TRAIL_REFERENCE_HEIGHT_2D: f32 = 13.5;
 
-/// The arrowhead outline in its own XY space, pointing along +X: tip, then the
-/// two base corners. Every mark shares these exact points and carries its
-/// placement in the transform, so all of them draw from ONE cached polygon mesh
-/// (`PolygonMesh` keys on point count and skips re-upload when the points
-/// match).
-const ARROW_POINTS: [[f32; 2]; 3] = [[1.0, 0.0], [-0.5, 0.6], [-0.5, -0.6]];
+/// The arrowhead outline in its own XY space, pointing along +X: tip, the two
+/// base corners, and a notched tail between them (a kite, wound CCW). Every
+/// mark shares these exact points and carries its placement in the transform,
+/// so on the GPU they all resolve to ONE cached polygon mesh — `PolygonMesh`
+/// keys on POINT COUNT and skips the re-upload when the points already match.
+/// Scene-side each mark still allocates its own point `Vec`; that is fine here
+/// (preview-only, bounded by the sample count).
+///
+/// The point count is deliberately FOUR, not three. Sharing a cache slot only
+/// pays off while the points agree, and slot 3 is exactly where a user's own
+/// `Sprite.polygon` triangle would land — alternating draws would then each
+/// re-upload via `buffer_sub_data`. A kite cannot collide with user triangles.
+const ARROW_POINTS: [[f32; 2]; 4] = [[1.0, 0.0], [-0.4, 0.6], [-0.8, 0.0], [-0.4, -0.6]];
 
-/// World size of one arrowhead per unit of trail radius: an arrow 1.5 units
-/// long in [`ARROW_POINTS`] space becomes ~3.3 radii long and ~2.6 wide, about
+/// World size of one arrowhead per unit of trail radius: an arrow 1.8 units
+/// long in [`ARROW_POINTS`] space becomes ~4.0 radii long and ~2.6 wide, about
 /// the visual weight of the sphere it replaces.
 const ARROW_SCALE: f32 = 2.2;
+
+/// Radius of the mark's sphere core, in the arrow's own (already-scaled) frame.
+/// Both flat heads CONTAIN the direction of travel, so a mark heading straight
+/// at or away from the camera collapses to a pair of hairline crosses. The
+/// core is the floor on that: an edge-on mark degrades to a dot — what the
+/// trail drew before arrows — instead of disappearing.
+const ARROW_CORE: f32 = 0.35;
 
 /// Minimum local displacement, as a fraction of the mark radius, for a heading
 /// to be meaningful. Below it the mover is effectively stationary at this
@@ -366,28 +380,36 @@ fn trail_dot(p: Vector3<f32>, radius: f32) -> Scene3D {
     trail_mark(vec![sphere], Matrix4::from_translation(p))
 }
 
-/// Rotation taking +X onto the unit vector `dir`, with an arbitrary (but
-/// stable) roll: the arrowhead is symmetric about its axis, so only the axis
-/// matters. The helper axis avoids the degenerate cross product when `dir` is
-/// near +Y.
+/// Rotation taking +X onto the unit vector `dir` by the SHORTEST arc. The
+/// arrowhead is symmetric about its axis, so only the axis is load-bearing —
+/// but the roll must not jump: picking a transverse basis from a helper axis
+/// chosen by a threshold on `dir` makes the crossed heads snap through 90° as
+/// a smooth heading crosses that threshold. The shortest arc varies
+/// continuously everywhere except the antiparallel pole, where `from_arc`
+/// takes the explicit fallback axis (any unit vector perpendicular to +X).
 fn heading_rotation(dir: Vector3<f32>) -> Matrix4<f32> {
-    let helper = if dir.y.abs() < 0.9 {
-        Vector3::new(0.0, 1.0, 0.0)
-    } else {
-        Vector3::new(0.0, 0.0, 1.0)
-    };
-    let x = dir;
-    let z = x.cross(helper).normalize();
-    let y = z.cross(x);
-    Matrix4::from_cols(x.extend(0.0), y.extend(0.0), z.extend(0.0), vec4(0.0, 0.0, 0.0, 1.0))
+    Matrix4::from(Quaternion::from_arc(
+        Vector3::unit_x(),
+        dir,
+        Some(Vector3::unit_z()),
+    ))
 }
 
 /// A marker pointing along `dir` (which the caller has established is longer
 /// than the heading threshold). In 3D the arrowhead is two flat heads crossed
-/// at 90° about the direction of travel, so it reads as an arrow from any
-/// camera angle instead of vanishing edge-on; a sprite layer is viewed from one
-/// fixed side, so one flat head in the XY plane is exactly right there.
-fn trail_arrow(p: Vector3<f32>, dir: Vector3<f32>, radius: f32, space: TrailSpace) -> Scene3D {
+/// at 90° about the direction of travel plus a sphere core, so it reads as an
+/// arrow from most angles and as a dot edge-on rather than vanishing; a sprite
+/// layer is viewed from one fixed side, so one flat head in the XY plane is
+/// exactly right there and needs no core.
+///
+/// `None` when this space cannot orient the mark from `dir` — see the
+/// `Sprite2D` arm — leaving the caller to draw the direction-free dot.
+fn trail_arrow(
+    p: Vector3<f32>,
+    dir: Vector3<f32>,
+    radius: f32,
+    space: TrailSpace,
+) -> Option<Scene3D> {
     let head = Scene3D {
         obj: SceneObject::Geometry(Shape::ConvexPolygon {
             points: ARROW_POINTS.to_vec(),
@@ -399,32 +421,48 @@ fn trail_arrow(p: Vector3<f32>, dir: Vector3<f32>, radius: f32, space: TrailSpac
             vec![
                 head.clone(),
                 head.transform(Matrix4::from_angle_x(Deg(90.0))),
+                Scene3D::sphere().transform(Matrix4::from_scale(ARROW_CORE)),
             ],
             heading_rotation(dir.normalize()),
         ),
         // Motion is in the layer's XY plane; spin the head about Z so it always
-        // faces the 2D camera.
-        TrailSpace::Sprite2D => (
-            vec![head],
-            Matrix4::from_angle_z(Rad(dir.y.atan2(dir.x))),
-        ),
+        // faces the 2D camera. Only x/y orient that spin, so the IN-PLANE
+        // displacement is what has to clear the threshold: a (currently
+        // unreachable — sprite lowering pins z = 0) mostly-z displacement would
+        // pass a 3D-magnitude gate and then leave `atan2(~0, ~0)` pointing +X
+        // arbitrarily. Guard the invariant rather than rely on the lowering.
+        TrailSpace::Sprite2D => {
+            let planar = dir.truncate();
+            if planar.magnitude() <= radius * HEADING_EPS_RADII {
+                return None;
+            }
+            (vec![head], Matrix4::from_angle_z(Rad(planar.y.atan2(planar.x))))
+        }
     };
-    trail_mark(
+    Some(trail_mark(
         heads,
         Matrix4::from_translation(p) * rotation * Matrix4::from_scale(radius * ARROW_SCALE),
-    )
+    ))
 }
 
 /// The local direction of travel at sample `i`: the segment between its
 /// neighbors (central difference) where both exist, and the one-sided segment
 /// at each end of the track. `None` when the displacement is too small to be a
 /// heading — see [`HEADING_EPS_RADII`].
+///
+/// The threshold is compared PER STEP, not against the raw segment. An
+/// interior sample spans two steps while the endpoints span one, so testing
+/// both against the same epsilon would apply a 2x stricter rule at the ends —
+/// a track moving at just under 2x the threshold would draw dot endpoints
+/// around arrow interiors. Dividing by the span makes the mark form depend
+/// only on the SPEED, so it is consistent along a constant-velocity track.
 fn heading_at(worlds: &[Matrix4<f32>], i: usize, radius: f32) -> Option<Vector3<f32>> {
-    let before = if i > 0 { &worlds[i - 1] } else { &worlds[i] };
-    let after = worlds.get(i + 1).unwrap_or(&worlds[i]);
-    let dir = world_pos(after) - world_pos(before);
+    let lo = i.saturating_sub(1);
+    let hi = (i + 1).min(worlds.len() - 1);
+    let dir = world_pos(&worlds[hi]) - world_pos(&worlds[lo]);
+    let steps = (hi - lo).max(1) as f32;
     let eps = radius * HEADING_EPS_RADII;
-    (dir.magnitude() > eps).then_some(dir)
+    (dir.magnitude() / steps > eps).then_some(dir)
 }
 
 /// The 1-based future-sample index the strobe's `c`-th copy stands on, for a
@@ -463,10 +501,11 @@ fn trail_from_tracks(
                 continue;
             }
             let p = world_pos(w);
-            marks.push(match heading_at(&track.worlds, i, radius) {
-                Some(dir) => trail_arrow(p, dir, radius, space),
-                None => trail_dot(p, radius),
-            });
+            marks.push(
+                heading_at(&track.worlds, i, radius)
+                    .and_then(|dir| trail_arrow(p, dir, radius, space))
+                    .unwrap_or_else(|| trail_dot(p, radius)),
+            );
         }
     }
     if marks.is_empty() {
@@ -1459,15 +1498,19 @@ mod tests {
         assert_eq!(along_x_marks.len(), 4);
         for mark in &along_x_marks {
             assert_close(mark_heading(mark), vec3(1.0, 0.0, 0.0));
+            let shapes = mark_shapes(mark);
             assert_eq!(
-                mark_shapes(mark).len(),
-                2,
-                "a 3D arrowhead is two crossed heads"
+                shapes.len(),
+                3,
+                "a 3D mark is two crossed heads plus the sphere core"
             );
-            assert!(matches!(
-                mark_shapes(mark)[0],
-                Shape::ConvexPolygon { .. }
-            ));
+            assert!(matches!(shapes[0], Shape::ConvexPolygon { .. }));
+            assert!(matches!(shapes[1], Shape::ConvexPolygon { .. }));
+            assert!(
+                matches!(shapes[2], Shape::Sphere),
+                "the core keeps an edge-on mark visible, got {:?}",
+                shapes[2]
+            );
         }
 
         let along_z = |z: f32| Scene3D {
@@ -1534,6 +1577,98 @@ mod tests {
                 1,
                 "a sprite mark is one flat arrowhead"
             );
+        }
+    }
+
+    #[test]
+    fn a_falling_track_points_straight_down() {
+        // The branch the physics preview leans on: gravity pulls movers along
+        // -Y, and every mark on the fall must point that way.
+        let frames: Vec<Scene3D> = (0..=3).map(|i| frame(0.0, -(i as f32))).collect();
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let trail = trajectory_trail(&refs, 0.05, 3.0).expect("a trail");
+        for mark in marks(&trail) {
+            assert_close(mark_heading(&mark), vec3(0.0, -1.0, 0.0));
+        }
+    }
+
+    // Every mark of a constant-velocity track moving `step` per sample, as
+    // "is it an arrow?" flags. The mover epsilon is well below the heading
+    // threshold here so the track still counts as moving at speeds that do
+    // NOT earn a heading — the band this test is about.
+    fn mark_forms_at_speed(step: f32) -> Vec<bool> {
+        let frames: Vec<Scene3D> = (0..=3).map(|i| frame(i as f32 * step, 0.0)).collect();
+        let refs: Vec<&Scene3D> = frames.iter().collect();
+        let trail = trajectory_trail(&refs, 0.001, 3.0).expect("a trail");
+        marks(&trail)
+            .iter()
+            .map(|m| matches!(mark_shapes(m)[0], Shape::ConvexPolygon { .. }))
+            .collect()
+    }
+
+    #[test]
+    fn constant_velocity_gives_one_mark_form_across_the_whole_track() {
+        // The threshold is per STEP, so a constant-velocity track is all
+        // arrows or all dots — never dot ends around arrow interiors. An
+        // interior sample spans two steps and the endpoints one, so a
+        // raw-segment comparison would flip form exactly in this band: just
+        // under the per-step threshold, where the two-step interior still
+        // clears it.
+        let eps = TRAIL_RADIUS_3D * HEADING_EPS_RADII;
+        let slow = mark_forms_at_speed(eps * 0.75);
+        assert_eq!(
+            slow,
+            vec![false; 4],
+            "below the per-step threshold every mark is a dot"
+        );
+        let fast = mark_forms_at_speed(eps * 1.25);
+        assert_eq!(
+            fast,
+            vec![true; 4],
+            "above the per-step threshold every mark is an arrow"
+        );
+    }
+
+    #[test]
+    fn the_marks_basis_varies_continuously_with_the_heading() {
+        // The transverse basis (and so the crossed heads' roll) must not snap
+        // as a heading sweeps past any particular elevation — a helper-axis
+        // switch at |dir.y| = 0.9 used to spin the mark ~90 degrees there.
+        let basis = |y: f32| {
+            let dir = vec3((1.0f32 - y * y).sqrt(), y, 0.0).normalize();
+            heading_rotation(dir)
+        };
+        for &y in &[0.88, 0.89, 0.90, 0.91, 0.92] {
+            let a = basis(y);
+            let b = basis(y + 0.005);
+            for (col_a, col_b) in [(a.y, b.y), (a.z, b.z)] {
+                let delta = (col_a.truncate() - col_b.truncate()).magnitude();
+                assert!(
+                    delta < 0.1,
+                    "basis jumped by {delta} between y = {y} and y = {}",
+                    y + 0.005
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sprite_marks_follow_leftward_motion() {
+        // Negative dx must point the mark along -X, not fold onto +X.
+        let sprite_at = |x: f32| {
+            let mut rendered = Frame::new(Camera::default(), Scene3D::cube());
+            rendered.sprite_layers.push(SpriteLayer {
+                camera: Camera2D::new(24.0, 13.5),
+                scene: frame(x, 0.0),
+            });
+            rendered
+        };
+        let frames: Vec<Frame> = (0..=2).map(|i| sprite_at(-(i as f32))).collect();
+        let futures: Vec<&Frame> = frames.iter().skip(1).collect();
+        let preview = preview_from_frames(&frames[0], &futures, &preview_options(true, false));
+        let trail = preview.sprite_layers[0].trail.as_ref().expect("a trail");
+        for mark in marks(trail) {
+            assert_close(mark_heading(&mark), vec3(-1.0, 0.0, 0.0));
         }
     }
 

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -714,8 +714,9 @@ pub struct Args {
     ghost_divisions: usize,
 
     /// Scene-diff trajectory preview (docs/time-travel.md T6, scene-diff
-    /// variant): forward-simulate the model and draw a clean dotted trail
-    /// tracing ONLY the scene nodes that move — derived by the runtime from
+    /// variant): forward-simulate the model and draw a clean trail of
+    /// direction-of-travel arrowheads tracing ONLY the scene nodes that move
+    /// — derived by the runtime from
     /// `draw`, with no game logic. Unlike --ghost's whole-scene strobe, static
     /// geometry contributes nothing. Capturable under --fixed-time.
     #[arg(long)]

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1239,7 +1239,7 @@ async fn run_async() -> Result<(), JsValue> {
         let mut pending_detach = false;
         let mut pending_debug_camera_reset = false;
 
-        // Future preview (docs/time-travel.md T6/T6d): trail dots, scene-space
+        // Future preview (docs/time-travel.md T6/T6d): trail marks, scene-space
         // strobe copies, or the screen-space ghost compositor — one mode, driven
         // by the DOM preview <select>, with the shared forward window/samples
         // from the ⚙ popover. Same anchor cache as the desktop shell: while
@@ -1571,7 +1571,7 @@ async fn run_async() -> Result<(), JsValue> {
                 } else {
                     // The SIM samples fine (~20/s — the trail's smooth-arc
                     // rate) while the ⚙ rate governs STROBE COPIES per second,
-                    // so dots stay visible between copies and both hold their
+                    // so marks stay visible between copies and both hold their
                     // density as the window resizes.
                     const TRAIL_RATE: f32 = 20.0;
                     let divisions = ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);


### PR DESCRIPTION
## What

Extrapolation trails now show **direction of motion**: the emissive-sphere trail dots are replaced with velocity-oriented arrowhead marks, in 3D and in 2D sprite layers. This is PR 1 of the bidirectional-extrapolation arc (next: remove the ghost mode + ⚙ settings; then the backward trail).

- **3D mark**: two flat convex-polygon kite heads crossed at 90° about the direction of travel, plus a small sphere core so an edge-on mark (travel parallel to the view) degrades to a dot instead of vanishing. All marks share one cached GPU polygon mesh — orientation lives in the transform.
- **2D mark**: a single flat kite head rotated by `atan2(dy, dx)` in the layer plane.
- **Heading**: central difference between neighboring track samples (one-sided at the ends), rotated via shortest-arc `Quaternion::from_arc` (continuous — no roll jumps as the heading swings). A sample whose per-step displacement is below 0.25× the mark radius falls back to the original dot, so marks never point somewhere arbitrary.
- The kite is deliberately **4 points**: the polygon mesh cache is keyed by point count, so a 3-point head would share a GPU slot with any user `Sprite.polygon` triangle and thrash `buffer_sub_data`.
- Strobe/both cadence (`strobe_idx`) untouched — in `both` mode the arrows still fill the gaps *between* strobe copies.

## Verification

- `cargo test -p functor_runtime_common`: 620 + 11 green; trajectory module 25/25 (7 new tests: orientation along travel, vertical fall ≈(0,−1,0), leftward 2D, near-stationary dot fallback, constant-velocity form consistency, basis continuity across headings, 2D marks stay in-plane).
- **frame_bench** (release, 3 runs/side, min column): `allocs/frame` and `bytes/frame` **byte-identical** before/after at all three grids (13877/843387 · 54717/3307227 · 106973/6460251); wall-clock deltas ≤1.4%, inside run-to-run spread. Note: frame_bench does not exercise the preview path at all — this is a no-collateral-regression check; trail marks only exist inside the preview overlay.
- Goldens unaffected: no scenario in `golden-scenarios.json` enables preview flags.
- Headless before/after captures (deterministic `--capture-frame --fixed-time`): `examples/physics` `--trajectory` and `--strobe`, `examples/mario` driving `jump.script`. Visuals below (pr-visuals to follow).

## Cross-engine review (xreview: Claude + Codex, adversarial, with capture media)

No Critical/High. All Mediums/Lows fixed in 7e479ec except three explicitly deferred:

| Deferred finding | Why |
|---|---|
| Arrows partially occluded behind strobe copies in `both` mode (Codex M) | Inherent to overlaying real-geometry copies; trail mode carries the reading. Possible follow-up: depth-bias/x-ray the preview overlay. |
| Mark shadows cast dark chains on the ground (Claude M, visual) | Pre-existing: the before/dots capture shows identical shadow chains. Follow-up: exclude the preview overlay from the shadow pass. |
| Per-mark scene-side point `Vec` allocations (Codex L) | Preview-only, bounded (marks per window ≤64 divisions); GPU mesh is cached. Comment now states the actual guarantee. |

## Incidental (not in this PR)

`examples/mario/assets.fun`'s committed header predates the generator's joints line — running mario auto-regenerates it. Pre-existing drift; worth a separate one-line chore commit.


## Visuals

![extrapolation trail arrow marks — examples/physics](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/trail-arrows-physics.gif)

<sub>`examples/physics` under `--trajectory`: crates and the ball fall while their trails project ahead of them, arrowheads pointing down the fall and bending horizontal as bodies hit the ground and slide. Rendered headlessly via `--capture-frame` with deterministic scripted playback (`--input-script` + `--capture-at-frame`, 24 frames).</sub>

### Before → after

![physics before/after](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/beforeafter-physics.png)

![mario before/after](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/beforeafter-mario.png)

![mario before/after, zoomed](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/beforeafter-mario-zoom.png)

<sub>Same scene, same fixed time — before = `main` (round dots), after = this branch (velocity-oriented kite arrowheads). The zoom shows the 2D arc: marks rotate through ascent, flatten at the apex, and tip downward on descent.</sub>

### Stills

![physics trail arrows](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/still-physics-arrows.png)

![trajectory composed with strobe](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/still-physics-trajectory-strobe.png)

<sub>`--trajectory` alone, and `--trajectory --strobe` composed. 2D bonus: the mario jump script under `--trajectory`.</sub>

![mario jump trail arrows](https://gist.githubusercontent.com/tommy-xr/2a36932650342c9539c3c78f4c3dbf52/raw/trail-arrows-mario.gif)

<sub>All media rendered headlessly via `--capture-frame` / `--fixed-time`; before = main (dots), after = this branch (oriented arrow marks).</sub>
