### PR TITLE
feat(docs): generate the standard library API reference

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -481,11 +481,17 @@ open Widget                                              // …or open, bringing
 - Prelude interface documentation uses `//!` for the module overview and `///`
   directly above a type/signature for its public API prose. Plain `//` remains
   an ordinary comment and still appears in user-code hover for backwards
-  compatibility. `functor docs` renders the embedded prelude as Markdown or
-  JSON; in the repository, `npm run generate:docs` recreates the gitignored
-  local reference artifacts and `npm run check:docs` validates both renderers.
-  Both repository scripts reject a prelude module, type, or signature without
-  explicit public documentation.
+  compatibility. `functor docs` renders the embedded API as Markdown or
+  JSON — the engine prelude AND the language standard library (`List`, `Map`,
+  `Text`, `Math`, `Random`, `Debug`, `Option`, `Result`, `Key`, `Mouse`,
+  documented in `functor-lang/stdlib/`), as two groups; in the repository,
+  `npm run generate:docs` recreates the gitignored local reference artifacts
+  and `npm run check:docs` validates both renderers. Both repository scripts
+  reject a module, type, or signature without explicit public documentation.
+  The builtin namespaces have no Functor Lang source of their own, so their
+  `.funi` documentation files are pinned to `builtin_signature` by a drift
+  test — a builtin added or retyped without a documentation update fails
+  `cargo test -p functor-lang`.
 
 ## Inline tests (`expect`)
 

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -58,7 +58,7 @@ jobs:
       # that is deliberate: it guards the MAX_EVAL_DEPTH-fits-2-MiB budget (#221).
       - name: Run tests
         run: |
-          cargo test -p functor_runtime_common -p functor-lang
+          cargo test -p functor_runtime_common -p functor-lang -p functor-docgen
 
       - name: Validate API documentation generation
         run: npm run check:docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,12 +190,13 @@ window — feels like a hang), and rapier physics steps are similarly far off re
 The wasm bundle is unaffected either way: `wasm-pack build` is release by default, so
 `run wasm` and the site always ship optimized wasm.
 
-**Generate the API reference.** The lightweight generator reads the exact `.funi`
-prelude embedded in Functor and recreates gitignored local Markdown + JSON artifacts;
-it does not build the GL-linked CLI or the wasm runtime. The check command validates
-both renderers without requiring generated files to exist. Generation and checking
-fails if a prelude module, type, or signature lacks explicit `//!` / `///` public
-documentation:
+**Generate the API reference.** The lightweight generator reads the exact Functor
+Lang sources embedded in Functor — the engine's `.funi` prelude AND the language
+standard library (`functor-lang/stdlib/`, rendered as its own group) — and recreates
+gitignored local Markdown + JSON artifacts; it does not build the GL-linked CLI or
+the wasm runtime. The check command validates both renderers without requiring
+generated files to exist. Generation and checking fails if a module, type, or
+signature lacks explicit `//!` / `///` public documentation:
 
 ```sh
 npm run generate:docs

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ use `./target/release/functor` instead — see [DEVELOPMENT.md](DEVELOPMENT.md).
 | `functor -d <dir> build [native\|wasm]` | Typecheck the `.fun` project (diagnostics are errors) |
 | `functor -d <dir> run [native\|wasm]` | Interpret and run the game (native window / browser) |
 | `functor -d <dir> develop [native\|wasm]` | Same as `run` — Functor Lang hot-reload is built into the runtime — plus, on native, the debug runtime on `localhost:8077` (`--no-debug` to skip it) |
-| `functor docs [--format markdown\|json]` | Generate the engine API reference from the embedded `.funi` prelude |
+| `functor docs [--format markdown\|json]` | Generate the API reference — the embedded engine prelude plus the language standard library |
 
 For build-from-source instructions and what `build`/`run` do under the hood, see
 [DEVELOPMENT.md](DEVELOPMENT.md).

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,8 +103,9 @@ impl Environment {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Generate the Functor engine API reference from the embedded `.funi`
-    /// prelude. Writes Markdown to stdout by default.
+    /// Generate the Functor API reference from the embedded sources: the
+    /// engine's `.funi` prelude plus the Functor Lang standard library.
+    /// Writes Markdown to stdout by default.
     Docs {
         /// Generated representation.
         #[arg(long, value_enum, default_value = "markdown")]

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -307,6 +307,37 @@ fn core_modules() -> Vec<BundledModule> {
     ]
 }
 
+/// One standard-library module as the API-reference generator sees it.
+///
+/// Deliberately NOT a [`BundledModule`]: half of these are documentation-only
+/// interfaces for Rust builtins, and linking one would shadow the builtin
+/// registry with externals nothing implements. This type cannot be handed to a
+/// loader at all.
+pub struct DocumentationModule {
+    name: &'static str,
+    source: &'static str,
+    /// Bodyless `.funi` signatures, versus executable `.fun` code whose
+    /// signatures come from its own annotations.
+    interface: bool,
+}
+
+impl DocumentationModule {
+    /// Module name used by qualified access (`List`, `Option`, …).
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// The documented source text.
+    pub fn source(&self) -> &'static str {
+        self.source
+    }
+
+    /// Whether the source is a bodyless `.funi` interface.
+    pub fn is_interface(&self) -> bool {
+        self.interface
+    }
+}
+
 /// The Functor Lang standard library as documentation sources, in reference
 /// order — what `functor docs` renders beside the engine prelude.
 ///
@@ -319,19 +350,29 @@ fn core_modules() -> Vec<BundledModule> {
 ///   a drift test;
 /// - the modules written in Functor Lang and linked into every project
 ///   (`Option`, `Result`, `Key`, `Mouse`), documented from the exact source
-///   that runs.
-pub fn stdlib_documentation_modules() -> Vec<BundledModule> {
+///   that runs, so those cannot drift at all.
+pub fn stdlib_documentation_modules() -> Vec<DocumentationModule> {
+    let interface = |name, source| DocumentationModule {
+        name,
+        source,
+        interface: true,
+    };
+    let implementation = |name, source| DocumentationModule {
+        name,
+        source,
+        interface: false,
+    };
     vec![
-        BundledModule::builtin("List", LIST_DOC_SRC, BundledModuleKind::Interface),
-        BundledModule::builtin("Map", MAP_DOC_SRC, BundledModuleKind::Interface),
-        BundledModule::builtin("Text", TEXT_DOC_SRC, BundledModuleKind::Interface),
-        BundledModule::builtin("Math", MATH_DOC_SRC, BundledModuleKind::Interface),
-        BundledModule::builtin("Random", RANDOM_MODULE_SRC, BundledModuleKind::Interface),
-        BundledModule::builtin("Debug", DEBUG_DOC_SRC, BundledModuleKind::Interface),
-        BundledModule::implementation("Option", OPTION_MODULE_SRC),
-        BundledModule::implementation("Result", RESULT_MODULE_SRC),
-        BundledModule::builtin("Key", KEY_MODULE_SRC, BundledModuleKind::Implementation),
-        BundledModule::builtin("Mouse", MOUSE_MODULE_SRC, BundledModuleKind::Implementation),
+        interface("List", LIST_DOC_SRC),
+        interface("Map", MAP_DOC_SRC),
+        interface("Text", TEXT_DOC_SRC),
+        interface("Math", MATH_DOC_SRC),
+        interface("Random", RANDOM_MODULE_SRC),
+        interface("Debug", DEBUG_DOC_SRC),
+        implementation("Option", OPTION_MODULE_SRC),
+        implementation("Result", RESULT_MODULE_SRC),
+        implementation("Key", KEY_MODULE_SRC),
+        implementation("Mouse", MOUSE_MODULE_SRC),
     ]
 }
 

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -253,11 +253,7 @@ const NET_MODULE_SRC: &str = "type NetEvent =\n\
 /// ([`crate::eval::Builtin`]); these signatures both type them (the checker
 /// prefers a signature over a builtin scheme) and keep the qualified names
 /// resolving now that a `Random` module exists.
-const RANDOM_MODULE_SRC: &str = "type Seed\n\
-     let seed : (float) => Seed\n\
-     let step : (Seed) => (float, Seed)\n\
-     let range : (float, float, Seed) => (float, Seed)\n\
-     let fork : (float, Seed) => Seed\n";
+const RANDOM_MODULE_SRC: &str = include_str!("../stdlib/random.funi");
 
 /// The built-in `Key` module (injected beside `Net` in [`link`]): the variant
 /// the `input` hook's `key` parameter carries — `Key.W`, `Key.Up`,
@@ -267,12 +263,7 @@ const RANDOM_MODULE_SRC: &str = "type Seed\n\
 /// filtered before dispatch and deliberately has no constructor here. Keep in
 /// sync with the `Key` enum in `functor_runtime_common::input` (the digit row
 /// is `Num0`..`Num9` — constructor names must be identifiers).
-const KEY_MODULE_SRC: &str = "type t =\n\
-     | A | B | C | D | E | F | G | H | I | J | K | L | M\n\
-     | N | O | P | Q | R | S | T | U | V | W | X | Y | Z\n\
-     | Up | Down | Left | Right\n\
-     | Space | Enter | Escape\n\
-     | Num0 | Num1 | Num2 | Num3 | Num4 | Num5 | Num6 | Num7 | Num8 | Num9\n";
+const KEY_MODULE_SRC: &str = include_str!("../stdlib/key.fun");
 
 /// The built-in `Mouse` module (the mouse twin of `Key`): the variant the
 /// `mouseButton` hook's `button` parameter carries — `Mouse.Left`,
@@ -282,11 +273,25 @@ const KEY_MODULE_SRC: &str = "type t =\n\
 /// `Unknown` is filtered before dispatch and deliberately has no constructor
 /// here. Keep in sync with the `MouseButton` enum in
 /// `functor_runtime_common::input`.
-const MOUSE_MODULE_SRC: &str = "type t =\n\
-     | Left | Right | Middle\n";
+const MOUSE_MODULE_SRC: &str = include_str!("../stdlib/mouse.fun");
 
 const OPTION_MODULE_SRC: &str = include_str!("../stdlib/option.fun");
 const RESULT_MODULE_SRC: &str = include_str!("../stdlib/result.fun");
+
+/// Documentation-only interfaces for the namespaces the INTERPRETER
+/// implements in Rust ([`crate::eval::Builtin`]) rather than in Functor Lang
+/// source. They are never linked into a project — the builtin registry
+/// already resolves and types those calls — but they give the API-reference
+/// generator the same `//!` / `///` prose surface every other module has.
+///
+/// Their signatures are pinned to [`crate::types::builtin_signature`] by a
+/// drift test (`builtin_documentation_matches_the_registry`), so a builtin
+/// added, removed, or retyped without updating these files fails the build.
+const LIST_DOC_SRC: &str = include_str!("../stdlib/list.funi");
+const MAP_DOC_SRC: &str = include_str!("../stdlib/map.funi");
+const TEXT_DOC_SRC: &str = include_str!("../stdlib/text.funi");
+const MATH_DOC_SRC: &str = include_str!("../stdlib/math.funi");
+const DEBUG_DOC_SRC: &str = include_str!("../stdlib/debug.funi");
 
 /// Language-owned modules available in every embedding, including the plain
 /// `functor-lang` CLI. Keeping them in the same descriptor shape as host
@@ -299,6 +304,34 @@ fn core_modules() -> Vec<BundledModule> {
         BundledModule::builtin("Mouse", MOUSE_MODULE_SRC, BundledModuleKind::Implementation),
         BundledModule::implementation("Option", OPTION_MODULE_SRC),
         BundledModule::implementation("Result", RESULT_MODULE_SRC),
+    ]
+}
+
+/// The Functor Lang standard library as documentation sources, in reference
+/// order — what `functor docs` renders beside the engine prelude.
+///
+/// Two kinds of module appear here, and the difference is invisible to a game:
+///
+/// - the namespaces the interpreter implements in Rust (`List`, `Map`,
+///   `Text`, `Math`, `Random`, `Debug`), documented by the `.funi` sources
+///   above — `Random`'s is the very module [`core_modules`] injects, and the
+///   rest are documentation-only interfaces pinned to the builtin registry by
+///   a drift test;
+/// - the modules written in Functor Lang and linked into every project
+///   (`Option`, `Result`, `Key`, `Mouse`), documented from the exact source
+///   that runs.
+pub fn stdlib_documentation_modules() -> Vec<BundledModule> {
+    vec![
+        BundledModule::builtin("List", LIST_DOC_SRC, BundledModuleKind::Interface),
+        BundledModule::builtin("Map", MAP_DOC_SRC, BundledModuleKind::Interface),
+        BundledModule::builtin("Text", TEXT_DOC_SRC, BundledModuleKind::Interface),
+        BundledModule::builtin("Math", MATH_DOC_SRC, BundledModuleKind::Interface),
+        BundledModule::builtin("Random", RANDOM_MODULE_SRC, BundledModuleKind::Interface),
+        BundledModule::builtin("Debug", DEBUG_DOC_SRC, BundledModuleKind::Interface),
+        BundledModule::implementation("Option", OPTION_MODULE_SRC),
+        BundledModule::implementation("Result", RESULT_MODULE_SRC),
+        BundledModule::builtin("Key", KEY_MODULE_SRC, BundledModuleKind::Implementation),
+        BundledModule::builtin("Mouse", MOUSE_MODULE_SRC, BundledModuleKind::Implementation),
     ]
 }
 

--- a/functor-lang/stdlib/debug.funi
+++ b/functor-lang/stdlib/debug.funi
@@ -1,0 +1,20 @@
+//! The observability escape hatch.
+//!
+//! `Debug` is the one impure corner of the standard library, and it is impure
+//! only in the direction of the terminal: it cannot influence the model or the
+//! simulation, so a game with and without it evolves identically.
+
+/// Log `label: value` and return `value` UNCHANGED — an Elm-style trace.
+///
+/// The value is rendered exactly as `functor-lang run` displays it, whatever
+/// its type. Because the label comes first and the subject last, it reads
+/// standalone (`Debug.log("x", model.x)`) and threads through a pipeline
+/// (`model.x |> Debug.log("x") |> Math.clamp01`) without changing what flows
+/// through.
+///
+/// Under the plain `functor-lang` CLI the line goes to stdout; under the game
+/// runner it goes to the CLI's log stream, or the browser console on wasm. It
+/// is NOT rate-limited, so a call in `tick` or `draw` fires every frame —
+/// prefer an event path such as `input` or `update`, or remove the call when
+/// you are done with it.
+let log : (string, 'a) => 'a

--- a/functor-lang/stdlib/key.fun
+++ b/functor-lang/stdlib/key.fun
@@ -1,0 +1,19 @@
+//! Keyboard keys, as a variant rather than strings.
+//!
+//! `Key` is built in — no declaration and no import. The `input` hook's `key`
+//! parameter and the `Input.snapshot` key sets all carry these constructors,
+//! so a misspelling (`Key.Enterr`) is a load-time error instead of an arm that
+//! silently never matches. Match them (`| Key.W =>`) or compare them
+//! (`key == Key.Enter`).
+
+/// A keyboard key.
+///
+/// The digit row is `Num0` … `Num9` — constructor names have to be
+/// identifiers, so a bare digit is not one of them. Keys the platform reports
+/// that Functor does not name are never delivered to game logic.
+type t =
+  | A | B | C | D | E | F | G | H | I | J | K | L | M
+  | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
+  | Up | Down | Left | Right
+  | Space | Enter | Escape
+  | Num0 | Num1 | Num2 | Num3 | Num4 | Num5 | Num6 | Num7 | Num8 | Num9

--- a/functor-lang/stdlib/list.funi
+++ b/functor-lang/stdlib/list.funi
@@ -1,0 +1,102 @@
+//! Immutable list operations.
+//!
+//! Functor Lang has no loops: iteration is `List.map`, `List.filter`, and
+//! `List.fold`, which run iteratively in the interpreter and so consume no
+//! evaluation depth (unlike a hand-rolled recursive walk, which trips the
+//! recursion cap).
+//!
+//! Every function takes its list LAST, so it threads through the thread-last
+//! pipeline operator: `xs |> List.map(f)` is exactly `List.map(f, xs)`.
+//!
+//! The partial accessors — `nth`, `head`, `last`, `find` — answer with
+//! `Option.t`, never a sentinel, so the absent case has to be handled.
+
+/// Apply `fn` to every element, preserving order and length.
+let map : (('a) => 'b, List<'a>) => List<'b>
+
+/// Apply `fn` to every element with its 0-based index, as `fn(index, element)`
+/// — index FIRST, unlike the subject-last list argument.
+let indexedMap : ((float, 'a) => 'b, List<'a>) => List<'b>
+
+/// Keep the elements the predicate accepts, in order.
+let filter : (('a) => bool, List<'a>) => List<'a>
+
+/// Reduce left-to-right from an initial accumulator, calling `fn(acc, element)`.
+/// This is the iteration primitive to reach for when `map` and `filter` do not
+/// fit — a recursive walk hits the interpreter's recursion cap around 40–60
+/// elements, while `fold` has no such limit.
+let fold : (('b, 'a) => 'b, 'b, List<'a>) => 'b
+
+/// Map each element to a list and concatenate the results (one level).
+let concatMap : (('a) => List<'b>, List<'a>) => List<'b>
+
+/// `[0, 1, … n - 1]`. A non-positive `n` gives the empty list.
+let range : (float) => List<float>
+
+/// Build a `rows` x `cols` grid by calling `fn(row, col)` for every cell, both
+/// 0-based — the procedural-heightmap shape, e.g.
+/// `Scene.heightmap(List.grid(height, rows, cols))`.
+let grid : ((float, float) => 'a, float, float) => List<List<'a>>
+
+/// The largest number in the list. Errors on an empty list — the one accessor
+/// that predates `Option` and still raises rather than answering `None`.
+let maximum : (List<float>) => float
+
+/// The sum of the numbers. The empty list sums to `0.0`.
+let sum : (List<float>) => float
+
+/// How many elements the list has, as a number.
+let length : (List<'a>) => float
+
+/// Whether the list has no elements.
+let isEmpty : (List<'a>) => bool
+
+/// The list in reverse order.
+let reverse : (List<'a>) => List<'a>
+
+/// The piped list followed by `other`: `xs |> List.append(ys)` is `xs` then
+/// `ys`.
+let append : (List<'a>, List<'a>) => List<'a>
+
+/// Concatenate a list of lists, one level deep.
+let flatten : (List<List<'a>>) => List<'a>
+
+/// Pair each element of the piped list with the element of `other` at the same
+/// index — the PIPED list fills the first slot of every tuple. The result
+/// truncates to the shorter of the two.
+let zip : (List<'b>, List<'a>) => List<('a, 'b)>
+
+/// Sort ascending by the number `fn` returns. The sort is STABLE and calls
+/// `fn` exactly once per element. NaN keys sort last, tied with each other
+/// regardless of sign, so the order is identical on every platform; `-0.0` and
+/// `0.0` tie.
+let sortBy : (('a) => float, List<'a>) => List<'a>
+
+/// The first `count` elements, saturating: past the end gives the whole list,
+/// and a negative count behaves as `0`.
+let take : (float, List<'a>) => List<'a>
+
+/// Everything after the first `count` elements, saturating: past the end gives
+/// the empty list, and a negative count behaves as `0`.
+let drop : (float, List<'a>) => List<'a>
+
+/// Whether ANY element satisfies the predicate. The empty list is `false`.
+let any : (('a) => bool, List<'a>) => bool
+
+/// Whether EVERY element satisfies the predicate. The empty list is `true`.
+let all : (('a) => bool, List<'a>) => bool
+
+/// The element at a 0-based `index`, or `Option.None` when the index is out of
+/// range. A FRACTIONAL index is an error rather than an absence — it is a
+/// caller bug, not a missing element.
+let nth : (float, List<'a>) => Option.t<'a>
+
+/// The first element, or `Option.None` for an empty list.
+let head : (List<'a>) => Option.t<'a>
+
+/// The last element, or `Option.None` for an empty list.
+let last : (List<'a>) => Option.t<'a>
+
+/// The first element satisfying the predicate, or `Option.None` when none
+/// does.
+let find : (('a) => bool, List<'a>) => Option.t<'a>

--- a/functor-lang/stdlib/list.funi
+++ b/functor-lang/stdlib/list.funi
@@ -40,9 +40,14 @@ let range : (float) => List<float>
 /// whole and non-negative, and the cells must total at most one million.
 let grid : ((float, float) => 'a, float, float) => List<List<'a>>
 
-/// The largest number in the list. Errors on an empty list — the one accessor
-/// that predates `Option` and still raises rather than answering `None`.
-let maximum : (List<float>) => float
+/// The largest number in the list as `Option.Some`, or `Option.None` for an
+/// empty list — partial like `nth`/`head`/`last`/`find`. NaN elements are
+/// ignored unless every element is NaN.
+let maximum : (List<float>) => Option.t<float>
+
+/// The smallest number in the list as `Option.Some`, or `Option.None` for an
+/// empty list — `maximum`'s mirror, with the same NaN rule.
+let minimum : (List<float>) => Option.t<float>
 
 /// The sum of the numbers. The empty list sums to `0.0`.
 let sum : (List<float>) => float

--- a/functor-lang/stdlib/list.funi
+++ b/functor-lang/stdlib/list.funi
@@ -30,12 +30,14 @@ let fold : (('b, 'a) => 'b, 'b, List<'a>) => 'b
 /// Map each element to a list and concatenate the results (one level).
 let concatMap : (('a) => List<'b>, List<'a>) => List<'b>
 
-/// `[0, 1, … n - 1]`. A non-positive `n` gives the empty list.
+/// `[0, 1, … n - 1]`. A non-positive `n` gives the empty list; a count that
+/// is not finite, or above one million, is an error.
 let range : (float) => List<float>
 
 /// Build a `rows` x `cols` grid by calling `fn(row, col)` for every cell, both
 /// 0-based — the procedural-heightmap shape, e.g.
-/// `Scene.heightmap(List.grid(height, rows, cols))`.
+/// `Scene.heightmap(List.grid(height, rows, cols))`. Both counts must be
+/// whole and non-negative, and the cells must total at most one million.
 let grid : ((float, float) => 'a, float, float) => List<List<'a>>
 
 /// The largest number in the list. Errors on an empty list — the one accessor
@@ -73,11 +75,14 @@ let zip : (List<'b>, List<'a>) => List<('a, 'b)>
 let sortBy : (('a) => float, List<'a>) => List<'a>
 
 /// The first `count` elements, saturating: past the end gives the whole list,
-/// and a negative count behaves as `0`.
+/// and a negative count behaves as `0`. A fractional count truncates toward
+/// zero rather than raising — unlike `nth`, where a fractional index is a
+/// caller bug.
 let take : (float, List<'a>) => List<'a>
 
 /// Everything after the first `count` elements, saturating: past the end gives
-/// the empty list, and a negative count behaves as `0`.
+/// the empty list, and a negative count behaves as `0`. A fractional count
+/// truncates, like `take`.
 let drop : (float, List<'a>) => List<'a>
 
 /// Whether ANY element satisfies the predicate. The empty list is `false`.
@@ -87,8 +92,8 @@ let any : (('a) => bool, List<'a>) => bool
 let all : (('a) => bool, List<'a>) => bool
 
 /// The element at a 0-based `index`, or `Option.None` when the index is out of
-/// range. A FRACTIONAL index is an error rather than an absence — it is a
-/// caller bug, not a missing element.
+/// range. An index that is not a whole, finite number is an ERROR rather than
+/// an absence — that is a caller bug, not a missing element.
 let nth : (float, List<'a>) => Option.t<'a>
 
 /// The first element, or `Option.None` for an empty list.

--- a/functor-lang/stdlib/map.funi
+++ b/functor-lang/stdlib/map.funi
@@ -1,0 +1,46 @@
+//! Immutable keyed collections.
+//!
+//! A `Map` is plain data: it compares structurally, displays, snapshots, and
+//! survives hot reload. Every operation returns a NEW map rather than mutating
+//! the old one, and every function takes the map LAST so it threads through a
+//! pipeline.
+//!
+//! Keys are bounded to `bool`, FINITE `float`, and `string`. Inference keeps a
+//! map homogeneous in ordinary code, and a generic or `unknown` seam is
+//! checked again at runtime; NaN and the infinities are refused, while `-0.0`
+//! and `0.0` are the same key.
+//!
+//! Every map is stored in one canonical key order — bool before float before
+//! string, then `false` before `true`, ascending numerically, and strings by
+//! Unicode scalar value (not locale-aware). So `values`, `toList`, structural
+//! equality, and display all agree byte-for-byte between native and wasm.
+//!
+//! `get` and `member` are logarithmic; the immutable `insert` and `remove`
+//! copy the ordered storage and are linear, as are `values` and `toList`;
+//! `fromList` is O(n log n).
+
+/// The empty map.
+let empty : () => Map<'a, 'b>
+
+/// The value stored under `key`, or `Option.None` when the map has no such
+/// key.
+let get : ('a, Map<'a, 'b>) => Option.t<'b>
+
+/// The map with `key` bound to `value`, replacing any existing binding.
+let insert : ('a, 'b, Map<'a, 'b>) => Map<'a, 'b>
+
+/// The map without `key`. Removing an absent key is not an error.
+let remove : ('a, Map<'a, 'b>) => Map<'a, 'b>
+
+/// Whether the map holds a binding for `key`.
+let member : ('a, Map<'a, 'b>) => bool
+
+/// Every value, in canonical key order.
+let values : (Map<'a, 'b>) => List<'b>
+
+/// Every `(key, value)` pair, in canonical key order.
+let toList : (Map<'a, 'b>) => List<('a, 'b)>
+
+/// Build a map from `(key, value)` pairs. For a repeated key the LAST pair
+/// wins.
+let fromList : (List<('a, 'b)>) => Map<'a, 'b>

--- a/functor-lang/stdlib/math.funi
+++ b/functor-lang/stdlib/math.funi
@@ -84,3 +84,15 @@ let clamp : (float, float, float) => float
 
 /// `n` confined to `[0, 1]` — the same as `Math.clamp(0.0, 1.0, n)`.
 let clamp01 : (float) => float
+
+/// Linear interpolation from `from` toward `target` by `t` (unclamped):
+/// `from + (target - from) * t`, and `t = 1.0` answers `target` exactly.
+/// Mirrors `Vec3.lerp(target, t, from)` — the pipe subject is the start
+/// value, so `x |> Math.lerp(target, t)` works like its vector sibling.
+/// (Deliberately NOT GLSL's `mix(a, b, t)` order.)
+let lerp : (float, float, float) => float
+
+/// Hermite smoothstep of `x` across `[edge0, edge1]`, clamped to `[0, 1]`.
+/// The edges must be a finite ascending range (`edge0 < edge1`, both finite
+/// and not overflow-wide) — anything else is an error, never a silent NaN.
+let smoothstep : (float, float, float) => float

--- a/functor-lang/stdlib/math.funi
+++ b/functor-lang/stdlib/math.funi
@@ -1,0 +1,86 @@
+//! Numeric functions and constants.
+//!
+//! Functor Lang has one number type (`float`, an f64) and a deliberately small
+//! operator set: `Math.mod` stands in for `%` and `Math.pow` for `^`.
+//! Arithmetic is IEEE throughout, so `1.0 / 0.0` is infinity and NaN compares
+//! false against everything, itself included.
+//!
+//! Two behaviors differ from the usual defaults and are worth knowing: `mod`
+//! is EUCLIDEAN (its result is never negative) and `round` goes half AWAY FROM
+//! ZERO (not banker's rounding).
+
+/// The ratio of a circle's circumference to its diameter — a constant VALUE,
+/// not a function, so it is written `Math.pi` with no parentheses.
+let pi : float
+
+/// The sine of an angle in radians.
+let sin : (float) => float
+
+/// The cosine of an angle in radians.
+let cos : (float) => float
+
+/// The tangent of an angle in radians.
+let tan : (float) => float
+
+/// The arcsine, in radians. NaN outside `[-1, 1]`: it does NOT clamp, so a dot
+/// product nudged past 1.0 by float error needs an explicit
+/// `|> Math.clamp(-1.0, 1.0)` first.
+let asin : (float) => float
+
+/// The arccosine, in radians. NaN outside `[-1, 1]`, exactly like `asin`.
+let acos : (float) => float
+
+/// The arctangent, in radians.
+let atan : (float) => float
+
+/// The angle in radians from the positive x-axis to the point `(x, y)`, using
+/// the standard mathematical argument order with `y` FIRST.
+let atan2 : (float, float) => float
+
+/// The non-negative square root.
+let sqrt : (float) => float
+
+/// `base` raised to `exp` — the language has no `^` operator.
+let pow : (float, float) => float
+
+/// The natural logarithm, base e — the inverse of `Math.exp`.
+let log : (float) => float
+
+/// e raised to the given power.
+let exp : (float) => float
+
+/// The magnitude, without sign.
+let abs : (float) => float
+
+/// `-1`, `0`, or `1` — and exactly `0` AT zero, so it is not a two-way branch.
+/// NaN answers NaN.
+let sign : (float) => float
+
+/// The largest whole number that is not greater than `n`.
+let floor : (float) => float
+
+/// The smallest whole number that is not less than `n`.
+let ceil : (float) => float
+
+/// The nearest whole number, rounding halves AWAY FROM ZERO rather than to
+/// even: `0.5` rounds to `1`, `2.5` to `3`, and `-2.5` to `-3`.
+let round : (float) => float
+
+/// The EUCLIDEAN remainder: the result always lands in `[0, abs(b))`, so
+/// negatives wrap positively — `Math.mod(-1.0, 8.0)` is `7.0`, the wraparound
+/// games want. A zero divisor answers NaN.
+let mod : (float, float) => float
+
+/// The smaller of two numbers.
+let min : (float, float) => float
+
+/// The larger of two numbers.
+let max : (float, float) => float
+
+/// `n` confined to `[low, high]`, subject-last so it pipes:
+/// `n |> Math.clamp(0.0, 10.0)`. A `low` greater than `high` is an error, not
+/// a silent swap.
+let clamp : (float, float, float) => float
+
+/// `n` confined to `[0, 1]` — the same as `Math.clamp(0.0, 1.0, n)`.
+let clamp01 : (float) => float

--- a/functor-lang/stdlib/mouse.fun
+++ b/functor-lang/stdlib/mouse.fun
@@ -1,0 +1,11 @@
+//! Mouse buttons, as a variant rather than strings.
+//!
+//! The mouse twin of `Key`, and built in the same way: the `mouseButton`
+//! hook's `button` parameter carries these constructors, so a typo is caught
+//! at load time. Match them (`| Mouse.Left =>`) or compare them
+//! (`button == Mouse.Right`).
+
+/// A mouse button. Buttons beyond these three are never delivered to game
+/// logic.
+type t =
+  | Left | Right | Middle

--- a/functor-lang/stdlib/option.fun
+++ b/functor-lang/stdlib/option.fun
@@ -1,53 +1,66 @@
-// An optional value. Helpers are subject-last so they compose with `|>`.
+//! A value that may be absent.
+//!
+//! `Option` is an ordinary generic variant bundled with the language, so it is
+//! available in every project and under the plain `functor-lang` CLI. It is
+//! what the partial accessors (`List.head`, `Map.get`, …) answer with instead
+//! of a sentinel, which is what forces the absent case to be handled.
+//!
+//! ALWAYS qualify the constructors: bare `Some` / `None` do not resolve — they
+//! belong to this module, so write `Option.Some(x)` and `Option.None` in both
+//! expressions and patterns (or `open Option` first).
+//!
+//! Helpers take the option LAST, so they thread through a pipeline:
+//! `Option.Some(41.0) |> Option.map((n) => n + 1.0) |> Option.defaultValue(0.0)`.
 
+/// A present value (`Option.Some`) or its absence (`Option.None`).
 type t<'value> =
   | Some(value: 'value)
   | None
 
-// Transform a present value; leave `None` unchanged.
+/// Transform a present value; leave `None` unchanged.
 let map = (fn: ('value) => 'mapped, option: t<'value>): t<'mapped> =>
   match option with
   | Some(value) => Some(fn(value))
   | None => None
 
-// Continue with an optional computation when a value is present.
+/// Continue with an optional computation when a value is present.
 let bind = (fn: ('value) => t<'mapped>, option: t<'value>): t<'mapped> =>
   match option with
   | Some(value) => fn(value)
   | None => None
 
-// Return the contained value, or an eager fallback for `None`.
+/// Return the contained value, or an eager fallback for `None`.
 let defaultValue = (fallback: 'value, option: t<'value>): 'value =>
   match option with
   | Some(value) => value
   | None => fallback
 
-// Return the contained value, computing the fallback only for `None`.
+/// Return the contained value, computing the fallback only for `None`.
 let defaultWith = (fallback: () => 'value, option: t<'value>): 'value =>
   match option with
   | Some(value) => value
   | None => fallback()
 
-// Whether the option contains a value.
+/// Whether the option contains a value.
 let isSome = (option: t<'value>): bool =>
   match option with
   | Some(_) => true
   | None => false
 
-// Whether the option is `None`.
+/// Whether the option is `None`.
 let isNone = (option: t<'value>): bool =>
   match option with
   | Some(_) => false
   | None => true
 
-// Keep a present value only when it satisfies the predicate.
+/// Keep a present value only when it satisfies the predicate.
 let filter = (predicate: ('value) => bool, option: t<'value>): t<'value> =>
   match option with
   | Some(value) =>
       if predicate(value) then Some(value) else None
   | None => None
 
-// Convert `Some(value)` to `[value]` and `None` to `[]`.
+/// Convert `Some(value)` to `[value]` and `None` to `[]`.
 let toList = (option: t<'value>): List<'value> =>
   match option with
   | Some(value) => [value]

--- a/functor-lang/stdlib/random.funi
+++ b/functor-lang/stdlib/random.funi
@@ -32,8 +32,12 @@ let seed : (float) => Seed
 /// otherwise the stream never advances.
 let step : (Seed) => (float, Seed)
 
-/// Draw one value rescaled into `[lo, hi)`, as `(value, nextSeed)`. Expects
-/// `lo <= hi`.
+/// Draw one value rescaled into `[lo, hi)`, as `(value, nextSeed)` — one
+/// `step` draw, interpolated between the bounds.
+///
+/// Only finiteness is checked, so the bounds are yours to get right: reversed
+/// ones simply interpolate the other way (landing in `(hi, lo]`), and equal
+/// ones always answer that value.
 let range : (float, float, Seed) => (float, Seed)
 
 /// The seed of decorrelated child stream `i` — the typed replacement for

--- a/functor-lang/stdlib/random.funi
+++ b/functor-lang/stdlib/random.funi
@@ -1,0 +1,42 @@
+//! Pure, seeded pseudo-random numbers.
+//!
+//! There is no hidden global generator: a draw takes a seed and hands back the
+//! NEXT seed alongside its value, so randomness is an ordinary part of the
+//! model. Thread the next seed through and a run is exactly reproducible —
+//! which is what makes rewind, replay, and hot reload work.
+//!
+//! Seed a stream once, at `init`: a fixed `Random.seed(42.0)` for a
+//! reproducible run, or `Effect.random` / `Effect.now` for a different stream
+//! each session. Distinct seeds produce DECORRELATED streams that share no
+//! prefix, so per-entity streams do not visibly rhyme with each other.
+
+/// An opaque PRNG seed.
+///
+/// The brand keeps seeds out of arithmetic: a bare number where a `Seed` is
+/// expected, or `seed + 1.0` to derive a sibling stream, is a check-time error
+/// — use `Random.fork` instead. At runtime a seed is still plain data, so it
+/// snapshots, hot-reloads, and time-travels like any other model field.
+type Seed
+
+/// Make a seed from any finite number.
+///
+/// The number's BITS are hashed, so fractional seeds are as usable as whole
+/// ones — `Random.seed(0.42)` from an `Effect.random` result names a distinct
+/// starting point just as `Random.seed(42.0)` does.
+let seed : (float) => Seed
+
+/// Draw the next value, as `(value, nextSeed)` with `value` in `[0, 1)`.
+///
+/// The same seed always yields the same pair. Bind both halves and carry the
+/// next seed forward — `let (v, next) = Random.step(model.seed) in …` —
+/// otherwise the stream never advances.
+let step : (Seed) => (float, Seed)
+
+/// Draw one value rescaled into `[lo, hi)`, as `(value, nextSeed)`. Expects
+/// `lo <= hi`.
+let range : (float, float, Seed) => (float, Seed)
+
+/// The seed of decorrelated child stream `i` — the typed replacement for
+/// deriving sibling streams by arithmetic. Subject-last, so per-entity streams
+/// read as `model.seed |> Random.fork(i)`, and any number may name a stream.
+let fork : (float, Seed) => Seed

--- a/functor-lang/stdlib/result.fun
+++ b/functor-lang/stdlib/result.fun
@@ -1,54 +1,66 @@
-// A successful value or an error. Helpers are subject-last so they compose
-// with `|>`.
+//! A computation that either succeeded or carries an error.
+//!
+//! `Result` is an ordinary generic variant bundled with the language, so it is
+//! available in every project and under the plain `functor-lang` CLI. Use it
+//! where a failure needs to explain itself; use `Option` where absence needs
+//! no explanation.
+//!
+//! ALWAYS qualify the constructors: bare `Ok` / `Error` do not resolve — write
+//! `Result.Ok(x)` and `Result.Error(e)` in both expressions and patterns (or
+//! `open Result` first).
+//!
+//! Helpers take the result LAST, so they thread through a pipeline.
 
+/// A success carrying a value (`Result.Ok`) or a failure carrying an error
+/// (`Result.Error`).
 type t<'value, 'error> =
   | Ok(value: 'value)
   | Error(error: 'error)
 
-// Transform a successful value; leave an error unchanged.
+/// Transform a successful value; leave an error unchanged.
 let map = (fn: ('value) => 'mapped, result: t<'value, 'error>): t<'mapped, 'error> =>
   match result with
   | Ok(value) => Ok(fn(value))
   | Error(error) => Error(error)
 
-// Transform an error; leave a successful value unchanged.
+/// Transform an error; leave a successful value unchanged.
 let mapError = (fn: ('error) => 'mapped, result: t<'value, 'error>): t<'value, 'mapped> =>
   match result with
   | Ok(value) => Ok(value)
   | Error(error) => Error(fn(error))
 
-// Continue with a result-producing computation after success.
+/// Continue with a result-producing computation after success.
 let bind =
   (fn: ('value) => t<'mapped, 'error>, result: t<'value, 'error>): t<'mapped, 'error> =>
     match result with
     | Ok(value) => fn(value)
     | Error(error) => Error(error)
 
-// Return the successful value, or an eager fallback for an error.
+/// Return the successful value, or an eager fallback for an error.
 let defaultValue = (fallback: 'value, result: t<'value, 'error>): 'value =>
   match result with
   | Ok(value) => value
   | Error(_) => fallback
 
-// Return the successful value, or compute a fallback from the error.
+/// Return the successful value, or compute a fallback from the error.
 let defaultWith = (fallback: ('error) => 'value, result: t<'value, 'error>): 'value =>
   match result with
   | Ok(value) => value
   | Error(error) => fallback(error)
 
-// Whether the result is successful.
+/// Whether the result is successful.
 let isOk = (result: t<'value, 'error>): bool =>
   match result with
   | Ok(_) => true
   | Error(_) => false
 
-// Whether the result contains an error.
+/// Whether the result contains an error.
 let isError = (result: t<'value, 'error>): bool =>
   match result with
   | Ok(_) => false
   | Error(_) => true
 
-// Convert `Ok(value)` to `Option.Some(value)` and an error to `Option.None`.
+/// Convert `Ok(value)` to `Option.Some(value)` and an error to `Option.None`.
 let toOption = (result: t<'value, 'error>): Option.t<'value> =>
   match result with
   | Ok(value) => Option.Some(value)

--- a/functor-lang/stdlib/text.funi
+++ b/functor-lang/stdlib/text.funi
@@ -1,0 +1,62 @@
+//! String building, formatting, and inspection.
+//!
+//! There is no string-concatenation operator and no character type:
+//! interpolation (`$"score: {n}"`) covers most formatting, `Text.concat` joins
+//! two strings, and single characters are one-character STRINGS.
+//!
+//! Functions with a clear subject take the string LAST so they thread through
+//! a pipeline: `s |> Text.contains("ab")` is `Text.contains("ab", s)`.
+//!
+//! Lengths and character splits count **Unicode scalar values** — not bytes,
+//! and not grapheme clusters. `Text.length(s)` always equals
+//! `List.length(Text.chars(s))`.
+
+/// `a` followed by `b`.
+let concat : (string, string) => string
+
+/// A number rendered in Functor Lang's canonical display form — the same text
+/// string interpolation produces.
+let fromFloat : (float) => string
+
+/// A number rendered with exactly `decimals` digits after the point.
+/// `Text.fixed(42.0, 0.0)` is `"42"`, the integer-formatting shape.
+let fixed : (float, float) => string
+
+/// The strings as a bulleted block, one item per line.
+let toBullets : (List<string>) => string
+
+/// Split the subject on every occurrence of `sep`. Splitting the empty string
+/// gives `[""]`; an empty separator is an error.
+let split : (string, string) => List<string>
+
+/// Join the strings with `sep` between them.
+let join : (string, List<string>) => string
+
+/// Parse a number, ignoring surrounding whitespace. Unparseable text answers
+/// `0.0` rather than raising — validate the input yourself when the difference
+/// matters.
+let parseFloat : (string) => float
+
+/// How many Unicode scalar values the string contains.
+let length : (string) => float
+
+/// The string's Unicode scalar values, each as a one-character string.
+let chars : (string) => List<string>
+
+/// The string uppercased, Unicode-aware — so the LENGTH may change (`"ß"`
+/// uppercases to `"SS"`).
+let toUpper : (string) => string
+
+/// The string lowercased, Unicode-aware — so the length may change.
+let toLower : (string) => string
+
+/// The string without leading or trailing whitespace.
+let trim : (string) => string
+
+/// Whether the subject contains `needle`. The empty needle is contained in
+/// every string.
+let contains : (string, string) => bool
+
+/// Replace EVERY occurrence of `from` with `to`, never re-scanning what was
+/// just written. An empty `from` is an error.
+let replace : (string, string, string) => string

--- a/functor-lang/stdlib/text.funi
+++ b/functor-lang/stdlib/text.funi
@@ -19,7 +19,8 @@ let concat : (string, string) => string
 let fromFloat : (float) => string
 
 /// A number rendered with exactly `decimals` digits after the point.
-/// `Text.fixed(42.0, 0.0)` is `"42"`, the integer-formatting shape.
+/// `Text.fixed(42.0, 0.0)` is `"42"`, the integer-formatting shape. The digit
+/// count must be a whole number from 0 to 12; anything else is an error.
 let fixed : (float, float) => string
 
 /// The strings as a bulleted block, one item per line.

--- a/functor-lang/tests/stdlib_docs.rs
+++ b/functor-lang/tests/stdlib_docs.rs
@@ -10,33 +10,74 @@
 //! than silently publishing a wrong reference.
 
 use functor_lang::ast::Item;
-use functor_lang::eval::{
-    builtin, builtin_members, builtin_name, ALL_BUILTINS, BUILTIN_NAMESPACES,
-};
+use functor_lang::eval::{builtin_name, ALL_BUILTINS, BUILTIN_NAMESPACES};
 use functor_lang::parse_interface;
 use functor_lang::project::stdlib_documentation_modules;
 use functor_lang::types::builtin_signature;
 use std::collections::BTreeMap;
 
 /// The `let name : Type` lines a documentation interface declares, by member
-/// name, exactly as written in the source.
+/// name, exactly as written in the source. A repeated member is a bug in the
+/// file (the generator would publish it twice), so it panics rather than
+/// letting the later one overwrite the earlier.
 fn declared_signatures(source: &str) -> BTreeMap<String, String> {
     let program = parse_interface(source).expect("a documentation interface parses");
-    program
-        .items
-        .into_iter()
-        .filter_map(|item| match item {
-            Item::Sig(decl) => {
-                let text = source
-                    .get(decl.span.start..decl.span.end)
-                    .expect("signature spans are char boundaries")
-                    .trim()
-                    .to_string();
-                Some((decl.name, text))
-            }
-            _ => None,
-        })
-        .collect()
+    let mut declared = BTreeMap::new();
+    for item in program.items {
+        let Item::Sig(decl) = item else { continue };
+        let text = source
+            .get(decl.span.start..decl.span.end)
+            .expect("signature spans are char boundaries")
+            .trim()
+            .to_string();
+        assert!(
+            declared.insert(decl.name.clone(), text).is_none(),
+            "`{}` is declared twice in one documentation interface",
+            decl.name
+        );
+    }
+    declared
+}
+
+/// Drop a module's own qualifier from a rendered type, the way its source
+/// writes it: inside `Random`, `builtin_signature` says `Random.Seed` where
+/// the file says `Seed`. Only a qualifier at an identifier boundary counts, so
+/// an unrelated `NotRandom.t` is left alone.
+fn unqualify(text: &str, module: &str) -> String {
+    let qualifier = format!("{module}.");
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find(&qualifier) {
+        let boundary = rest[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric() && c != '_' && c != '.');
+        out.push_str(&rest[..at]);
+        if boundary {
+            rest = &rest[at + qualifier.len()..];
+        } else {
+            out.push_str(&qualifier);
+            rest = &rest[at + qualifier.len()..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[test]
+fn unqualify_only_strips_at_an_identifier_boundary() {
+    assert_eq!(
+        unqualify("(Random.Seed) => Random.Seed", "Random"),
+        "(Seed) => Seed"
+    );
+    assert_eq!(
+        unqualify("(NotRandom.t) => t", "Random"),
+        "(NotRandom.t) => t"
+    );
+    assert_eq!(
+        unqualify("(List<'a>) => Option.t<'a>", "List"),
+        "(List<'a>) => Option.t<'a>"
+    );
 }
 
 fn documentation_source(module: &str) -> String {
@@ -59,9 +100,7 @@ fn builtin_documentation_matches_the_registry() {
             .iter()
             .filter_map(|b| {
                 let member = builtin_name(*b).strip_prefix(&format!("{namespace}."))?;
-                let signature = builtin_signature(*b)
-                    .to_string()
-                    .replace(&format!("{namespace}."), "");
+                let signature = unqualify(&builtin_signature(*b).to_string(), namespace);
                 Some((member.to_string(), format!("let {member} : {signature}")))
             })
             .collect();
@@ -77,40 +116,18 @@ fn builtin_documentation_matches_the_registry() {
 
 /// The namespace list itself is covered: a NEW builtin namespace has to bring
 /// documentation with it, rather than quietly missing from the reference.
+/// (`documentation_source` panics for an undocumented one, so this is what
+/// keeps the loop above from silently iterating over nothing.)
 #[test]
 fn every_builtin_namespace_has_a_documentation_module() {
-    let documented: Vec<String> = stdlib_documentation_modules()
+    let documented: Vec<&str> = stdlib_documentation_modules()
         .iter()
-        .map(|module| module.name().to_string())
+        .map(|module| module.name())
         .collect();
     for namespace in BUILTIN_NAMESPACES {
         assert!(
-            documented.contains(&namespace.to_string()),
+            documented.contains(namespace),
             "builtin namespace `{namespace}` is missing from stdlib_documentation_modules()"
-        );
-        // And nothing documents a member the registry does not dispatch.
-        for member in builtin_members(namespace) {
-            assert!(
-                builtin(&[namespace.to_string(), member.to_string()]).is_some(),
-                "`{namespace}.{member}` is documented but does not dispatch"
-            );
-        }
-    }
-}
-
-/// The Functor Lang-implemented modules are documented from the very source
-/// that is linked into every project, so those cannot drift by construction —
-/// this pins that they are all present.
-#[test]
-fn language_implemented_modules_are_documented() {
-    let documented: Vec<String> = stdlib_documentation_modules()
-        .iter()
-        .map(|module| module.name().to_string())
-        .collect();
-    for module in ["Option", "Result", "Key", "Mouse"] {
-        assert!(
-            documented.contains(&module.to_string()),
-            "`{module}` is missing from stdlib_documentation_modules()"
         );
     }
 }

--- a/functor-lang/tests/stdlib_docs.rs
+++ b/functor-lang/tests/stdlib_docs.rs
@@ -1,0 +1,116 @@
+//! The standard library's documentation sources must describe the standard
+//! library that actually runs.
+//!
+//! The namespaces the interpreter implements in Rust (`List`, `Math`, …) have
+//! no Functor Lang source of their own, so their documentation lives in
+//! `stdlib/*.funi` interfaces that nothing links. These tests are what stops
+//! those files from drifting: the member set and every signature are compared
+//! against the registry the checker and the interpreter share, so a builtin
+//! added, removed, or retyped without a documentation update fails here rather
+//! than silently publishing a wrong reference.
+
+use functor_lang::ast::Item;
+use functor_lang::eval::{
+    builtin, builtin_members, builtin_name, ALL_BUILTINS, BUILTIN_NAMESPACES,
+};
+use functor_lang::parse_interface;
+use functor_lang::project::stdlib_documentation_modules;
+use functor_lang::types::builtin_signature;
+use std::collections::BTreeMap;
+
+/// The `let name : Type` lines a documentation interface declares, by member
+/// name, exactly as written in the source.
+fn declared_signatures(source: &str) -> BTreeMap<String, String> {
+    let program = parse_interface(source).expect("a documentation interface parses");
+    program
+        .items
+        .into_iter()
+        .filter_map(|item| match item {
+            Item::Sig(decl) => {
+                let text = source
+                    .get(decl.span.start..decl.span.end)
+                    .expect("signature spans are char boundaries")
+                    .trim()
+                    .to_string();
+                Some((decl.name, text))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn documentation_source(module: &str) -> String {
+    stdlib_documentation_modules()
+        .into_iter()
+        .find(|candidate| candidate.name() == module)
+        .unwrap_or_else(|| panic!("`{module}` has no documentation module"))
+        .source()
+        .to_string()
+}
+
+/// Every builtin namespace is documented, member for member, with the exact
+/// signature the checker gives it. A module writes its OWN types unqualified
+/// (`Seed`, not `Random.Seed`), so the expectation is qualified the same way.
+#[test]
+fn builtin_documentation_matches_the_registry() {
+    for namespace in BUILTIN_NAMESPACES {
+        let source = documentation_source(namespace);
+        let expected: BTreeMap<String, String> = ALL_BUILTINS
+            .iter()
+            .filter_map(|b| {
+                let member = builtin_name(*b).strip_prefix(&format!("{namespace}."))?;
+                let signature = builtin_signature(*b)
+                    .to_string()
+                    .replace(&format!("{namespace}."), "");
+                Some((member.to_string(), format!("let {member} : {signature}")))
+            })
+            .collect();
+        assert_eq!(
+            declared_signatures(&source),
+            expected,
+            "`{namespace}`'s documentation interface has drifted from the builtin registry \
+             — update functor-lang/stdlib/{}.funi",
+            namespace.to_lowercase()
+        );
+    }
+}
+
+/// The namespace list itself is covered: a NEW builtin namespace has to bring
+/// documentation with it, rather than quietly missing from the reference.
+#[test]
+fn every_builtin_namespace_has_a_documentation_module() {
+    let documented: Vec<String> = stdlib_documentation_modules()
+        .iter()
+        .map(|module| module.name().to_string())
+        .collect();
+    for namespace in BUILTIN_NAMESPACES {
+        assert!(
+            documented.contains(&namespace.to_string()),
+            "builtin namespace `{namespace}` is missing from stdlib_documentation_modules()"
+        );
+        // And nothing documents a member the registry does not dispatch.
+        for member in builtin_members(namespace) {
+            assert!(
+                builtin(&[namespace.to_string(), member.to_string()]).is_some(),
+                "`{namespace}.{member}` is documented but does not dispatch"
+            );
+        }
+    }
+}
+
+/// The Functor Lang-implemented modules are documented from the very source
+/// that is linked into every project, so those cannot drift by construction —
+/// this pins that they are all present.
+#[test]
+fn language_implemented_modules_are_documented() {
+    let documented: Vec<String> = stdlib_documentation_modules()
+        .iter()
+        .map(|module| module.name().to_string())
+        .collect();
+    for module in ["Option", "Result", "Key", "Mouse"] {
+        assert!(
+            documented.contains(&module.to_string()),
+            "`{module}` is missing from stdlib_documentation_modules()"
+        );
+    }
+}

--- a/site/README.md
+++ b/site/README.md
@@ -44,7 +44,9 @@ npm run test:ide-page    # headless e2e — the IDE page (e2e/ide-page.mjs)
   and topic guides. Runnable examples link directly into the sandbox.
 - `docs/index.html` / `src/api-reference-html.mjs` / `src/api-docs.ts` — the API
   reference. `site:build` regenerates gitignored `generated/api-reference.json`
-  from the embedded prelude, then **prerenders** it into the page with
+  from the embedded prelude and language standard library (each module carries
+  its `group`, which the nav and the in-page dividers use), then **prerenders**
+  it into the page with
   `src/api-reference-html.mjs`; `src/api-docs.ts` only adds search/filter on top.
   The page is therefore complete without JavaScript — a plain `curl` (or an LLM
   agent) sees every signature. The build also publishes machine-readable mirrors

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -32,12 +32,13 @@
 
       <main class="docs-main api-main">
         <div class="api-intro">
-          <p class="api-kicker">BUILT-IN PRELUDE · GENERATED SOURCE OF TRUTH</p>
+          <p class="api-kicker">PRELUDE + STANDARD LIBRARY · GENERATED SOURCE OF TRUTH</p>
           <h1>Functor API reference</h1>
           <p>
-            Every engine type and function available to a runner-hosted
-            <code>.fun</code> game. This page is generated from the exact
-            <code>.funi</code> interfaces embedded in native, wasm, and editor tooling.
+            Every type and function a <code>.fun</code> game can call: the engine
+            modules the runner provides, and the standard library that ships with
+            Functor Lang itself. This page is generated from the exact sources
+            embedded in native, wasm, and editor tooling.
           </p>
           <div class="api-meta">
             <span><strong id="api-module-count"><!--api-module-count--></strong> modules</span>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -10,7 +10,7 @@
     <title>functor docs — API reference</title>
     <meta
       name="description"
-      content="The complete Functor engine API reference, generated directly from the prelude embedded in every runtime."
+      content="The complete Functor API reference — the engine prelude and the Functor Lang standard library — generated directly from the sources embedded in every runtime."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/src/api-docs.ts
+++ b/site/src/api-docs.ts
@@ -16,6 +16,9 @@ const filterReference = (): void => {
   const query = search.value.trim().toLowerCase();
   let visibleItems = 0;
   let visibleModules = 0;
+  // Modules still showing per group ("engine" / "stdlib"), so a group's
+  // divider and nav block disappear along with its last module.
+  const perGroup = new Map<string, number>();
 
   for (const section of referenceRoot.querySelectorAll<HTMLElement>(".api-module")) {
     const moduleMatches = query && section.dataset.search!.includes(query);
@@ -33,7 +36,15 @@ const filterReference = (): void => {
     if (moduleItems > 0) {
       visibleModules += 1;
       visibleItems += moduleItems;
+      const group = section.dataset.group ?? "engine";
+      perGroup.set(group, (perGroup.get(group) ?? 0) + 1);
     }
+  }
+
+  for (const element of document.querySelectorAll<HTMLElement>(
+    ".api-group-divider, .api-nav-group"
+  )) {
+    element.hidden = (perGroup.get(element.dataset.group ?? "engine") ?? 0) === 0;
   }
 
   results.textContent = query

--- a/site/src/api-reference-html.mjs
+++ b/site/src/api-reference-html.mjs
@@ -52,7 +52,7 @@ const module_ = (module) => {
   const id = slug(module.name);
   const entries = `${module.items.length} ${module.items.length === 1 ? "entry" : "entries"}`;
   return [
-    `<section class="api-module" id="${escapeAttr(id)}" data-search="${escapeAttr(`${module.name} ${module.docs}`.toLowerCase())}">`,
+    `<section class="api-module" id="${escapeAttr(id)}" data-group="${escapeAttr(module.group ?? "engine")}" data-search="${escapeAttr(`${module.name} ${module.docs}`.toLowerCase())}">`,
     `<h2><span>${escapeText(module.name)}</span><span class="api-module-count">${entries}</span></h2>`,
     prose(module.docs),
     `<div class="api-items">`,
@@ -62,15 +62,68 @@ const module_ = (module) => {
   ].join("\n");
 };
 
+const GROUP_LABELS = { engine: "Engine", stdlib: "Standard library" };
+
+const navLink = (module) =>
+  `<a href="#${escapeAttr(slug(module.name))}" data-module="${escapeAttr(module.name.toLowerCase())}">${escapeText(module.name)}</a>`;
+
+// The nav is grouped so the two halves of the API — what the game runner
+// provides, and what the language itself ships — are visibly distinct. Each
+// group is one element so the search filter can hide a whole empty group.
+const navGroups = (modules) => {
+  const groups = [];
+  for (const module of modules) {
+    const group = module.group ?? "engine";
+    if (groups.at(-1)?.group !== group) groups.push({ group, modules: [] });
+    groups.at(-1).modules.push(module);
+  }
+  return groups
+    .map((entry) =>
+      [
+        `<div class="api-nav-group" data-group="${escapeAttr(entry.group)}">`,
+        `<div class="api-nav-group-label">${escapeText(GROUP_LABELS[entry.group] ?? entry.group)}</div>`,
+        entry.modules.map(navLink).join("\n"),
+        `</div>`,
+      ].join("\n"),
+    )
+    .join("\n");
+};
+
+const GROUP_BLURBS = {
+  engine: "Provided by the game runner — available to a hosted <code>.fun</code> game.",
+  stdlib:
+    "Ships with the language — available in every Functor Lang program, runner or not.",
+};
+
+// A labelled divider announces each group in the scrolling reference. It is
+// presentational (the headings that structure the page are the module ones),
+// and api-docs.ts hides it when the filter empties its group.
+const divider = (group) =>
+  [
+    `<div class="api-group-divider" data-group="${escapeAttr(group)}">`,
+    `<h2>${escapeText(GROUP_LABELS[group] ?? group)}</h2>`,
+    `<p>${GROUP_BLURBS[group] ?? ""}</p>`,
+    `</div>`,
+  ].join("\n");
+
+const sections = (modules) => {
+  const out = [];
+  let group;
+  for (const module of modules) {
+    const moduleGroup = module.group ?? "engine";
+    if (moduleGroup !== group) {
+      group = moduleGroup;
+      out.push(divider(group));
+    }
+    out.push(module_(module));
+  }
+  return out.join("\n");
+};
+
 /** The static markup for the reference page: module nav, sections, and counts. */
 export const renderApiReference = (reference) => ({
-  nav: reference.modules
-    .map(
-      (module) =>
-        `<a href="#${escapeAttr(slug(module.name))}" data-module="${escapeAttr(module.name.toLowerCase())}">${escapeText(module.name)}</a>`,
-    )
-    .join("\n"),
-  sections: reference.modules.map(module_).join("\n"),
+  nav: navGroups(reference.modules),
+  sections: sections(reference.modules),
   moduleCount: reference.modules.length,
   itemCount: reference.modules.reduce((total, module) => total + module.items.length, 0),
 });

--- a/site/styles.css
+++ b/site/styles.css
@@ -1599,7 +1599,21 @@ a:hover {
 .api-nav > div:last-child {
   display: flex;
   flex-direction: column;
+  gap: 16px;
+}
+
+.api-nav-group {
+  display: flex;
+  flex-direction: column;
   gap: 4px;
+}
+
+.api-nav-group-label {
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-size: 0.58rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .api-intro {
@@ -1750,8 +1764,38 @@ a:hover {
 
 .api-module[hidden],
 .api-item[hidden],
+.api-group-divider[hidden],
+.api-nav-group[hidden],
 .api-nav a[hidden] {
   display: none;
+}
+
+/* The reference has two halves — what the runner provides, and what the
+   language ships. This announces the boundary while scrolling; the module
+   headings below it stay the page's real structure. */
+.api-group-divider {
+  margin: 46px 0 26px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.api-group-divider:first-child {
+  margin-top: 0;
+}
+
+.api-group-divider h2 {
+  margin: 0;
+  color: var(--cyan);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.api-group-divider p {
+  max-width: 68ch;
+  margin: 6px 0 0;
+  color: var(--text-dim);
+  font-size: 0.8rem;
 }
 
 .api-module > h2 {
@@ -1889,6 +1933,19 @@ a:hover {
     gap: 8px;
     overflow-x: auto;
     padding-bottom: 6px;
+  }
+
+  /* On narrow screens the nav is one scrolling chip row, so each group
+     inlines its label with its own chips instead of stacking. */
+  .api-nav-group {
+    flex: 0 0 auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .api-nav-group-label {
+    flex: 0 0 auto;
   }
 
   .api-nav a {

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -7,7 +7,7 @@
 //! only in the rendered output, as the [`ApiGroup`] each module carries.
 
 use functor_lang::ast::{ExprKind, Item, TypeName};
-use functor_lang::project::{stdlib_documentation_modules, BundledModule, BundledModuleKind};
+use functor_lang::project::stdlib_documentation_modules;
 use functor_lang::{docs::public_doc_comment_in_source, line_col, parse, parse_interface, Span};
 use serde::Serialize;
 use std::fmt;
@@ -141,21 +141,45 @@ impl ApiReference {
 /// Generate the whole API from the exact sources embedded in every Functor
 /// runtime and editor: the host prelude, then the language standard library.
 pub fn generate() -> Result<ApiReference, GenerateError> {
-    let mut modules = engine_modules()
+    let mut modules = functor_prelude::modules()
         .into_iter()
         .map(|(name, source)| extract_module(name, source, ApiGroup::Engine, Parse::Interface))
         .collect::<Result<Vec<_>, _>>()?;
     for module in stdlib_documentation_modules() {
-        modules.push(extract_bundled(&module, ApiGroup::Stdlib)?);
+        let parse_as = if module.is_interface() {
+            Parse::Interface
+        } else {
+            Parse::Implementation
+        };
+        modules.push(extract_module(
+            module.name().to_string(),
+            module.source().to_string(),
+            ApiGroup::Stdlib,
+            parse_as,
+        )?);
+    }
+    // The two halves share reserved namespaces (`Debug`, `List`, … are
+    // protected in both), and the page keys its anchors, nav links, and search
+    // filter on the module name — so a collision would silently desync the
+    // filter rather than look wrong. Refuse it here instead.
+    for (index, module) in modules.iter().enumerate() {
+        if let Some(earlier) = modules[..index].iter().find(|m| m.name == module.name) {
+            return Err(GenerateError {
+                module: module.name.clone(),
+                extension: "funi",
+                line: 1,
+                col: 1,
+                message: format!(
+                    "`{}` is documented twice (once as {:?}, once as {:?})",
+                    module.name, earlier.group, module.group
+                ),
+            });
+        }
     }
     Ok(ApiReference {
         schema_version: 2,
         modules,
     })
-}
-
-fn engine_modules() -> Vec<(String, String)> {
-    functor_prelude::modules()
 }
 
 /// Generate a reference from `(module name, .funi source)` pairs — the
@@ -171,19 +195,6 @@ pub fn generate_from_modules(
         schema_version: 2,
         modules,
     })
-}
-
-fn extract_bundled(module: &BundledModule, group: ApiGroup) -> Result<ApiModule, GenerateError> {
-    let parse_as = match module.kind() {
-        BundledModuleKind::Interface => Parse::Interface,
-        BundledModuleKind::Implementation => Parse::Implementation,
-    };
-    extract_module(
-        module.name().to_string(),
-        module.source().to_string(),
-        group,
-        parse_as,
-    )
 }
 
 /// Whether a documentation source is a bodyless `.funi` interface or an
@@ -418,7 +429,9 @@ fn module_doc(source: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{generate, generate_from_modules, render_markdown, ApiGroup, ApiItemKind};
+    use super::{
+        generate, generate_from_modules, render_markdown, ApiGroup, ApiItemKind, ApiModule,
+    };
 
     #[test]
     fn extracts_module_and_item_docs_with_exact_declarations() {
@@ -444,9 +457,23 @@ mod tests {
         assert!(markdown.contains("#### `Widget.make`"));
     }
 
+    /// Both halves of the embedded API are complete and fully documented. The
+    /// counts are inventory pins: a module or declaration dropping out of the
+    /// reference has to be a deliberate edit here, not a silent regression.
     #[test]
     fn embedded_api_is_a_complete_documented_surface() {
         let reference = generate().unwrap();
+        let count = |group: ApiGroup| {
+            let modules: Vec<&ApiModule> = reference
+                .modules
+                .iter()
+                .filter(|module| module.group == group)
+                .collect();
+            let items: usize = modules.iter().map(|module| module.items.len()).sum();
+            (modules.len(), items)
+        };
+        assert_eq!(count(ApiGroup::Engine), (27, 272));
+        assert_eq!(count(ApiGroup::Stdlib), (10, 94));
         assert!(reference
             .modules
             .iter()

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -1,8 +1,14 @@
-//! Structured API documentation generated from Functor's embedded `.funi`
-//! prelude.
+//! Structured API documentation generated from the exact Functor Lang sources
+//! embedded in Functor: the host's `.funi` prelude and the language's own
+//! standard library.
+//!
+//! The two are the same extraction — module `//!` prose, then a `///` block
+//! above each type or value — over different sources, and they stay separate
+//! only in the rendered output, as the [`ApiGroup`] each module carries.
 
-use functor_lang::ast::Item;
-use functor_lang::{docs::public_doc_comment_in_source, line_col, parse_interface, Span};
+use functor_lang::ast::{ExprKind, Item, TypeName};
+use functor_lang::project::{stdlib_documentation_modules, BundledModule, BundledModuleKind};
+use functor_lang::{docs::public_doc_comment_in_source, line_col, parse, parse_interface, Span};
 use serde::Serialize;
 use std::fmt;
 use std::io;
@@ -19,8 +25,44 @@ pub struct ApiReference {
 #[derive(Debug, Serialize)]
 pub struct ApiModule {
     pub name: String,
+    pub group: ApiGroup,
     pub docs: Option<String>,
     pub items: Vec<ApiItem>,
+}
+
+/// Which half of the API a module belongs to. Engine modules exist only under
+/// a game runner; standard-library modules ship with the language and are
+/// available everywhere Functor Lang runs, the plain CLI included.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiGroup {
+    Engine,
+    Stdlib,
+}
+
+impl ApiGroup {
+    /// The heading this group renders under.
+    pub fn title(self) -> &'static str {
+        match self {
+            ApiGroup::Engine => "Engine modules",
+            ApiGroup::Stdlib => "Language standard library",
+        }
+    }
+
+    /// One line of orientation, rendered under the group heading.
+    pub fn summary(self) -> &'static str {
+        match self {
+            ApiGroup::Engine => {
+                "Provided by the game runner. These resolve when Functor runs a game — \
+                 natively, on the web, or in a headless test — and not under the plain \
+                 `functor-lang` CLI."
+            }
+            ApiGroup::Stdlib => {
+                "Ships with the language. These are available in every Functor Lang \
+                 program, with or without a game runner."
+            }
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -48,6 +90,9 @@ pub enum OutputFormat {
 #[derive(Debug)]
 pub struct GenerateError {
     module: String,
+    /// The extension the module's source would carry on disk, so the error
+    /// names a plausible file (`Option.fun`, not `Option.funi`).
+    extension: &'static str,
     line: usize,
     col: usize,
     message: String,
@@ -57,8 +102,8 @@ impl fmt::Display for GenerateError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}.funi:{}:{}: {}",
-            self.module, self.line, self.col, self.message
+            "{}.{}:{}:{}: {}",
+            self.module, self.extension, self.line, self.col, self.message
         )
     }
 }
@@ -93,24 +138,60 @@ impl ApiReference {
     }
 }
 
-/// Generate the engine API from the exact prelude sources embedded in every
-/// Functor runtime and editor.
+/// Generate the whole API from the exact sources embedded in every Functor
+/// runtime and editor: the host prelude, then the language standard library.
 pub fn generate() -> Result<ApiReference, GenerateError> {
-    generate_from_modules(functor_prelude::modules())
+    let mut modules = engine_modules()
+        .into_iter()
+        .map(|(name, source)| extract_module(name, source, ApiGroup::Engine, Parse::Interface))
+        .collect::<Result<Vec<_>, _>>()?;
+    for module in stdlib_documentation_modules() {
+        modules.push(extract_bundled(&module, ApiGroup::Stdlib)?);
+    }
+    Ok(ApiReference {
+        schema_version: 2,
+        modules,
+    })
 }
 
-/// Generate a reference from `(module name, .funi source)` pairs.
+fn engine_modules() -> Vec<(String, String)> {
+    functor_prelude::modules()
+}
+
+/// Generate a reference from `(module name, .funi source)` pairs — the
+/// interface-only shape, used by tests.
 pub fn generate_from_modules(
     modules: impl IntoIterator<Item = (String, String)>,
 ) -> Result<ApiReference, GenerateError> {
     let modules = modules
         .into_iter()
-        .map(|(name, source)| extract_module(name, source))
+        .map(|(name, source)| extract_module(name, source, ApiGroup::Engine, Parse::Interface))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(ApiReference {
-        schema_version: 1,
+        schema_version: 2,
         modules,
     })
+}
+
+fn extract_bundled(module: &BundledModule, group: ApiGroup) -> Result<ApiModule, GenerateError> {
+    let parse_as = match module.kind() {
+        BundledModuleKind::Interface => Parse::Interface,
+        BundledModuleKind::Implementation => Parse::Implementation,
+    };
+    extract_module(
+        module.name().to_string(),
+        module.source().to_string(),
+        group,
+        parse_as,
+    )
+}
+
+/// Whether a documentation source is a bodyless `.funi` interface or an
+/// executable `.fun` module whose signatures come from its annotations.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum Parse {
+    Interface,
+    Implementation,
 }
 
 pub fn render(format: OutputFormat) -> Result<String, GenerateError> {
@@ -152,10 +233,20 @@ pub fn render_markdown(reference: &ApiReference) -> String {
     let mut out = String::from(
         "<!-- Generated by `npm run generate:docs`; do not edit by hand. -->\n\n\
          # Functor API reference\n\n\
-         This reference is generated from the `.funi` interface files embedded in Functor.\n",
+         This reference is generated from the Functor Lang sources embedded in Functor: \
+         the host runtime's `.funi` prelude and the language's own standard library.\n",
     );
+    let mut group = None;
     for module in &reference.modules {
-        out.push_str("\n## ");
+        if group != Some(module.group) {
+            group = Some(module.group);
+            out.push_str("\n## ");
+            out.push_str(module.group.title());
+            out.push_str("\n\n");
+            out.push_str(module.group.summary());
+            out.push('\n');
+        }
+        out.push_str("\n### ");
         out.push_str(&module.name);
         out.push('\n');
         if let Some(docs) = &module.docs {
@@ -164,7 +255,7 @@ pub fn render_markdown(reference: &ApiReference) -> String {
             out.push('\n');
         }
         for item in &module.items {
-            out.push_str("\n### `");
+            out.push_str("\n#### `");
             out.push_str(&item.qualified_name);
             out.push_str("`\n\n```functor\n");
             out.push_str(&item.declaration);
@@ -179,30 +270,53 @@ pub fn render_markdown(reference: &ApiReference) -> String {
     out
 }
 
-fn extract_module(name: String, source: String) -> Result<ApiModule, GenerateError> {
-    let program = parse_interface(&source).map_err(|error| {
-        let (line, col) = line_col(&source, error.span.start);
+fn extract_module(
+    name: String,
+    source: String,
+    group: ApiGroup,
+    parse_as: Parse,
+) -> Result<ApiModule, GenerateError> {
+    let error_at = |span: Span, message: String| {
+        let (line, col) = line_col(&source, span.start);
         GenerateError {
             module: name.clone(),
+            extension: match parse_as {
+                Parse::Interface => "funi",
+                Parse::Implementation => "fun",
+            },
             line,
             col,
-            message: error.message,
+            message,
         }
-    })?;
+    };
+    let parsed = match parse_as {
+        Parse::Interface => parse_interface(&source),
+        Parse::Implementation => parse(&source),
+    };
+    let program = parsed.map_err(|error| error_at(error.span, error.message))?;
     let mut items = Vec::new();
     for item in program.items {
-        let (item_name, kind, span) = match item {
-            Item::Type(decl) => (decl.name, ApiItemKind::Type, decl.span),
-            Item::Sig(decl) => (decl.name, ApiItemKind::Value, decl.span),
-            // `.funi` interfaces have neither (both are parse errors there).
+        let (item_name, kind, span, declaration) = match item {
+            Item::Type(decl) => {
+                let declaration = declaration_at(&source, decl.span)
+                    .ok_or_else(|| error_at(decl.span, invalid_span(&decl.name)))?;
+                (decl.name, ApiItemKind::Type, decl.span, declaration)
+            }
+            Item::Sig(decl) => {
+                let declaration = declaration_at(&source, decl.span)
+                    .ok_or_else(|| error_at(decl.span, invalid_span(&decl.name)))?;
+                (decl.name, ApiItemKind::Value, decl.span, declaration)
+            }
+            // An executable module's public surface is its `let`s; the
+            // reference shows the SIGNATURE, not the implementation, so it is
+            // rebuilt from the definition's own annotations.
+            Item::Let(decl) if parse_as == Parse::Implementation => {
+                let declaration =
+                    signature_of(&source, &decl).map_err(|message| error_at(decl.span, message))?;
+                (decl.name, ApiItemKind::Value, decl.span, declaration)
+            }
             Item::Let(_) | Item::Open(_) | Item::Expect(_) | Item::Module(_) => continue,
         };
-        let declaration = declaration_at(&source, span).ok_or_else(|| GenerateError {
-            module: name.clone(),
-            line: 1,
-            col: 1,
-            message: format!("invalid source span for `{item_name}`"),
-        })?;
         items.push(ApiItem {
             qualified_name: format!("{name}.{item_name}"),
             name: item_name,
@@ -213,9 +327,63 @@ fn extract_module(name: String, source: String) -> Result<ApiModule, GenerateErr
     }
     Ok(ApiModule {
         name,
+        group,
         docs: module_doc(&source),
         items,
     })
+}
+
+fn invalid_span(name: &str) -> String {
+    format!("invalid source span for `{name}`")
+}
+
+/// The `let name : Type` line for a definition in an executable module, built
+/// from the annotations the definition itself carries. Each type is quoted
+/// VERBATIM from the source (every `TypeName` knows its own span), so the
+/// published signature cannot disagree with the code it documents.
+///
+/// A public definition therefore has to be fully annotated; an unannotated one
+/// is an error rather than a silently vague entry.
+fn signature_of(source: &str, decl: &functor_lang::ast::LetDecl) -> Result<String, String> {
+    if let Some(ty) = &decl.ty {
+        return Ok(format!("let {} : {}", decl.name, type_text(source, ty)?));
+    }
+    let ExprKind::Lambda { params, ret, .. } = &decl.value.kind else {
+        return Err(format!(
+            "`{}` needs a type annotation to appear in the API reference",
+            decl.name
+        ));
+    };
+    let mut rendered = Vec::with_capacity(params.len());
+    for param in params {
+        let ty = param.ty.as_ref().ok_or_else(|| {
+            format!(
+                "`{}`'s parameter `{}` needs a type annotation to appear in the \
+                 API reference",
+                decl.name, param.name
+            )
+        })?;
+        rendered.push(type_text(source, ty)?);
+    }
+    let ret = ret.as_ref().ok_or_else(|| {
+        format!(
+            "`{}` needs a return type annotation to appear in the API reference",
+            decl.name
+        )
+    })?;
+    Ok(format!(
+        "let {} : ({}) => {}",
+        decl.name,
+        rendered.join(", "),
+        type_text(source, ret)?
+    ))
+}
+
+fn type_text(source: &str, ty: &TypeName) -> Result<String, String> {
+    source
+        .get(ty.span.start..ty.span.end)
+        .map(|text| normalize_newlines(text.trim()))
+        .ok_or_else(|| format!("invalid source span for the type `{}`", ty.name))
 }
 
 fn declaration_at(source: &str, span: Span) -> Option<String> {
@@ -250,7 +418,7 @@ fn module_doc(source: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{generate, generate_from_modules, render_markdown, ApiItemKind};
+    use super::{generate, generate_from_modules, render_markdown, ApiGroup, ApiItemKind};
 
     #[test]
     fn extracts_module_and_item_docs_with_exact_declarations() {
@@ -272,30 +440,88 @@ mod tests {
         assert_eq!(module.items[1].docs.as_deref(), Some("Make one."));
 
         let markdown = render_markdown(&reference);
-        assert!(markdown.contains("## Widget"));
-        assert!(markdown.contains("### `Widget.make`"));
+        assert!(markdown.contains("### Widget"));
+        assert!(markdown.contains("#### `Widget.make`"));
     }
 
     #[test]
-    fn embedded_prelude_is_a_complete_parseable_surface() {
+    fn embedded_api_is_a_complete_documented_surface() {
         let reference = generate().unwrap();
-        assert_eq!(reference.modules.len(), 25);
-        assert_eq!(
-            reference
-                .modules
-                .iter()
-                .flat_map(|module| &module.items)
-                .count(),
-            214
-        );
         assert!(reference
             .modules
             .iter()
-            .any(|module| module.name == "Scene"));
+            .any(|module| module.name == "Scene" && module.group == ApiGroup::Engine));
         assert_eq!(
             reference.undocumented(),
             Vec::<String>::new(),
             "the embedded public API must stay fully documented"
+        );
+    }
+
+    /// Every language-owned module reaches the reference, and the two groups
+    /// stay contiguous so the rendered output has one heading each.
+    #[test]
+    fn the_standard_library_is_documented_beside_the_engine() {
+        let reference = generate().unwrap();
+        let groups: Vec<ApiGroup> = reference
+            .modules
+            .iter()
+            .map(|module| module.group)
+            .collect();
+        let switches = groups.windows(2).filter(|pair| pair[0] != pair[1]).count();
+        assert_eq!(switches, 1, "modules must be grouped, not interleaved");
+
+        let stdlib: Vec<&str> = reference
+            .modules
+            .iter()
+            .filter(|module| module.group == ApiGroup::Stdlib)
+            .map(|module| module.name.as_str())
+            .collect();
+        assert_eq!(
+            stdlib,
+            [
+                "List", "Map", "Text", "Math", "Random", "Debug", "Option", "Result", "Key",
+                "Mouse"
+            ]
+        );
+    }
+
+    /// A `.fun` module's entries are its SIGNATURES, taken from the
+    /// definition's own annotations rather than its body.
+    #[test]
+    fn executable_modules_publish_signatures_not_bodies() {
+        let reference = generate().unwrap();
+        let option = reference
+            .modules
+            .iter()
+            .find(|module| module.name == "Option")
+            .expect("Option is documented");
+        let map = option
+            .items
+            .iter()
+            .find(|item| item.name == "map")
+            .expect("Option.map is documented");
+        assert_eq!(
+            map.declaration,
+            "let map : (('value) => 'mapped, t<'value>) => t<'mapped>"
+        );
+        assert!(matches!(map.kind, ApiItemKind::Value));
+    }
+
+    /// A public definition without annotations cannot be documented honestly,
+    /// so it is a generation error rather than a vague entry.
+    #[test]
+    fn unannotated_definitions_fail_generation() {
+        let error = super::extract_module(
+            "Widget".to_string(),
+            "//! Widgets.\n/// Make one.\nlet make = (size) => size\n".to_string(),
+            ApiGroup::Stdlib,
+            super::Parse::Implementation,
+        )
+        .expect_err("an unannotated parameter cannot be documented");
+        assert!(
+            error.to_string().contains("parameter `size`"),
+            "unexpected error: {error}"
         );
     }
 

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -473,7 +473,7 @@ mod tests {
             (modules.len(), items)
         };
         assert_eq!(count(ApiGroup::Engine), (27, 272));
-        assert_eq!(count(ApiGroup::Stdlib), (10, 94));
+        assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules
             .iter()


### PR DESCRIPTION
The generated API reference covered only the engine `.funi` prelude, so the
Functor Lang **standard library** — `List`, `Map`, `Text`, `Math`, `Random`,
`Debug`, `Option`, `Result`, `Key`, `Mouse` — was hand-documented in the manual
and free to drift from the interpreter. It is now generated from the same
sources everything else runs on, at the same quality bar (generation still fails
on any module, type, or signature without explicit `//!` / `///` prose).

**27 → 37 modules, 272 → 366 declarations.**

## The anti-drift design

Two kinds of standard-library module, handled differently, because they have
different amounts of truth available:

**1. Namespaces the interpreter implements in Rust** (`List`, `Map`, `Text`,
`Math`, `Random`, `Debug`) have no Functor Lang source at all, so they get
`.funi` documentation interfaces in `functor-lang/stdlib/`. Nothing links them —
the builtin registry already resolves and types those calls — and a new drift
test (`functor-lang/tests/stdlib_docs.rs`) pins **every member name and every
signature** to `types::builtin_signature`, the exact table the checker and the
interpreter share:

```
assert_eq!(declared_signatures(&source), expected)   // per builtin namespace
```

A builtin added, removed, or retyped without a documentation update fails
`cargo test -p functor-lang`. Hand-copied signatures with no pin were explicitly
not acceptable, and this is the pin.

`Random`'s file is not documentation-only: it **replaces** the hand-maintained
`RANDOM_MODULE_SRC` string constant the loader injects, so the interface that
types your code and the interface that documents it are now one file. (`Key` and
`Mouse` moved from inline constants to `stdlib/key.fun` / `stdlib/mouse.fun` the
same way — they needed somewhere to put `//!` prose, and hover benefits too.)

**2. Modules written in Functor Lang** (`Option`, `Result`, `Key`, `Mouse`) are
documented from the exact source that runs, so they cannot drift at all. For an
executable module the generator publishes the **signature**, rebuilt from the
definition's own annotations with each type quoted verbatim from its span:

```functor
let map : (('value) => 'mapped, t<'value>) => t<'mapped>
```

An unannotated public definition is a generation error, not a vague entry.

## Grouping

The reference renders as two groups — **Engine modules** (what the runner
provides) and **Language standard library** (what ships with the language) —
with a `group` field per module in the JSON (`schema_version` 1 → 2), a labelled
divider in the page, and a grouped nav. The search filter hides a group's
divider and nav block along with its last matching module.

Prose is written fresh and neutral, and documents the semantics that actually
bite: Euclidean `Math.mod`, half-away-from-zero `Math.round`, the
`Option`-returning partial accessors, thread-last pipe positions, `Map`'s
canonical key order, `List.maximum` still raising on an empty list.

## Screenshots (desktop + mobile, before/after)

The site was built normally (`npm install`, `wasm-pack build
runtime/functor-runtime-web --target=web`, `npm run site:build`) and captured
headlessly at 1440px and 390px; "before" is the same build at the base ref.

|  | before | after |
| --- | --- | --- |
| desktop, top | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/desktop-top-before.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/desktop-top-after.png" width="420"> |
| desktop, the new boundary | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/desktop-stdlib-before.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/desktop-stdlib-after.png" width="420"> |
| mobile, top | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/mobile-top-before.png" width="220"> | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/mobile-top-after.png" width="220"> |
| mobile, the new boundary | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/mobile-stdlib-before.png" width="220"> | <img src="https://gist.githubusercontent.com/tommy-xr/3ec5008e229f509c50fb183c7a92f173/raw/mobile-stdlib-after.png" width="220"> |

## Verification

- `npm run generate:docs` / `npm run check:docs` — pass.
- `cargo test -p functor-lang` (incl. the new drift pin), `-p functor-docgen`,
  `-p functor_runtime_common` — pass.
- `functor docs --format markdown` renders 366 declarations;
  `functor docs --check docs/api-reference.md` agrees with the generated file.
- `npm run check:site` (tsc), `npm run site:build` — pass; the search filter's
  group hiding verified in the built page headlessly.
- `cargo clippy` / `cargo fmt --check` clean on the changed files.
- CI now runs `-p functor-docgen` (it never did), so the generation and
  documentation-completeness assertions actually gate.

## Review dispositions (`/xreview`: Claude subagent + Codex, run in parallel)

No Critical findings from either engine. Everything below is fixed in
`5df6f0f` unless marked otherwise.

| Finding | Engine(s) | Disposition |
| --- | --- | --- |
| Inventory pins removed — only "Scene exists" remained, so a dropped module/declaration could ship silently | both **[AGREED]** | Fixed: engine 27/272 and stdlib 10/94 pinned |
| `functor-docgen`'s tests never ran in CI | Claude | Fixed: added `-p functor-docgen` to `build-native.yml` |
| `Random.range` prose claimed it expects `lo <= hi`; the implementation only checks finiteness | both **[AGREED]** | Fixed: prose now describes the real behavior (reversed bounds interpolate the other way; equal bounds answer that value) |
| Doc-only modules smuggled through `BundledModule` — linking one would shadow the builtin registry | Claude | Fixed: dedicated `DocumentationModule` type that cannot reach a loader |
| Drift pin's `BTreeMap` silently kept the last of a duplicated member | Codex | Fixed: duplicates now panic |
| Qualifier stripping was not identifier-boundary-aware (`NotRandom.t`) | Codex | Fixed: boundary-aware `unqualify` + unit test |
| No guard against two modules sharing a name (anchors/nav/search key on it) | Claude | Fixed: generation error |
| Missing prose edge cases (`List.range`/`grid` limits, `Text.fixed` 0–12 whole decimals, `take`/`drop` fractional truncation, `nth` non-finite index) | Claude | Fixed |
| Tautological assertion in the drift test | Claude | Fixed: removed |
| Docs page meta description still said "engine API reference" | Codex | Fixed |
| The manual still hand-documents the stdlib, so there are now two sources | Claude | **Deferred by design** — a follow-up PR removes `site/manual/index.html`'s stdlib section once this lands; that file is deliberately untouched here |
| `Map`'s signatures display as `('a, 'b)` rather than `(key, value)` | Claude | **Won't fix here** — the display comes from `builtin_signature`'s `Var(0)`/`Var(1)`, which is the pinned truth; renaming would mean either an unpinned override or a language-crate change. The module's `//!` prose names the key/value roles instead. |
| No duplication signals touching the change | dupfinder n/a | — |

## Note for the open PRs

**#596** (`List.maximum` → `Option`) and **#598** (adds `Math.lerp` /
`Math.smoothstep` / `List.minimum`) are unmerged. Each will need a one-entry
edit to `functor-lang/stdlib/list.funi` or `math.funi` when it lands — and the
drift test failing loudly until it does is exactly the mechanism working. The
structure is per-module files, so those edits are additive and rebase-friendly.
Rebased on `80c110d`; `origin/main` has not moved.
