### PR TITLE
feat(site): a server pane in the sandbox — run examples/mp end-to-end

### DIFF
--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -105,6 +105,13 @@ jobs:
       - name: Run net-coordinator e2e
         run: npm run test:net-coordinator
 
+      # The same session as the PRODUCT: pick the client/server sample in the
+      # sandbox and get a server pane plus N client panes in the pane grid.
+      # The suite above proves the routing substrate on a bare fixture; this
+      # one proves the sandbox actually wires it up.
+      - name: Run sandbox multiplayer e2e
+        run: npm run test:sandbox-mp
+
       # Remote (URL) asset loading in the browser: builds a wasm bundle that
       # loads a good URL and a 404 URL from a localhost CORS server and asserts
       # the real fetches (200 / 404) + graceful fallback. Hermetic — no network.

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -1,0 +1,260 @@
+// Sandbox multiplayer e2e: the SERVER PANE, end to end.
+//
+// e2e/net-coordinator.mjs proves the routing substrate on a bare fixture page.
+// This one proves the PRODUCT: pick "Arena (client/server)" in the sandbox and
+// you get a working session in the pane grid — a server pane plus N client
+// panes, wired by the same host coordinator, with the clients actually joining
+// the server's world.
+//
+// It asserts:
+//
+//   1. mp at the default count mounts a server pane beside ONE client (the
+//      server is extra at every client count, not a client you gave up);
+//   2. #clients=2 grows to server + two clients, and the pill counts them
+//      honestly as "2+1 running";
+//   3. both clients reach `status: "in-world"` — read from each pane's paused
+//      inspector trace, the same path the net-coordinator e2e uses — so the
+//      panes are one session, not three lonely sims;
+//   4. every pane header shows its coordinator link state;
+//   5. switching to a single-role example removes the server pane again.
+//
+// Run manually (needs the web-runtime wasm bundle):
+//
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/sandbox-mp.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const PORT = Number(process.env.FUNCTOR_MP_PORT ?? 8125);
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+const check = (ok, what, detail = "") => {
+  console.log(`${ok ? "  ok" : "FAIL"}  ${what}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+const build = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+try {
+  await fetch(BASE);
+  console.error(`port ${PORT} is already in use — kill the process on it first`);
+  process.exit(1);
+} catch {
+  // Nothing listening: good.
+}
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+process.on("exit", () => server.kill());
+for (let i = 0; ; i++) {
+  try {
+    await fetch(BASE);
+    break;
+  } catch {
+    if (i > 50) throw new Error("site server never came up");
+    await sleep(200);
+  }
+}
+
+// The host-page probe: pane roles straight off the rendered chrome, plus the
+// paused-inspector relay (a pane publishes its trace when it parks, and every
+// entry point binds the model as `m`).
+const installProbe = (page) =>
+  page.evaluate(() => {
+    const traces = new Map();
+    const shells = () =>
+      [...document.querySelectorAll(".mp-pane")].map((shell, index) => ({
+        role: shell.classList.contains("server") ? "server" : `client ${index + 1}`,
+        frame: shell.querySelector("iframe"),
+        header: shell.querySelector(".mp-pane-hd").innerText.replace(/\s+/g, " ").trim(),
+      }));
+    window.addEventListener("message", (event) => {
+      if (event.data?.type !== "functor-inspector-trace") return;
+      const hit = shells().find((s) => s.frame.contentWindow === event.source);
+      if (hit) traces.set(hit.role, event.data.trace);
+    });
+    window.__mpProbe = {
+      roles: () => shells().map((s) => s.role),
+      headers: () => shells().map((s) => s.header),
+      pill: () => document.getElementById("status").textContent.trim(),
+      pauseAll: () => document.getElementById("mp-pause").click(),
+      model: (role) => {
+        const trace = traces.get(role);
+        const invocations = trace?.invocations ?? [];
+        const inv = invocations.find((i) => i.entry === "draw") ?? invocations[0];
+        return inv?.bindings?.find((b) => b.name === "m")?.value ?? null;
+      },
+    };
+  });
+
+const browser = await chromium.launch();
+try {
+  // --- 1. One client + a server pane. -----------------------------------------
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await page.goto(`${BASE}/sandbox.html?example=mp`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    check(
+      roles.length === 2 && roles[0] === "client 1" && roles[1] === "server",
+      "mp at one client mounts a server pane beside it",
+      roles.join(", ")
+    );
+    const clientsControl = await page.inputValue("#client-count");
+    check(clientsControl === "1", "the CLIENTS control counts clients only", clientsControl);
+    await page.close();
+  }
+
+  // --- 2–4. Two clients + a server: one joined session. -----------------------
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const consoleLog = [];
+    page.on("console", (m) => consoleLog.push(m.text()));
+    page.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+    await page.goto(`${BASE}/sandbox.html?example=mp#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    check(
+      roles.join(", ") === "client 1, client 2, server",
+      "#clients=2 runs two clients and one server, server last",
+      roles.join(", ")
+    );
+
+    // The link indicator: every pane linked through the coordinator.
+    const linked = await page
+      .waitForFunction(
+        () => window.__mpProbe.headers().every((h) => h.includes("linked")),
+        null,
+        { timeout: 20000 }
+      )
+      .then(() => true)
+      .catch(() => false);
+    const headers = await page.evaluate(() => window.__mpProbe.headers());
+    check(linked, "every pane header shows its coordinator link state", headers.join(" | "));
+    check(
+      headers[2].startsWith("SERVER") && !headers[2].includes("⇅"),
+      "the server pane is labelled SERVER in its chrome and carries no link chip",
+      headers[2]
+    );
+
+    const pill = await page
+      .waitForFunction(() => window.__mpProbe.pill().includes("2+1 running"), null, {
+        timeout: 20000,
+      })
+      .then(() => page.evaluate(() => window.__mpProbe.pill()))
+      .catch(() => page.evaluate(() => window.__mpProbe.pill()));
+    check(pill.includes("2+1 running"), "the pill counts clients and server apart", pill);
+
+    // Both clients joined the SERVER's world — the assertion that makes this a
+    // session rather than three independent sims.
+    await sleep(2500);
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(1500);
+    const models = await page.evaluate(() => ({
+      c1: window.__mpProbe.model("client 1"),
+      c2: window.__mpProbe.model("client 2"),
+      server: window.__mpProbe.model("server"),
+    }));
+    check(
+      typeof models.c1 === "string" &&
+        typeof models.c2 === "string" &&
+        models.c1.includes('status: "in-world"') &&
+        models.c2.includes('status: "in-world"'),
+      "both client panes joined the server pane's world",
+      JSON.stringify(models.c1)
+    );
+    check(
+      typeof models.server === "string" && (models.server.match(/cid: /g) ?? []).length === 2,
+      "the server pane tracks both clients",
+      String(models.server)
+    );
+    const errors = consoleLog.filter((line) => line.includes("[functor-lang]") && line.includes("error"));
+    check(errors.length === 0, "no pane reported a runtime error", errors.slice(0, 3).join(" | "));
+    await page.close();
+  }
+
+  // --- 4b. A LIVE client-count change leaves the authority running. -----------
+  // Re-appending a mounted iframe reloads it, so growing the client set must
+  // insert the new tile BEFORE the server's rather than moving the server to
+  // the end — otherwise the world (and every client's join) is wiped whenever
+  // someone changes the count.
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await page.goto(`${BASE}/sandbox.html?example=mp`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    await page.evaluate(() => {
+      const serverWindow = () =>
+        document.querySelector(".mp-pane.server")?.querySelector("iframe").contentWindow ?? null;
+      window.__mpProbe.serverFrame = () => serverWindow()?.__scrub?.frame() ?? null;
+      // A document-lifetime marker: a reloaded iframe gets a fresh realm and
+      // loses it, which a frame counter cannot tell you (a rebooted pane
+      // counts back up past whatever the old one had reached).
+      window.__mpProbe.markServer = () => {
+        const win = serverWindow();
+        if (win) win.__mpAlive = true;
+      };
+      window.__mpProbe.serverAlive = () => serverWindow()?.__mpAlive === true;
+    });
+    await page.waitForFunction(() => window.__mpProbe.serverFrame() > 60, { timeout: 30000 });
+    const before = await page.evaluate(() => {
+      window.__mpProbe.markServer();
+      return window.__mpProbe.serverFrame();
+    });
+    await page.selectOption("#client-count", "2");
+    await sleep(3000);
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    const state = await page.evaluate(() => ({
+      alive: window.__mpProbe.serverAlive(),
+      frame: window.__mpProbe.serverFrame(),
+    }));
+    check(
+      roles.join(", ") === "client 1, client 2, server" && state.alive && state.frame > before,
+      "growing the client set live keeps the server pane running (no reload)",
+      `${roles.join(", ")}; alive=${state.alive}; server frame ${before} -> ${state.frame}`
+    );
+    await page.close();
+  }
+
+  // --- 5. Switching away drops the server pane. -------------------------------
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await page.goto(`${BASE}/sandbox.html?example=mp`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    await page.selectOption("#example-picker", "counter");
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    const gone = await page
+      .waitForFunction(() => window.__mpProbe.roles().length === 1, null, { timeout: 10000 })
+      .then(() => true)
+      .catch(() => false);
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    check(gone, "switching to a single-role example removes the server pane", roles.join(", "));
+    await page.close();
+  }
+} finally {
+  await browser.close();
+  server.kill();
+}
+
+console.log(failures === 0 ? "\nALL CHECKS PASSED" : `\n${failures} CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "site:serve": "node site/serve.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
     "test:net-coordinator": "node e2e/net-coordinator.mjs",
+    "test:sandbox-mp": "node e2e/sandbox-mp.mjs",
     "test:detached-camera": "node e2e/detached-camera.mjs",
     "test:ide": "node e2e/ide-project.mjs",
     "test:ide-page": "node e2e/ide-page.mjs",

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -47,6 +47,18 @@ export interface Example {
    * clientInit/clientTick/…). Passed to the player as `?prefix=`.
    */
   prefix?: string;
+  /**
+   * The sample's SERVER role, as a dist path in its own file list. The pane
+   * grid mounts a server pane for every example that declares one — booted
+   * from the same project files with this file as the entry — and the host's
+   * net coordinator routes the client panes' traffic to it. The editable
+   * `source` stays the CLIENT entry.
+   *
+   * The file must ALSO appear in `siblings`: that is what copies it into the
+   * built site and puts it in the fetched project file list. Naming a file
+   * here that nothing copies would 404 the server pane.
+   */
+  server?: { file: string };
 }
 
 /**
@@ -132,6 +144,24 @@ export const EXAMPLES: Example[] = [
     // The sandbox plays the `client` role of the same-file entries —
     // functor.json maps it to { "file": "game.fun", "prefix": "client" }.
     prefix: "client",
+  },
+  // The client/server sample: two ROLES over a shared typed protocol, run
+  // end-to-end in the pane grid — the client panes and a server pane, wired to
+  // each other by the host's net coordinator (no sockets, no server process).
+  // The editable buffer is the CLIENT entry (copied to `examples/mp.fun`, so
+  // its module is `Mp`); the other three files ride along as siblings, and the
+  // pane grid re-enters the same file list at `server.fun` for the server pane.
+  {
+    id: "mp",
+    label: "Arena (client/server)",
+    source: "examples/mp/client.fun",
+    multiplayer: true,
+    server: { file: "examples/mp/server.fun" },
+    siblings: [
+      { source: "examples/mp/protocol.fun", output: "examples/mp/protocol.fun" },
+      { source: "examples/mp/view.fun", output: "examples/mp/view.fun" },
+      { source: "examples/mp/server.fun", output: "examples/mp/server.fun" },
+    ],
   },
   {
     id: "mario",

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -117,8 +117,18 @@ interface LinkProfile {
 
 type PaneState = PillState["state"];
 
+/**
+ * What a pane IS in the session. A `client` pane is a player: numbered, player
+ * colored, focusable, and the thing the CLIENTS control counts. The `server`
+ * pane is the authority: one per session, unnumbered, subdued, and outside the
+ * client count — see the server-pane block further down for the full contract.
+ */
+type PaneRole = "client" | "server";
+
 interface Pane {
-  index: number;
+  role: PaneRole;
+  /** The pane's routing identity in the coordinator ("client 2", "server"). */
+  id: string;
   /** Aborts every listener this pane registered outside its own subtree. */
   scope: AbortController;
   iframe: HTMLIFrameElement;
@@ -128,6 +138,7 @@ interface Pane {
   link: LinkProfile;
   frameLabels: HTMLElement[];
   dots: HTMLElement[];
+  conn: HTMLElement;
   errStrip: HTMLElement;
 }
 
@@ -142,7 +153,12 @@ export interface MultiplayerPanesOptions {
 }
 
 export interface MultiplayerPanes {
-  setSrc(src: string): void;
+  /**
+   * Load a fresh program into every pane. `serverSrc` is the player URL of the
+   * example's SERVER role (examples.ts `server`), or null for a sample that
+   * declares none — passing it mounts the server pane, passing null removes it.
+   */
+  setSrc(src: string, serverSrc?: string | null): void;
   push(source: string): void;
   reset(): void;
   aggregateStatus(state: PaneState, text: string, detail: string): void;
@@ -306,21 +322,41 @@ export function initMultiplayerPanes({
   const net = new NetCoordinator();
 
   const panes: Pane[] = [];
-  const makePane = (index: number, iframe: HTMLIFrameElement): Pane => {
-    const color = PLAYER_COLORS[index % PLAYER_COLORS.length];
+
+  // The server pane, when the current example declares one (examples.ts
+  // `server`). It is NOT in `panes`: `panes` is the client set the CLIENTS
+  // control sizes and the mirror bookkeeping pops from. Everything that is
+  // about "every running pane" — the scrub broadcasts, the aggregate pill, the
+  // frame labels, the coordinator's routing table — goes through `allPanes()`,
+  // with the server always LAST so client indices (and their digits) never move.
+  let serverPane: { pane: Pane; bridge: PlayerBridge } | null = null;
+  const allPanes = (): Pane[] => (serverPane ? [...panes, serverPane.pane] : panes);
+
+  const makePane = (role: PaneRole, index: number, iframe: HTMLIFrameElement): Pane => {
+    const client = role === "client";
+    const id = client ? `client ${index + 1}` : "server";
+    const color = client ? PLAYER_COLORS[index % PLAYER_COLORS.length] : "var(--scrub-server)";
     const shell = document.createElement("div");
-    shell.className = "mp-pane";
+    shell.className = client ? "mp-pane" : "mp-pane server";
     shell.style.setProperty("--pc", color);
+    // The server pane's header says what it is instead of who it is: no digit
+    // (it is not in the client sequence), no link chip (latency is a property
+    // of a client's link — the authority has none), no "⌨ you".
     shell.innerHTML = `
       <div class="mp-pane-hd">
-        <span class="mp-digit">${index + 1}</span>
-        <span class="mp-role">client</span>
-        <span class="mp-link-host">
+        ${client ? `<span class="mp-digit">${index + 1}</span>` : ""}
+        <span class="mp-role">${client ? "client" : "SERVER"}</span>
+        ${
+          client
+            ? `<span class="mp-link-host">
           <button class="mp-link-chip"
             title="Link impairment for this client (prototype — recorded per client; applies once the coordinator's link impairment lands)">⇅ Wi-Fi ▾</button>
-        </span>
+        </span>`
+            : `<span class="mp-authority">authority</span>`
+        }
         <span class="mp-hd-r">
-          <span class="mp-you" hidden>⌨ you</span>
+          ${client ? `<span class="mp-you" hidden>⌨ you</span>` : ""}
+          <span class="mp-conn" hidden></span>
           <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
           <span class="mp-st" data-state="busy"></span>
         </span>
@@ -328,18 +364,24 @@ export function initMultiplayerPanes({
       <div class="mp-pane-body"></div>
       <div class="mp-pane-err" hidden></div>`;
     shell.querySelector(".mp-pane-body")!.appendChild(iframe);
-    grid.appendChild(shell);
+    // A client tile is INSERTED BEFORE the server's, never appended after it:
+    // re-appending a mounted node is a remove + insert, and that reloads an
+    // iframe — the same invariant that keeps pane 1 in place would be broken
+    // for the authority, wiping the world every time the count changed.
+    const before = client && serverPane ? serverPane.pane : null;
+    grid.insertBefore(shell, before?.shell ?? null);
 
     const tab = document.createElement("button");
-    tab.className = "mp-tab";
+    tab.className = client ? "mp-tab" : "mp-tab server";
     tab.style.setProperty("--pc", color);
-    tab.innerHTML = `<span class="mp-digit">${index + 1}</span> client
+    tab.innerHTML = `${client ? `<span class="mp-digit">${index + 1}</span> client` : "SERVER"}
       <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
       <span class="mp-st" data-state="busy"></span>`;
-    tabsStrip.appendChild(tab);
+    tabsStrip.insertBefore(tab, before?.tab ?? null);
 
     const pane: Pane = {
-      index,
+      role,
+      id,
       iframe,
       shell,
       tab,
@@ -354,14 +396,22 @@ export function initMultiplayerPanes({
         shell.querySelector(".mp-st") as HTMLElement,
         tab.querySelector(".mp-st") as HTMLElement,
       ],
+      conn: shell.querySelector(".mp-conn") as HTMLElement,
       errStrip: shell.querySelector(".mp-pane-err") as HTMLElement,
     };
 
-    shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", () => focusPane(index));
-    tab.addEventListener("click", () => focusPane(index));
-    buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement, pane.scope.signal);
-    net.addPane(`client ${index + 1}`, iframe, pane.scope.signal);
-    panes.push(pane);
+    // Selecting a pane is what tabs mode needs to show it, so the server pane
+    // is selectable by click — but it never joins the KEYBOARD client cycle
+    // (digits / `[` / `]`) and never claims "⌨ you": game input belongs to a
+    // client, and the authority has no player to drive.
+    const select = () => focusPane(allPanes().indexOf(pane));
+    shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", select);
+    tab.addEventListener("click", select);
+    if (client) {
+      buildLinkMenu(pane, shell.querySelector(".mp-link-host") as HTMLElement, pane.scope.signal);
+      panes.push(pane);
+    }
+    net.addPane(id, iframe, pane.scope.signal);
     return pane;
   };
 
@@ -369,43 +419,82 @@ export function initMultiplayerPanes({
   // the primary bridge keep talking to it untouched). Panes 2..N are mirrors,
   // added and removed LIVE — pane 1's iframe never moves again after this
   // wrap, so its running model survives every count change.
-  makePane(0, frame);
+  makePane("client", 0, frame);
   const mirrors: { pane: Pane; bridge: PlayerBridge }[] = [];
 
-  const addMirror = (pushCurrent: boolean) => {
-    const index = panes.length;
-    const label = `client ${index + 1}`;
-    const iframe = document.createElement("iframe");
-    iframe.title = `${label} preview`;
-    iframe.allow = "pointer-lock";
-    const pane = makePane(index, iframe);
-    const bridge = new PlayerBridge(iframe, {
+  // Everything a pane the module created itself needs: its own status bridge
+  // and its own prefixed console relay. Pane 1 is excluded by construction —
+  // the PAGE owns its bridge (see `aggregateStatus`).
+  const attachBridge = (pane: Pane): PlayerBridge => {
+    const bridge = new PlayerBridge(pane.iframe, {
       onReloading: () => setPaneState(pane, "busy"),
       onLive: () => setPaneState(pane, "live"),
       onResult: (ok, message) => {
         setPaneState(pane, ok ? "live" : "error", message);
-        if (!ok) statusBar.appendOutput("error", `[${label}] ${message}`);
+        if (!ok) statusBar.appendOutput("error", `[${pane.id}] ${message}`);
       },
       signal: pane.scope.signal,
     });
-    mirrors.push({ pane, bridge });
-    // Runtime console lines from this mirror, prefixed with its identity.
     window.addEventListener(
       "message",
       (event) => {
         const data = asPlayerMessage(event.data);
         if (!data || data.type !== "functor-lang-console") return;
-        if (event.source !== iframe.contentWindow) return;
-        statusBar.appendOutput(data.level, `[${label}] ${data.message}`, data.frame ?? null);
+        if (event.source !== pane.iframe.contentWindow) return;
+        statusBar.appendOutput(data.level, `[${pane.id}] ${data.message}`, data.frame ?? null);
       },
       { signal: pane.scope.signal }
     );
+    return bridge;
+  };
+
+  const addMirror = (pushCurrent: boolean) => {
+    const index = panes.length;
+    const iframe = document.createElement("iframe");
+    iframe.title = `client ${index + 1} preview`;
+    iframe.allow = "pointer-lock";
+    const pane = makePane("client", index, iframe);
+    const bridge = attachBridge(pane);
+    mirrors.push({ pane, bridge });
     // A mirror added mid-session boots the served program, then catches up to
     // the (possibly edited) buffer; the bridge holds the push until ready.
     if (frame.getAttribute("src")) {
       iframe.src = frame.src; // already carries ?scrubber=hidden (the page adds it)
       if (pushCurrent) bridge.push(getSource());
     }
+  };
+
+  // ------------------------------------------------------------ server pane
+  // Mounted for an example that declares a SERVER role, at every client count
+  // including 1, and left alone by count changes — its world is the session's,
+  // not a client's. It runs the same project files with the server file as the
+  // entry, and its packets reach the clients through the same coordinator.
+  //
+  // It does NOT take editor pushes: `functor-lang-set-source` replaces the
+  // ENTRY module's source, and the sandbox's buffer is the client entry —
+  // pushing it here would swap the server's program for the client's. So an
+  // edit hot-reloads the clients live while the server keeps running the
+  // served build. Editing server.fun needs the multi-file `set-project` path
+  // (the IDE already speaks it); until the sandbox grows a file switcher,
+  // `↺ reset` reboots both roles from disk.
+  const mountServer = (src: string) => {
+    const iframe = document.createElement("iframe");
+    iframe.title = "server preview";
+    iframe.allow = "pointer-lock";
+    const pane = makePane("server", panes.length, iframe);
+    serverPane = { pane, bridge: attachBridge(pane) };
+    iframe.src = src;
+  };
+
+  const unmountServer = () => {
+    if (!serverPane) return;
+    serverPane.bridge.reset();
+    serverPane.pane.scope.abort();
+    serverPane.pane.shell.remove();
+    serverPane.pane.tab.remove();
+    paneDetails.delete(serverPane.pane);
+    serverPane = null;
+    if (focusedPane === null || !allPanes().includes(focusedPane)) focusPane(0);
   };
 
   const removeMirror = () => {
@@ -421,21 +510,25 @@ export function initMultiplayerPanes({
   for (let i = 1; i < count; i++) addMirror(false);
 
   // ------------------------------------------------------------ focus model
-  let focused = 0;
+  // Focus is held by IDENTITY, not by index: the server pane sits after the
+  // clients, so growing or shrinking the client set would otherwise slide the
+  // selection onto a different pane.
+  let focusedPane: Pane | null = null;
+  const focusedIndex = () => (focusedPane ? allPanes().indexOf(focusedPane) : 0);
   function focusPane(index: number) {
-    if (index !== focused) {
-      const previous = panes[focused];
-      if (previous && seamOf(previous.iframe)?.detached()) {
-        exitPanePointerLock(previous.iframe);
-      }
+    const current = allPanes();
+    const next = current[index] ?? current[0] ?? null;
+    if (next !== focusedPane && focusedPane && seamOf(focusedPane.iframe)?.detached()) {
+      exitPanePointerLock(focusedPane.iframe);
     }
-    focused = index;
-    for (const pane of panes) {
-      const on = pane.index === index;
+    focusedPane = next;
+    current.forEach((pane) => {
+      const on = pane === focusedPane;
       pane.shell.classList.toggle("focus", on);
       pane.tab.classList.toggle("focus", on);
-      (pane.shell.querySelector(".mp-you") as HTMLElement).hidden = !on;
-    }
+      const you = pane.shell.querySelector(".mp-you") as HTMLElement | null;
+      if (you) you.hidden = !on;
+    });
   }
   focusPane(0);
 
@@ -456,8 +549,8 @@ export function initMultiplayerPanes({
   window.addEventListener("blur", () => {
     closePopovers();
     const active = document.activeElement;
-    const pane = panes.find((candidate) => candidate.iframe === active);
-    if (pane) focusPane(pane.index);
+    const position = allPanes().findIndex((candidate) => candidate.iframe === active);
+    if (position >= 0) focusPane(position);
   }, { signal: moduleScope.signal });
 
 
@@ -471,12 +564,19 @@ export function initMultiplayerPanes({
       return;
     }
     if (target.closest?.(".cm-editor") || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
+    // Digits and `[` `]` walk the CLIENTS only — they are the keyboard's
+    // player picker, and the authority has no player. (Its tab still selects
+    // it, which is what tabs mode needs to show it at all.)
     if (/^[1-9]$/.test(event.key)) {
       const index = Number(event.key) - 1;
       if (index < panes.length) focusPane(index);
     } else if (event.key === "[" || event.key === "]") {
       const delta = event.key === "]" ? 1 : -1;
-      focusPane((focused + delta + panes.length) % panes.length);
+      const from = focusedIndex();
+      // From the server pane (which sits past the clients), the cycle re-enters
+      // the client set at whichever end the direction implies.
+      if (from >= panes.length) focusPane(delta === 1 ? 0 : panes.length - 1);
+      else focusPane((from + delta + panes.length) % panes.length);
     } else if (event.key === "f") {
       setView(grid.dataset.view === "tiled" ? "tabs" : "tiled");
     }
@@ -484,7 +584,7 @@ export function initMultiplayerPanes({
 
   // ------------------------------------------------------- tiled / tabs view
   const setView = (view: "tiled" | "tabs", force = false) => {
-    if (panes.length === 1 && !force) return;
+    if (allPanes().length === 1 && !force) return;
     grid.dataset.view = view;
     tabsStrip.hidden = view !== "tabs";
     $btn("mp-view-tiled").setAttribute("aria-pressed", String(view === "tiled"));
@@ -496,8 +596,10 @@ export function initMultiplayerPanes({
   // Everything on the chrono bar that depends on how many panes exist.
   // (CSS keyed on data-count hides the pane header / 🔮 / view toggle.)
   const updateChrome = () => {
-    const single = panes.length === 1;
-    previewPane.dataset.count = String(panes.length);
+    // "Single" is about TILES, not clients: one client plus a server is still
+    // a grid, so it keeps its pane headers and the tiled/tabs toggle.
+    const single = allPanes().length === 1;
+    previewPane.dataset.count = String(allPanes().length);
     $btn("mp-view-tiled").disabled = single;
     $btn("mp-view-tabs").disabled = single;
     if (single) setView("tiled", true);
@@ -515,7 +617,7 @@ export function initMultiplayerPanes({
     }
     while (panes.length < target) addMirror(true);
     while (panes.length > target) removeMirror();
-    if (focused >= panes.length) focusPane(0);
+    if (focusedPane === null || !allPanes().includes(focusedPane)) focusPane(0);
     updateChrome();
     paintAggregate();
   };
@@ -608,24 +710,38 @@ export function initMultiplayerPanes({
     paintAggregate();
   };
   const paintAggregate = () => {
-    if (panes.length === 1) {
+    const running = allPanes();
+    if (running.length === 1) {
       if (lastMain) setPill(lastMain.state, lastMain.text, lastMain.detail);
       return;
     }
-    const states = [mainState, ...panes.slice(1).map((pane) => pane.state)];
+    // Pane 1's state is the page's (`mainState`); the rest report their own.
+    const states = [mainState, ...running.slice(1).map((pane) => pane.state)];
     if (states.includes("error")) {
-      const failing = panes.find((pane) => pane.state === "error");
+      const failing = running.find((pane) => pane.state === "error");
       setPill("error", "✕ build error", (failing && paneDetails.get(failing)) || mainDetail);
     } else if (states.includes("busy")) {
       setPill("busy", "◐ reloading…", "");
     } else {
-      setPill("live", `● ${panes.length} running`, mainDetail);
+      // The clients and the server are counted SEPARATELY ("2+1 running"): the
+      // CLIENTS control says 2, and a bare "3" would read as a third client.
+      setPill(
+        "live",
+        serverPane ? `● ${panes.length}+1 running` : `● ${running.length} running`,
+        mainDetail
+      );
     }
   };
 
   // ------------------------------------------------------ chrono bar wiring
-  const seams = () => panes.map((pane) => seamOf(pane.iframe)).filter((s): s is ScrubSeam => !!s);
-  const primarySeam = () => seamOf(panes[focused].iframe) ?? seams()[0] ?? null;
+  // The transport speaks to EVERY pane, server included: the authority parks
+  // and steps with its clients, or a paused session keeps simulating.
+  const seams = () =>
+    allPanes()
+      .map((pane) => seamOf(pane.iframe))
+      .filter((s): s is ScrubSeam => !!s);
+  const primarySeam = () =>
+    (focusedPane ? seamOf(focusedPane.iframe) : null) ?? seams()[0] ?? null;
   let pendingDetached:
     | { seam: ScrubSeam; generation: number; iframe: HTMLIFrameElement }
     | null = null;
@@ -635,7 +751,7 @@ export function initMultiplayerPanes({
       pendingPointerLock !== null &&
       (!pendingPointerLock.iframe.isConnected ||
         seamOf(pendingPointerLock.iframe) !== pendingPointerLock.seam ||
-        panes[focused]?.iframe !== pendingPointerLock.iframe)
+        focusedPane?.iframe !== pendingPointerLock.iframe)
     ) {
       try {
         pendingPointerLock.seam.setDetachedPointerLockPending(false);
@@ -668,7 +784,7 @@ export function initMultiplayerPanes({
         // Treat a destroyed realm as a refused request.
       }
     }
-    if (!detached || panes[focused]?.iframe !== request.iframe) {
+    if (!detached || focusedPane?.iframe !== request.iframe) {
       exitPanePointerLock(request.iframe);
     }
   };
@@ -683,7 +799,7 @@ export function initMultiplayerPanes({
     for (const seam of seams()) seam.step();
   });
   $btn("mp-camera").addEventListener("click", () => {
-    const iframe = panes[focused].iframe;
+    const iframe = focusedPane!.iframe;
     const seam = seamOf(iframe);
     if (!seam?.canDetach()) return;
     const setPointerClaim = (pending: boolean) => {
@@ -720,7 +836,7 @@ export function initMultiplayerPanes({
         pendingPointerLock.iframe !== iframe ||
         !iframe.isConnected ||
         seamOf(iframe) !== seam ||
-        panes[focused]?.iframe !== iframe
+        focusedPane?.iframe !== iframe
       ) {
         if (pendingPointerLock?.seam === seam && pendingPointerLock.iframe === iframe) {
           pendingPointerLock = null;
@@ -996,7 +1112,7 @@ export function initMultiplayerPanes({
       pauseBtn.textContent = current.paused ? "▶" : "⏸";
       pauseBtn.setAttribute("aria-label", current.paused ? "Resume" : "Pause");
       const cameraBtn = $btn("mp-camera");
-      const cameraSeam = seamOf(panes[focused].iframe);
+      const cameraSeam = focusedPane ? seamOf(focusedPane.iframe) : null;
       const canDetach = cameraSeam?.canDetach() ?? false;
       const detached = cameraSeam?.detached() ?? false;
       cameraBtn.hidden = !canDetach;
@@ -1058,7 +1174,7 @@ export function initMultiplayerPanes({
       // Event markers (input / reload / reload-error): the reload ticks are the
       // "source changes on the timeline" — every hot-swap is already recorded.
       const key =
-        `${focused}|` +
+        `${focusedPane?.id ?? ""}|` +
         current.eventMarkers
           .map(
             (marker) =>
@@ -1093,12 +1209,33 @@ export function initMultiplayerPanes({
         );
       }
     }
-    for (const pane of panes) {
+    // Link state, straight from the coordinator's connection table — the seed
+    // of the link chip becoming real. Only a session that HAS an authority
+    // shows it: in a single-player example there is nothing to wait for.
+    const links = serverPane ? net.connectionCounts() : null;
+    for (const pane of allPanes()) {
       const seam = seamOf(pane.iframe);
       const frameNow = seam ? seam.frame() : null;
       const text = frameNow === null || frameNow === undefined ? "—" : String(frameNow);
       for (const label of pane.frameLabels) {
         if (label.textContent !== text) label.textContent = text;
+      }
+      pane.conn.hidden = !links;
+      if (!links) continue;
+      const count = links.get(pane.id) ?? 0;
+      const linked =
+        count > 0
+          ? pane.role === "server"
+            ? `● ${count} linked`
+            : "● linked"
+          : "○ waiting";
+      if (pane.conn.textContent !== linked) {
+        pane.conn.textContent = linked;
+        pane.conn.dataset.linked = String(count > 0);
+        pane.conn.title =
+          count > 0
+            ? "Connected through the host net coordinator (perfect link)"
+            : "No connection yet — waiting for the server pane's Sub.listen";
       }
     }
   };
@@ -1114,15 +1251,27 @@ export function initMultiplayerPanes({
   raf = requestAnimationFrame(tickLoop);
 
   return {
-    // Mirror a fresh program load into the extra panes.
-    setSrc(src) {
+    // Mirror a fresh program load into the extra panes, and mount/remove the
+    // server pane to match what the newly loaded example declares.
+    setSrc(src, serverSrc = null) {
       for (const { pane, bridge } of mirrors) {
         bridge.reset();
         setPaneState(pane, "busy");
         pane.iframe.src = src;
       }
+      if (!serverSrc) unmountServer();
+      else if (serverPane) {
+        serverPane.bridge.reset();
+        setPaneState(serverPane.pane, "busy");
+        serverPane.pane.iframe.src = serverSrc;
+      } else {
+        mountServer(serverSrc);
+      }
+      updateChrome();
+      paintAggregate();
     },
-    // Mirror a debounced hot-reload push.
+    // Mirror a debounced hot-reload push. The server pane is deliberately not
+    // a target — the buffer being edited is the CLIENT entry (see mountServer).
     push(source) {
       for (const { bridge } of mirrors) bridge.push(source);
     },
@@ -1144,6 +1293,7 @@ export function initMultiplayerPanes({
       cancelAnimationFrame(raf);
       net.destroy();
       moduleScope.abort();
+      unmountServer();
       while (mirrors.length) removeMirror();
     },
   };

--- a/site/src/net-coordinator.ts
+++ b/site/src/net-coordinator.ts
@@ -203,6 +203,21 @@ export class NetCoordinator {
     return this.log;
   }
 
+  /**
+   * How many live connections each pane holds. The coordinator is the only
+   * place that knows who is actually talking to whom, so this is what a pane's
+   * link indicator reads — a pane absent from the map is still waiting.
+   */
+  connectionCounts(): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const row of this.conns.values()) {
+      for (const side of [row.client, row.server]) {
+        counts.set(side.pane, (counts.get(side.pane) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }
+
   destroy(): void {
     cancelAnimationFrame(this.raf);
     this.abort.abort();

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -427,7 +427,25 @@ const loadExample = async (id: string) => {
   // prefixed contract (e.g. orbs' clientInit/clientTick/…).
   if (example?.prefix) params.set("prefix", example.prefix);
   frame.src = `player.html?${params}`;
-  mp?.setSrc(frame.src);
+  // A sample with a SERVER role (examples.ts `server`) also boots a server
+  // pane: the SAME file list re-entered at the server file. `?file=` is the
+  // whole project with the ENTRY FIRST, so the two roles differ only in which
+  // module the runtime looks the entry points up in.
+  const serverFile = example?.server?.file;
+  let serverSrc: string | null = null;
+  if (serverFile) {
+    // Derived from the client's params, so every project setting the sample
+    // declares (prefix, cursor, mouseCapture) reaches the server pane too —
+    // only the entry and the file ORDER differ.
+    const serverParams = new URLSearchParams(params);
+    serverParams.set("game", serverFile);
+    serverParams.delete("file");
+    for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
+      serverParams.append("file", file);
+    }
+    serverSrc = `player.html?${serverParams}`;
+  }
+  mp?.setSrc(frame.src, serverSrc);
 };
 
 const selectExample = (value: string) => {

--- a/site/styles.css
+++ b/site/styles.css
@@ -24,6 +24,10 @@
   --scrub-p2: var(--pink);
   --scrub-p3: var(--amber);
   --scrub-p4: var(--green);
+  /* The authority's ink. Deliberately the one hue in the pane vocabulary with
+     no saturation: a server is not a fifth player, so it reads as absence of
+     player identity rather than as another color in the set. */
+  --scrub-server: #8b83ad;
 
   /* Spacing scale — a single rhythm the whole landing page snaps to. */
   --space-sm: 16px;
@@ -2834,6 +2838,10 @@ a:hover {
   gap: 8px;
   padding: 5px 9px;
   font: 10.5px/1 var(--font-mono);
+  /* One row, always. NOT overflow:hidden — the link menu drops out of this
+     header and must escape it (see the pane shell's note); the chip truncates
+     itself instead. */
+  white-space: nowrap;
   color: var(--text-dim);
   background: color-mix(in srgb, var(--pc) 8%, var(--bg-raised));
   border-bottom: 1px solid color-mix(in srgb, var(--pc) 14%, var(--line));
@@ -2932,13 +2940,73 @@ a:hover {
   border-top: 1px solid rgba(242, 99, 127, 0.35);
 }
 
+/* ---- the server pane: the authority, not a player ----
+
+   Clients are lit and numbered because they are a sequence you pick from. The
+   server is one per session and never picked, so it drops every device that
+   says "which one": no digit, no link chip (latency is a property of a
+   client's link), no "⌨ you". What is left carries the identity — a hairline
+   DASHED frame instead of the clients' solid glow-tinted one, and the label
+   itself, tracked wide. Quiet where the clients are lit. */
+
+.mp-pane.server {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--pc) 30%, transparent);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+}
+
+.mp-pane.server .mp-pane-hd {
+  background: color-mix(in srgb, var(--pc) 5%, var(--bg-panel));
+  border-bottom-style: dashed;
+  filter: none;
+}
+
+.mp-pane.server .mp-role,
+.mp-tab.server {
+  letter-spacing: 0.14em;
+}
+
+/* The one-word caption that says what "SERVER" MEANS — it holds the authority
+   of the session. Set as a quiet aside, not a badge. */
+.mp-authority {
+  font-size: 9px;
+  color: var(--text-dim);
+  opacity: 0.62;
+  letter-spacing: 0.04em;
+}
+
+.mp-tab.server {
+  filter: none;
+}
+
+/* ---- per-pane link state (the coordinator's connection table) ---- */
+
+.mp-conn {
+  font-size: 9.5px;
+  color: var(--text-dim);
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.mp-conn[data-linked="true"] {
+  color: var(--green);
+}
+
 /* ---- per-pane link chip + menu ---- */
 
 .mp-link-host {
   position: relative;
+  min-width: 0;
 }
 
 .mp-link-chip {
+  /* Never wrap: at three tiles the pane header is narrow, and a two-line chip
+     doubles the header's height. It truncates instead. */
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font: 10px/1 var(--font-mono);
   color: var(--text-dim);
   cursor: pointer;


### PR DESCRIPTION
![Arena session — 2 clients + the server pane](https://gist.githubusercontent.com/tommy-xr/a29657ad056d64ddb1247895dd7ec78e/raw/mpux-2clients.gif)

<sub>**Arena (client/server)** at `#clients=2`: two client panes plus the dashed **SERVER · authority** pane, all three linked and stepping together on the shared chrono bar. Captured headlessly (Playwright + the panes' `__scrub` seam, seeked frame-by-frame so the pacing is deterministic).</sub>

**2 clients + server, tiled** — `● 2 linked`, pill reads `2+1 running`:

![2 clients + server, tiled](https://gist.githubusercontent.com/tommy-xr/a29657ad056d64ddb1247895dd7ec78e/raw/mpux-2clients-tiled.png)

**1 client + server, tiled** — the server pane is present at every client count:

![1 client + server, tiled](https://gist.githubusercontent.com/tommy-xr/a29657ad056d64ddb1247895dd7ec78e/raw/mpux-1client-tiled.png)

**Tabs mode** — the server is selectable but carries no digit and is never `⌨ you`:

![2 clients + server, tabs](https://gist.githubusercontent.com/tommy-xr/a29657ad056d64ddb1247895dd7ec78e/raw/mpux-2clients-tabs.png)

---

PR 4 of the **coordinator transport arc** (stacked on #600 ← #593 ← #591): the sandbox grows the multiplayer UX. Pick **Arena (client/server)** in the scene picker and the pane grid runs a real session — N client panes plus a **SERVER pane**, packets routed by #593's in-page coordinator. No sockets, no server process.

**The role seam:** `Example.server?: { file }` — an example that declares a server role gets a server pane, always present (every client count, including 1), booted from the same project files with the server file as entry. The CLIENTS control counts *clients*; the pill reads `2+1 running` so the server never masquerades as a third client.

**Server-pane semantics (v1 decisions, for iteration):**
- Chrome-only identity: desaturated slate, dashed frame, `SERVER · authority` label, `● N linked` — no digit, no player color, no link chip (latency belongs to clients), and the label never appears in-game (the asteroids-era lesson).
- Selectable by click (tabs mode needs it) but excluded from the keyboard client cycle and never `⌨ you`.
- Full participant in the chrono bar's pause/step/seek — a session parks together or not at all.
- Hot-reload limitation, documented: the editor buffer is the client entry, so client panes hot-reload live while the server keeps its build until `↺ reset` (multi-file editing is the tracked follow-up).
- Design doc §5 ships as thumbnail-tile-only; the model panel and **wire log** (the piece that makes protocols debuggable) are the next slice.

**Connection surfacing:** pane headers now show `● linked` / `○ waiting` from the coordinator's connection table (`NetCoordinator.connectionCounts()`) — the seed of the link chips becoming real when impairment lands.

**Cross-engine review (Claude + Codex), all findings applied.** The Claude engine caught a High the e2e missed: growing the client set re-appended the server iframe, and re-appending a mounted iframe *reloads* it — wiping the authority's world on every count change. Fixed (clients insert before the server) with a document-lifetime regression check confirmed failing against the buggy version. Also applied: server URL derives from the client's params (was dropping `prefix`/`cursor`/`mouseCapture`), focus tracked by pane identity instead of index, `test:sandbox-mp` wired into wasm-smoke CI, listener/detail cleanup on unmount, pointer-lock allowed on the server iframe, `[`/`]` re-entry from the server pane. Noted-not-taken (Low, both engines): the `server.file` ↔ `siblings` path duplication — kept with the coupling documented.

**Verification:** `tsc -p site --noEmit` strict clean; site rebuilt from scratch; `npm run test:site` ALL CHECKS PASSED (including the picker-derived mp smoke); `e2e/net-coordinator.mjs` 15/15 unchanged; NEW `e2e/sandbox-mp.mjs` 11/11 (server+1 at count 1, server+2 at `#clients=2`, both clients in-world via the trace path, pill text, server removed on example switch) — wired into CI.

Known, pre-existing, out of scope: the `1 problem` indicator on mp is the sandbox's single-file lang-intel not seeing sibling modules — the tracked "project-wide Problems" follow-up.

Next in the stack: the wire log + server model panel (§5's remaining sections), orbs adopts the transport, link impairment + packet log on the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

