### PR TITLE
test(lsp): update prelude hover assertion to current Scene.cube doc text

### DIFF
--- a/tools/functor-lang-lsp/tests/e2e.rs
+++ b/tools/functor-lang-lsp/tests/e2e.rs
@@ -682,7 +682,7 @@ fn prelude_gives_host_calls_real_types() {
     let response = server.recv();
     assert_eq!(
         response["result"]["contents"]["value"],
-        "```functor\nScene.cube : () => Scene.t\n```\n\nPrimitive geometry.",
+        "```functor\nScene.cube : () => Scene.t\n```\n\nCreate a unit cube centered at the origin.",
         "prelude hover carries the .funi doc block: {response}"
     );
 


### PR DESCRIPTION
The e2e test `prelude_gives_host_calls_real_types` asserts the old `Scene.cube` doc text ("Primitive geometry."), but the `scene.funi` doc was since updated to "Create a unit cube centered at the origin." — so the test fails on main. One-line assertion update; `cargo test -p functor-lang-lsp` now fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)