### PR TITLE
feat(lang): entries resolve roles from inline modules

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -224,16 +224,22 @@ SAME directory of sibling modules; `functor --entry <name>` picks one
 bindings are the bare `init`/`tick`/`draw` roots; the other entry is just a
 qualified sibling module), so roles share code — `examples/mp`'s client and
 server share a `protocol.fun` wire codec — without drifting. A role may also
-be an object pointing at a **shared file** with a binding prefix —
-`"server": { "file": "game.fun", "prefix": "server" }` — resolving every
-canonical entry binding through the prefix as camelCase
-(`serverInit`/`serverTick`/`serverDraw`/…; empty/absent prefix = the plain
-names), so two roles live in ONE file and hot-reload atomically.
-`examples/orbs` is the same-file reference (both roles prefixed). Prefixed
-roles run on native and wasm (`run wasm`/`build wasm` bake the prefix into
-the page's boot config; the site player takes `?prefix=<ident>`); vr still
-loads the unprefixed contract only. `entry` and `entries` together are
-refused.
+be an object pointing at a **shared file**, so two roles live in ONE file and
+hot-reload atomically. The preferred form names an **inline module** —
+`"server": { "file": "game.fun", "module": "Server" }` — whose members ARE
+that role's contract (`Server.init`/`Server.tick`/`Server.draw`/…, resolved
+against the block's canonical path; an unknown block name is a load/build
+error listing the blocks the file does declare). The transitional form names
+a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
+— resolving every canonical entry binding through the prefix as camelCase
+(`serverInit`/`serverTick`/…). A role declares at most one of the two.
+`examples/orbs` is the same-file reference: its `client` role is the file's
+plain top-level contract and its `server` role is a `module Server { … }`
+block. Module roles are **native-only** for now (`run wasm`/`build wasm`/
+`run vr` refuse them, like vr already refuses prefixes); prefixed roles run
+on native and wasm (`run wasm`/`build wasm` bake the prefix into the page's
+boot config; the site player takes `?prefix=<ident>`). `entry` and `entries`
+together are refused.
 
 ```functor
 // utils.fun                                  // → module Utils
@@ -427,8 +433,12 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   apart (`Utils.Grid` / `Helpers.Grid`) and neither shadows the other.
 - **Dependency edges are between FILES**: a sibling's `Game.Server.foo`
   records a dep on `Game`, so cycles are detected exactly as before.
-- **The entry contract is unchanged**: `init`/`tick`/`draw` are bare
-  top-level lookups. `module Main { let tick = … }` does NOT satisfy it.
+- **The default entry contract is unchanged**: `init`/`tick`/`draw` are bare
+  top-level lookups, so `module Main { let tick = … }` does NOT satisfy a
+  plain entry. A functor.json ROLE may opt into a block instead —
+  `"server": { "file": "game.fun", "module": "Server" }` resolves
+  `Server.init`/`Server.tick`/… (see `entries` above); `examples/orbs` is the
+  reference, and the role is native-only for now.
 - **Hot reload**: canonical names are the rebind identity, so an inline
   module's closures rebind normally — but MOVING a def into (or out of) a
   module renames it (`step` → `Server.step`), which the rebinder treats

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -225,7 +225,8 @@ bindings are the bare `init`/`tick`/`draw` roots; the other entry is just a
 qualified sibling module), so roles share code — `examples/mp`'s client and
 server share a `protocol.fun` wire codec — without drifting. A role may also
 be an object pointing at a **shared file**, so two roles live in ONE file and
-hot-reload atomically. The preferred form names an **inline module** —
+hot-reload atomically. The preferred form on native names an **inline module**
+—
 `"server": { "file": "game.fun", "module": "Server" }` — whose members ARE
 that role's contract (`Server.init`/`Server.tick`/`Server.draw`/…, resolved
 against the block's canonical path; an unknown block name is a load/build
@@ -236,8 +237,9 @@ a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
 `examples/orbs` is the same-file reference: its `client` role is the file's
 plain top-level contract and its `server` role is a `module Server { … }`
 block. Module roles are **native-only** for now (`run wasm`/`build wasm`/
-`run vr` refuse them, like vr already refuses prefixes); prefixed roles run
-on native and wasm (`run wasm`/`build wasm` bake the prefix into the page's
+`run vr` refuse them, like vr already refuses prefixes), so a role that must
+also run in the browser stays on the prefix form until the web runtime learns
+the module one; prefixed roles run on native and wasm (`run wasm`/`build wasm` bake the prefix into the page's
 boot config; the site player takes `?prefix=<ident>`). `entry` and `entries`
 together are refused.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ directory of sibling modules (file = module). `--entry <name>` picks the role
 `functor -d examples/mp run native --entry server`. `examples/mp` is the reference —
 client + authoritative server over a shared `protocol.fun`. A role may also be an
 object pointing at a **shared file**, so two roles live in ONE file and an edit
-hot-reloads both atomically. The preferred form names an **inline module** —
+hot-reloads both atomically. The preferred form on native names an **inline module** —
 `"server": {"file": "game.fun", "module": "Server"}` — whose members are that role's
 contract (`Server.init`/`Server.tick`/`Server.draw`/…; an unknown block is a load/build
 error listing the file's blocks). The transitional form names a binding **prefix** —
@@ -249,7 +249,8 @@ error listing the file's blocks). The transitional form names a binding **prefix
 binding through the prefix as camelCase (`serverInit`/`serverTick`/…); a role declares at
 most one of the two. `build` validates every declared role's contract with its resolved
 names. Module roles are native-only for now (`run wasm`/`build wasm`/`run vr` refuse
-them); prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
+them, so a role that must also run in the browser stays on the prefix form);
+prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
 page's boot config; the site player takes `?prefix=<ident>`) — vr loads the unprefixed
 contract only. `examples/orbs` is the same-file reference: its `client` role is the
 file's plain top-level contract and its `server` role is a `module Server { … }` block.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,15 +240,19 @@ directory of sibling modules (file = module). `--entry <name>` picks the role
 (default: `client`, or the sole entry), anywhere on the line:
 `functor -d examples/mp run native --entry server`. `examples/mp` is the reference —
 client + authoritative server over a shared `protocol.fun`. A role may also be an
-object pointing at a **shared file** with a binding prefix —
-`"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical
-entry binding through the prefix as camelCase (`serverInit`/`serverTick`/`serverDraw`/…;
-empty/absent prefix = the plain names), so two roles live in ONE file and an edit
-hot-reloads both atomically. `build` validates every declared role's contract with its
-prefixed names; prefixed roles run on native and wasm (`run wasm`/`build wasm` bake the
-prefix into the page's boot config; the site player takes `?prefix=<ident>`) — vr still
-loads the unprefixed contract only. `examples/orbs` is the same-file reference (both
-roles are prefixed: `client` wraps the CLIENT section, `server` the SERVER section).
+object pointing at a **shared file**, so two roles live in ONE file and an edit
+hot-reloads both atomically. The preferred form names an **inline module** —
+`"server": {"file": "game.fun", "module": "Server"}` — whose members are that role's
+contract (`Server.init`/`Server.tick`/`Server.draw`/…; an unknown block is a load/build
+error listing the file's blocks). The transitional form names a binding **prefix** —
+`"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical entry
+binding through the prefix as camelCase (`serverInit`/`serverTick`/…); a role declares at
+most one of the two. `build` validates every declared role's contract with its resolved
+names. Module roles are native-only for now (`run wasm`/`build wasm`/`run vr` refuse
+them); prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
+page's boot config; the site player takes `?prefix=<ident>`) — vr loads the unprefixed
+contract only. `examples/orbs` is the same-file reference: its `client` role is the
+file's plain top-level contract and its `server` role is a `module Server { … }` block.
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -39,6 +39,16 @@ pub struct FunctorLangProject {
     /// contract. Declared per role as `{ "file": "game.fun", "prefix":
     /// "server" }` so two roles can share one file.
     pub prefix: String,
+    /// The role's inline entry MODULE (same-file entries): the role's entry
+    /// bindings are that `module` block's members (`"Server"` →
+    /// `Server.init`/`Server.tick`/…). Declared per role as `{ "file":
+    /// "game.fun", "module": "Server" }` — the PREFERRED same-file form
+    /// (`prefix` is the transitional one, and the two are mutually
+    /// exclusive). Empty = not a module role.
+    pub module: String,
+    /// The role's name in `entries` (`server`), or empty for a project with a
+    /// single `entry` — config errors name the role.
+    pub role: String,
     /// Whether physical relative mouse input is captured and routed to the game.
     pub mouse_capture: bool,
     /// Whether the shell exposes an absolute pointer to the game.
@@ -168,11 +178,15 @@ because capture is now the default",
         // capture unless the manifest explicitly asks for the contradictory
         // combination above.
         let mouse_capture = requested_mouse_capture.unwrap_or(cursor != CursorPolicy::Visible);
-        let project = |entry: String, prefix: String| FunctorLangProject {
-            entry,
-            prefix,
-            mouse_capture,
-            cursor,
+        let project = |role: &str, entry: String, prefix: String, module: String| {
+            FunctorLangProject {
+                entry,
+                prefix,
+                module,
+                role: role.to_string(),
+                mouse_capture,
+                cursor,
+            }
         };
         match &self.entries {
             FunctorLangEntries::Conflicting => Err(Error::other(
@@ -180,10 +194,10 @@ because capture is now the default",
             )),
             FunctorLangEntries::Malformed => Err(Error::other(
                 "functor.json `entries` must be a map of name → .fun path (or \
-{ \"file\": …, \"prefix\": … }) — e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"}",
+{ \"file\": …, \"module\": … }) — e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"}",
             )),
             FunctorLangEntries::Single(entry) => match requested {
-                None => Ok(project(entry.clone(), String::new())),
+                None => Ok(project("", entry.clone(), String::new(), String::new())),
                 Some(name) => Err(Error::other(format!(
                     "--entry {name}: this project has a single `entry` — `--entry` picks from \
 an `entries` map in functor.json"
@@ -197,7 +211,8 @@ an `entries` map in functor.json"
                         .join(", ")
                 };
                 let pick = |name: &str, value: &serde_json::Value| {
-                    pick_entry(name, value).map(|(entry, prefix)| project(entry, prefix))
+                    pick_entry(name, value)
+                        .map(|(entry, prefix, module)| project(name, entry, prefix, module))
                 };
                 match requested {
                     Some(name) => match map.iter().find(|(k, _)| k == name) {
@@ -247,23 +262,28 @@ name → .fun path (e.g. {\"client\": \"client.fun\", \"server\": \"server.fun\"
     }
 }
 
-/// Resolve one `entries` value: the classic string form (`"client.fun"`) or
-/// the object form (`{ "file": "game.fun", "prefix": "server" }` — same-file
-/// entries, where the role's entry bindings resolve through the prefix as
-/// camelCase: `serverInit`/`serverTick`/…). Malformed shapes get teaching
-/// errors naming the exact fix. Returns the `(entry, prefix)` pair; the
-/// caller folds in the project-wide settings.
-fn pick_entry(name: &str, value: &serde_json::Value) -> Result<(String, String), Error> {
+/// Resolve one `entries` value: the classic string form (`"client.fun"`), or
+/// the object form for same-file entries — `{ "file": "game.fun", "module":
+/// "Server" }`, whose entry bindings ARE that inline module's members
+/// (`Server.init`/`Server.tick`/…), and the transitional `{ "file":
+/// "game.fun", "prefix": "server" }`, which resolves them through the prefix
+/// as camelCase (`serverInit`/`serverTick`/…). The two name bindings
+/// differently, so a role declares at most one. Malformed shapes get teaching
+/// errors naming the exact fix. Returns the `(entry, prefix, module)` triple;
+/// the caller folds in the project-wide settings.
+fn pick_entry(name: &str, value: &serde_json::Value) -> Result<(String, String, String), Error> {
     match value {
         serde_json::Value::String(entry) if !entry.is_empty() => {
-            Ok((entry.clone(), String::new()))
+            Ok((entry.clone(), String::new(), String::new()))
         }
         serde_json::Value::Object(map) => {
-            if let Some(unknown) = map.keys().find(|k| k.as_str() != "file" && k.as_str() != "prefix")
+            if let Some(unknown) = map
+                .keys()
+                .find(|k| !matches!(k.as_str(), "file" | "prefix" | "module"))
             {
                 return Err(Error::other(format!(
                     "functor.json entry `{name}`: unknown key \"{unknown}\" — the object form \
-takes \"file\" and an optional \"prefix\""
+takes \"file\" and one of \"module\" / \"prefix\""
                 )));
             }
             let entry = match map.get("file") {
@@ -271,7 +291,8 @@ takes \"file\" and an optional \"prefix\""
                 _ => {
                     return Err(Error::other(format!(
                         "functor.json entry `{name}`: the object form needs a \"file\" — \
-{{ \"file\": \"game.fun\", \"prefix\": \"{name}\" }}"
+{{ \"file\": \"game.fun\", \"module\": \"{}\" }}",
+                        capitalized(name)
                     )))
                 }
             };
@@ -302,12 +323,60 @@ camelCase binding prefix (e.g. \"server\" resolves serverInit/serverTick/…)"
 (it becomes the binding prefix: `{prefix}Init`, `{prefix}Tick`, …)"
                 )));
             }
-            Ok((entry, prefix))
+            let module = match map.get("module") {
+                None | Some(serde_json::Value::Null) => String::new(),
+                Some(serde_json::Value::String(module)) => module.clone(),
+                Some(_) => {
+                    return Err(Error::other(format!(
+                        "functor.json entry `{name}`: \"module\" must be a string — the inline \
+module holding this role's entry bindings (e.g. \"Server\" resolves Server.init/Server.tick/…)"
+                    )))
+                }
+            };
+            // The two same-file forms name bindings differently, so a role
+            // declaring both is ambiguous — refused like `entry` + `entries`.
+            if !module.is_empty() && !prefix.is_empty() {
+                return Err(Error::other(format!(
+                    "functor.json entry `{name}`: keep one of \"module\" and \"prefix\" — \
+\"module\" resolves {module}.init/{module}.tick/…, \"prefix\" resolves \
+{prefix}Init/{prefix}Tick/…"
+                )));
+            }
+            // A module role names a `module Server { … }` block, so it must be
+            // spelled like one — refuse `"my server"` (or a lowercase name,
+            // which the parser rejects at the declaration) here, not as a
+            // baffling missing-block error later.
+            let mut chars = module.chars();
+            let valid = match chars.next() {
+                None => true,
+                Some(first) => {
+                    first.is_ascii_uppercase()
+                        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+                }
+            };
+            if !valid {
+                return Err(Error::other(format!(
+                    "functor.json entry `{name}`: \"module\" must be a Capitalized inline \
+module name (it is the block's own name: `module {module} {{ … }}`)"
+                )));
+            }
+            Ok((entry, prefix, module))
         }
         _ => Err(Error::other(format!(
             "functor.json entry `{name}` must be a path to a .fun file, or \
-{{ \"file\": \"game.fun\", \"prefix\": \"{name}\" }} for a same-file role"
+{{ \"file\": \"game.fun\", \"module\": \"{}\" }} for a same-file role",
+            capitalized(name)
         ))),
+    }
+}
+
+/// A role name spelled as an inline module name (`server` → `Server`) — used
+/// only to make the config errors' suggestions concrete.
+fn capitalized(name: &str) -> String {
+    let mut chars = name.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
     }
 }
 
@@ -449,12 +518,26 @@ impl FunctorLangProject {
         Ok(project)
     }
 
+    /// This role's binding-name scheme, as the runtimes' shared resolver
+    /// takes it: an inline `module` block (the preferred same-file form) or a
+    /// binding prefix. The config refuses both at once, so the choice is
+    /// unambiguous here.
+    fn entry_role(&self) -> functor_runtime_common::functor_lang_producer::EntryRole {
+        use functor_runtime_common::functor_lang_producer::EntryRole;
+        if self.module.is_empty() {
+            EntryRole::Prefix(self.prefix.clone())
+        } else {
+            EntryRole::Module(self.module.clone())
+        }
+    }
+
     /// `build`'s per-role contract gate (same-file entries): load a Session
     /// under the ENGINE prelude from the project [`Self::build`] already
     /// typechecked, and validate THIS role's entry-point contract — its
-    /// (possibly prefixed) names at their required arities. A project
-    /// declaring a server role whose `serverTick` is missing or misarityed
-    /// fails here with an error naming `serverTick`, instead of at launch.
+    /// resolved names (prefixed, or the inline module's members) at their
+    /// required arities. A project declaring a server role whose `serverTick`
+    /// / `Server.tick` is missing or misarityed fails here with an error
+    /// naming that binding, instead of at launch.
     /// The validation body is the exact one the runtimes use at load
     /// (`functor_runtime_common::functor_lang_producer::validate_contract`).
     pub fn check_contract(
@@ -462,7 +545,15 @@ impl FunctorLangProject {
         project: &functor_lang::project::Project,
     ) -> Result<(), Error> {
         use functor_runtime_common::functor_lang_prelude::FunctorHost;
-        use functor_runtime_common::functor_lang_producer::{validate_contract, EntryNames};
+        use functor_runtime_common::functor_lang_producer::validate_contract;
+        // A module role resolves against the linked project (the block's
+        // CANONICAL path); an unknown block is a build error naming the role.
+        let names = self.entry_role().resolve(&self.entry, project).map_err(|e| {
+            Error::other(match self.role.as_str() {
+                "" => e,
+                role => format!("functor.json entry `{role}`: {e}"),
+            })
+        })?;
         let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
             .map_err(|f| {
                 Error::other(format!(
@@ -471,7 +562,6 @@ impl FunctorLangProject {
                     project.sources.render(f.error.span.start, &f.error.message)
                 ))
             })?;
-        let names = EntryNames::with_prefix(&self.prefix);
         validate_contract(&self.entry, &session, &names)
             .map(|_| ())
             .map_err(Error::other)
@@ -558,6 +648,21 @@ impl FunctorLangProject {
                 self.prefix
             )));
         }
+        // An inline-module role is native-only for now: the wasm host page and
+        // the device push path both boot their embedded producer with the
+        // unprefixed contract, so running it there would silently play the
+        // wrong role. (Native passes --entry-module.)
+        if !self.module.is_empty() && matches!(environment, Environment::Vr | Environment::Wasm) {
+            return Err(Error::other(format!(
+                "entry module `{}` is not supported on {} yet — run this role with \
+`run native` (that shell loads the unprefixed contract)",
+                self.module,
+                match environment {
+                    Environment::Vr => "vr",
+                    _ => "wasm",
+                }
+            )));
+        }
         if matches!(environment, Environment::Vr) {
             if !runner_args.is_empty() {
                 emit(Event::Warning {
@@ -611,6 +716,12 @@ impl FunctorLangProject {
             // resolves `serverInit`/`serverTick`/… through it.
             argv.push("--entry-prefix".to_string());
             argv.push(self.prefix.clone());
+        }
+        if !self.module.is_empty() {
+            // The role's inline entry module (same-file entries): the runtime
+            // resolves `Server.init`/`Server.tick`/… as its members.
+            argv.push("--entry-module".to_string());
+            argv.push(self.module.clone());
         }
         if self.mouse_capture {
             argv.push("--mouse-capture".to_string());
@@ -886,6 +997,16 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         #[cfg(feature = "web")]
         {
             self.entry_path(working_directory)?;
+            // Same restriction as `run wasm`: the exported page boots the web
+            // runtime's unprefixed contract, so a module role would ship as
+            // the wrong role.
+            if !self.module.is_empty() {
+                return Err(Error::other(format!(
+                    "entry module `{}` is not supported on wasm yet — `build native` this role \
+(the wasm bundle loads the unprefixed contract)",
+                    self.module
+                )));
+            }
             // Same constraint as `run wasm`: the bundle carries the project
             // directory, so the entry must live inside it.
             if entry_escapes_project(&self.entry) {
@@ -1512,7 +1633,7 @@ mod tests {
     use super::entry_escapes_project;
     use super::{
         manifest_mouse_capture, nth_line, project_asset_files, resolve_debug_args, CursorPolicy,
-        FunctorLangConfig, FunctorLangEntries,
+        FunctorLangConfig, FunctorLangEntries, FunctorLangProject,
     };
 
     fn resolve(develop: bool, args: &[&str]) -> (Vec<String>, Option<String>) {
@@ -1845,6 +1966,76 @@ mod tests {
     }
 
     #[test]
+    fn an_object_entry_resolves_file_and_module() {
+        let config = named_json(&[
+            ("client", serde_json::json!("game.fun")),
+            (
+                "server",
+                serde_json::json!({ "file": "game.fun", "module": "Server" }),
+            ),
+        ]);
+        let client = config.select(Some("client")).unwrap();
+        assert_eq!(
+            (client.entry.as_str(), client.module.as_str()),
+            ("game.fun", "")
+        );
+        let server = config.select(Some("server")).unwrap();
+        assert_eq!(
+            (
+                server.entry.as_str(),
+                server.module.as_str(),
+                server.prefix.as_str(),
+                server.role.as_str()
+            ),
+            ("game.fun", "Server", "", "server")
+        );
+    }
+
+    /// The two same-file forms name bindings differently, so one role cannot
+    /// declare both (the `entry` + `entries` rule, one level down).
+    #[test]
+    fn a_role_declaring_both_module_and_prefix_is_refused() {
+        let config = named_json(&[(
+            "server",
+            serde_json::json!({ "file": "game.fun", "module": "Server", "prefix": "server" }),
+        )]);
+        let err = config.select(Some("server")).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("keep one of \"module\" and \"prefix\""),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_non_string_module_is_refused() {
+        let config = named_json(&[(
+            "server",
+            serde_json::json!({ "file": "game.fun", "module": 3 }),
+        )]);
+        let err = config.select(Some("server")).unwrap_err();
+        assert!(err.to_string().contains("must be a string"), "{err}");
+    }
+
+    /// An inline module's name is Capitalized (the parser refuses anything
+    /// else at the declaration), so the config refuses it too — up front,
+    /// instead of as a missing-block error at load.
+    #[test]
+    fn a_non_module_shaped_name_is_refused() {
+        for name in ["server", "my Server"] {
+            let config = named_json(&[(
+                "server",
+                serde_json::json!({ "file": "game.fun", "module": name }),
+            )]);
+            let err = config.select(Some("server")).unwrap_err();
+            assert!(
+                err.to_string().contains("Capitalized inline module name"),
+                "{err}"
+            );
+        }
+    }
+
+    #[test]
     fn an_unknown_object_key_is_refused() {
         let config = named_json(&[(
             "server",
@@ -1882,6 +2073,80 @@ mod tests {
         };
         let err = config.select(None).unwrap_err();
         assert!(err.to_string().contains("must be a path"), "{err}");
+    }
+
+    /// Load a one-file project in a scratch dir — the input `build`'s
+    /// contract gate takes.
+    fn loaded_project(tag: &str, src: &str) -> (String, functor_lang::project::Project) {
+        let root = std::env::temp_dir().join(format!(
+            "functor-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("game.fun"), src).unwrap();
+        let project = functor_lang::project::load_with_bundled_modules(
+            &root.join("game.fun"),
+            &std::collections::HashMap::new(),
+            &functor_prelude::bundled_modules(),
+        )
+        .unwrap_or_else(|e| panic!("the scratch project loads: {}", e.message));
+        (root.to_string_lossy().into_owned(), project)
+    }
+
+    const MODULE_ROLE_SRC: &str = "let init = { n: 0.0 }\n\
+let tick = (m, dt, tts) => m\n\
+let draw = (m, tts) => Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 5.0), \
+Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
+module Server {\n\
+  let init = { n: 1.0 }\n\
+  let tick = (m, dt, tts) => { n: m.n + dt }\n\
+  let draw = (m, tts) => Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 5.0), \
+Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
+}\n";
+
+    fn module_role(name: &str) -> FunctorLangProject {
+        named_json(&[(
+            "server",
+            serde_json::json!({ "file": "game.fun", "module": name }),
+        )])
+        .select(Some("server"))
+        .unwrap()
+    }
+
+    /// A module role's contract is the BLOCK's members: the same file whose
+    /// top level satisfies the plain contract also satisfies `Server.*`.
+    #[test]
+    fn a_module_role_validates_its_blocks_contract() {
+        let (_, project) = loaded_project("module-role", MODULE_ROLE_SRC);
+        module_role("Server").check_contract(&project).unwrap();
+    }
+
+    /// …and a missing binding is reported as the RESOLVED name, so the error
+    /// points at the block, not at a top-level `tick` that exists.
+    #[test]
+    fn a_module_role_names_its_missing_binding() {
+        let src = MODULE_ROLE_SRC.replace("let tick = (m, dt, tts) => { n: m.n + dt }\n", "");
+        let (_, project) = loaded_project("module-role-missing", &src);
+        let err = module_role("Server")
+            .check_contract(&project)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Server.tick"), "{err}");
+    }
+
+    /// An unknown block name names the role and lists what the file declares.
+    #[test]
+    fn an_unknown_role_module_lists_the_files_blocks() {
+        let (_, project) = loaded_project("module-role-unknown", MODULE_ROLE_SRC);
+        let err = module_role("Sever")
+            .check_contract(&project)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("functor.json entry `server`"), "{err}");
+        assert!(err.contains("module Sever"), "{err}");
+        assert!(err.contains("it declares: Server"), "{err}");
     }
 
     #[test]

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -651,15 +651,18 @@ impl FunctorLangProject {
         // An inline-module role is native-only for now: the wasm host page and
         // the device push path both boot their embedded producer with the
         // unprefixed contract, so running it there would silently play the
-        // wrong role. (Native passes --entry-module.)
-        if !self.module.is_empty() && matches!(environment, Environment::Vr | Environment::Wasm) {
+        // wrong role. (Native passes --entry-module.) The test is "not
+        // native", so a future environment is refused until it is taught the
+        // form, rather than silently booting the wrong role.
+        if !self.module.is_empty() && !matches!(environment, Environment::Native) {
             return Err(Error::other(format!(
                 "entry module `{}` is not supported on {} yet — run this role with \
-`run native` (that shell loads the unprefixed contract)",
+`run native` (the other shells load the unprefixed contract)",
                 self.module,
                 match environment {
                     Environment::Vr => "vr",
-                    _ => "wasm",
+                    Environment::Wasm => "wasm",
+                    Environment::Native => unreachable!("guarded above"),
                 }
             )));
         }

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -658,7 +658,6 @@ snapshots — no GPU, fully agent-verifiable.
       canonicalization, shadowing (values and record types), opens
       (local + cross-file, collision + cycle), each collision, file-level
       cycle attribution, and cross-reload rebind.
-      Follow-ups: a `functor.json` `entries` form that names them as roles.
       **Part 7 — module-aware editor tooling — done:** the cursor's
       namespace is now span-based (the `module` block it sits in, from the
       project's `inline_modules` index), so bare completion inside a block
@@ -673,6 +672,29 @@ snapshots — no GPU, fully agent-verifiable.
       grammar highlights the `module` keyword. *Verify:* completion,
       goto, hover, codelens, inlay, and docs unit tests, plus an
       end-to-end LSP test for in-block completion scope + folding.
+      **Part 8 — `entries` roles resolve from inline modules — done:** a
+      functor.json role may point at a block in its file —
+      `"server": { "file": "game.fun", "module": "Server" }` — and its
+      entry contract IS that block's members (`Server.init`/`Server.tick`/…).
+      This is the PREFERRED same-file form; the `prefix` form (Part of the
+      same-file entries work) keeps working as the transitional one, and a
+      role declaring both is a config error. The role's names resolve
+      against the LINKED project's `inline_modules` index, so the canonical
+      path comes from the lowerer and an unknown block is a load/build error
+      naming the role, the file, and the blocks it does declare — re-resolved
+      on every hot reload, so deleting the block fails loudly and keeps the
+      old program instead of reporting every binding missing. Module roles
+      are native-only for now (`run wasm`/`build wasm`/`run vr` refuse them,
+      as vr already refuses prefixes) because those shells boot the
+      unprefixed contract. `examples/orbs` is the reference: its `client`
+      role is now the file's plain top-level contract (so the sandbox and
+      the docs teach the same `init`/`tick`/`draw`) and its `server` role is
+      a `module Server { … }` block. *Verify:* config-shape tests
+      (module form, module+prefix refusal, non-string/non-Capitalized names,
+      unknown keys), contract tests naming `Server.tick`, an unknown-block
+      error test, a desktop load + hot-reload test for a module role, the
+      example sweep over both orbs roles, and headless captures of both
+      roles.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/examples/orbs/functor.json
+++ b/examples/orbs/functor.json
@@ -1,7 +1,7 @@
 {
   "language": "functor-lang",
   "entries": {
-    "client": { "file": "game.fun", "prefix": "client" },
-    "server": { "file": "game.fun", "prefix": "server" }
+    "client": "game.fun",
+    "server": { "file": "game.fun", "module": "Server" }
   }
 }

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -156,8 +156,8 @@ let botIntent = (ship: Ship, orbs: List<Orb>): Intent =>
       thrust: not arrived, claim: arrived }
 
 // ===========================  CLIENT  =================================
-// The `client` role: functor.json maps it to { "file": "game.fun",
-// "prefix": "client" }, so the runner resolves clientInit/clientTick/… here.
+// The `client` role is this file's ordinary top-level contract
+// (init/sampledInput/tick/draw — functor.json maps it to "game.fun").
 // YOU (cyan) and the bot (pink) join through the real protocol path; both
 // Intents fold in as Steers + Claims, then `step` runs. With a real
 // transport the client keeps only its OWN sends; nothing changes shape.
@@ -170,14 +170,19 @@ let orbFree = () => Color.rgb(0.85, 0.88, 0.95)   // unclaimed: dim white glow
 let wallColor = () => Color.rgb(0.3, 0.35, 0.55)
 let bg = () => Color.rgb(0.02, 0.025, 0.06)
 
-let clientInit =
+// The starting model: two seats joined through the handshake. Both roles
+// start from it (the `Server` block calls it too), so it is a FUNCTION —
+// `init` is a value, and a value can only be spent once.
+let newGame = () =>
   let (w1, meWelcome) = join(newWorld()) in
   let (w2, botWelcome) = join(w1) in
   { myPid: welcomePid(meWelcome), botPid: welcomePid(botWelcome),
     world: w2, intent: coast }
 
+let init = newGame()
+
 // Held LEVELS, read once per tick — exactly what a transport forwards as a Steer.
-let clientSampledInput = (m, snap: Input.snapshot) =>
+let sampledInput = (m, snap: Input.snapshot) =>
   let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
   { m with intent: {
       turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
@@ -196,7 +201,7 @@ let sendClaim = (pid: float, intent: Intent, w: World): World =>
        | Option.Some(o) => w |> recv(pid, Claim(o.id))
        | Option.None => w)
 
-let clientTick = (m, dt: float, tts: float) =>
+let tick = (m, dt: float, tts: float) =>
   let bot =
     (match shipOf(m.botPid, m.world) with
      | Option.None => coast
@@ -234,7 +239,9 @@ let hud = (m) =>
     Text.concat("BOT ", Text.fixed(scoreOf(m.botPid, m.world.orbs), 0.0))
       |> Sprite.text(pink(), 1.2) |> Sprite.move(halfW * 0.5, halfH + 2.2)])
 
-let clientDraw = (m, tts: float) =>
+// The board both roles render. `draw` aliases it rather than owning the body,
+// so the `Server` block can render the same view without shadowing itself.
+let board = (m, tts: float) =>
   Frame.create2D(
     Camera2D.create((halfW + 2.0) * 2.0, (halfH + 3.0) * 2.0),
     Sprite.group(
@@ -245,23 +252,29 @@ let clientDraw = (m, tts: float) =>
         |> List.append([hud(m)])))
     |> Frame.withClearColor(bg())
 
+let draw = board
+
 // ========================  SERVER ROLE  ===============================
 // The same file is ALSO the `server` entry: functor.json maps the role to
-// { "file": "game.fun", "prefix": "server" }, so the runner resolves
-// serverInit/serverTick/serverDraw here (functor -d examples/orbs run
-// native --entry server) — one buffer, both roles, one hot reload. The
-// role is the authoritative SERVER section stepped directly, with the bot
-// steering both seats so the view moves on its own.
+// { "file": "game.fun", "module": "Server" }, so the runner resolves this
+// block's members as the contract — Server.init/Server.tick/Server.draw
+// (functor -d examples/orbs run native --entry server). One buffer, both
+// roles, one hot reload. The role is the authoritative SERVER section
+// stepped directly, with the bot steering both seats so the view moves on
+// its own. Everything at the file's top level (the protocol, the world
+// step, the renderer) is visible in here bare.
 
-let serverInit = clientInit
+module Server {
+  let init = newGame()
 
-let serverTick = (m, dt: float, tts: float) =>
-  let steer = (pid: float, w: World): World =>
-    (match shipOf(pid, w) with
-     | Option.None => w
-     | Option.Some(s) =>
-       let i = botIntent(s, w.orbs) in
-       w |> recv(pid, Steer(i)) |> sendClaim(pid, i)) in
-  { m with world: m.world |> steer(m.myPid) |> steer(m.botPid) |> step(dt) }
+  let tick = (m, dt: float, tts: float) =>
+    let steer = (pid: float, w: World): World =>
+      (match shipOf(pid, w) with
+       | Option.None => w
+       | Option.Some(s) =>
+         let i = botIntent(s, w.orbs) in
+         w |> recv(pid, Steer(i)) |> sendClaim(pid, i)) in
+    { m with world: m.world |> steer(m.myPid) |> steer(m.botPid) |> step(dt) }
 
-let serverDraw = clientDraw   // the same board, seen from the authority
+  let draw = board   // the same board, seen from the authority
+}

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -170,16 +170,17 @@ let orbFree = () => Color.rgb(0.85, 0.88, 0.95)   // unclaimed: dim white glow
 let wallColor = () => Color.rgb(0.3, 0.35, 0.55)
 let bg = () => Color.rgb(0.02, 0.025, 0.06)
 
-// The starting model: two seats joined through the handshake. Both roles
-// start from it (the `Server` block calls it too), so it is a FUNCTION —
-// `init` is a value, and a value can only be spent once.
-let newGame = () =>
+// The starting model both roles begin from: two seats joined through the
+// handshake. `init` aliases it rather than owning it (like `draw`/`board`
+// below), so the `Server` block can start from the same model without
+// shadowing itself.
+let initialGame =
   let (w1, meWelcome) = join(newWorld()) in
   let (w2, botWelcome) = join(w1) in
   { myPid: welcomePid(meWelcome), botPid: welcomePid(botWelcome),
     world: w2, intent: coast }
 
-let init = newGame()
+let init = initialGame
 
 // Held LEVELS, read once per tick — exactly what a transport forwards as a Steer.
 let sampledInput = (m, snap: Input.snapshot) =>
@@ -265,7 +266,7 @@ let draw = board
 // step, the renderer) is visible in here bare.
 
 module Server {
-  let init = newGame()
+  let init = initialGame
 
   let tick = (m, dt: float, tts: float) =>
     let steer = (pid: float, w: World): World =>

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -118,7 +118,7 @@ impl EntryNames {
         if prefix.is_empty() {
             return EntryNames::UNPREFIXED;
         }
-        let n = |base: &'static str| {
+        EntryNames::map(|base| {
             let mut name = String::with_capacity(prefix.len() + base.len());
             name.push_str(prefix);
             let mut chars = base.chars();
@@ -127,8 +127,24 @@ impl EntryNames {
                 name.push_str(chars.as_str());
             }
             intern(name)
-        };
+        })
+    }
+
+    /// The name-mapping rule for a role resolved inside an INLINE MODULE
+    /// (`{ "file": "game.fun", "module": "Server" }`): every entry binding is
+    /// a member of that block, so it resolves against the module's CANONICAL
+    /// path — `Server.init`, `Server.tick`, … The canonical path comes from
+    /// the linked project ([`EntryRole::resolve`]), never from the bare block
+    /// name.
+    pub fn in_module(path: &str) -> EntryNames {
+        EntryNames::map(|base| intern(format!("{path}.{base}")))
+    }
+
+    /// Build one role's names by mapping each canonical base — the single
+    /// place the 14-entry contract is enumerated.
+    fn map(resolve: impl Fn(&'static str) -> &'static str) -> EntryNames {
         let u = EntryNames::UNPREFIXED;
+        let n = resolve;
         EntryNames {
             init: n(u.init),
             tick: n(u.tick),
@@ -144,6 +160,62 @@ impl EntryNames {
             sound_scape: n(u.sound_scape),
             ui: n(u.ui),
             webview: n(u.webview),
+        }
+    }
+}
+
+/// How a functor.json role names its entry bindings — the declaration, before
+/// a project is linked. [`EntryRole::resolve`] turns it into the role's
+/// [`EntryNames`] against the loaded project, so an inline-module role is
+/// re-resolved on every (hot-)reload: an edit that renames or deletes the
+/// block fails loudly there instead of resolving stale names.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntryRole {
+    /// The classic contract, or a `{ "file": …, "prefix": "server" }` role:
+    /// camelCase-prefixed names (an empty prefix = the plain contract).
+    Prefix(String),
+    /// A `{ "file": …, "module": "Server" }` role: the entry bindings are
+    /// members of that inline `module` block in the role's own file.
+    Module(String),
+}
+
+impl EntryRole {
+    /// Resolve this role's binding names against the linked `project` whose
+    /// entry is the role's file. An inline-module role names a block of THAT
+    /// file; an unknown name is an error listing the blocks it does declare.
+    pub fn resolve(
+        &self,
+        path: &str,
+        project: &functor_lang::project::Project,
+    ) -> Result<EntryNames, String> {
+        match self {
+            EntryRole::Prefix(prefix) => Ok(EntryNames::with_prefix(prefix)),
+            EntryRole::Module(name) => {
+                let in_entry = || {
+                    project
+                        .inline_modules
+                        .iter()
+                        .filter(|module| module.file == project.entry)
+                };
+                match in_entry().find(|module| &module.name == name) {
+                    // The canonical path, not the bare block name: that is
+                    // what the lowerer keyed the block's members by.
+                    Some(module) => Ok(EntryNames::in_module(&module.path)),
+                    None => {
+                        let declared: Vec<&str> =
+                            in_entry().map(|module| module.name.as_str()).collect();
+                        let known = if declared.is_empty() {
+                            "it declares no inline modules".to_string()
+                        } else {
+                            format!("it declares: {}", declared.join(", "))
+                        };
+                        Err(format!(
+                            "{path} has no inline `module {name} {{ … }}` for this entry role — \
+{known}"
+                        ))
+                    }
+                }
+            }
         }
     }
 }
@@ -2088,6 +2160,49 @@ mod tests {
         // Interned: rebuilding the same prefix (every hot reload) reuses the
         // same leaked names instead of growing the table.
         assert!(std::ptr::eq(EntryNames::with_prefix("server").tick, names.tick));
+    }
+
+    /// The module form of the same rule: an inline-module role's bindings are
+    /// the block's members, under its CANONICAL path — and interned just as
+    /// the prefixed ones are, so hot reloads don't grow the table.
+    #[test]
+    fn entry_names_resolve_a_module_as_its_members() {
+        let names = EntryNames::in_module("Server");
+        assert_eq!(names.init, "Server.init");
+        assert_eq!(names.tick, "Server.tick");
+        assert_eq!(names.draw, "Server.draw");
+        assert_eq!(names.sampled_input, "Server.sampledInput");
+        assert_eq!(names.sound_scape, "Server.soundScape");
+        // A sibling file's block canonicalizes file-qualified.
+        assert_eq!(EntryNames::in_module("Utils.Grid").tick, "Utils.Grid.tick");
+        assert!(std::ptr::eq(EntryNames::in_module("Server").tick, names.tick));
+    }
+
+    /// A module role resolves against the LINKED project, so the canonical
+    /// path comes from the lowerer — and an unknown block is an error naming
+    /// the file's real ones, not a pile of missing bindings.
+    #[test]
+    fn a_module_role_resolves_against_the_projects_blocks() {
+        let src = "module Server {\n  let init = 0.0\n}\nmodule Client {\n  let init = 1.0\n}\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let names = EntryRole::Module("Server".to_string())
+            .resolve("game.fun", &project)
+            .expect("the block resolves");
+        assert_eq!(names.init, "Server.init");
+        let err = EntryRole::Module("Sever".to_string())
+            .resolve("game.fun", &project)
+            .expect_err("an unknown block is refused");
+        assert!(err.contains("game.fun"), "{err}");
+        assert!(err.contains("module Sever"), "{err}");
+        assert!(err.contains("it declares: Server, Client"), "{err}");
+        // A prefix role needs no project lookup.
+        assert_eq!(
+            EntryRole::Prefix("server".to_string())
+                .resolve("game.fun", &project)
+                .expect("a prefix always resolves"),
+            EntryNames::with_prefix("server")
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -135,16 +135,17 @@ impl EntryNames {
     /// a member of that block, so it resolves against the module's CANONICAL
     /// path — `Server.init`, `Server.tick`, … The canonical path comes from
     /// the linked project ([`EntryRole::resolve`]), never from the bare block
-    /// name.
+    /// name. Today a role's file IS its project's entry, whose blocks
+    /// canonicalize bare, so `path` is one segment; taking it from the
+    /// lowerer is what keeps that an implementation detail.
     pub fn in_module(path: &str) -> EntryNames {
         EntryNames::map(|base| intern(format!("{path}.{base}")))
     }
 
     /// Build one role's names by mapping each canonical base — the single
     /// place the 14-entry contract is enumerated.
-    fn map(resolve: impl Fn(&'static str) -> &'static str) -> EntryNames {
+    fn map(n: impl Fn(&'static str) -> &'static str) -> EntryNames {
         let u = EntryNames::UNPREFIXED;
-        let n = resolve;
         EntryNames {
             init: n(u.init),
             tick: n(u.tick),

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -1737,7 +1737,6 @@ mod tests {
         );
     }
 
-    /// A pushed entry buffer survives a SIBLING-file reload: editing
     /// A `{ "file": …, "module": "Server" }` role runs the BLOCK's members as
     /// its contract, and keeps hot-reloading: the block is re-resolved against
     /// each reloaded project (model preserved), while an edit that removes it
@@ -1801,6 +1800,7 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// A pushed entry buffer survives a SIBLING-file reload: editing
     /// `config.fun` must reload around the pushed `game.fun`, and only an
     /// on-disk edit of the entry itself reverts to disk (last-write-wins,
     /// per file). [Codex Medium — B8 review]

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -40,7 +40,7 @@ use functor_runtime_common::functor_lang_prelude::{
     EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
-    journal_arm, journal_push, journal_swap, validate_contract, EntryNames, FrameCtx,
+    journal_arm, journal_push, journal_swap, validate_contract, EntryNames, EntryRole, FrameCtx,
     JournalEntry, Provenance, Reporter, SpanSource,
 };
 use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, InspectorSource};
@@ -62,8 +62,11 @@ fn replay_status(history_replay: Option<(usize, f64)>) -> String {
 
 pub struct FunctorLangGame {
     path: String,
-    /// The role's resolved entry-point names (same-file entries): built once
-    /// from the role's prefix at create time and reused by every reload —
+    /// How the role names its entry bindings (same-file entries): a binding
+    /// prefix or an inline `module` block. Kept because an inline-module role
+    /// re-resolves against every (re)loaded project.
+    role: EntryRole,
+    /// The role's resolved entry-point names, from the CURRENT program —
     /// every canonical lookup and contract error goes through it.
     names: EntryNames,
     /// Per-file mtimes of the WHOLE project (every sibling `.fun` — B8:
@@ -239,6 +242,9 @@ fn round1(x: f64) -> f64 {
 
 /// A successfully loaded, contract-validated game project.
 struct Loaded {
+    /// The role's binding names, resolved against THIS load (an inline-module
+    /// role's canonical path comes from the linked project).
+    names: EntryNames,
     sources: SourceMap,
     module: functor_lang::ir::Module,
     session: Session,
@@ -260,18 +266,18 @@ struct Loaded {
 /// every sibling `.fun` file — file = module). Errors come back as fully
 /// rendered strings (`path:line:col: message`) so `create` can exit loud with
 /// them and hot-reload can print-and-keep-running with the same text.
-fn load_game(path: &str, names: &EntryNames) -> Result<Loaded, String> {
-    load_project(path, None, names)
+fn load_game(path: &str, role: &EntryRole) -> Result<Loaded, String> {
+    load_project(path, None, role)
 }
 
 /// The source-shaped half of [`load_game`]: the pushed source stands in for
 /// the ENTRY file (the network reload path, `reload_source`); sibling
 /// modules still load from disk.
-fn load_source(path: &str, src: String, names: &EntryNames) -> Result<Loaded, String> {
-    load_project(path, Some(src), names)
+fn load_source(path: &str, src: String, role: &EntryRole) -> Result<Loaded, String> {
+    load_project(path, Some(src), role)
 }
 
-fn load_project(path: &str, entry_src: Option<String>, names: &EntryNames) -> Result<Loaded, String> {
+fn load_project(path: &str, entry_src: Option<String>, role: &EntryRole) -> Result<Loaded, String> {
     let entry = std::path::Path::new(path);
     // A pushed buffer (network reload) stands in for the entry file; siblings
     // still load from disk.
@@ -286,13 +292,13 @@ fn load_project(path: &str, entry_src: Option<String>, names: &EntryNames) -> Re
         &functor_prelude::bundled_modules(),
     )
     .map_err(|e| format!("cannot load {}", e.render()))?;
-    finish_load(path, project, names)
+    finish_load(path, project, role)
 }
 
 /// Load an exact in-memory project: entry first, then sibling modules. This
 /// is the desktop counterpart of the embedded/Quest producer's whole-project
 /// push and deliberately performs no filesystem reads.
-fn load_sources(files: &[(String, String)], names: &EntryNames) -> Result<Loaded, String> {
+fn load_sources(files: &[(String, String)], role: &EntryRole) -> Result<Loaded, String> {
     let path = files
         .first()
         .map(|(path, _)| path.as_str())
@@ -306,7 +312,7 @@ fn load_sources(files: &[(String, String)], names: &EntryNames) -> Result<Loaded
         &functor_prelude::bundled_modules(),
     )
     .map_err(|e| format!("cannot load {}", e.render()))?;
-    finish_load(path, project, names)
+    finish_load(path, project, role)
 }
 
 /// The project's OWN files out of a linked source map: bundled prelude and
@@ -334,8 +340,12 @@ fn project_sources_of(sources: &SourceMap) -> Vec<(String, String)> {
 fn finish_load(
     path: &str,
     project: functor_lang::project::Project,
-    names: &EntryNames,
+    role: &EntryRole,
 ) -> Result<Loaded, String> {
+    // An inline-module role resolves against the linked project, so a reload
+    // that renamed or deleted the block fails here — naming the block — rather
+    // than reporting its every entry binding as missing.
+    let names = role.resolve(path, &project)?;
     // Type diagnostics are advisory in the dev loop: print, keep going.
     for diag in project.check() {
         eprintln!(
@@ -355,8 +365,9 @@ fn finish_load(
     // arity, optional hooks well-shaped) is shared with the embedded producer
     // and the CLI's build gate — errors name the ROLE'S resolved bindings
     // (`serverTick`, not `tick`) via `names`.
-    let contract = validate_contract(path, &session, names)?;
+    let contract = validate_contract(path, &session, &names)?;
     Ok(Loaded {
+        names,
         sources,
         module,
         session,
@@ -400,24 +411,23 @@ fn project_stamp(path: &str) -> Vec<(PathBuf, SystemTime)> {
 
 impl FunctorLangGame {
     pub fn create(path: &str) -> FunctorLangGame {
-        Self::create_with_prefix(path, "")
+        Self::create_for_role(path, EntryRole::Prefix(String::new()))
     }
 
-    /// [`Self::create`] for a PREFIXED role (same-file entries): every
-    /// canonical entry binding resolves through `prefix` as camelCase
-    /// (`"server"` → `serverInit`/`serverTick`/…). An empty prefix is the
-    /// classic unprefixed contract.
-    pub fn create_with_prefix(path: &str, prefix: &str) -> FunctorLangGame {
+    /// [`Self::create`] for one same-file ROLE: either a binding prefix
+    /// (`"server"` → `serverInit`/`serverTick`/…, empty = the classic
+    /// unprefixed contract) or an inline `module Server { … }` block, whose
+    /// members ARE the role's contract (`Server.init`/`Server.tick`/…).
+    pub fn create_for_role(path: &str, role: EntryRole) -> FunctorLangGame {
         // Route Functor Lang `Debug.log` traces into the region-aware event stream (once
         // per process; survives hot-reload's Session rebuild — the sink is
         // installed on the process, not the Session). See functor_lang_prelude.
         functor_runtime_common::functor_lang_prelude::install_debug_log_sink();
-        let names = EntryNames::with_prefix(prefix);
         // Stat BEFORE reading: an edit that lands mid-load then compares
         // unequal on the next frame and triggers a reload, instead of being
         // silently absorbed into a stale session.
         let stamp = project_stamp(path);
-        let loaded = match load_game(path, &names) {
+        let loaded = match load_game(path, &role) {
             Ok(loaded) => loaded,
             Err(message) => {
                 eprintln!("error: {message}");
@@ -434,7 +444,8 @@ impl FunctorLangGame {
         let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
         FunctorLangGame {
             path: path.to_string(),
-            names,
+            role,
+            names: loaded.names,
             stamp,
             pushed_entry: None,
             pushed_project: None,
@@ -550,6 +561,7 @@ impl FunctorLangGame {
         journal_swap(); // discard any partial current-frame journal
         self.reporter
             .set_source(SpanSource::Project(loaded.sources));
+        self.names = loaded.names;
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -643,6 +655,7 @@ impl FunctorLangGame {
         journal_swap();
         self.reporter
             .set_source(SpanSource::Project(loaded.sources));
+        self.names = loaded.names;
         self.module = loaded.module;
         self.session = loaded.session;
         self.model = loaded.init;
@@ -755,8 +768,8 @@ impl Game for FunctorLangGame {
         }
         let started = Instant::now();
         let loaded = match &self.pushed_entry {
-            Some(src) => load_source(&self.path, src.clone(), &self.names),
-            None => load_game(&self.path, &self.names),
+            Some(src) => load_source(&self.path, src.clone(), &self.role),
+            None => load_game(&self.path, &self.role),
         };
         match loaded {
             Ok(loaded) => {
@@ -812,8 +825,8 @@ impl Game for FunctorLangGame {
             files
         });
         let loaded = match &pushed_project {
-            Some(files) => load_sources(files, &self.names),
-            None => load_source(&self.path, source.to_string(), &self.names),
+            Some(files) => load_sources(files, &self.role),
+            None => load_source(&self.path, source.to_string(), &self.role),
         }?;
         if let Some(files) = pushed_project {
             self.pushed_project = Some(files);
@@ -847,7 +860,7 @@ impl Game for FunctorLangGame {
         }
         let started = Instant::now();
         let stamp = project_stamp(&self.path);
-        let loaded = load_sources(files, &self.names)?;
+        let loaded = load_sources(files, &self.role)?;
         self.pushed_project = Some(files.to_vec());
         self.pushed_entry = None;
         let (rebound, history_replay) = self.swap_in(loaded);
@@ -877,7 +890,7 @@ impl Game for FunctorLangGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = Instant::now();
-        let loaded = load_sources(files, &self.names)?;
+        let loaded = load_sources(files, &self.role)?;
         self.pushed_project = Some(files.to_vec());
         self.pushed_entry = None;
         self.reset_in(loaded);
@@ -1679,9 +1692,12 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("create temp project dir");
         let path = dir.join("game.fun");
         std::fs::write(&path, src).expect("write temp game");
-        let err = load_game(path.to_str().expect("utf-8 temp path"), &EntryNames::UNPREFIXED)
-            .err()
-            .expect("load should fail");
+        let err = load_game(
+            path.to_str().expect("utf-8 temp path"),
+            &EntryRole::Prefix(String::new()),
+        )
+        .err()
+        .expect("load should fail");
         let _ = std::fs::remove_dir_all(&dir);
         err
     }
@@ -1722,6 +1738,69 @@ mod tests {
     }
 
     /// A pushed entry buffer survives a SIBLING-file reload: editing
+    /// A `{ "file": …, "module": "Server" }` role runs the BLOCK's members as
+    /// its contract, and keeps hot-reloading: the block is re-resolved against
+    /// each reloaded project (model preserved), while an edit that removes it
+    /// fails loudly and keeps the old program.
+    #[test]
+    fn a_module_role_loads_and_hot_reloads() {
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-module-role",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        let entry = dir.join("game.fun");
+        let role_src = |probe: f64| {
+            format!(
+                "{BASE}module Server {{\n\
+                 let init = {{ n: 7.0 }}\n\
+                 let tick = (m, dt, tts) => m\n\
+                 let draw = (m, tts) => Frame.create(Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), \
+Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
+                 let probe = {probe}.0\n\
+                 }}\n"
+            )
+        };
+        std::fs::write(&entry, role_src(1.0)).expect("write entry");
+        let mut game = FunctorLangGame::create_for_role(
+            entry.to_str().expect("utf-8 path"),
+            EntryRole::Module("Server".to_string()),
+        );
+        // The role's contract is the block's, not the file's top level.
+        assert_eq!(game.names.tick, "Server.tick");
+        assert_eq!(game.model.to_string(), "{ n: 7 }");
+
+        // Edit: the model survives and the block re-resolves.
+        std::thread::sleep(std::time::Duration::from_millis(20)); // distinct mtime
+        std::fs::write(&entry, role_src(2.0)).expect("edit entry");
+        game.check_hot_reload(FrameTime { tts: 0.0, dts: 0.0 });
+        assert_eq!(
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
+            "2",
+            "the edit must have landed"
+        );
+        assert_eq!(game.names.tick, "Server.tick");
+        assert_eq!(game.model.to_string(), "{ n: 7 }", "model preserved");
+
+        // Delete the block: the reload fails naming it, keeping the program.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&entry, BASE).expect("edit entry");
+        game.check_hot_reload(FrameTime { tts: 0.0, dts: 0.0 });
+        assert_eq!(
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
+            "2",
+            "a role whose module vanished keeps the old program"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     /// `config.fun` must reload around the pushed `game.fun`, and only an
     /// on-disk edit of the entry itself reverts to disk (last-write-wins,
     /// per file). [Codex Medium — B8 review]

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -3375,9 +3375,9 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
                Scene.cube() |> Scene.translate(Vec3.make(m.n, 0.0, 0.0)))\n",
         )
         .expect("write game");
-        let mut game = FunctorLangGame::create_with_prefix(
+        let mut game = FunctorLangGame::create_for_role(
             dir.join("game.fun").to_str().expect("utf-8 path"),
-            "client",
+            EntryRole::Prefix("client".to_string()),
         );
 
         const SUB_DT: f32 = 1.0 / 60.0;

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -576,6 +576,14 @@ pub struct Args {
     #[arg(long, default_value = "")]
     entry_prefix: String,
 
+    /// The role's inline entry MODULE (same-file entries): resolve every
+    /// canonical entry binding as a member of that `module` block
+    /// (`Server` → `Server.init`/`Server.tick`/…). The CLI passes it for a
+    /// functor.json role declared as `{ "file": …, "module": … }`; it is the
+    /// preferred form, and mutually exclusive with `--entry-prefix`.
+    #[arg(long, default_value = "", conflicts_with = "entry_prefix")]
+    entry_module: String,
+
     /// Treat --game-path as a frame-recording JSON (a single serialized `Frame`
     /// or a JSON array of them — the exact format `GET /scene` emits) and replay
     /// it instead of loading a game dylib. A proof producer for the
@@ -1288,9 +1296,18 @@ pub fn run(args: Args) {
     let mut game: Box<dyn Game> = if args.replay {
         Box::new(replay_game::ReplayGame::create(game_path.as_str()))
     } else if args.functor_lang {
-        Box::new(functor_lang_game::FunctorLangGame::create_with_prefix(
+        let role = if args.entry_module.is_empty() {
+            functor_runtime_common::functor_lang_producer::EntryRole::Prefix(
+                args.entry_prefix.clone(),
+            )
+        } else {
+            functor_runtime_common::functor_lang_producer::EntryRole::Module(
+                args.entry_module.clone(),
+            )
+        };
+        Box::new(functor_lang_game::FunctorLangGame::create_for_role(
             game_path.as_str(),
-            &args.entry_prefix,
+            role,
         ))
     } else {
         // Functor Lang is the only game producer now (the F#/dylib path was removed in

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -42,9 +42,11 @@ export interface Example {
    */
   multiplayer?: boolean;
   /**
-   * The entry-point binding prefix of the role the sandbox plays (same-file
-   * entries, like examples/orbs's `client` role resolving
-   * clientInit/clientTick/…). Passed to the player as `?prefix=`.
+   * The entry-point binding prefix of the role the sandbox plays, for a
+   * same-file-entries sample whose role is declared as
+   * `{ "file": …, "prefix": "client" }` (resolving clientInit/clientTick/…).
+   * Passed to the player as `?prefix=`. The `{ "file": …, "module": … }`
+   * form is native-only, so a module role cannot be played here.
    */
   prefix?: string;
   /**

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -141,9 +141,9 @@ export const EXAMPLES: Example[] = [
     label: "Orbs (multiplayer)",
     source: "examples/orbs/game.fun",
     multiplayer: true,
-    // The sandbox plays the `client` role of the same-file entries —
-    // functor.json maps it to { "file": "game.fun", "prefix": "client" }.
-    prefix: "client",
+    // The sandbox plays the `client` role, which is the file's ordinary
+    // top-level contract (the `server` role lives in its `module Server`
+    // block, a native-only entries form) — so no `prefix` is needed.
   },
   // The client/server sample: two ROLES over a shared typed protocol, run
   // end-to-end in the pane grid — the client panes and a server pane, wired to


### PR DESCRIPTION
**PR 3 of a 3-PR stack**, based on #595 (`feat/inline-modules-lsp`), which is
based on #590. It completes the series: #590 (the language core) → #595 (editor
tooling) → this (the `functor.json` form that makes an inline module a ROLE).
Base is `feat/inline-modules-lsp`, not main.

#554 landed same-file entries through a binding **prefix** and explicitly
reserved room for this `module:` form. Here it is:

```json
{ "entries": {
    "client": "game.fun",
    "server": { "file": "game.fun", "module": "Server" }
} }
```

The `server` role's entry contract IS that block's members — `Server.init`,
`Server.tick`, `Server.draw`, … — so one buffer holds a plain game *and* an
authoritative role, and one edit hot-reloads both.

## Design decisions

1. **`module` + `prefix` on one role is a config error** (the `entry` +
   `entries` rule, one level down). The prefix form keeps working; docs and the
   skill present `module:` as the preferred form ON NATIVE and prefix as the
   transitional one a browser-facing role still needs (decision 5).
2. **Names come from the LINKED project, never from the bare block name.** A new
   `EntryRole::{Prefix, Module}` resolves to `EntryNames` against
   `Project::inline_modules` (PR 2's index), so the canonical path is the
   lowerer's. An unknown block errors naming the role, the file, and what
   exists: ``functor.json entry `server`: game.fun has no inline `module Sever
   { … }` for this entry role — it declares: Server``.
3. **Re-resolved on every load, not once at create.** The desktop producer stores
   the `role` and re-resolves `names` per (re)load — that is what makes an edit
   deleting the block fail loudly and keep the old program, instead of reporting
   all fourteen bindings missing.
4. **Contract validation is #554's shared `validate_contract`**, unchanged: its
   errors already name the resolved binding, so a module role's missing `tick`
   reports `Server.tick`.
5. **Native-only for now**, the restriction shape #554 used for vr: `run wasm`,
   `build wasm`, and `run vr` refuse a module role with a teaching error, because
   those shells boot the unprefixed contract.
6. `EntryNames` gained `in_module`; both constructors now go through one private
   `map`, so the 14-entry contract is enumerated once.

## The orbs migration (and its friction)

`examples/orbs` moves off prefixes — but **not** to two module roles, because of
decision 5: the sandbox plays orbs' `client` role on wasm, where a module role
cannot boot. So:

- `client` → the file's **plain top-level contract** (`init`/`sampledInput`/
  `tick`/`draw`), i.e. `"client": "game.fun"`.
- `server` → **`module Server { … }`** with `{ "file": …, "module": "Server" }`.

That turned out to be the better shape: it closes the tradeoff #554 recorded in
its own body ("prefixing the client role means orbs' sandbox source teaches
`clientInit`/`clientTick` where docs teach `init`/`tick` … in-file `module
Client/Server` supersedes prefixes later"). The sandbox now shows a sample that
reads exactly like the docs, and `site/src/examples.ts` drops orbs'
`?prefix=client`.

Two friction points worth recording:

- **Self-shadowing aliases.** Inside `module Server`, the block's own `init` /
  `draw` shadow the file's, so #554's `let serverInit = clientInit` has no direct
  translation (`let init = init` would be self-referential). The file now names
  the shared pieces at the top level — `initialGame` and `board` — and both
  roles alias them. Clearer, but a rewrite, not a rename: **migrating a prefix
  role to a module role is not mechanical when the roles alias each other.**
- **The wasm gap is felt immediately.** The natural end state (both roles as
  modules) is blocked until the web/embedded producer can boot a role descriptor.

## Verification

- `cargo test -p functor-lang` — 11/11 suites green (138 lib, 163 check, 131
  project, 83 …).
- `cargo test -p functor_runtime_common` — 625 + 12 green.
- `cargo test -p functor-runtime-desktop` — green, incl. the new
  `a_module_role_loads_and_hot_reloads`.
- `cargo test -p functor-cli` — 115 green, incl. the new config-shape tests, the
  contract tests, and the example sweep over both orbs roles.
- `cargo clippy -p functor-cli -p functor-runtime-desktop -p functor_runtime_common`
  — no new warnings in the changed hunks.
- `npm run check:site` clean. `npm run test:site` — **ALL CHECKS PASSED**
  (it needs a locally built web-runtime bundle; with the stale one this
  worktree started with, it fails identically on the base ref).
- `node e2e/wasm-smoke.mjs orbs` — **PASS**: the migrated client role loads,
  hot-reloads through the push seam, and runs frames in the browser runtime
  *unprefixed*. `run wasm --entry server` / `run vr --entry server` /
  `build wasm` for a module role all refuse with the teaching error.
- **Headless captures of both orbs roles** with the debug CLI
  (`--capture-frame`): `run native` and `run native --entry server` both render
  the board, the server capture showing both seats bot-steered and orbs claimed
  (the authoritative loop is live). `functor -d examples/orbs build native`
  validates both roles' contracts.

New tests: `entry_names_resolve_a_module_as_its_members` (naming + interning),
`a_module_role_resolves_against_the_projects_blocks` (canonical path, the
unknown-block error, prefix parity), `a_module_role_loads_and_hot_reloads`
(contract is the block's, model preserved across an edit, a deleted block keeps
the old program), and the CLI siblings of #554's config tests
(`an_object_entry_resolves_file_and_module`,
`a_role_declaring_both_module_and_prefix_is_refused`,
`a_non_string_module_is_refused`, `a_non_module_shaped_name_is_refused`,
unknown-key parity) plus `a_module_role_validates_its_blocks_contract`,
`a_module_role_names_its_missing_binding`,
`an_unknown_role_module_lists_the_files_blocks`.

## frame_bench (release, back-to-back, same machine)

Role names resolve at LOAD, so parity was expected — and `allocs/frame` /
`bytes/frame` are **byte-identical** (the deterministic signal). Interning is
unchanged: a module role's names intern exactly like a prefix role's.

| cells | base us/frame (min, 2 runs) | change us/frame (min, 2 runs) | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 400 | 472.1 / 434.1 | 455.4 / 434.2 | 13877 → 13877 | 843393 → 843393 |
| 1600 | 1730.3 / 1698.7 | 1755.6 / 1704.4 | 54717 → 54717 | 3307233 → 3307233 |
| 3136 | 3370.7 / 3326.8 | 3415.8 / 3377.8 | 106973 → 106973 | 6460257 → 6460257 |

Wall-clock deltas are inside run-to-run spread.

## xreview dispositions

Two independent reviewers (a Claude subagent + the Codex CLI) over
`HEAD~1...HEAD` (the merge of main below it is mechanical). **Neither engine
raised a Critical or High finding**; Codex found exactly one Low. Everything
actionable is fixed.

| # | Finding | Engine | Disposition |
| --- | --- | --- | --- |
| 1 | **Medium** — the wasm/vr refusal said "run this role with `run native` (that shell loads the unprefixed contract)", i.e. it described the one shell that DOES load the module contract | Claude | **Fixed.** Reworded to "(the other shells load the unprefixed contract)". |
| 2 | **Medium** — the platform guard matched `Vr \| Wasm` positively, so a future `Environment` variant would default to ALLOWED and silently boot the wrong role | Claude | **Fixed.** The guard is now `!matches!(environment, Native)`, so anything new is refused until taught the form. Making the embedded producer itself take an `EntryRole` is the right seam-level fix and is recorded as the wasm follow-up below — it is the same work that unblocks module roles in the browser. |
| 3 | **Low** — the new desktop test's doc comment was spliced into `pushed_entry_survives_sibling_reloads`'s, orphaning its opening sentence | Claude | **Fixed.** Both doc comments restored. |
| 4 | **Low** (simplicity) — `newGame()` was an unnecessary function and its comment ("a value can only be spent once") was false, disproved three lines later by `let draw = board` | Claude | **Fixed.** `let initialGame = …` at the top level, with `init` and `Server.init` both aliasing it — symmetric with `board`/`draw`, one concept fewer, and the world is built once per load instead of twice. |
| 5 | **Low** (simplicity) — the prefix and module identifier validators are near-identical | Claude | **Won't fix.** They differ in the rule that matters (any identifier vs. Capitalized) and unifying them would rewrite #554's validator for two call sites. Noted: an empty/`null` `module` degrades to the plain contract, matching the pre-existing `prefix` behavior — deliberate, so `{ "file": … }` alone keeps meaning "the plain top-level contract". |
| 6 | **Low** — `in_module`'s file-qualified case is unreachable today (a role's file IS its project entry, whose blocks canonicalize bare) | Claude | **Fixed** as documentation: the doc comment now says so, and explains that taking the path from the lowerer is what keeps it an implementation detail. The test keeps the `Utils.Grid` assertion as a pin on the naming rule. |
| 7 | **Low** — docs called `module` "preferred" while only `prefix` runs on wasm; migrating orbs' server role also removed a working `run wasm --entry server` | Claude | **Fixed** (wording): "the preferred form **on native**", plus an explicit "a role that must also run in the browser stays on the prefix form" in both the skill and CLAUDE.md. The capability loss is real and intentional — orbs' server role is an authoritative-loop demo, and the sandbox plays the client, which now runs on wasm *unprefixed* (verified). |
| 8 | **Low** — `site/src/examples.ts`'s `prefix` doc still cited orbs' `clientInit`/`clientTick` after the migration | Codex | **Fixed** in `76bc124` (before the review landed): the comment is generic and notes module roles can't be played there. |
| — | `let n = resolve;` was a pointless rebinding in `EntryNames::map` | Claude | **Fixed** (the parameter is named `n`). |

Both engines independently confirmed clean: no path re-resolves with stale
names (`swap_in`/`reset_in` assign `self.names = loaded.names` before any
consumer, and every load path threads `&self.role`), the
`module.file == project.entry` lookup is the right comparison (both are module
NAMES), the CLI's wasm/vr/`export_wasm` refusals are the only reachable entry
points and `sandbox.tsx` guards on `example?.prefix`, and orbs' migrated
semantics are equivalent (deterministic `join`/`initialOrbs`, neither role
gaining or losing an optional hook). Codex found no correctness or simplicity
issue at all beyond #8. Minimality: no hunk outside the stated goal.

Re-validated after the fixes: `cargo test -p functor-cli` (115),
`-p functor_runtime_common` (625 + 12), `-p functor-runtime-desktop` (81 + …)
all green; `functor -d examples/orbs build native` validates both roles; both
role captures re-rendered; `run wasm --entry server` still refuses with the
corrected message.

## Docs

`.claude/skills/functor-lang/SKILL.md` (the `entries` paragraph + the
inline-module subsection) and `CLAUDE.md` present `module:` as the preferred
same-file form; `docs/functor-lang.md` records this as B8 **Part 8** and drops
Part 6's follow-up line (this is it).

## Follow-ups the series leaves open

- **Module roles on wasm/vr.** Both shells boot the unprefixed contract, and the
  web `sim.rs` multi-instance path still can't express same-file roles (deferred
  in #554). A role DESCRIPTOR through the embedded producer + host page would let
  orbs' `client` become `module Client` too.
- Once that lands, the `prefix` form can be deprecated — it is transitional now.
