### PR TITLE
refactor(time-travel): remove the ghost preview mode and the extrapolation settings popover

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -276,7 +276,7 @@ The scripted transition also appears once in `mouse.pressed` or
 `mouse.released` on that frame's sampled snapshot.
 
 A `Mouse.* up` with no preceding press is a **parse error**, not a silently
-dropped line: live playback would suppress it while the `--ghost` forward-step
+dropped line: live playback would suppress it while the forward-step trajectory
 preview would replay it, so a stray release is rejected rather than allowed to
 make the preview and the real run disagree.
 

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -315,14 +315,22 @@ there: two models, one pure `draw`, one blend.
 
 ### Trajectory preview — forward-ghosting (Inventing on Principle)
 
-Tweak a constant, see the whole future at once. Rather than a per-object trail,
-this is **chronophotography**: from the paused snapshot, step the whole scene
-forward over a window (start with ~2s / 10 divisions) and composite the divisions
-into one image, each at `1/divisions` weight. Static geometry averages to itself
-(solid); anything moving smears into a faint strobe of its own future positions.
-It needs **no new scene-description API** — you call the existing `draw` on each
-stepped state — and it captures *all* motion, not one hand-picked entity, so it
-works for any scene under a fixed camera.
+Tweak a constant, see the whole future at once. From the paused snapshot, step
+the whole scene forward over a window (~2s by default) and show every division at
+once: a **trail** of direction-of-travel arrowheads per mover, and/or
+**chronophotography** — real-geometry copies of each mover at its future poses,
+faded by age. It needs **no new scene-description API** — you call the existing
+`draw` on each stepped state — and it derives every mover from the rendered
+scene rather than one hand-picked entity. What it depicts is *transform* motion
+across matching scene nodes: non-geometry change (animated lighting, materials)
+and camera movement are outside it.
+
+A screen-space variant (composite N whole frames at `1/N` weight, so static
+geometry averages to itself and movers smear) was the original prototype. It was
+removed: it pinned every copy at `1/N` opacity, capped divisions at the
+compositor's 8 targets, and froze the camera — the scene-space overlays below
+read better at every window, and the debug camera covers the "see the future from
+elsewhere" case it was uniquely good at.
 
 The scene-diff trail/strobe modes follow the same rule for both render families:
 they traverse `Frame.scene` and every anchor `Frame.sprite_layers` scene, then
@@ -332,27 +340,16 @@ truncates every 2D track rather than cross-wiring it; same-count layer reorderin
 remains a positional-identity limitation until layers have stable ids. Sprite
 copies use each future frame's art/material and fade by alpha, while marker size
 scales with the anchor camera's visible world height. These overlays stay in the
-anchor `Camera2D`'s world coordinates. Use the full-frame ghost compositor when
-future camera movement itself should be visible.
+anchor `Camera2D`'s world coordinates, so future *camera* movement is not itself
+depicted — detach the debug camera to watch the projection from elsewhere.
 
-Two implementation points decide whether it looks right:
+One implementation point decides whether it looks right:
 
-- **Composite in screen space, not the depth buffer.** Render each division to its
-  own offscreen target (normal depth-testing *within* a division), then **average**
-  the targets. Averaging is what makes static=solid / moving=faint fall out of the
-  math — no per-object opacity logic, and it sidesteps the order-dependent garbage
-  of alpha-blending N depth-tested scenes into one buffer. A **progressive
-  running-average** (step one division per real frame, blend into an accumulator at
-  `1/(k+1)`) keeps per-frame cost at ~1 extra render, needs only two targets, and
-  *builds up* over the window — then holds until something changes. (The engine's
-  double-buffered `RenderTargetBuffers` + a fullscreen composite quad, modelled on
-  `draw_skybox`, is nearly all the machinery.)
 - **Replay recorded inputs, freeze the camera.** Forward-stepping replays the
   frame-indexed input log (see "The event log") for frames it has, then coasts;
   all divisions render with the *paused* camera so only world motion smears, not
-  the view. If the future switches between pure 2D and 3D/mixed rendering, or
-  changes a pure-2D layer count, the preview stops at that boundary rather than
-  applying an incompatible pinned view to later frames. After a safe hot reload,
+  the view. If the future changes a pure-2D layer count, the preview truncates
+  every track at that boundary rather than cross-wiring it. After a safe hot reload,
   an input-only model game with complete
   retained history first replays from the edited program's `init` to rebuild the
   complete retained timeline and adopt the selected frame; otherwise that
@@ -364,16 +361,15 @@ Two implementation points decide whether it looks right:
   control is deferred so authors can preview that branch without first resuming.
 
 The "tweak a constant" half rides existing hot-reload: swap the `.fun` with the
-model preserved, re-run the window, the ghost redraws — so you can tweak a jump
+model preserved, re-run the window, the preview redraws — so you can tweak a jump
 impulse until the arc clears a chasm and *see* it clear before you resume. This is
 the single most compelling demo in the set and it is within reach.
 
-**Fork+overlay and forward-ghosting are the same engine primitive** — a
-screen-space compositor that renders K scenes to K offscreen targets and averages
-them with weights. Fork+overlay is K=2 at (0.5, 0.5) from two branches; ghosting
-is K=N at `1/N` from one branch stepped forward. Build the compositor once and
-both land; the old polyline/trail primitive becomes an optional later "precise
-single-path read," not a prerequisite.
+The screen-space compositor that the removed presentation used still ships for
+**fork+overlay** (T5): it renders K scenes to K offscreen targets and averages
+them with weights (K=2 at 0.5/0.5 from two branches). Forward-stepping and
+compositing remain independent — the forward-sim (`ghost_frames`) feeds the
+scene-space overlays directly.
 
 ## Deferred follow-ups: keep and reconstruct the old future
 
@@ -444,8 +440,8 @@ the project's "design for agent verifiability" rule.
 | **T2. Pointer/click input plumbing** | Feed real pointer `RawInput` to egui (desktop); DOM mouse for the web scrubber. `.interactable(false)` dropped for the scrubber panel. | **Shipped** (#226) |
 | **T3. Scrubber overlay** | Draggable timeline (non-destructive scrub + branch-on-resume) + Pause/Step. **Desktop:** egui-in-canvas, `~` console toggle (hidden by default). **Web:** custom DOM/SVG timeline with two accessible handles, a frozen paused viewport, and input/reload markers. Game-owned mouse capture defaults on when captured hooks exist (`"mouseCapture": false` opts out). Independently, every project has a runtime-owned debug view while playing or paused: FPS/orbit for 3D/mixed frames, pan/zoom for pure 2D, plus a capability-filtered contextual drawer for transparent/normal/tangent materials, physics, authored-frustum, FOV, and game-UI diagnostics. Debug navigation never mutates game state/history or replaces the authored culling/portal camera. | **Shipped** (#226 + follow-ups) |
 | **T4. Interactive Functor Lang `View`** | `View` gains an action-carrying node (`Button { label, onClick }`, storable Functor Lang closure); egui hit-tests and dispatches back into `update`. Independent of the scrubber (which is shell-owned) — a general game-UI capability. | Not started |
-| **T5. Fork + overlay** | Keep-the-branch instead of truncate; hold two model+world states; a **screen-space compositor** (new fullscreen average pass at the tail of `render_frame`, reusing the double-buffered `RenderTargetBuffers`) renders each scene to its own target and averages them (K=2, weights 0.5/0.5). Shares its whole implementation with T6. | Not started |
-| **T6. Forward-ghosting (trajectory preview)** | A frame-indexed **input log** in the recorder (plain data, survives reload) + a headless deterministic forward-step (replay inputs, suppress effects) + the T5 compositor at K=N, `1/N` weights; wire to hot-reload for the tweak-a-constant loop; slider once T4 lands. The *Inventing on Principle* demo — no trail primitive needed. | Not started |
+| **T5. Fork + overlay** | Keep-the-branch instead of truncate; hold two model+world states; a **screen-space compositor** (new fullscreen average pass at the tail of `render_frame`, reusing the double-buffered `RenderTargetBuffers`) renders each scene to its own target and averages them (K=2, weights 0.5/0.5). | Not started |
+| **T6. Forward-ghosting (trajectory preview)** | A frame-indexed **input log** in the recorder (plain data, survives reload) + a headless deterministic forward-step (replay inputs, suppress effects) + scene-space trail/strobe overlays derived by diffing the stepped frames; wire to hot-reload for the tweak-a-constant loop. The *Inventing on Principle* demo. (The screen-space `1/N` compositor presentation was prototyped and then removed in favor of the scene-space overlays.) | Not started |
 | **T7. Event timeline** | Record inputs *and* effects as one plain-data event log keyed by frame (inputs in / effects out); render them as markers on the scrubber; use the log to suppress-on-replay. Web now renders recorded inputs and reload boundaries; effect/coeffect markers and a unified cross-shell protocol remain. | **In progress** |
 | **T8. Coeffect record/replay** | Record & replay effect *responses* (http/ws) so a recorded window re-runs faithfully. Pure replay is positional/exact; replay-under-a-tweak needs identity-matching + a visible **divergence marker** when a changed model asks for an un-recorded response (never fire live). | Later |
 

--- a/runtime/functor-runtime-common/src/composite.rs
+++ b/runtime/functor-runtime-common/src/composite.rs
@@ -1,12 +1,12 @@
 //! Screen-space compositor (docs/time-travel.md T5).
 //!
-//! The shared foundation for fork+overlay (K=2 at 0.5/0.5) and forward-ghosting
-//! (K=N at 1/N): render K pure `Frame`s into K offscreen targets, then composite
-//! them onto the backbuffer as a weighted average. The average is done
-//! **in-shader** (sample the K textures, sum with per-texture weight) rather than
-//! via GL blend state — the 3D path keeps blending off, and an exact in-shader
-//! sum makes "static geometry averages to itself (solid), motion smears (faint)"
-//! fall straight out of the math.
+//! The foundation for fork+overlay (K=2 at 0.5/0.5): render K pure `Frame`s into
+//! K offscreen targets, then composite them onto the backbuffer as a weighted
+//! average. The average is done **in-shader** (sample the K textures, sum with
+//! per-texture weight) rather than via GL blend state — the 3D path keeps
+//! blending off, and an exact in-shader sum makes "geometry shared by every
+//! input averages to itself (solid), anything differing goes faint" fall
+//! straight out of the math.
 //!
 //! The GL side lives in `SceneContext::draw_composite`; the per-frame
 //! orchestration in `renderer::render_composited_frames`. This module owns the

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -312,7 +312,7 @@ fn require_function(path: &str, session: &Session, name: &str, arity: usize) -> 
 // A THREAD-LOCAL sink (rather than a `FrameCtx` field) keeps this off the web
 // producer entirely (it never arms it → the pushes are a `None` check) and off
 // the shared effect machinery's signatures. The dry-run forward-step pauses it
-// ([`JournalPause`]) so `--ghost` calls are never journaled.
+// ([`JournalPause`]) so `ghost_frames` calls are never journaled.
 // ---------------------------------------------------------------------------
 
 /// One journaled model-updating call: the entry name, its Rc-cloned args, and a
@@ -471,7 +471,7 @@ pub fn journal_disarm() {
 
 /// RAII guard that PAUSES journaling for its lifetime: takes the current
 /// journal out (leaving `None`, so nested pushes no-op) and restores it on
-/// drop. Wraps the dry-run forward-step so `--ghost` forward-projection calls
+/// drop. Wraps the dry-run forward-step so its forward-projection calls
 /// never land in the journal, even on an unwind from stepped game code.
 struct JournalPause(Option<Vec<JournalEntry>>);
 
@@ -1572,7 +1572,7 @@ fn forward_step_scene_with_error(
     Vec<(Value, Option<physics::PhysicsSnapshot>)>,
     Option<String>,
 ) {
-    // Pause the paused-inspector journal for the whole dry run: `--ghost`
+    // Pause the paused-inspector journal for the whole dry run: the
     // forward-projection replays `tick`/`update` over throwaway state, and those
     // calls must NOT land in the live frame's journal (they are not real frame
     // executions). Restored on drop, including on an unwind from stepped game
@@ -2693,9 +2693,9 @@ mod tests {
         let last_frame = journal_swap().expect("armed");
         assert_eq!(last_frame.len(), 3);
 
-        // A dry-run forward-step (the `--ghost` projection) calls tick/update
-        // over throwaway state — and must NOT touch the live journal. After it,
-        // the freshly-armed journal is still empty (ghost calls excluded).
+        // A dry-run forward-step (the `ghost_frames` projection) calls
+        // tick/update over throwaway state — and must NOT touch the live
+        // journal. After it, the freshly-armed journal is still empty.
         let _ = forward_step_scene(
             &session,
             &EntryNames::UNPREFIXED,

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -446,22 +446,22 @@ fn render_sprite_layers(
 
 /// Render K `Frame`s into K offscreen targets and composite them onto the bound
 /// framebuffer as a weighted average — the screen-space compositor (T5, the
-/// shared foundation for fork+overlay and forward-ghosting, docs/time-travel.md).
+/// foundation for fork+overlay, docs/time-travel.md).
 ///
 /// Each frame renders through the same shadow + forward path as a normal frame
 /// AT ITS OWN paired [`FrameTime`], into its own full-viewport-sized RGBA8
 /// target (keyed `__composite_{i}`, reused across frames), then
 /// `SceneContext::draw_composite` sums them in-shader. Per-frame time is what
 /// lets render-time animation (the skinned-skeleton pose, sampled from the
-/// render pass's `tts`) advance across a ghost strobe instead of freezing every
-/// division at the paused pose. The composite lands in the default framebuffer
+/// render pass's `tts`) advance across the composite instead of freezing every
+/// input at one pose. The composite lands in the default framebuffer
 /// *after* the forward work and before any UI overlay, so it shows up in
 /// `--capture-frame` PNGs.
 ///
 /// Inputs beyond `MAX_COMPOSITE` are dropped; `weights` is truncated/normalized
 /// to the retained count (so equal weights average). Nested render targets inside
 /// an input frame are ignored — the compositor renders each frame's main scene
-/// only (fork/ghost frames are plain scenes).
+/// only (fork frames are plain scenes).
 pub fn render_composited_frames(
     gl: &glow::Context,
     shader_version: &str,

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -6,12 +6,9 @@
 //! - a **trail** of arrowheads tracing each mover's path, each pointing along
 //!   the local direction of travel (the clean-lines view), and
 //! - a **scene-space strobe**: real-geometry copies of each mover at its future
-//!   poses, color- or alpha-faded by age (the chronophotography view). Unlike the
-//!   screen-space `--ghost` compositor — which averages N whole frames, pinning
-//!   every ghost copy at 1/N opacity — copies here use the normal render path:
-//!   independently faded, with no division cap, while the camera stays live.
-//!   (The compositor remains the right tool for non-geometry motion such as
-//!   animated lighting, which no geometry copy can represent.)
+//!   poses, color- or alpha-faded by age (the chronophotography view). Copies
+//!   use the normal render path: independently faded, with no division cap,
+//!   while the camera stays live.
 //!
 //! The point is that this needs NO game cooperation: the runtime derives
 //! everything purely from what `draw` already renders. It diffs the rendered
@@ -29,9 +26,7 @@ use std::collections::BTreeMap;
 use cgmath::{vec4, Deg, InnerSpace, Matrix4, Quaternion, Rad, SquareMatrix, Vector3, Vector4};
 
 use crate::protocol::GameProducer;
-use crate::{
-    Camera2D, Frame, MaterialDescription, RecordedInput, Scene3D, SceneObject, Shape, SpriteLayer,
-};
+use crate::{Camera2D, Frame, MaterialDescription, RecordedInput, Scene3D, SceneObject, Shape};
 
 const TRAIL_RADIUS_3D: f32 = 0.07;
 const TRAIL_REFERENCE_HEIGHT_2D: f32 = 13.5;
@@ -532,9 +527,9 @@ pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<
 
 /// Scene-space strobe options.
 pub struct StrobeOptions {
-    /// Ghost copies per mover across the window (evenly sampled from its track).
+    /// Strobe copies per mover across the window (evenly sampled from its track).
     pub copies: usize,
-    /// The color ghosts fade toward with age — pick the scene's background so
+    /// The color copies fade toward with age — pick the scene's background so
     /// far-future copies read as receding into it.
     pub fade_to: [f32; 3],
     /// Color retention at (nearest, farthest) future — e.g. `(0.8, 0.2)` draws
@@ -797,13 +792,11 @@ pub fn overlay(scene: &mut Scene3D, trail: Scene3D) {
     };
 }
 
-/// The interactive future-preview mode — what the scrubber's selector (and the
-/// `--trajectory`/`--strobe`/`--ghost` launch flags, which seed it) ask the
-/// shell to overlay. One selector covers both preview families: the scene-diff
-/// overlays (trail / strobe / both — geometry on the normal render path) and
-/// `Ghost`, the screen-space compositor strobe (the only mode that can depict
-/// non-geometry motion such as animated lighting). Shared by both shells so
-/// the wire encoding and cycle order match.
+/// The interactive future-preview mode — what the scrubber (and the
+/// `--trajectory`/`--strobe` launch flags, which seed it) ask the shell to
+/// overlay: scene-diff overlays (trail / strobe / both) drawn as geometry on
+/// the normal render path. Shared by both shells so the wire encoding and
+/// cycle order match.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum PreviewMode {
     #[default]
@@ -811,7 +804,6 @@ pub enum PreviewMode {
     Trail,
     Strobe,
     Both,
-    Ghost,
 }
 
 impl PreviewMode {
@@ -820,10 +812,6 @@ impl PreviewMode {
     }
     pub fn wants_strobe(self) -> bool {
         matches!(self, PreviewMode::Strobe | PreviewMode::Both)
-    }
-    /// The screen-space compositor strobe (docs/time-travel.md T6d).
-    pub fn wants_ghost(self) -> bool {
-        matches!(self, PreviewMode::Ghost)
     }
     /// Any mode that forward-simulates (i.e. everything but `Off`) — the
     /// timeline's future pseudo-bar shows exactly when this is true.
@@ -836,17 +824,16 @@ impl PreviewMode {
             PreviewMode::Trail => "trail",
             PreviewMode::Strobe => "strobe",
             PreviewMode::Both => "both",
-            PreviewMode::Ghost => "ghost",
         }
     }
-    /// Stable wire encoding for the wasm scrubber bridge (the DOM `<select>`
-    /// values); anything unknown is `Off`.
+    /// Stable wire encoding for the wasm scrubber bridge (`window.__scrub`'s
+    /// `setPreview({ mode })`); anything unknown is `Off`. Index 4 was the
+    /// removed screen-space ghost compositor and now falls through to `Off`.
     pub fn from_index(i: u32) -> PreviewMode {
         match i {
             1 => PreviewMode::Trail,
             2 => PreviewMode::Strobe,
             3 => PreviewMode::Both,
-            4 => PreviewMode::Ghost,
             _ => PreviewMode::Off,
         }
     }
@@ -860,7 +847,6 @@ impl PreviewMode {
 pub struct InteractivePreview {
     pub trail: bool,
     pub strobe: bool,
-    pub ghost: bool,
 }
 
 pub fn interactive_preview(
@@ -874,7 +860,6 @@ pub fn interactive_preview(
     InteractivePreview {
         trail: mode.wants_trail(),
         strobe: mode.wants_strobe(),
-        ghost: mode.wants_ghost(),
     }
 }
 
@@ -912,14 +897,12 @@ impl SceneOverlays {
         self.trail.is_none() && self.strobe.is_none()
     }
 
-    fn apply(&self, scene: &mut Scene3D, include_strobe: bool) {
+    fn apply(&self, scene: &mut Scene3D) {
         if let Some(trail) = &self.trail {
             overlay(scene, trail.clone());
         }
-        if include_strobe {
-            if let Some(strobe) = &self.strobe {
-                overlay(scene, strobe.clone());
-            }
+        if let Some(strobe) = &self.strobe {
+            overlay(scene, strobe.clone());
         }
     }
 }
@@ -927,13 +910,11 @@ impl SceneOverlays {
 /// A computed preview for the complete render frame. Sprite overlays use the
 /// anchor frame's layer order and camera. A future layer-count change truncates
 /// every layer conservatively; same-count reordering remains a positional-
-/// identity limitation until sprite layers have stable ids. Full-frame ghosting
-/// is still the mode that depicts future camera changes.
+/// identity limitation until sprite layers have stable ids.
 #[derive(Clone, Default)]
 pub struct FramePreview {
     pub scene: SceneOverlays,
     pub sprite_layers: Vec<SceneOverlays>,
-    sprite_cameras: Vec<Camera2D>,
 }
 
 impl FramePreview {
@@ -941,61 +922,14 @@ impl FramePreview {
         self.scene.is_empty() && self.sprite_layers.iter().all(SceneOverlays::is_empty)
     }
 
-    /// Add only trails to `frame`. The screen-space ghost compositor
-    /// uses this so trails remain solid across every averaged future frame.
-    /// Sprite trails get their own layer with the anchor camera, preventing a
-    /// panning future camera from smearing the marker path.
-    pub fn apply_trails(&self, frame: &mut Frame) -> bool {
-        self.scene.apply(&mut frame.scene, false);
-        if frame.sprite_layers.len() != self.sprite_layers.len() {
-            return false;
-        }
-        for index in (0..self.sprite_layers.len()).rev() {
-            if let Some(trail) = &self.sprite_layers[index].trail {
-                frame.sprite_layers.insert(
-                    index + 1,
-                    SpriteLayer {
-                        camera: self.sprite_cameras[index].clone(),
-                        scene: trail.clone(),
-                    },
-                );
-            }
-        }
-        true
-    }
-
-    /// Expand one debug-camera override per authored sprite layer to match the
-    /// trail layers inserted by [`Self::apply_trails`]. Each trail shares its
-    /// source layer's observer camera; later authored layers keep their index.
-    pub fn trail_camera_overrides(&self, cameras: &[Camera2D]) -> Vec<Camera2D> {
-        if cameras.len() != self.sprite_layers.len() {
-            return cameras.to_vec();
-        }
-        let mut expanded = Vec::with_capacity(
-            cameras.len()
-                + self
-                    .sprite_layers
-                    .iter()
-                    .filter(|overlays| overlays.trail.is_some())
-                    .count(),
-        );
-        for (camera, overlays) in cameras.iter().zip(&self.sprite_layers) {
-            expanded.push(camera.clone());
-            if overlays.trail.is_some() {
-                expanded.push(camera.clone());
-            }
-        }
-        expanded
-    }
-
     /// Add every requested scene-space overlay to a normal display frame.
     pub fn apply_all(&self, frame: &mut Frame) {
-        self.scene.apply(&mut frame.scene, true);
+        self.scene.apply(&mut frame.scene);
         if frame.sprite_layers.len() != self.sprite_layers.len() {
             return;
         }
         for (layer, overlays) in frame.sprite_layers.iter_mut().zip(&self.sprite_layers) {
-            overlays.apply(&mut layer.scene, true);
+            overlays.apply(&mut layer.scene);
         }
     }
 }
@@ -1110,11 +1044,6 @@ fn preview_from_frames(anchor: &Frame, futures: &[&Frame], opts: &PreviewOptions
     FramePreview {
         scene: scene_overlays(&scenes, opts, TRAIL_RADIUS_3D),
         sprite_layers,
-        sprite_cameras: anchor
-            .sprite_layers
-            .iter()
-            .map(|layer| layer.camera.clone())
-            .collect(),
     }
 }
 
@@ -1156,15 +1085,13 @@ mod tests {
             InteractivePreview {
                 trail: true,
                 strobe: true,
-                ghost: false,
             }
         );
         assert_eq!(
-            interactive_preview(PreviewMode::Ghost, true, false),
+            interactive_preview(PreviewMode::Trail, true, false),
             InteractivePreview {
-                trail: false,
+                trail: true,
                 strobe: false,
-                ghost: true,
             }
         );
         assert_eq!(
@@ -1273,57 +1200,7 @@ mod tests {
 
         assert!(
             preview.is_empty(),
-            "scene-space overlays use the anchor Camera2D; full-frame ghosting depicts camera motion"
-        );
-    }
-
-    #[test]
-    fn ghosted_sprite_trails_keep_the_anchor_camera() {
-        let mut anchor = rendered_frame_with_sprite(0.0, 0.0);
-        anchor.sprite_layers.push(SpriteLayer {
-            camera: Camera2D::new(24.0, 13.5).with_center(20.0, 0.0),
-            scene: frame(8.0, 0.0),
-        });
-        let mut future = rendered_frame_with_sprite(0.5, 5.0);
-        future.sprite_layers.push(anchor.sprite_layers[1].clone());
-        let preview = preview_from_frames(&anchor, &[&future], &preview_options(true, false));
-        let mut ghost = future.clone();
-
-        assert!(preview.apply_trails(&mut ghost));
-
-        assert_eq!(ghost.sprite_layers.len(), 3);
-        assert_eq!(
-            ghost.sprite_layers[1].camera, anchor.sprite_layers[0].camera,
-            "the added trail layer must not inherit the future camera"
-        );
-        assert_eq!(
-            ghost.sprite_layers[2].camera, future.sprite_layers[1].camera,
-            "the trail stays below the later HUD/foreground layer"
-        );
-        let debug_cameras = [
-            anchor.sprite_layers[0]
-                .camera
-                .clone()
-                .with_center(-4.0, 3.0),
-            anchor.sprite_layers[1]
-                .camera
-                .clone()
-                .with_center(16.0, 3.0),
-        ];
-        let expanded = preview.trail_camera_overrides(&debug_cameras);
-        assert_eq!(expanded.len(), 3);
-        assert_eq!(expanded[0], debug_cameras[0]);
-        assert_eq!(expanded[1], debug_cameras[0]);
-        assert_eq!(expanded[2], debug_cameras[1]);
-
-        let mut mismatched = ghost.clone();
-        mismatched.sprite_layers.push(SpriteLayer {
-            camera: Camera2D::new(8.0, 4.5),
-            scene: frame(0.0, 0.0),
-        });
-        assert!(
-            !preview.apply_trails(&mut mismatched),
-            "a heterogeneous ghost reports that its debug-camera indices cannot be expanded"
+            "scene-space overlays use the anchor Camera2D, so camera motion alone moves nothing"
         );
     }
 

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -701,20 +701,19 @@ pub struct ScrubberState {
     pub camera_fov_degrees: Option<f32>,
     pub camera_zoom_2d: Option<f32>,
     pub debug_presentation: crate::viewer::DebugPresentation,
-    /// The bar's single future-preview switch (docs/time-travel.md T6/T6d):
-    /// "extrapolate" on/off. What it SHOWS when on is `preview_mode`,
-    /// configured in the ⚙ popover. Interactive companion to the
-    /// `--trajectory`/`--strobe`/`--ghost` launch flags.
+    /// The bar's single future-preview switch (docs/time-travel.md T6):
+    /// "extrapolate" on/off. What it SHOWS when on is `preview_mode`, which
+    /// only the seam/CLI configure. Interactive companion to the
+    /// `--trajectory`/`--strobe` launch flags.
     pub extrapolate: bool,
     /// The preview family shown while extrapolating (never `Off` here — the
-    /// checkbox is the off switch): trail / strobe / both / ghost.
+    /// checkbox is the off switch): trail / strobe / both.
     pub preview_mode: crate::trajectory::PreviewMode,
     /// The forward window in seconds, shared by every preview mode; also sizes
     /// the timeline's translucent future segment.
     pub preview_window: f32,
     /// Forward samples PER SECOND — density stays constant as the window is
-    /// resized (total samples = rate × window, clamped; the ghost compositor
-    /// further clamps to its 8-target cap at use).
+    /// resized (total samples = rate × window, clamped).
     pub preview_rate: usize,
 }
 
@@ -737,11 +736,12 @@ pub enum ScrubberAction {
     Step,
     /// Toggle the bar's "extrapolate" switch.
     SetExtrapolate(bool),
-    /// Set the preview family shown while extrapolating (the ⚙ popover).
+    /// Set the preview family shown while extrapolating (seam/CLI only).
     SetPreviewMode(crate::trajectory::PreviewMode),
-    /// Set the preview's forward window in seconds (the ⚙ popover).
+    /// Set the preview's forward window in seconds (the rail's endpoint
+    /// handle, the seam, or the CLI).
     SetPreviewWindow(f32),
-    /// Set the preview's forward samples per second (the ⚙ popover).
+    /// Set the preview's forward samples per second (seam/CLI only).
     SetPreviewRate(usize),
 }
 
@@ -915,8 +915,8 @@ impl Scrubber {
                                             // The segment's END CAP: a small
                                             // grabber hanging under the window
                                             // end — drag to resize the forward
-                                            // window in place (the ⚙ slider's
-                                            // direct-manipulation twin).
+                                            // window in place (the only way to
+                                            // set it from the UI).
                                             // Offset BELOW the track so it
                                             // never fights the seek handle.
                                             let cap = egui::Rect::from_min_max(
@@ -957,60 +957,15 @@ impl Scrubber {
                                     action = Some(ScrubberAction::Step);
                                 }
 
-                                // Future preview (docs/time-travel.md T6/T6d):
-                                // ONE switch on the bar; the mode /
-                                // window / rate knobs live in the ⚙ popover.
+                                // Future preview (docs/time-travel.md T6):
+                                // ONE switch on the bar. The window is set by
+                                // dragging the rail's extrapolation endpoint;
+                                // mode and rate are seam-only knobs.
                                 ui.separator();
                                 let mut on = state.extrapolate;
                                 if ui.checkbox(&mut on, "extrapolate").changed() {
                                     action = Some(ScrubberAction::SetExtrapolate(on));
                                 }
-                                ui.menu_button("⚙", |ui| {
-                                    ui.label("show");
-                                    ui.horizontal(|ui| {
-                                        use crate::trajectory::PreviewMode as PM;
-                                        for mode in [PM::Trail, PM::Strobe, PM::Both, PM::Ghost]
-                                        {
-                                            if ui
-                                                .selectable_label(
-                                                    state.preview_mode == mode,
-                                                    mode.label(),
-                                                )
-                                                .clicked()
-                                            {
-                                                action =
-                                                    Some(ScrubberAction::SetPreviewMode(mode));
-                                            }
-                                        }
-                                    });
-                                    ui.label("forward window");
-                                    let mut window = state.preview_window;
-                                    if ui
-                                        .add(egui::Slider::new(&mut window, 0.5..=5.0).suffix("s"))
-                                        .changed()
-                                    {
-                                        action = Some(ScrubberAction::SetPreviewWindow(window));
-                                    }
-                                    ui.label("rate");
-                                    let mut rate = state.preview_rate.clamp(1, 30);
-                                    if ui
-                                        .add(
-                                            egui::DragValue::new(&mut rate)
-                                                .range(1..=30)
-                                                .suffix("/s"),
-                                        )
-                                        .changed()
-                                    {
-                                        action = Some(ScrubberAction::SetPreviewRate(rate));
-                                    }
-                                    ui.label(
-                                        egui::RichText::new(
-                                            "strobe copies per second — the trail samples\nfiner; ghost composites ≤8 total",
-                                        )
-                                        .weak()
-                                        .size(10.0),
-                                    );
-                                });
                             });
                             // The frame counter: tiny, faded, PAINTED just
                             // under the timeline rail and centered on IT (not

--- a/runtime/functor-runtime-common/src/viewer.rs
+++ b/runtime/functor-runtime-common/src/viewer.rs
@@ -304,28 +304,6 @@ impl DebugCamera {
         }
     }
 
-    /// Number of projected frames that can share one pinned observer view.
-    ///
-    /// A preview is temporal, so compatibility is a prefix: once a future
-    /// switches between 2D and 3D (or changes a pure-2D layer count), later
-    /// frames must not be stitched back in after the incompatible boundary.
-    pub fn compatible_prefix_len<'a>(
-        anchor: &Frame,
-        frames: impl IntoIterator<Item = &'a Frame>,
-    ) -> usize {
-        frames
-            .into_iter()
-            .take_while(|candidate| {
-                if anchor.is_pure_2d() {
-                    candidate.is_pure_2d()
-                        && candidate.sprite_layers.len() == anchor.sprite_layers.len()
-                } else {
-                    !candidate.is_pure_2d()
-                }
-            })
-            .count()
-    }
-
     /// The effective main 3D view camera. A 2D debug view leaves the frame's
     /// dummy/main 3D camera alone.
     pub fn camera<'a>(&'a self, authored: &'a Camera) -> &'a Camera {
@@ -923,38 +901,6 @@ mod tests {
         assert!(debug.detach(&two_layers));
         assert!(!debug.is_compatible(&frame_2d()));
         assert!(!debug.is_compatible(&frame_3d()));
-    }
-
-    #[test]
-    fn pinned_preview_stops_at_the_first_incompatible_view_layout() {
-        let anchor_3d = frame_3d();
-        let projected_3d = frame_3d();
-        let projected_2d = frame_2d();
-        let later_3d = frame_3d();
-        assert_eq!(
-            DebugCamera::compatible_prefix_len(
-                &anchor_3d,
-                [&projected_3d, &projected_2d, &later_3d]
-            ),
-            1
-        );
-
-        let anchor_2d = frame_2d();
-        let matching_2d = frame_2d();
-        let changed_layers = Frame::with_2d(
-            frame_2d(),
-            SpriteLayer {
-                camera: Camera2D::new(10.0, 10.0),
-                scene: Scene3D::quad(),
-            },
-        );
-        assert_eq!(
-            DebugCamera::compatible_prefix_len(
-                &anchor_2d,
-                [&matching_2d, &changed_layers, &matching_2d]
-            ),
-            1
-        );
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -462,7 +462,7 @@ fn parse_input_script(path: &str) -> Result<HashMap<u64, Vec<RecordedInput>>, St
 ///
 /// This is a real inconsistency, not a style rule. Live playback applies the
 /// held-state discipline (`apply_mouse_button_edge`) and SUPPRESSES such a
-/// release, but the `--ghost` / trail forward-step preview replays the script's
+/// release, but the trail forward-step preview replays the script's
 /// events unconditionally — so a malformed script would preview a future the
 /// real run never plays. Failing the parse keeps the two paths honest by
 /// construction, and a stray release is an authoring mistake either way.
@@ -707,52 +707,36 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = CompositeDemoArg::Off)]
     composite_demo: CompositeDemoArg,
 
-    /// Forward-ghosting trajectory preview (docs/time-travel.md T6d): composite
-    /// N forward-stepped frames into one image (chronophotography), so moving
-    /// elements smear into a strobe of their ~2s future positions while static
-    /// geometry stays solid. Off by default; when on it composites every frame
-    /// (no pause gating), so it's deterministically capturable under
-    /// --fixed-time. The window is fixed at ~2s (`dt = 2.0 / --ghost-divisions`).
-    #[arg(long)]
-    ghost: bool,
-
-    /// Number of forward divisions composited by --ghost (clamped to 8, the
-    /// compositor max). More divisions = a finer strobe over the same ~2s window.
-    #[arg(long, default_value_t = 8)]
-    ghost_divisions: usize,
-
     /// Scene-diff trajectory preview (docs/time-travel.md T6, scene-diff
     /// variant): forward-simulate the model and draw a clean trail of
     /// direction-of-travel arrowheads tracing ONLY the scene nodes that move
     /// — derived by the runtime from
-    /// `draw`, with no game logic. Unlike --ghost's whole-scene strobe, static
-    /// geometry contributes nothing. Capturable under --fixed-time.
+    /// `draw`, with no game logic. Static geometry contributes nothing.
+    /// Capturable under --fixed-time.
     #[arg(long)]
     trajectory: bool,
 
     /// Scene-space strobe preview: forward-simulate the model and overlay
     /// real-geometry copies of each MOVING scene node at its future poses,
     /// color-faded by age — full-intensity chronophotography on the normal
-    /// render path. The geometry complement to --ghost's screen-space
-    /// compositor (which pins every copy at 1/N opacity and freezes the
-    /// camera); like --trajectory it's runtime-derived from `draw`, shares one
-    /// forward-sim with it, and is capturable under --fixed-time.
+    /// render path. Like --trajectory it's runtime-derived from `draw`, shares
+    /// one forward-sim with it, and is capturable under --fixed-time.
     #[arg(long)]
     strobe: bool,
 
     /// Start with the time-travel scrubber overlay visible (it is otherwise
     /// hidden until summoned with `~`). Useful for demos and captures of the
     /// scrubber itself. NOTE: with the overlay up, previews follow the
-    /// interactive rule (paused only) — combine with --trajectory/--strobe/
-    /// --ghost WITHOUT --scrubber for headless overlay captures.
+    /// interactive rule (paused only) — combine with --trajectory/--strobe
+    /// WITHOUT --scrubber for headless overlay captures.
     #[arg(long)]
     scrubber: bool,
 
     /// Narrate the game clock + time-travel seams to stderr: pause/resume/seek
-    /// rebases (with the tts they land on), ghost on/off, and per-frame HITCH
-    /// warnings when a rendered frame's dt blows past 33ms (the tell-tale of the
-    /// ghost compositor starving the frame loop). High-signal diagnostics for the
-    /// interactive scrubber — off by default.
+    /// rebases (with the tts they land on), preview mode changes, and
+    /// per-frame HITCH warnings when a rendered frame's dt blows past 33ms (the
+    /// tell-tale of a forward-sim starving the frame loop). High-signal
+    /// diagnostics for the interactive scrubber — off by default.
     #[arg(long)]
     debug_clock: bool,
 
@@ -1529,22 +1513,20 @@ Escape releases while captured"
         // you can scrub right away; --scrubber starts it open, e.g. for
         // captures). The wasm/vscode preview shows it always.
         let mut scrubber_visible = args.scrubber;
-        // Future-preview (docs/time-travel.md T6/T6d) state, driven
-        // interactively from the scrubber's "extrapolate" switch and ⚙ popover
-        // (mode / window / rate). Extrapolation defaults ON with trail+strobe
-        // out of the box (the demo default), and the launch
-        // flags pick the mode; they stay authoritative while the overlay is
-        // hidden (the headless-capture escape hatch), where they may also
-        // COMBINE (--ghost --trajectory composes the trail into the strobe).
+        // Future-preview (docs/time-travel.md T6) state, driven interactively
+        // from the scrubber's "extrapolate" switch (and, for the window, the
+        // rail's endpoint handle). Extrapolation defaults ON with trail+strobe
+        // out of the box (the demo default), and the launch flags pick the
+        // mode; they stay authoritative while the overlay is hidden (the
+        // headless-capture escape hatch).
         let mut extrapolate_on = true;
-        let mut preview_mode = match (args.ghost, args.trajectory, args.strobe) {
-            (true, _, _) => functor_runtime_common::PreviewMode::Ghost,
-            (false, true, false) => functor_runtime_common::PreviewMode::Trail,
-            (false, false, true) => functor_runtime_common::PreviewMode::Strobe,
+        let mut preview_mode = match (args.trajectory, args.strobe) {
+            (true, false) => functor_runtime_common::PreviewMode::Trail,
+            (false, true) => functor_runtime_common::PreviewMode::Strobe,
             _ => functor_runtime_common::PreviewMode::Both,
         };
-        // The ⚙ popover's shared forward window and samples-per-second rate
-        // (density holds as the window resizes: total samples = rate × window).
+        // The shared forward window and samples-per-second rate (density holds
+        // as the window resizes: total samples = rate × window).
         let mut preview_window: f32 = 2.0;
         let mut preview_rate: usize = 5;
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
@@ -1562,12 +1544,6 @@ Escape releases while captured"
         )> = None;
         let mut trail_refresh: u32 = 0;
         let mut next_live_trail_refresh: f32 = 0.0;
-        let mut ghost_cache: Option<(
-            (Option<u64>, u32, bool, u64, usize, u32),
-            Vec<(Frame, FrameTime)>,
-        )> = None;
-        let mut ghost_refresh: u32 = 0;
-        let mut next_live_ghost_refresh: f32 = 0.0;
 
         gl.clear_color(0.1, 0.2, 0.3, 1.0);
 
@@ -1703,17 +1679,13 @@ Escape releases while captured"
             // wall-clock, so frame N is always the same sim state. Queued as a
             // one-shot step (which the clock consumes in `frame()` below), making
             // every rendered frame a single fixed dt regardless of real timing.
-            // Under --ghost the script drives the GHOST, not the live game (F2,
-            // docs/time-travel.md): the live game stays at its init anchor, so
-            // don't fixed-step its clock — the ghost forward-step supplies the
-            // deterministic sub-dt itself.
-            if input_script.is_some() && !args.ghost {
+            if input_script.is_some() {
                 clock.step(args.script_dt);
             }
             // The fixed-timestep model loop (docs/time-travel.md): advance `tick`
             // in whole 1/60 steps decoupled from the render rate, so the sim is
             // deterministic and a recorded frame is exactly one forward-step fine
-            // step (the ghost replay's assumption). Scripted playback queued a
+            // step (the forward-step replay's assumption). Scripted playback queued a
             // one-shot `step` above, so that yields one sub-frame per iteration
             // (a debug `advance` batch can queue more, draining ≤8 per frame);
             // --fixed-time / the debug pin yields one {dts:0} sub-frame; paused
@@ -1730,8 +1702,8 @@ Escape releases while captured"
             };
 
             // Surface frame hitches (a real delta past 33ms = under 30fps) — the
-            // signature of the ghost compositor's N forward-steps starving the
-            // loop, which reads to the user as "jerky / can't move".
+            // signature of a preview's N forward-steps starving the loop, which
+            // reads to the user as "jerky / can't move".
             if args.debug_clock && real_delta > 1.0 / 30.0 {
                 eprintln!(
                     "[clock] HITCH dt={:.1}ms tts={:.3} (slow frame)",
@@ -2413,14 +2385,12 @@ Escape again to quit"
             // Run this render frame's fixed model steps (0..N). Scripted input
             // (docs/time-travel.md T6b) is fed per fixed frame through the SAME
             // `key_event` path the live GLFW handlers use, before that frame's
-            // tick. Under --ghost the script drives the GHOST instead (F2): leave
-            // the live game at its init anchor so the strobed arc reads against a
-            // clean, static pose. `--capture-at-frame` fires on the fixed frame it
+            // tick. `--capture-at-frame` fires on the fixed frame it
             // names — scripted playback is exactly one fixed step per render frame,
             // so that index stays deterministic.
             let mut capture_due = false;
             for sub in &sub_frames {
-                if let Some(script) = input_script.as_ref().filter(|_| !args.ghost) {
+                if let Some(script) = input_script.as_ref() {
                     if let Some(events) = script.get(&frame_count) {
                         apply_scripted_events(
                             &mut *game,
@@ -2474,37 +2444,24 @@ Escape again to quit"
             // trajectory overlay goes on a render-only copy below.
             let frame = game.render(time.clone());
 
-            // Drive the ghost from the interactive toggle when the overlay is up,
-            // and from the `--ghost` launch flag when it's hidden (the headless
-            // capture path — F2 demo, goldens, tests — is byte-for-byte
-            // unchanged). Computed HERE, above the scene-diff preview, because
-            // the preview's gating reads it.
-            // One wanted-set drives every future preview (docs/time-travel.md
-            // T6/T6d): the scene-diff trail/strobe overlays AND the
-            // screen-space ghost compositor. With the overlay up, the
-            // scrubber's selector picks ONE mode. Its anchor follows the live
-            // tail while playing and freezes when paused. With the overlay
-            // hidden the launch flags drive it — several may combine
-            // there (--ghost --trajectory composes the trail into the strobe) —
-            // so headless captures are byte-for-byte unchanged.
-            let (trail_wanted, strobe_wanted, ghost_active) = if scrubber_visible {
+            // One wanted-set drives the future preview
+            // (docs/time-travel.md T6): the scene-diff trail/strobe overlays.
+            // With the overlay up, the seam-selected mode drives it; its
+            // anchor follows the live tail while playing and freezes when
+            // paused. With the overlay hidden the launch flags drive it, so
+            // headless captures are byte-for-byte unchanged.
+            let (trail_wanted, strobe_wanted) = if scrubber_visible {
                 let selected = functor_runtime_common::interactive_preview(
                     preview_mode,
                     extrapolate_on,
                     clock.pending_frames() > 0,
                 );
-                (selected.trail, selected.strobe, selected.ghost)
+                (selected.trail, selected.strobe)
             } else {
-                (args.trajectory, args.strobe, args.ghost)
+                (args.trajectory, args.strobe)
             };
-            // Under the screen-space ghost compositor the scene-space strobe
-            // would double-ghost — and the compositor arm never draws the
-            // display frame — so while the ghost is active the strobe is off
-            // (the trail still shows: it rides IN the composited frames), and
-            // it must not silently burn a forward-sim it can't display.
-            let strobe_wanted = strobe_wanted && !ghost_active;
             // Forward window/densities. The SIM samples fine (~20/s — the
-            // trail's smooth-arc rate) while the ⚙ rate governs STROBE COPIES
+            // trail's smooth-arc rate) while the preview rate governs STROBE COPIES
             // per second, so dots stay visible between copies and both hold
             // their density as the window resizes. The flag path keeps its
             // historical constants (32 samples over 1.6s, 8 copies), keeping
@@ -2527,8 +2484,8 @@ Escape again to quit"
                 && clock.pending_frames() == 0
                 && clock.pending_steps() == 0;
             let preview: Option<functor_runtime_common::FramePreview> = if preview_active {
-                // Not bound by the 8-target compositor cap — this only reads node
-                // transforms — so sample finely for a smooth arc.
+                // Sample finely for a smooth arc — this only reads node
+                // transforms.
                 let divisions = preview_divisions;
                 let window = preview_window_s;
                 let dt = window / divisions as f32;
@@ -2564,8 +2521,8 @@ Escape again to quit"
                     trail_cache.as_ref().map(|(_, p)| p.clone())
                 } else {
                     // Under --input-script the live loop keeps consuming the
-                    // script (its gate is `!args.ghost`), so the forward-sim must
-                    // replay the SAME upcoming slice — with `None` it would
+                    // script, so the forward-sim must replay the SAME upcoming
+                    // slice — with `None` it would
                     // replay the recorder's (empty-at-head) log and predict an
                     // input-free future the game won't play. The slice anchors at
                     // the fine step after the newest recorded frame, mirroring
@@ -2575,25 +2532,9 @@ Escape again to quit"
                             let sub_dt = 1.0f32 / 60.0;
                             let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
                             let total = (divisions * steps_per_division) as u64;
-                            // Under --ghost the live loop does NOT consume the
-                            // script (the model holds at the init anchor while
-                            // the recorder still advances), and the ghost slice
-                            // below replays from frame 0 — anchor the trail the
-                            // same way or the two projections diverge. Live
-                            // playback consumes the script, so there the next
+                            // Live playback consumes the script, so the next
                             // unconsumed frame (k + 1) is the right anchor.
-                            // Deliberately keyed on the LAUNCH FLAG, not the
-                            // interactive mode: `--ghost --input-script` is the
-                            // F2 session semantic (the script drives the
-                            // anchored future, never the live game), so
-                            // selecting trail/strobe there previews the SAME
-                            // scripted future — switching modes changes the
-                            // visualization, not the script routing.
-                            let base = if args.ghost {
-                                0
-                            } else {
-                                game.current_scene_frame().map_or(0, |k| k + 1)
-                            };
+                            let base = game.current_scene_frame().map_or(0, |k| k + 1);
                             (0..total)
                                 .map(|j| script.get(&(base + j)).cloned().unwrap_or_default())
                                 .collect()
@@ -2633,133 +2574,6 @@ Escape again to quit"
                 next_live_trail_refresh = 0.0;
                 None
             };
-
-            // Forward-ghosting (docs/time-travel.md T6d): when --ghost is on, step
-            // the scene forward over a ~2s window and collect a Frame per division
-            // (a dry run — the live producer is untouched), for the compositor arm
-            // in the render ladder below. Empty when --ghost is off (or the
-            // producer has no model history, e.g. web's trait default). `start_tts
-            // = time.tts` (under --fixed-time T, that's T, so the ghost projects
-            // T+dt … T+N·dt). Always composites when on — no pause gating — so it's
-            // deterministically capturable under --fixed-time.
-            // Gate on the full ladder condition so we don't pay the dry-run + N
-            // draws only to have stereo / composite-demo outrank the ghost arm.
-            // (`ghost_active` is computed above the scene-diff preview block.)
-            let ghost_frames = if ghost_active
-                && !args.stereo_sbs
-                && args.composite_demo == CompositeDemoArg::Off
-                // Skipped during a catch-up or batched-advance drain, like the
-                // scene-diff preview.
-                && clock.pending_frames() == 0
-                && clock.pending_steps() == 0
-            {
-                const MAX_GHOST: usize = 8;
-                // Interactive: the ⚙ popover's rate × window (clamped to the
-                // compositor's 8-target cap). Flag path: the historical
-                // --ghost-divisions over a 2s window, byte-identical captures.
-                let (divisions, ghost_window) = if scrubber_visible {
-                    (
-                        ((preview_rate as f32 * preview_window).round() as usize)
-                            .clamp(1, MAX_GHOST),
-                        preview_window,
-                    )
-                } else {
-                    (args.ghost_divisions.clamp(1, MAX_GHOST), 2.0f32)
-                };
-                let dt = ghost_window / divisions as f32;
-                // F2 (docs/time-travel.md): when an --input-script is loaded, the
-                // ghost previews the SCRIPT's trajectory from the live anchor
-                // (mario at init) rather than the recorder's own input log. Build a
-                // per-fine-step slice covering the ghost window (frame f → the
-                // script's events at f, empty when it has none). The fine step is
-                // 1/60 and script frames advance by 1/60, so the frame index maps
-                // straight to the fine-step index. `None` keeps the T6d behavior
-                // (e.g. the lighting ghost, which has no script).
-                let script_slice: Option<Vec<Vec<RecordedInput>>> =
-                    input_script.as_ref().map(|script| {
-                        let sub_dt = 1.0f32 / 60.0;
-                        let steps_per_division = ((dt / sub_dt).round() as usize).max(1);
-                        let total = (divisions * steps_per_division) as u64;
-                        (0..total)
-                            .map(|f| script.get(&f).cloned().unwrap_or_default())
-                            .collect()
-                    });
-                if scrubber_visible {
-                    let key = (
-                        game.current_scene_frame(),
-                        time.tts.to_bits(),
-                        clock.is_paused(),
-                        game.scene_program_revision(),
-                        divisions,
-                        ghost_window.to_bits(),
-                    );
-                    let cache_hit = ghost_cache.as_ref().is_some_and(|(k, _)| {
-                        if clock.is_paused() {
-                            ghost_refresh > 0 && *k == key
-                        } else {
-                            elapsed_time < next_live_ghost_refresh
-                                && !k.2
-                                && k.3 == key.3
-                                && k.4 == key.4
-                                && k.5 == key.5
-                        }
-                    });
-                    if cache_hit {
-                        if clock.is_paused() {
-                            ghost_refresh -= 1;
-                        }
-                        ghost_cache
-                            .as_ref()
-                            .map(|(_, frames)| frames.clone())
-                            .unwrap_or_default()
-                    } else {
-                        let frames = game.ghost_frames(
-                            divisions,
-                            dt,
-                            time.tts as f64,
-                            script_slice.as_deref(),
-                        );
-                        if clock.is_paused() {
-                            ghost_refresh = PAUSED_PREVIEW_REUSE_FRAMES;
-                        } else {
-                            ghost_refresh = 0;
-                            next_live_ghost_refresh =
-                                start_time.elapsed().as_secs_f32() + LIVE_PREVIEW_INTERVAL_SECONDS;
-                        }
-                        ghost_cache = Some((key, frames.clone()));
-                        frames
-                    }
-                } else {
-                    ghost_cache = None;
-                    next_live_ghost_refresh = 0.0;
-                    game.ghost_frames(divisions, dt, time.tts as f64, script_slice.as_deref())
-                }
-            } else {
-                ghost_cache = None;
-                next_live_ghost_refresh = 0.0;
-                Vec::new()
-            };
-            // The trail composes with --ghost's screen-space strobe by riding IN
-            // each composited frame: 3D dots repeat at identical world positions,
-            // while 2D dots repeat in an extra layer using the anchor Camera2D.
-            // The equal-weight average therefore reconstructs both at full
-            // intensity (unlike movers, which appear in only one frame each).
-            // Without this the ghost render arm draws only `ghost_frames` and
-            // the trail would silently vanish.
-            // The scene-space strobe is deliberately NOT folded in — layering
-            // geometry copies under the compositor's strobe would double-ghost.
-            let mut ghost_frames = ghost_frames;
-            let compatible_ghosts = DebugCamera::compatible_prefix_len(
-                &frame,
-                ghost_frames.iter().map(|(candidate, _)| candidate),
-            );
-            ghost_frames.truncate(compatible_ghosts);
-            let mut ghost_sprite_layers_compatible = true;
-            if let Some(preview) = &preview {
-                for (f, _) in ghost_frames.iter_mut() {
-                    ghost_sprite_layers_compatible &= preview.apply_trails(f);
-                }
-            }
 
             // A live game may switch between a pure 2D and a 3D/mixed frame.
             // Never retain a debug snapshot whose navigation semantics no
@@ -2849,10 +2663,8 @@ Escape again to quit"
 
             // The frame the render ladder draws: the game frame plus the
             // preview overlays (`frame` itself stays pristine for GET /scene).
-            // Skipped when the ghost arm will draw instead — the trail already
-            // rides inside `ghost_frames`.
-            let display_frame = match (&preview, ghost_frames.is_empty()) {
-                (Some(p), true) if !p.is_empty() => {
+            let display_frame = match &preview {
+                Some(p) if !p.is_empty() => {
                     let mut f = frame.clone();
                     p.apply_all(&mut f);
                     Some(f)
@@ -2972,35 +2784,6 @@ Escape again to quit"
                     &[0.5, 0.5],
                     Some(&view_camera),
                     detached_camera.sprite_cameras(),
-                    viewport,
-                    diagnostics.render_mode,
-                );
-            } else if !ghost_frames.is_empty() {
-                // Forward-ghosting (docs/time-travel.md T6d): composite the ~2s
-                // forward-stepped frames (computed above) at equal weight so moving
-                // elements strobe across their future and static geometry stays
-                // solid. Each frame renders at ITS OWN division-boundary time, so
-                // render-time animation (the skinned pose) advances through the
-                // strobe. Empty (→ this arm skipped) when --ghost is off or the
-                // producer yields no frames, so live rendering is unchanged.
-                let weights = vec![1.0f32; ghost_frames.len()];
-                let ghost_sprite_cameras = ghost_sprite_layers_compatible
-                    .then(|| detached_camera.sprite_cameras())
-                    .flatten()
-                    .map(|cameras| match &preview {
-                        Some(preview) => preview.trail_camera_overrides(cameras),
-                        None => cameras.to_vec(),
-                    });
-                functor_runtime_common::render_composited_frames_with_view(
-                    &gl,
-                    shader_version,
-                    asset_cache.clone(),
-                    &scene_context,
-                    &shadow_map,
-                    &ghost_frames,
-                    &weights,
-                    Some(&view_camera),
-                    ghost_sprite_cameras.as_deref(),
                     viewport,
                     diagnostics.render_mode,
                 );

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -68,17 +68,17 @@ const STYLE = `
 #scrub-main {
   display: flex; align-items: center; gap: 8px; flex-wrap: nowrap;
 }
-#scrubber button, #scrub-adv > summary {
+#scrubber button {
   font: 14px/1 var(--sb-font); color: var(--sb-text); cursor: pointer;
   background: rgba(65, 216, 230, 0.10); border: 1px solid var(--sb-line);
   border-radius: 6px; padding: 6px 9px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
   transition: box-shadow 0.12s ease, border-color 0.12s ease, transform 0.12s ease;
 }
-#scrubber button:hover, #scrub-adv > summary:hover {
+#scrubber button:hover {
   border-color: var(--sb-accent); box-shadow: 0 3px 10px rgba(0, 0, 0, 0.5);
   transform: translateY(-1px);
 }
-#scrubber button:active, #scrub-adv > summary:active {
+#scrubber button:active {
   transform: translateY(0); box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 #scrub-rail {
@@ -168,32 +168,16 @@ const STYLE = `
 #scrub-debug input[type="checkbox"] { accent-color: var(--sb-accent); }
 #scrub-debug-fov { width: 110px; }
 #scrub-debug-lens { color: var(--sb-text); min-width: 42px; }
-#scrub-adv { position: relative; }
-#scrub-adv > summary { list-style: none; user-select: none; }
-#scrub-adv > summary::-webkit-details-marker { display: none; }
-#scrub-adv[open] > summary { border-color: var(--sb-accent); }
-#scrub-adv-pop {
-  position: absolute; top: calc(100% + 10px); right: 0; z-index: 11;
-  display: flex; flex-direction: column; gap: 8px; padding: 10px 12px;
-  background: var(--sb-bg); border-radius: 8px; border: 1px solid var(--sb-line);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5); white-space: nowrap;
-}
-#scrub-adv-pop label { display: flex; align-items: center; gap: 6px; justify-content: space-between; }
-#scrub-adv-pop select, #scrub-adv-pop input[type="number"] {
-  font: 12px/1 var(--sb-font); color: var(--sb-text); background: rgba(65, 216, 230, 0.10);
-  border: 1px solid var(--sb-line); border-radius: 5px; padding: 4px 5px;
-}
-#scrub-adv-pop input[type="number"] { width: 46px; }
 @media (max-width: 520px) {
   #scrubber { padding: 7px 8px 17px; }
   #scrub-main { gap: 6px; }
   #scrub-debug { gap: 8px; }
-  #scrubber button, #scrub-adv > summary { padding: 6px 7px; }
+  #scrubber button { padding: 6px 7px; }
   #scrub-rail { min-width: 48px; }
 }
 @media (max-width: 380px) {
   #scrub-main { gap: 4px; }
-  #scrubber button, #scrub-adv > summary { padding: 6px 5px; font-size: 13px; }
+  #scrubber button { padding: 6px 5px; font-size: 13px; }
 }`;
 
 const HTML = `
@@ -229,19 +213,6 @@ const HTML = `
     <span id="scrub-label"><span id="scrub-count"></span></span>
     </span>
     <button id="scrub-extrapolate" title="Extrapolate the game into the future">🔮</button>
-    <details id="scrub-adv">
-      <summary title="Extrapolation settings">⚙</summary>
-      <div id="scrub-adv-pop">
-        <label>show
-          <select id="scrub-mode">
-            <option value="1">trail</option><option value="2">strobe</option>
-            <option value="3" selected>both</option><option value="4">ghost</option>
-          </select>
-        </label>
-        <label>window <input id="scrub-win" type="number" step="0.5" min="0.5" max="5" value="2" />s</label>
-        <label>rate <input id="scrub-rate" type="number" min="1" max="30" value="5" />/s</label>
-      </div>
-    </details>
   </div>
   <section id="scrub-debug" aria-label="Debug Camera controls">
     <span id="scrub-debug-title">Debug Camera</span>
@@ -316,9 +287,6 @@ export function mountScrubber({ hidden = false } = {}) {
   const eventDetail = $("scrub-event-detail");
   const eventLayer = $("scrub-events");
   const extrapolate = $("scrub-extrapolate");
-  const mode = $("scrub-mode");
-  const win = $("scrub-win");
-  const rate = $("scrub-rate");
   const debugMode = $("scrub-debug-mode");
   const debugPan2d = $("scrub-debug-pan2d");
   const debugFov = $("scrub-debug-fov");
@@ -332,6 +300,12 @@ export function mountScrubber({ hidden = false } = {}) {
   const debugFrustumLabel = $("scrub-debug-frustum-label");
   const debugGameUi = $("scrub-debug-game-ui");
   const debugReset = $("scrub-debug-reset");
+
+  // The preview family pushed to the renderer (1 trail / 2 strobe / 3 both;
+  // any other index is Off — `PreviewMode::from_index` owns that mapping, so
+  // this only forwards the wire value). Seam-only config with no chrome, so it
+  // is NOT part of the reducer's state.
+  let previewMode = 3;
 
   let state = createTimelineState();
   let pendingSeek = null;
@@ -365,14 +339,10 @@ export function mountScrubber({ hidden = false } = {}) {
     zoom2d: functor_lang_viewer_zoom_2d(),
   });
   const pushPreview = () =>
-    functor_lang_scrub_set_preview(state.preview.enabled ? Number(mode.value) : 0);
+    functor_lang_scrub_set_preview(state.preview.enabled ? previewMode : 0);
   const pushConfig = () => {
     const config = canonicalConfig();
     functor_lang_scrub_set_preview_config(config.seconds, config.rate);
-  };
-  const syncInputs = () => {
-    win.value = String(state.preview.seconds);
-    rate.value = String(state.preview.rate);
   };
 
   const requestSeek = (frame) => {
@@ -701,7 +671,6 @@ export function mountScrubber({ hidden = false } = {}) {
       type: "preview-changed",
       preview: { seconds: previewDrag.seconds + deltaFrames / TIMELINE_FPS },
     });
-    syncInputs();
     pushConfig();
   });
   const endPreviewDrag = () => (previewDrag = null);
@@ -761,7 +730,6 @@ export function mountScrubber({ hidden = false } = {}) {
     } else {
       return;
     }
-    syncInputs();
     pushConfig();
   });
 
@@ -811,19 +779,6 @@ export function mountScrubber({ hidden = false } = {}) {
     dispatch({ type: "preview-changed", preview: { enabled: !state.preview.enabled } });
     pushPreview();
   });
-  mode.addEventListener("change", pushPreview);
-
-  const updateConfigFromInputs = () => {
-    const seconds = win.valueAsNumber;
-    const nextRate = rate.valueAsNumber;
-    if (!win.validity.valid || !rate.validity.valid) return;
-    dispatch({ type: "preview-changed", preview: { seconds, rate: nextRate } });
-    pushConfig();
-  };
-  win.addEventListener("input", updateConfigFromInputs);
-  rate.addEventListener("input", updateConfigFromInputs);
-  win.addEventListener("change", syncInputs);
-  rate.addEventListener("change", syncInputs);
   debugMode.addEventListener("change", () =>
     functor_lang_viewer_set_mode(Number(debugMode.value))
   );
@@ -845,7 +800,6 @@ export function mountScrubber({ hidden = false } = {}) {
   );
   debugReset.addEventListener("click", () => functor_lang_viewer_reset());
 
-  syncInputs();
   pushPreview();
   pushConfig();
 
@@ -893,17 +847,14 @@ export function mountScrubber({ hidden = false } = {}) {
     events: () => state.events,
     selectEvent: (id) => dispatch({ type: "event-selected", id }),
     // Accepts the timeline-model preview fields plus `mode` (1 trail /
-    // 2 strobe / 3 both / 4 ghost) — the ghost-mode select isn't part of the
-    // reducer's state, so hosts driving a hidden mount set it through here.
-    setPreview: ({ mode: previewMode, ...preview }) => {
-      // Only accept a mode the select actually offers — assigning an unknown
-      // value would blank the select and push mode 0 (renderer off) while the
-      // model still says enabled.
-      if (previewMode !== undefined && mode.querySelector(`option[value="${previewMode}"]`)) {
-        mode.value = String(previewMode);
+    // 2 strobe / 3 both; any other index is Off, per `PreviewMode::from_index`).
+    // The mode has no chrome — it is seam-only config — so it lives beside the
+    // reducer's state, not in it.
+    setPreview: ({ mode: nextMode, ...preview }) => {
+      if (nextMode !== undefined && Number.isFinite(Number(nextMode))) {
+        previewMode = Number(nextMode);
       }
       dispatch({ type: "preview-changed", preview });
-      syncInputs();
       pushPreview();
       pushConfig();
     },

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -479,12 +479,12 @@ pub enum ScrubControl {
         frame: u64,
         request_id: u32,
     },
-    /// Future-preview mode (docs/time-travel.md T6/T6d), pushed by the DOM
-    /// preview `<select>` (PreviewMode wire index: 0 off / 1 trail / 2 strobe /
-    /// 3 both / 4 ghost). The frame loop owns the preview state.
+    /// Future-preview mode (docs/time-travel.md T6), pushed by the
+    /// `window.__scrub` seam (PreviewMode wire index: 0 off / 1 trail /
+    /// 2 strobe / 3 both). The frame loop owns the preview state.
     SetPreview(u32),
-    /// The ⚙ popover's shared forward window (seconds) + samples-per-second
-    /// rate, pushed by the DOM inputs on change.
+    /// The shared forward window (seconds) + samples-per-second rate, pushed by
+    /// the rail's endpoint handle and the `window.__scrub` seam.
     SetPreviewConfig {
         window: f32,
         rate: usize,
@@ -1018,16 +1018,16 @@ pub fn functor_lang_scrub_step() {
     push_scrub(ScrubControl::Step);
 }
 
-/// Page → runtime: set the future-preview mode (the DOM preview `<select>`;
-/// 0 off / 1 trail / 2 strobe / 3 both / 4 ghost — `PreviewMode::from_index`).
+/// Page → runtime: set the future-preview mode (the `window.__scrub` seam;
+/// 0 off / 1 trail / 2 strobe / 3 both — `PreviewMode::from_index`).
 #[wasm_bindgen]
 pub fn functor_lang_scrub_set_preview(mode: u32) {
     push_scrub(ScrubControl::SetPreview(mode));
 }
 
 /// Page → runtime: set the preview's shared forward window (seconds) and
-/// samples-per-second rate (the ⚙ popover; JS owns the inputs and pushes on
-/// change).
+/// samples-per-second rate (pushed by the rail's endpoint handle and the
+/// `window.__scrub` seam).
 #[wasm_bindgen]
 pub fn functor_lang_scrub_set_preview_config(window: f32, rate: usize) {
     push_scrub(ScrubControl::SetPreviewConfig { window, rate });

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1405,10 +1405,9 @@ async fn run_async() -> Result<(), JsValue> {
         let mut pending_detach = false;
         let mut pending_debug_camera_reset = false;
 
-        // Future preview (docs/time-travel.md T6/T6d): trail marks, scene-space
-        // strobe copies, or the screen-space ghost compositor — one mode, driven
-        // by the DOM preview <select>, with the shared forward window/samples
-        // from the ⚙ popover. Same anchor cache as the desktop shell: while
+        // Future preview (docs/time-travel.md T6): trail marks and/or
+        // scene-space strobe copies — one mode, set through the `window.__scrub`
+        // seam. Same anchor cache as the desktop shell: while
         // paused the anchor (scene frame + tts) is frozen, so reuse the
         // computed preview; the program revision invalidates immediately on a
         // pushed source edit. Live projections remain painted every frame but
@@ -1424,12 +1423,6 @@ async fn run_async() -> Result<(), JsValue> {
         )> = None;
         let mut preview_refresh: u32 = 0;
         let mut next_live_preview_refresh: f32 = 0.0;
-        let mut ghost_cache: Option<(
-            (Option<u64>, u32, bool, u64, usize, u32),
-            Vec<(Frame, FrameTime)>,
-        )> = None;
-        let mut ghost_refresh: u32 = 0;
-        let mut next_live_ghost_refresh: f32 = 0.0;
 
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer.
@@ -1686,23 +1679,20 @@ async fn run_async() -> Result<(), JsValue> {
             // reconcile the desired looping voices against the live ones.
             update_soundscape(&**game, &view_camera);
 
-            // Scene-diff preview (docs/time-travel.md T6): the DOM preview
-            // <select>'s trail/strobe overlays, from ONE shared forward-sim —
+            // Scene-diff preview (docs/time-travel.md T6): the seam-selected
+            // trail/strobe overlays, from ONE shared forward-sim —
             // `frame_preview`, the same step the desktop shell runs. While live,
             // its anchor follows the newest frame; pausing freezes that anchor
             // instead of enabling the preview. Script inputs are `None`: web has
             // no --input-script.
-            // While a drag-into-the-future catch-up is draining, skip preview
-            // and ghost recomputes (the anchor moves every frame — a full
+            // While a drag-into-the-future catch-up is draining, skip the
+            // preview recompute (the anchor moves every frame — a full
             // forward-sim per frame would throttle the catch-up to a crawl);
-            // they snap back in on arrival.
+            // it snaps back in on arrival.
             let catching_up = clock.pending_frames() > 0;
             let selected =
                 functor_runtime_common::interactive_preview(preview_mode, true, catching_up);
             let trail_wanted = selected.trail;
-            // The selector is single-valued, so a strobe mode and the ghost
-            // compositor can never be on together (the double-ghost hazard the
-            // desktop flag path still guards against).
             let strobe_wanted = selected.strobe;
             let preview = if trail_wanted || strobe_wanted {
                 let key = (
@@ -1736,9 +1726,9 @@ async fn run_async() -> Result<(), JsValue> {
                     preview_cache.as_ref().map(|(_, p)| p.clone())
                 } else {
                     // The SIM samples fine (~20/s — the trail's smooth-arc
-                    // rate) while the ⚙ rate governs STROBE COPIES per second,
-                    // so marks stay visible between copies and both hold their
-                    // density as the window resizes.
+                    // rate) while the preview rate governs STROBE COPIES per
+                    // second, so marks stay visible between copies and both
+                    // hold their density as the window resizes.
                     const TRAIL_RATE: f32 = 20.0;
                     let divisions = ((TRAIL_RATE * preview_window).round() as usize).clamp(1, 64);
                     let copies = ((preview_rate as f32 * preview_window).round() as usize)
@@ -1820,111 +1810,24 @@ async fn run_async() -> Result<(), JsValue> {
                 debug_lines.extend(camera_frustum_lines(&frame.camera, viewport.aspect()));
             }
 
-            // Forward-ghosting (docs/time-travel.md T6d): when the preview
-            // selector is on `ghost`, forward-step the scene over the ⚙
-            // popover's window in up to 8 slices and composite them at equal
-            // weight, so moving elements strobe across their future and static
-            // geometry stays solid. While live the anchor advances each frame;
-            // pausing freezes it. `None` = the recorded-log/coast path (web has
-            // no --input-script). Empty (→ this arm skipped) leaves live
-            // rendering unchanged.
-            let mut ghosts = if selected.ghost {
-                // The ⚙ popover's rate × window, clamped to the compositor's
-                // 8-target cap.
-                let divisions =
-                    ((preview_rate as f32 * preview_window).round() as usize).clamp(1, 8);
-                let dt = preview_window / divisions as f32;
-                let key = (
-                    game.current_scene_frame(),
-                    frame_time.tts.to_bits(),
-                    clock.is_paused(),
-                    game.scene_program_revision(),
-                    divisions,
-                    preview_window.to_bits(),
-                );
-                let cache_hit = ghost_cache.as_ref().is_some_and(|(k, _)| {
-                    if clock.is_paused() {
-                        ghost_refresh > 0 && *k == key
-                    } else {
-                        now < next_live_ghost_refresh
-                            && ghost_refresh == 0
-                            && !k.2
-                            && k.3 == key.3
-                            && k.4 == key.4
-                            && k.5 == key.5
-                    }
-                });
-                if cache_hit {
-                    if clock.is_paused() {
-                        ghost_refresh -= 1;
-                    }
-                    ghost_cache
-                        .as_ref()
-                        .map(|(_, frames)| frames.clone())
-                        .unwrap_or_default()
-                } else {
-                    let frames = game.ghost_frames(divisions, dt, frame_time.tts as f64, None);
-                    if clock.is_paused() {
-                        ghost_refresh = PAUSED_PREVIEW_REUSE_FRAMES;
-                    } else {
-                        ghost_refresh = 0;
-                        next_live_ghost_refresh =
-                            performance.now() as f32 + LIVE_PREVIEW_INTERVAL_MS;
-                    }
-                    ghost_cache = Some((key, frames.clone()));
-                    frames
-                }
-            } else {
-                ghost_cache = None;
-                next_live_ghost_refresh = 0.0;
-                Vec::new()
-            };
-            let compatible_ghosts = DebugCamera::compatible_prefix_len(
-                &frame,
-                ghosts.iter().map(|(candidate, _)| candidate),
-            );
-            ghosts.truncate(compatible_ghosts);
-
-            // Preview overlays go on the live frame. (The single-valued mode
-            // selector means the scene-diff preview and the ghost compositor
-            // are never on together here — unlike the desktop flag path, where
-            // --ghost --trajectory composes the trail into the ghost frames.)
+            // Preview overlays go on the live frame.
             if let Some(p) = &preview {
                 p.apply_all(&mut frame);
             }
-            // Shadow + forward passes, shared with the desktop runtime. Each
-            // ghost frame renders at ITS OWN division-boundary time, so
-            // render-time animation (the skinned pose) advances through the
-            // strobe instead of freezing at the paused pose.
-            if !ghosts.is_empty() {
-                functor_runtime_common::render_composited_frames_with_view(
-                    &gl,
-                    shader_version,
-                    asset_cache.clone(),
-                    &scene_context,
-                    &shadow_map,
-                    &ghosts,
-                    &vec![1.0f32; ghosts.len()],
-                    Some(&view_camera),
-                    detached_camera.sprite_cameras(),
-                    viewport,
-                    diagnostics.render_mode,
-                );
-            } else {
-                functor_runtime_common::render_frame_with_view(
-                    &gl,
-                    shader_version,
-                    asset_cache.clone(),
-                    &scene_context,
-                    &shadow_map,
-                    &frame,
-                    &view_camera,
-                    detached_camera.sprite_cameras(),
-                    frame_time.clone(),
-                    viewport,
-                    diagnostics.render_mode,
-                );
-            }
+            // Shadow + forward passes, shared with the desktop runtime.
+            functor_runtime_common::render_frame_with_view(
+                &gl,
+                shader_version,
+                asset_cache.clone(),
+                &scene_context,
+                &shadow_map,
+                &frame,
+                &view_camera,
+                detached_camera.sprite_cameras(),
+                frame_time.clone(),
+                viewport,
+                diagnostics.render_mode,
+            );
             if !debug_lines.is_empty() {
                 functor_runtime_common::render_debug_lines(
                     &gl,

--- a/site/demos/time-travel.mjs
+++ b/site/demos/time-travel.mjs
@@ -33,8 +33,8 @@ const GIF_WIDTH = 640;
 const FPS = Number(process.env.DEMO_FPS || 18);
 
 // Extrapolation preview settings (tweakable): window in seconds of predicted
-// future, strobe samples per second, and mode (1 trail / 2 strobe / 3 both /
-// 4 ghost). A short window + low rate reads as a clean "where it's headed next"
+// future, strobe samples per second, and mode (1 trail / 2 strobe / 3 both).
+// A short window + low rate reads as a clean "where it's headed next"
 // prediction rather than a busy full-arc fan.
 const WIN = Number(process.env.DEMO_WIN || 1);
 const RATE = Number(process.env.DEMO_RATE || 2);
@@ -120,16 +120,9 @@ await hold(5);
 // the prediction visibly tracks.
 await page.evaluate(
   ({ win, rate, mode }) => {
-    // mode (trail/strobe/both/ghost) is driven by the select; the window and
-    // strobe rate go through the scrub seam so they apply authoritatively
-    // (setting #scrub-win by hand raced with the seam and could land on the
-    // default window instead).
-    const sel = document.querySelector("#scrub-mode");
-    if (sel) {
-      sel.value = String(mode);
-      sel.dispatchEvent(new Event("change", { bubbles: true }));
-    }
-    window.__scrub.setPreview({ enabled: true, seconds: win, rate });
+    // Mode, window and strobe rate all go through the scrub seam — the only
+    // configuration surface for the preview.
+    window.__scrub.setPreview({ enabled: true, seconds: win, rate, mode });
   },
   { win: WIN, rate: RATE, mode: MODE }
 );

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -4,7 +4,7 @@
 //
 // The preview column becomes:
 //
-//   ┌ chrono bar ─ ⏸ ⏭ ═══rail═══╪══ 🔮 ⚙ | ⊞ tiled ▤ tabs ┐   (game side only —
+//   ┌ chrono bar ─ ⏸ ⏭ ═══rail═══╪══ 🔮 | ⊞ tiled ▤ tabs ┐   (game side only —
 //   ├ pane grid ──────────────────────────────────────────────┤    the editor keeps
 //   │  ╔ 1 client · cyan  ⇅ Wi-Fi ▾   #f 841 ● ╗  ┌ 2 client ┐│    its full height)
 //   │  ║             iframe                    ║  │  iframe   ││
@@ -73,7 +73,7 @@ interface ScrubSeam {
     enabled?: boolean;
     seconds?: number;
     rate?: number;
-    /** 1 trail / 2 strobe / 3 both / 4 ghost (scrubber.js seam extension). */
+    /** 1 trail / 2 strobe / 3 both (scrubber.js seam extension). */
     mode?: number;
   }): void;
 }
@@ -233,19 +233,6 @@ export function initMultiplayerPanes({
       <span class="mp-rail-label"><b>#f</b> <span id="mp-frame">—</span></span>
     </span>
     <button class="mp-sbtn" id="mp-extrap" title="Extrapolate: speculatively simulate forward from the parked frame">🔮</button>
-    <details class="mp-adv" id="mp-adv">
-      <summary title="Extrapolation settings">⚙</summary>
-      <div class="mp-adv-pop">
-        <label>show
-          <select id="mp-adv-mode">
-            <option value="1">trail</option><option value="2">strobe</option>
-            <option value="3" selected>both</option><option value="4">ghost</option>
-          </select>
-        </label>
-        <label>window <input id="mp-adv-win" type="number" step="0.5" min="0.5" max="5" value="2" />s</label>
-        <label>rate <input id="mp-adv-rate" type="number" min="1" max="30" value="5" />/s</label>
-      </div>
-    </details>
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
       <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every client visible">⊞ tiled</button>
       <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one client full-size (f)">▤ tabs</button>
@@ -442,13 +429,12 @@ export function initMultiplayerPanes({
   }
   focusPane(0);
 
-  // Every transient surface (link menus, the ⚙ popover) dismisses together —
-  // popovers behave modally without blocking the page.
+  // Every transient surface (the link menus) dismisses together — popovers
+  // behave modally without blocking the page.
   const closePopovers = () => {
     for (const menu of document.querySelectorAll<HTMLElement>(".mp-link-menu")) {
       menu.hidden = true;
     }
-    (chrono.querySelector("#mp-adv") as HTMLDetailsElement).open = false;
   };
 
   const moduleScope = new AbortController();
@@ -516,7 +502,6 @@ export function initMultiplayerPanes({
     // speculatively re-simulating with no way to stop it.
     if (panes.length === 1 && target > 1) {
       for (const seam of seams()) seam.setPreview({ enabled: false });
-      (chrono.querySelector("#mp-adv") as HTMLDetailsElement).open = false;
     }
     while (panes.length < target) addMirror(true);
     while (panes.length > target) removeMirror();
@@ -788,23 +773,6 @@ export function initMultiplayerPanes({
     for (const seam of seams()) seam.setPreview({ enabled });
   });
 
-  // ⚙ advanced — everything goes through the seam (the panes' scrubber DOM is
-  // never attached, so there is nothing to reach into cross-frame).
-  const advWin = chrono.querySelector("#mp-adv-win") as HTMLInputElement;
-  const advRate = chrono.querySelector("#mp-adv-rate") as HTMLInputElement;
-  const advMode = chrono.querySelector("#mp-adv-mode") as HTMLSelectElement;
-  const pushAdv = () => {
-    if (!advWin.validity.valid || !advRate.validity.valid) return;
-    for (const seam of seams()) {
-      seam.setPreview({ seconds: advWin.valueAsNumber, rate: advRate.valueAsNumber });
-    }
-  };
-  advWin.addEventListener("input", pushAdv);
-  advRate.addEventListener("input", pushAdv);
-  advMode.addEventListener("change", () => {
-    for (const seam of seams()) seam.setPreview({ mode: Number(advMode.value) });
-  });
-
   // The pink preview handle: drag (or arrow keys) to stretch the window.
   const previewHandle = $("mp-preview-handle");
   let previewDrag: { x: number; seconds: number } | null = null;
@@ -824,8 +792,6 @@ export function initMultiplayerPanes({
     for (const seam of seams()) {
       seam.setPreview({ seconds: previewDrag.seconds + deltaFrames / 60 });
     }
-    const settled = primarySeam()?.model().preview.seconds;
-    if (settled !== undefined) advWin.value = String(settled);
   });
   const endPreviewDrag = () => {
     previewDrag = null;
@@ -839,7 +805,6 @@ export function initMultiplayerPanes({
       event.stopPropagation();
       const seconds = event.key === "Home" ? 0.5 : 5;
       for (const seam of seams()) seam.setPreview({ seconds });
-      advWin.value = String(seconds);
       return;
     }
     const step = event.shiftKey ? 1 : 0.5;
@@ -853,8 +818,6 @@ export function initMultiplayerPanes({
     event.stopPropagation();
     const seconds = (primarySeam()?.model().preview.seconds ?? 2) + delta;
     for (const seam of seams()) seam.setPreview({ seconds });
-    const settled = primarySeam()?.model().preview.seconds;
-    if (settled !== undefined) advWin.value = String(settled);
   });
   const tip = $("mp-evt-tip");
   const showTip = (unit: number, text: string) => {
@@ -918,27 +881,12 @@ export function initMultiplayerPanes({
   const ticksHost = $("mp-ticks");
   let markerKey = "";
   let lastLabel = "";
-  // The host owns the ⚙ configuration: a freshly navigated player boots with
-  // the seam defaults (2s / 5 / both), which would silently diverge from the
-  // values the inputs display — push them whenever the primary seam changes.
-  let lastPrimaryWindow: Window | null = null;
   const paint = () => {
     // Reconcile against the pane that initiated the request even while the
     // focused pane is loading. Navigation/removal makes that old seam unable
     // to acknowledge, so treat it as a refusal instead of stalling the bar.
     reconcilePendingCamera();
     const primary = primarySeam();
-    const primaryWindow = panes[focused]?.iframe.contentWindow ?? null;
-    if (primary && primaryWindow !== lastPrimaryWindow) {
-      lastPrimaryWindow = primaryWindow;
-      if (advWin.validity.valid && advRate.validity.valid) {
-        primary.setPreview({
-          seconds: advWin.valueAsNumber,
-          rate: advRate.valueAsNumber,
-          mode: Number(advMode.value),
-        });
-      }
-    }
     const current = primary?.view();
     if (!primary?.detached()) debugDrawer.hidden = true;
     chrono.classList.toggle("dormant", !current);

--- a/site/styles.css
+++ b/site/styles.css
@@ -2499,7 +2499,7 @@ a:hover {
     0 14px 36px rgba(0, 0, 0, 0.38);
   position: relative;
   /* Above the pane grid (pane headers are z-index 6 for their link menus), so
-     the ⚙ popover and event tooltip never clip under the window chrome. */
+     the debug drawer and event tooltip never clip under the window chrome. */
   z-index: 12;
 }
 
@@ -3106,7 +3106,7 @@ a:hover {
   box-shadow: none;
 }
 
-/* ---- restored scrubber polish: handles, tooltip, overflow chip, ⚙ ---- */
+/* ---- restored scrubber polish: handles, tooltip, overflow chip ---- */
 
 /* Breathing room between the rail (whose playhead overhangs its right edge
    when fully caught up) and the 🔮 button. */
@@ -3152,8 +3152,7 @@ a:hover {
    speculative re-simulations — not v1); multiplayer gets tiled/tabs in that
    slot, and with one client the view toggle is meaningless. Hidden, not
    disabled (design-multiplayer-ide-frontend.md §1). */
-.preview-pane.mp:not([data-count="1"]) #mp-extrap,
-.preview-pane.mp:not([data-count="1"]) .mp-adv {
+.preview-pane.mp:not([data-count="1"]) #mp-extrap {
   display: none;
 }
 
@@ -3276,84 +3275,3 @@ a:hover {
   pointer-events: none;
 }
 
-.mp-adv {
-  position: relative;
-}
-
-.mp-adv > summary {
-  list-style: none;
-  user-select: none;
-  font: 13px/1 var(--font-mono);
-  color: var(--text);
-  cursor: pointer;
-  background: rgba(65, 216, 230, 0.1);
-  border: 1px solid var(--line);
-  border-radius: 5px;
-  padding: 5px 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
-}
-
-.mp-adv > summary::-webkit-details-marker {
-  display: none;
-}
-
-.mp-adv > summary:hover,
-.mp-adv[open] > summary {
-  border-color: var(--cyan);
-}
-
-.mp-adv-pop {
-  position: absolute;
-  top: calc(100% + 10px);
-  right: 0;
-  z-index: 30;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px 12px;
-  background: rgba(30, 24, 51, 0.98);
-  border-radius: 8px;
-  border: 1px solid var(--line);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
-  white-space: nowrap;
-  font-size: 12px;
-}
-
-.mp-adv-pop label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  justify-content: space-between;
-}
-
-.mp-adv-pop select,
-.mp-adv-pop input[type="number"] {
-  font: 12px/1 var(--font-mono);
-  color: var(--text);
-  background: rgba(65, 216, 230, 0.1);
-  border: 1px solid var(--line);
-  border-radius: 5px;
-  padding: 4px 5px;
-}
-
-.mp-adv-pop select {
-  appearance: none;
-  -webkit-appearance: none;
-  padding-right: 20px;
-  cursor: pointer;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5'%3E%3Cpath d='M0 0h8L4 5z' fill='%239b94b3'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 7px center;
-}
-
-.mp-adv-pop input[type="number"] {
-  width: 46px;
-  appearance: textfield;
-  -moz-appearance: textfield;
-}
-
-.mp-adv-pop input[type="number"]::-webkit-inner-spin-button,
-.mp-adv-pop input[type="number"]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
-}


### PR DESCRIPTION
## What

PR 2 of the bidirectional-extrapolation arc (stacked on #599). Two removals decided in design review:

1. **The ghost preview mode is deleted.** It was the initial extrapolation prototype — a screen-space whole-frame compositor — and trail/strobe (especially combined with the debug camera) supersede it. Gone: `PreviewMode::Ghost`, the desktop `--ghost`/`--ghost-divisions` flags and their compute+render arm, the web shell's ghost cache/compositing ladder, and the ghost option in every UI.
2. **The ⚙ extrapolation settings popover is deleted from all three surfaces** (web scrubber, native egui scrubber, sandbox chrono bar). The mode collapses to the one good default (trail + strobe interleaved); the window is set by dragging the on-rail extrapolation endpoint handle; the rate is derived by the runtime.

Net **−730 lines** (+199/−929, 15 files), including code that existed solely for the compositor and became dead (`FramePreview::apply_trails`, `trail_camera_overrides`, `DebugCamera::compatible_prefix_len`, …).

**The programmatic seam keeps every knob** — this is the "settings live in configuration" split: `window.__scrub.setPreview({enabled, seconds, rate, mode})` (modes 1–3; unknown → Off, owned by `PreviewMode::from_index`), the wasm exports, `ScrubberAction::SetPreview*`, and the `--trajectory`/`--strobe` capture flags all remain for tooling, demos, and MCP.

## Deliberate "ghost" survivors

`ghost_frames` (the forward-simulation producer API powering trail/strobe — **not** the deleted mode) and its tests; the inspector's unrelated `ghost: bool` dry-run invocation flag; "forward-ghosting" prose describing the forward-sim; T5 branch-history "ghosts" (unbuilt); a CSS class and a physics test tag (coincidences).

## Behavior change worth review attention

`args.ghost` was load-bearing beyond presentation: it gated `--input-script` routing (clock stepping, live script consumption, the forward-sim's script anchor). With the flag gone, `--input-script` always advances the live game — the F2 "script drives an anchored future while the live game stays frozen at init" session semantic is removed with it. Both review engines independently confirmed the surviving path is byte-identical to the old non-ghost branch.

## Verification

- `functor_runtime_common` 629 ✓, `functor-lang` 638 ✓, `functor-runtime-desktop` 85 ✓, timeline-model `node --test` 19/19 ✓, `tsc -p site --noEmit` clean, wasm warnings at baseline.
- Built site contains zero `scrub-adv`/`mp-adv`/`scrub-mode` markup.
- Headless before/after captures (same `--fixed-time`): scene + trail arrows byte-identical, only the ⚙ gone. Embedded below.

## Cross-engine review (xreview: Claude + Codex)

No Critical/High. Both [AGREED] findings fixed in-branch (seam forwards the wire index so `from_index` alone owns unknown→Off; dead `lastPrimaryWindow` removed) and re-validated (post-fix capture byte-identical). One finding deliberately declined: deleting `ScrubberAction::SetPreviewMode`/`SetPreviewRate` (~30 more lines) — they are the retained tooling config surface by design.


## Visuals

![before/after: native scrubber, settings popover removed](https://gist.githubusercontent.com/tommy-xr/639b96ed7a7dea7c68b6e9473fdc7e2f/raw/beforeafter-scrubber.png)

<sub>Native egui scrubber over `examples/physics` (`--strobe --scrubber`), same `--fixed-time 1.5` — scene and trail marks byte-identical, only the ⚙ popover button is gone. Web: the built site contains zero `scrub-adv`/`scrub-mode` markup (static check). Rendered headlessly via `--capture-frame`.</sub>
