### PR TITLE
feat(time-travel): backward trail — the recorded past beside the predicted future

### DIFF
--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -371,6 +371,52 @@ them with weights (K=2 at 0.5/0.5 from two branches). Forward-stepping and
 compositing remain independent — the forward-sim (`ghost_frames`) feeds the
 scene-space overlays directly.
 
+### Both directions at once — the backward trail (T6e)
+
+Extrapolation is **bidirectional**. With 🔮 on, the preview shows one
+**symmetric window**: the same number of seconds *behind* the playhead as ahead
+of it. The two halves are not the same kind of thing, and the UI says so:
+
+- **Forward is projection.** The future half is simulated by `ghost_frames`, and
+  it is a guess — right only as far as the replayed inputs and the current code
+  are.
+- **Backward is fact.** The past half is *reconstructed*, never simulated, by
+  `history_frames`: it seeks the recorder's rings, and re-`draw`s each recorded
+  model at its own recorded `tts` with that frame's recorded physics world
+  scoped active. Nothing is re-stepped, so the marks land exactly where the game
+  actually was — the same `DryWorld` discipline forward-ghosting uses for
+  projected worlds, restoring recorded snapshots instead of stepped ones.
+
+**Color carries the direction.** Past marks and strobe copies are **cyan**
+(the scrubber rail's accent), future ones **pink** (the rail's future segment) —
+so the scene and the timeline agree about which way is which. Trail arrowheads
+take the flat side color. Strobe copies are real geometry in the *mover's own*
+material, so the direction tint has to **dominate** — at a light tint, past and
+future copies of one object are indistinguishable and the two directions read as
+a single muddy cloud. The tint keeps only a small fraction of the source color
+(weight 0.8), enough to hint at what the copy is a copy of. Arrowheads on the
+past side point along the *direction of travel* (i.e. toward the playhead), so
+past and future read as one continuous flow through the present rather than two
+trails pointing away from each other.
+
+The backward window **clips, it does not extrapolate**: it stops at the oldest
+recorded frame, and at the striped region an unsafe reload left unavailable. A
+5-second window over 1 second of history simply shows 1 second, with the clipped
+frame count surfaced on the handle exactly as the forward side already does at
+the right edge.
+
+Both scrubbers grow a mirrored endpoint handle, and **either handle sets the one
+shared window** — drag one side and both resize. The seam is unchanged:
+`setPreview({ enabled, seconds, rate, mode })` still takes one `seconds`, now
+read as the per-side window.
+
+**Cost.** The past half is one `draw` per division with no simulation, so it is
+strictly cheaper than the forward half. It shares the forward side's cache, keyed
+on the selected frame, window, rate, program revision, and timeline generation —
+so a paused scrub (the hot case) recomputes only when something actually changes,
+and live play refreshes both directions together on the same ~10 Hz cadence, never
+per frame.
+
 ## Deferred follow-ups: keep and reconstruct the old future
 
 Today's stripe after Resume has a specific meaning: the selected frame became a

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -390,7 +390,17 @@ of it. The two halves are not the same kind of thing, and the UI says so:
 **Color carries the direction.** Past marks and strobe copies are **cyan**
 (the scrubber rail's accent), future ones **pink** (the rail's future segment) —
 so the scene and the timeline agree about which way is which. Trail arrowheads
-take the flat side color. Strobe copies are real geometry in the *mover's own*
+are flat emissive in the exact side color, and they are the *authoritative*
+direction signal.
+
+Strobe copies are only approximately those colors, because a copy keeps its
+source material: on a **textured** mover (notably 2D sprite copies, which fade by
+alpha) the side color lands as a colour *multiply* over the texture rather than a
+replacement, so the hue shifts toward the side instead of becoming it — an orange
+sprite reads olive in the past and red in the future. The two directions stay
+clearly distinguishable, which is the requirement, but don't expect exact cyan and
+pink there, and don't rely on the strobe alone to tell direction apart on a
+textured 2D game — that is what the arrows are for. Strobe copies are real geometry in the *mover's own*
 material, so the direction tint has to **dominate** — at a light tint, past and
 future copies of one object are indistinguishable and the two directions read as
 a single muddy cloud. The tint keeps only a small fraction of the source color
@@ -410,12 +420,22 @@ shared window** — drag one side and both resize. The seam is unchanged:
 `setPreview({ enabled, seconds, rate, mode })` still takes one `seconds`, now
 read as the per-side window.
 
-**Cost.** The past half is one `draw` per division with no simulation, so it is
-strictly cheaper than the forward half. It shares the forward side's cache, keyed
-on the selected frame, window, rate, program revision, and timeline generation —
-so a paused scrub (the hot case) recomputes only when something actually changes,
-and live play refreshes both directions together on the same ~10 Hz cadence, never
-per frame.
+**Cost.** The past half runs one `draw` per division and never advances the
+*model* — but for a physics game it is not free: restoring a recorded world seeks
+the physics `TimelineLog`, which replays from the nearest keyframe, so a pick can
+re-step up to `KEYFRAME_INTERVAL - 1` fixed frames. Per division that is bounded
+and independent of how far back the window reaches, but it means the backward half
+can cost *more* than the forward half on a physics-heavy scene, not less.
+
+The policy that makes this fine is caching, not cheapness. Both directions share
+one cache keyed on the selected frame, window, rate, program revision, and timeline
+generation. **Paused scrubbing — the hot case — recomputes only when one of those
+actually changes**, so holding a paused frame costs nothing. Live play refreshes
+both directions together on the same ~10 Hz cadence, never per frame. If the
+backward half ever shows up in a profile, the fix is to restore once at the oldest
+pick and walk *forward* through the picks (re-stepping only between consecutive
+picks) instead of seeking each independently — deliberately not done here, since it
+trades real complexity for a cost the cache already hides.
 
 ## Deferred follow-ups: keep and reconstruct the old future
 

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -729,6 +729,20 @@ impl GameProducer for FunctorLangEmbeddedGame {
         self.recorder.current_scene_frame_tts()
     }
 
+    /// Backward-trailing (docs/time-travel.md T6e) — delegated to the shared
+    /// producer body (`functor_lang_producer::history_frames`), identical to
+    /// the other producers.
+    fn history_frames(&self, divisions: usize, dt: f32) -> Vec<(Frame, FrameTime)> {
+        crate::functor_lang_producer::history_frames(
+            &self.session,
+            &self.recorder,
+            &self.physics_rt,
+            self.has_physics,
+            divisions,
+            dt,
+        )
+    }
+
     /// Forward-ghosting (docs/time-travel.md T6d) — delegated to the shared
     /// producer body (`functor_lang_producer::ghost_frames`), identical to the
     /// other producers.

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -735,6 +735,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
     fn history_frames(&self, divisions: usize, dt: f32) -> Vec<(Frame, FrameTime)> {
         crate::functor_lang_producer::history_frames(
             &self.session,
+            &self.names,
             &self.recorder,
             &self.physics_rt,
             self.has_physics,

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1918,8 +1918,10 @@ pub fn ghost_frames(
 /// yields 1 second of trail. Frames whose `draw` errors, or that resolve to a
 /// frame already emitted (a window finer than the recording cadence), are
 /// skipped — so the result may be shorter than `divisions`.
+#[allow(clippy::too_many_arguments)]
 pub fn history_frames(
     session: &Session,
+    names: &EntryNames,
     recorder: &SceneRecorder,
     physics: &SteppedPhysics,
     has_physics: bool,
@@ -2008,8 +2010,12 @@ pub fn history_frames(
             _ => None,
         };
         let args = vec![model.clone(), Value::Number(tts)];
-        // A draw error or non-Frame return for a division is skipped, not fatal.
-        if let Ok(value) = session.call("draw", args, &mut FunctorHost) {
+        // Resolve `draw` through the ROLE's entry names, exactly as
+        // `ghost_frames` does. A multi-entry project binds `clientDraw` /
+        // `serverDraw`, so a hardcoded "draw" would fail every call — and
+        // since a failed draw is deliberately skipped rather than fatal, the
+        // backward trail would silently come back EMPTY instead of erroring.
+        if let Ok(value) = session.call(names.draw, args, &mut FunctorHost) {
             if let Some(frame) = frame_value(&value) {
                 frames.push((
                     frame.clone(),

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1972,19 +1972,40 @@ pub fn history_frames(
     // One throwaway world reused across divisions (each restore overwrites
     // it); the `DryWorld` guard removes it on every exit path. Built only when
     // the game has physics AND something is actually restorable.
-    let draw_world = (has_physics && physics.seekable_range().is_some())
-        .then(|| DryWorld(physics::create_world([0.0, -9.81, 0.0])));
+    let physics_range = has_physics.then(|| physics.seekable_range()).flatten();
+    let draw_world =
+        physics_range.map(|_| DryWorld(physics::create_world([0.0, -9.81, 0.0])));
 
     let mut frames = Vec::with_capacity(picks.len());
     for pick in picks {
         let Some((model, tts, world_frame)) = recorder.recorded_frame(pick) else {
             continue;
         };
-        let _world_scope = match &draw_world {
-            Some(dry) => physics
-                .restore_recorded_into(world_frame, dry.0)
-                .then(|| physics::ActiveWorldScope::enter(dry.0)),
-            None => None,
+        let _world_scope = match (&draw_world, physics_range) {
+            (Some(dry), Some((flo, fhi))) => {
+                if world_frame < flo {
+                    // Pruned from the WORLD history even though the model ring
+                    // still has this frame (the two rings count different
+                    // units — rendered vs fixed frames — so they can disagree
+                    // near the floor). Drawing it anyway would resolve
+                    // `Physics.transformed` against the LIVE world and present
+                    // the CURRENT pose as recorded fact. Refuse instead: every
+                    // older pick is pruned too, so the window clips here — the
+                    // same exact-or-refused rule the coupled seek uses.
+                    break;
+                }
+                if world_frame > fhi {
+                    // Nothing stepped after this frame, so its end-of-frame
+                    // world IS the live world — no restore needed (the
+                    // `physics_seek_target` "already the live append" case).
+                    None
+                } else {
+                    physics
+                        .restore_recorded_into(world_frame, dry.0)
+                        .then(|| physics::ActiveWorldScope::enter(dry.0))
+                }
+            }
+            _ => None,
         };
         let args = vec![model.clone(), Value::Number(tts)];
         // A draw error or non-Frame return for a division is skipped, not fatal.

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1896,6 +1896,113 @@ pub fn ghost_frames(
     frames
 }
 
+/// Backward-trailing (docs/time-travel.md T6e): the shared producer body behind
+/// both shells' `GameProducer::history_frames`, and the mirror image of
+/// [`ghost_frames`]. Where the forward side SIMULATES a projection, this side
+/// simulates NOTHING — the past already happened, so it is *reconstructed* from
+/// the recorder's rings: seek back over a window of `divisions` divisions, each
+/// `dt` wide, from the selected frame, and `draw` each recorded model at ITS
+/// recorded `tts` — with that frame's RECORDED physics world restored into a
+/// throwaway world and scoped active for the draw, so `Physics.transformed` /
+/// `Physics.position` in `draw` render the poses the bodies actually had, not
+/// the live ones (the same `DryWorld` discipline `ghost_frames` uses for
+/// projected worlds).
+///
+/// Frames come back NEAREST-PAST-FIRST (`[t-1, t-2, …]`), so index 0 is
+/// adjacent to the anchor — the ordering [`crate::trajectory::frame_preview`]
+/// needs to diff a backward track against the live frame. Each is paired with
+/// the `FrameTime` it was drawn at (`dts = 0`: a still of the past).
+///
+/// The window is CLIPPED, never extrapolated: the walk stops at the ring's
+/// oldest recorded frame (`lo`), so a 5-second window over 1 second of history
+/// yields 1 second of trail. Frames whose `draw` errors, or that resolve to a
+/// frame already emitted (a window finer than the recording cadence), are
+/// skipped — so the result may be shorter than `divisions`.
+pub fn history_frames(
+    session: &Session,
+    recorder: &SceneRecorder,
+    physics: &SteppedPhysics,
+    has_physics: bool,
+    divisions: usize,
+    dt: f32,
+) -> Vec<(Frame, FrameTime)> {
+    let Some(anchor) = recorder.current_scene_frame() else {
+        return Vec::new();
+    };
+    let Some((lo, _hi)) = recorder.scene_frame_range() else {
+        return Vec::new();
+    };
+    let Some((_, anchor_tts, _)) = recorder.recorded_frame(anchor) else {
+        return Vec::new();
+    };
+
+    // Resolve each division boundary to the recorded frame whose `tts` is
+    // closest at or before it, walking back from the anchor. The rings are
+    // per-rendered-frame and `tts` is monotonic within a branch, so one
+    // continuous backward scan visits each frame at most once.
+    let mut picks: Vec<u64> = Vec::with_capacity(divisions);
+    let mut cursor = anchor;
+    for div in 1..=divisions {
+        let target = anchor_tts - (div as f64) * dt as f64;
+        // Walk back while the previous frame is still at or after the target,
+        // so we land on the newest frame whose tts <= target.
+        while cursor > lo {
+            let Some((_, tts, _)) = recorder.recorded_frame(cursor) else {
+                break;
+            };
+            if tts <= target {
+                break;
+            }
+            cursor -= 1;
+        }
+        // A division that resolves to a frame we already emitted (or to the
+        // anchor itself) adds a zero-length track segment; skip it.
+        if cursor == anchor || picks.last() == Some(&cursor) {
+            if cursor == lo {
+                break; // clipped at the ring's floor — nothing older exists
+            }
+            continue;
+        }
+        picks.push(cursor);
+        if cursor == lo {
+            break;
+        }
+    }
+
+    // One throwaway world reused across divisions (each restore overwrites
+    // it); the `DryWorld` guard removes it on every exit path. Built only when
+    // the game has physics AND something is actually restorable.
+    let draw_world = (has_physics && physics.seekable_range().is_some())
+        .then(|| DryWorld(physics::create_world([0.0, -9.81, 0.0])));
+
+    let mut frames = Vec::with_capacity(picks.len());
+    for pick in picks {
+        let Some((model, tts, world_frame)) = recorder.recorded_frame(pick) else {
+            continue;
+        };
+        let _world_scope = match &draw_world {
+            Some(dry) => physics
+                .restore_recorded_into(world_frame, dry.0)
+                .then(|| physics::ActiveWorldScope::enter(dry.0)),
+            None => None,
+        };
+        let args = vec![model.clone(), Value::Number(tts)];
+        // A draw error or non-Frame return for a division is skipped, not fatal.
+        if let Ok(value) = session.call("draw", args, &mut FunctorHost) {
+            if let Some(frame) = frame_value(&value) {
+                frames.push((
+                    frame.clone(),
+                    FrameTime {
+                        dts: 0.0,
+                        tts: tts as f32,
+                    },
+                ));
+            }
+        }
+    }
+    frames
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -106,6 +106,30 @@ impl SteppedPhysics {
         with_world(self.world, |w| w.checkpoint())
     }
 
+    /// Restore recorded fixed `frame` into `dest` — a THROWAWAY world — and
+    /// return its byte-exact checkpoint, without touching the live world, the
+    /// live driver, or the timeline. The backward preview
+    /// (docs/time-travel.md T6e) reconstructs each past rendered frame's world
+    /// this way, so past `draw`s read RECORDED poses instead of the live ones.
+    /// `false` when the frame is outside the seekable range (pruned, or
+    /// nothing stepped yet) or `dest` does not exist — the caller then draws
+    /// without a scoped world rather than against a wrong one.
+    pub fn restore_recorded_into(&self, frame: u64, dest: WorldId) -> bool {
+        let Some((lo, hi)) = self.seekable_range() else {
+            return false;
+        };
+        if frame < lo || frame > hi {
+            return false;
+        }
+        with_world(dest, |w| {
+            self.timeline.restore_into(frame, w);
+            // The replayed steps re-emit events/warnings nobody should re-observe.
+            let _ = w.take_events();
+            let _ = w.take_command_warnings();
+        })
+        .is_some()
+    }
+
     /// One rendered frame's worth of recorded physics: simulate whole fixed
     /// substeps from `real_dt`, recording each through the Timeline. The
     /// declared `scene` reconciles on the frame's first recorded substep —

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -106,15 +106,21 @@ impl SteppedPhysics {
         with_world(self.world, |w| w.checkpoint())
     }
 
-    /// Restore recorded fixed `frame` into `dest` — a THROWAWAY world — and
-    /// return its byte-exact checkpoint, without touching the live world, the
-    /// live driver, or the timeline. The backward preview
+    /// Restore recorded fixed `frame` into `dest` — a THROWAWAY world —
+    /// without touching the live world, the live driver, or the timeline. The backward preview
     /// (docs/time-travel.md T6e) reconstructs each past rendered frame's world
     /// this way, so past `draw`s read RECORDED poses instead of the live ones.
     /// `false` when the frame is outside the seekable range (pruned, or
     /// nothing stepped yet) or `dest` does not exist — the caller then draws
     /// without a scoped world rather than against a wrong one.
     pub fn restore_recorded_into(&self, frame: u64, dest: WorldId) -> bool {
+        // The whole contract is "the live world is untouched", and this takes
+        // `&self` — so a caller passing the live world would silently violate
+        // it through a shared borrow.
+        debug_assert_ne!(
+            dest, self.world,
+            "restore_recorded_into must target a throwaway world, not the live one"
+        );
         let Some((lo, hi)) = self.seekable_range() else {
             return false;
         };

--- a/runtime/functor-runtime-common/src/physics/timeline.rs
+++ b/runtime/functor-runtime-common/src/physics/timeline.rs
@@ -200,6 +200,35 @@ where
     fn next_frame(&self) -> Option<Frame> {
         (!self.commands.is_empty()).then(|| self.base + self.commands.len() as u64)
     }
+
+    /// Restore recorded `frame` into `sim` WITHOUT borrowing the log mutably —
+    /// the read-only seek. `Timeline::seek` is the same operation behind the
+    /// trait's `&mut self`; the backward preview (docs/time-travel.md T6e)
+    /// needs it while only holding a shared borrow of the live driver, so it
+    /// can reconstruct recorded worlds into a throwaway world.
+    ///
+    /// Panics on a frame outside recorded history, exactly like
+    /// [`Timeline::seek`] — callers check [`Self::recorded_range`] first.
+    pub fn restore_into(&self, frame: Frame, sim: &mut S) {
+        let next = self.next_frame().expect("seek on an empty timeline");
+        assert!(
+            frame >= self.base && frame < next,
+            "seek({frame}) outside recorded history [{}, {})",
+            self.base,
+            next
+        );
+        // Restore the nearest keyframe at or before `frame`, then re-step with
+        // the recorded commands. Determinism makes this land bit-exact.
+        let (&kf, snapshot) = self
+            .keyframes
+            .range(..=frame)
+            .next_back()
+            .expect("no keyframe at or below a recorded frame (pruned?)");
+        sim.restore(snapshot);
+        for f in kf..frame {
+            sim.step(&self.commands[(f - self.base) as usize]);
+        }
+    }
 }
 
 impl<S: Simulatable> Timeline<S> for TimelineLog<S>
@@ -221,24 +250,7 @@ where
     }
 
     fn seek(&mut self, frame: Frame, sim: &mut S) {
-        let next = self.next_frame().expect("seek on an empty timeline");
-        assert!(
-            frame >= self.base && frame < next,
-            "seek({frame}) outside recorded history [{}, {})",
-            self.base,
-            next
-        );
-        // Restore the nearest keyframe at or before `frame`, then re-step with
-        // the recorded commands. Determinism makes this land bit-exact.
-        let (&kf, snapshot) = self
-            .keyframes
-            .range(..=frame)
-            .next_back()
-            .expect("no keyframe at or below a recorded frame (pruned?)");
-        sim.restore(snapshot);
-        for f in kf..frame {
-            sim.step(&self.commands[(f - self.base) as usize]);
-        }
+        self.restore_into(frame, sim);
     }
 
     fn commands_since(&self, frame: Frame) -> &[Vec<S::Command>] {

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -252,6 +252,26 @@ pub trait GameProducer {
         Vec::new()
     }
 
+    /// Reconstruct the RECORDED past over a window of `divisions` divisions,
+    /// each `dt` seconds wide, ending at the currently selected frame — the
+    /// backward trail (docs/time-travel.md T6e), and the mirror of
+    /// [`Self::ghost_frames`]. Nothing is simulated: each frame is a recorded
+    /// model redrawn at its recorded `tts` against its recorded physics world,
+    /// so the backward side is fact, not projection.
+    ///
+    /// Frames come back NEAREST-PAST-FIRST (`[t-1, t-2, …]`), each paired with
+    /// the [`crate::FrameTime`] it was drawn at, so a shell can diff them
+    /// against the live frame exactly as it does the forward ghosts. The window
+    /// CLIPS at the oldest recorded frame rather than extrapolating past it.
+    /// The default is empty (no history) for producers without a model history.
+    fn history_frames(
+        &self,
+        _divisions: usize,
+        _dt: f32,
+    ) -> Vec<(crate::Frame, crate::FrameTime)> {
+        Vec::new()
+    }
+
     /// Seek the whole scene to a rendered frame for DISPLAY, WITHOUT branching
     /// (docs/time-travel.md T3, the draggable scrubber): restore model + world
     /// so the user can scrub back and forth freely while paused. The future is

--- a/runtime/functor-runtime-common/src/timetravel.rs
+++ b/runtime/functor-runtime-common/src/timetravel.rs
@@ -754,6 +754,22 @@ impl SceneRecorder {
         self.model_history.recorded_range()
     }
 
+    /// A recorded frame's model, `tts`, and end-of-frame physics fixed frame —
+    /// the three coupled rings, read WITHOUT seeking anything. `None` outside
+    /// the recorded range (the rings clamp on `seek`, which would silently
+    /// hand back the wrong frame). The backward preview
+    /// (docs/time-travel.md T6e) reconstructs past frames from exactly this.
+    pub fn recorded_frame(&self, frame: Frame) -> Option<(&Value, f64, u64)> {
+        let (lo, hi) = self.model_history.recorded_range()?;
+        (frame >= lo && frame <= hi).then(|| {
+            (
+                self.model_history.seek(frame),
+                *self.tts_history.seek(frame),
+                *self.world_frame_history.seek(frame),
+            )
+        })
+    }
+
     /// If play resumes (`dts > 0`) while parked on an earlier frame, branch the
     /// timeline from there BEFORE the frame advances. Call at the top of `tick`.
     /// Returns `true` if a branch was committed, so the producer can drop any

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -543,6 +543,13 @@ fn trail_from_tracks(
             if skip.contains(&i) {
                 continue;
             }
+            // Sample 0 is the ANCHOR, shared by both sides. The future side
+            // owns it; marking it on the past side too would stack two
+            // coplanar emissive marks in different colors on one spot
+            // (z-fighting), which is exactly where the eye is looking.
+            if i == 0 && side == PreviewSide::Past {
+                continue;
+            }
             let p = world_pos(w);
             marks.push(
                 heading_at(&track.worlds, i, radius)
@@ -1167,12 +1174,11 @@ fn side_overlays(
     opts: &PreviewOptions,
     side: PreviewSide,
 ) -> FramePreview {
-    let futures = others;
-    let mut scenes = Vec::with_capacity(futures.len() + 1);
+    let mut scenes = Vec::with_capacity(others.len() + 1);
     scenes.push(&anchor.scene);
-    scenes.extend(futures.iter().map(|frame| &frame.scene));
+    scenes.extend(others.iter().map(|frame| &frame.scene));
 
-    let matching_futures: Vec<_> = futures
+    let matching_futures: Vec<_> = others
         .iter()
         .take_while(|frame| frame.sprite_layers.len() == anchor.sprite_layers.len())
         .copied()
@@ -1182,7 +1188,7 @@ fn side_overlays(
         .iter()
         .enumerate()
         .map(|(index, anchor_layer)| {
-            let mut scenes = Vec::with_capacity(futures.len() + 1);
+            let mut scenes = Vec::with_capacity(others.len() + 1);
             scenes.push(&anchor_layer.scene);
             for future in &matching_futures {
                 scenes.push(&future.sprite_layers[index].scene);

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -31,6 +31,46 @@ use crate::{Camera2D, Frame, MaterialDescription, RecordedInput, Scene3D, SceneO
 const TRAIL_RADIUS_3D: f32 = 0.07;
 const TRAIL_REFERENCE_HEIGHT_2D: f32 = 13.5;
 
+/// The recorded PAST's color — cyan, matching the scrubber rail's accent
+/// (`#41d8e6`). See [`PreviewSide`].
+pub const PAST_COLOR: [f32; 3] = [0.25, 0.85, 1.0];
+
+/// The projected FUTURE's color — pink, matching the scrubber rail's future
+/// segment (`#e858b8`). See [`PreviewSide`].
+pub const FUTURE_COLOR: [f32; 3] = [0.906, 0.345, 0.722];
+
+/// How much of the DIRECTION's color a strobe copy keeps versus the mover's
+/// own (0 = the mover's color untouched, 1 = pure direction color).
+///
+/// Deliberately high. A strobe copy is real geometry in the mover's own
+/// material, so a light tint leaves past and future copies of the same object
+/// nearly identical — the two directions read as one muddy cloud, which is
+/// exactly the failure a UX prototype of this surfaced. At 0.8 the direction
+/// dominates and only a fifth of the source color survives, so a copy still
+/// hints at what it is a copy OF while being unambiguously past or future.
+pub const STROBE_TINT_WEIGHT: f32 = 0.8;
+
+/// Which side of the playhead a preview overlay describes — the recorded past
+/// or the projected future. The two sides render in different colors so a
+/// bidirectional preview reads as two directions rather than one cloud.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PreviewSide {
+    /// Reconstructed from the recorder's rings — fact.
+    Past,
+    /// Forward-simulated — projection.
+    Future,
+}
+
+impl PreviewSide {
+    /// The side's flat mark color, and the color its strobe copies tint toward.
+    pub fn color(self) -> [f32; 3] {
+        match self {
+            PreviewSide::Past => PAST_COLOR,
+            PreviewSide::Future => FUTURE_COLOR,
+        }
+    }
+}
+
 /// The arrowhead outline in its own XY space, pointing along +X: tip, the two
 /// base corners, and a notched tail between them (a kite, wound CCW). Every
 /// mark shares these exact points and carries its placement in the transform,
@@ -354,12 +394,16 @@ enum TrailSpace {
     Sprite2D,
 }
 
-/// The emissive cyan wrapper every trail mark shares. The renderer applies a
+/// The flat emissive wrapper every trail mark shares, in its side's color
+/// ([`PreviewSide::color`]). The renderer applies a
 /// node's `xform` on `Group`/`Geometry` but NOT on `Material`, so placement
 /// goes on the enclosing Group and the mark's own shape on the leaves.
-fn trail_mark(marks: Vec<Scene3D>, place: Matrix4<f32>) -> Scene3D {
+fn trail_mark(marks: Vec<Scene3D>, place: Matrix4<f32>, color: [f32; 3]) -> Scene3D {
     let material = Scene3D {
-        obj: SceneObject::Material(MaterialDescription::emissive(0.25, 0.85, 1.0, 1.0), marks),
+        obj: SceneObject::Material(
+            MaterialDescription::emissive(color[0], color[1], color[2], 1.0),
+            marks,
+        ),
         xform: Matrix4::identity(),
     };
     Scene3D {
@@ -370,9 +414,9 @@ fn trail_mark(marks: Vec<Scene3D>, place: Matrix4<f32>) -> Scene3D {
 
 /// A single dim emissive marker at a world position — the direction-free
 /// fallback for a sample with no meaningful heading.
-fn trail_dot(p: Vector3<f32>, radius: f32) -> Scene3D {
+fn trail_dot(p: Vector3<f32>, radius: f32, color: [f32; 3]) -> Scene3D {
     let sphere = Scene3D::sphere().transform(Matrix4::from_scale(radius));
-    trail_mark(vec![sphere], Matrix4::from_translation(p))
+    trail_mark(vec![sphere], Matrix4::from_translation(p), color)
 }
 
 /// Rotation taking +X onto the unit vector `dir` by the SHORTEST arc. The
@@ -404,6 +448,7 @@ fn trail_arrow(
     dir: Vector3<f32>,
     radius: f32,
     space: TrailSpace,
+    color: [f32; 3],
 ) -> Option<Scene3D> {
     let head = Scene3D {
         obj: SceneObject::Geometry(Shape::ConvexPolygon {
@@ -437,6 +482,7 @@ fn trail_arrow(
     Some(trail_mark(
         heads,
         Matrix4::from_translation(p) * rotation * Matrix4::from_scale(radius * ARROW_SCALE),
+        color,
     ))
 }
 
@@ -473,7 +519,9 @@ fn trail_from_tracks(
     strobe: Option<&StrobeOptions>,
     radius: f32,
     space: TrailSpace,
+    side: PreviewSide,
 ) -> Option<Scene3D> {
+    let color = side.color();
     let mut marks = Vec::new();
     for track in tracks {
         // A pure in-place spinner has a track (for the strobe) but no path to
@@ -498,8 +546,18 @@ fn trail_from_tracks(
             let p = world_pos(w);
             marks.push(
                 heading_at(&track.worlds, i, radius)
-                    .and_then(|dir| trail_arrow(p, dir, radius, space))
-                    .unwrap_or_else(|| trail_dot(p, radius)),
+                    // Sample order runs AWAY from the anchor on both sides, so
+                    // a past track's samples are ordered backwards in time.
+                    // Negating there keeps every arrow pointing along the
+                    // actual direction of travel, so past and future read as
+                    // one continuous flow THROUGH the playhead instead of two
+                    // trails pointing away from each other.
+                    .map(|dir| match side {
+                        PreviewSide::Past => -dir,
+                        PreviewSide::Future => dir,
+                    })
+                    .and_then(|dir| trail_arrow(p, dir, radius, space, color))
+                    .unwrap_or_else(|| trail_dot(p, radius, color)),
             );
         }
     }
@@ -522,10 +580,12 @@ pub fn trajectory_trail(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Option<
         None,
         TRAIL_RADIUS_3D,
         TrailSpace::Scene3D,
+        PreviewSide::Future,
     )
 }
 
 /// Scene-space strobe options.
+#[derive(Clone)]
 pub struct StrobeOptions {
     /// Strobe copies per mover across the window (evenly sampled from its track).
     pub copies: usize,
@@ -536,6 +596,22 @@ pub struct StrobeOptions {
     /// the next moment at 80% of the mover's own color and the window's end at
     /// 20%.
     pub fade: (f32, f32),
+    /// The DIRECTION tint: which side of the playhead these copies belong to,
+    /// and how strongly its color overrides the mover's own
+    /// ([`STROBE_TINT_WEIGHT`]). `None` leaves copies in the mover's own color
+    /// — the single-direction behavior.
+    pub tint: Option<([f32; 3], f32)>,
+}
+
+impl StrobeOptions {
+    /// This side's copies: same cadence and age-fade, tinted toward the side's
+    /// color so past and future copies of the SAME mover stay distinguishable.
+    fn for_side(&self, side: PreviewSide) -> StrobeOptions {
+        StrobeOptions {
+            tint: Some((side.color(), STROBE_TINT_WEIGHT)),
+            ..self.clone()
+        }
+    }
 }
 
 impl Default for StrobeOptions {
@@ -546,6 +622,7 @@ impl Default for StrobeOptions {
             // hosts whose scene has its own backdrop.
             fade_to: [0.1, 0.2, 0.3],
             fade: (0.8, 0.2),
+            tint: None,
         }
     }
 }
@@ -561,8 +638,21 @@ fn faded_material(
     material: Option<&MaterialDescription>,
     to: [f32; 3],
     k: f32,
+    tint: Option<([f32; 3], f32)>,
 ) -> Option<MaterialDescription> {
     let lerp = |c: Vector4<f32>| {
+        // The DIRECTION tint lands FIRST, so age-fading still runs from the
+        // copy's actual painted color toward the background. See
+        // [`STROBE_TINT_WEIGHT`] for why the tint has to dominate.
+        let c = match tint {
+            Some((t, w)) => vec4(
+                c.x + (t[0] - c.x) * w,
+                c.y + (t[1] - c.y) * w,
+                c.z + (t[2] - c.z) * w,
+                c.w,
+            ),
+            None => c,
+        };
         vec4(
             to[0] + (c.x - to[0]) * k,
             to[1] + (c.y - to[1]) * k,
@@ -611,8 +701,16 @@ fn faded_material(
 fn alpha_faded_material(
     material: Option<&MaterialDescription>,
     k: f32,
+    tint: Option<([f32; 3], f32)>,
 ) -> Option<MaterialDescription> {
     let fade = |mut color: Vector4<f32>| {
+        // Sprite copies fade by OPACITY, but they still have to say which
+        // direction they belong to — so the direction tint applies here too.
+        if let Some((t, w)) = tint {
+            color.x += (t[0] - color.x) * w;
+            color.y += (t[1] - color.y) * w;
+            color.z += (t[2] - color.z) * w;
+        }
         color.w *= k;
         color
     };
@@ -661,6 +759,7 @@ enum StrobeFade {
 /// One strobe copy: the mover's leaf at a future world pose, shaded by its
 /// (age-faded) material. Transforms go on a Group / the leaf itself — never on
 /// a Material node, which the renderer ignores (see [`trail_mark`]).
+#[allow(clippy::too_many_arguments)]
 fn strobe_copy(
     leaf: &SceneObject,
     material: Option<&MaterialDescription>,
@@ -668,14 +767,15 @@ fn strobe_copy(
     fade_to: [f32; 3],
     k: f32,
     fade: StrobeFade,
+    tint: Option<([f32; 3], f32)>,
 ) -> Scene3D {
     let leaf = Scene3D {
         obj: leaf.clone(),
         xform: Matrix4::identity(),
     };
     let material = match fade {
-        StrobeFade::Color => faded_material(material, fade_to, k),
-        StrobeFade::Alpha => alpha_faded_material(material, k),
+        StrobeFade::Color => faded_material(material, fade_to, k, tint),
+        StrobeFade::Alpha => alpha_faded_material(material, k, tint),
     };
     match material {
         Some(mat) => Scene3D {
@@ -728,6 +828,7 @@ pub fn strobe_overlay(tracks: &[MoverTrack], opts: &StrobeOptions) -> Option<Sce
                 opts.fade_to,
                 k,
                 StrobeFade::Color,
+                opts.tint,
             ));
         }
     }
@@ -763,6 +864,7 @@ fn sampled_strobe_overlay(
                 opts.fade_to,
                 strobe_age(idx, n_future, opts.fade),
                 fade,
+                opts.tint,
             ));
         }
     }
@@ -878,6 +980,10 @@ pub struct PreviewOptions {
     pub trail: bool,
     /// Emit the scene-space strobe?
     pub strobe: Option<StrobeOptions>,
+    /// Also emit the BACKWARD overlays — the recorded past, reconstructed from
+    /// the producer's history rings (docs/time-travel.md T6e). `window` is
+    /// SYMMETRIC: the same number of seconds back as forward.
+    pub backward: bool,
 }
 
 /// The overlays derived for one scene tree: either the frame's 3D scene or one
@@ -895,6 +1001,26 @@ pub type ScenePreview = SceneOverlays;
 impl SceneOverlays {
     fn is_empty(&self) -> bool {
         self.trail.is_none() && self.strobe.is_none()
+    }
+
+    /// Fold another side's overlays in, so one [`FramePreview`] carries both
+    /// directions. Same-kind overlays group together — each side already
+    /// carries its own color, so the merged tree needs no further distinction.
+    fn merge(&mut self, other: SceneOverlays) {
+        fn join(into: &mut Option<Scene3D>, add: Option<Scene3D>) {
+            let Some(add) = add else { return };
+            match into.take() {
+                Some(existing) => {
+                    *into = Some(Scene3D {
+                        obj: SceneObject::Group(vec![existing, add]),
+                        xform: Matrix4::identity(),
+                    })
+                }
+                None => *into = Some(add),
+            }
+        }
+        join(&mut self.trail, other.trail);
+        join(&mut self.strobe, other.strobe);
     }
 
     fn apply(&self, scene: &mut Scene3D) {
@@ -918,6 +1044,20 @@ pub struct FramePreview {
 }
 
 impl FramePreview {
+    /// Fold another side's preview in. Sprite layers merge positionally; a
+    /// side that derived a different layer count (a structural change inside
+    /// its window) contributes only its 3D overlays, matching how
+    /// [`Self::apply_all`] already refuses a mismatched layer list.
+    fn merge(&mut self, other: FramePreview) {
+        self.scene.merge(other.scene);
+        if self.sprite_layers.len() != other.sprite_layers.len() {
+            return;
+        }
+        for (layer, add) in self.sprite_layers.iter_mut().zip(other.sprite_layers) {
+            layer.merge(add);
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.scene.is_empty() && self.sprite_layers.iter().all(SceneOverlays::is_empty)
     }
@@ -938,6 +1078,7 @@ fn scene_overlays(
     scenes: &[&Scene3D],
     opts: &PreviewOptions,
     trail_radius: f32,
+    side: PreviewSide,
 ) -> SceneOverlays {
     let tracks = mover_tracks(scenes, opts.eps, opts.max_step);
     SceneOverlays {
@@ -948,6 +1089,7 @@ fn scene_overlays(
                 opts.strobe.as_ref(),
                 trail_radius,
                 TrailSpace::Scene3D,
+                side,
             )
         } else {
             None
@@ -955,7 +1097,7 @@ fn scene_overlays(
         strobe: opts
             .strobe
             .as_ref()
-            .and_then(|strobe| strobe_overlay(&tracks, strobe)),
+            .and_then(|strobe| strobe_overlay(&tracks, &strobe.for_side(side))),
     }
 }
 
@@ -963,6 +1105,7 @@ fn sprite_scene_overlays(
     scenes: &[&Scene3D],
     opts: &PreviewOptions,
     trail_radius: f32,
+    side: PreviewSide,
 ) -> SceneOverlays {
     let trail = if opts.trail {
         let tracks = mover_tracks(scenes, opts.eps, opts.max_step);
@@ -971,13 +1114,14 @@ fn sprite_scene_overlays(
             opts.strobe.as_ref(),
             trail_radius,
             TrailSpace::Sprite2D,
+            side,
         )
     } else {
         None
     };
     let strobe = opts.strobe.as_ref().and_then(|strobe| {
         let sampled = sampled_mover_tracks(scenes, opts.eps, opts.max_step);
-        sampled_strobe_overlay(&sampled, strobe, StrobeFade::Alpha)
+        sampled_strobe_overlay(&sampled, &strobe.for_side(side), StrobeFade::Alpha)
     });
     SceneOverlays {
         trail,
@@ -1010,10 +1154,20 @@ pub fn scene_preview(
     let futures = game.ghost_frames(divisions, dt, start_tts, script_inputs);
     let mut scenes: Vec<&Scene3D> = vec![anchor_scene];
     scenes.extend(futures.iter().map(|(frame, _)| &frame.scene));
-    scene_overlays(&scenes, opts, TRAIL_RADIUS_3D)
+    scene_overlays(&scenes, opts, TRAIL_RADIUS_3D, PreviewSide::Future)
 }
 
-fn preview_from_frames(anchor: &Frame, futures: &[&Frame], opts: &PreviewOptions) -> FramePreview {
+/// One side's overlays: diff the anchor against `others` — the frames walking
+/// AWAY from the playhead on that side (future ghosts, or past reconstructions
+/// nearest-first) — and build whichever overlays `opts` asks for, in the
+/// side's color.
+fn side_overlays(
+    anchor: &Frame,
+    others: &[&Frame],
+    opts: &PreviewOptions,
+    side: PreviewSide,
+) -> FramePreview {
+    let futures = others;
     let mut scenes = Vec::with_capacity(futures.len() + 1);
     scenes.push(&anchor.scene);
     scenes.extend(futures.iter().map(|frame| &frame.scene));
@@ -1037,12 +1191,13 @@ fn preview_from_frames(anchor: &Frame, futures: &[&Frame], opts: &PreviewOptions
                 &scenes,
                 opts,
                 sprite_trail_radius(&anchor_layer.camera),
+                side,
             )
         })
         .collect();
 
     FramePreview {
-        scene: scene_overlays(&scenes, opts, TRAIL_RADIUS_3D),
+        scene: scene_overlays(&scenes, opts, TRAIL_RADIUS_3D, side),
         sprite_layers,
     }
 }
@@ -1065,7 +1220,17 @@ pub fn frame_preview(
     let dt = opts.window / divisions as f32;
     let futures = game.ghost_frames(divisions, dt, start_tts, script_inputs);
     let future_frames: Vec<&Frame> = futures.iter().map(|(frame, _)| frame).collect();
-    preview_from_frames(anchor, &future_frames, opts)
+    let mut preview = side_overlays(anchor, &future_frames, opts, PreviewSide::Future);
+    if opts.backward {
+        // The same window, mirrored: `history_frames` reconstructs rather than
+        // simulates, and returns nearest-past-first — the same
+        // walking-away-from-the-anchor order the ghosts use, so the identical
+        // diff produces the backward tracks.
+        let past = game.history_frames(divisions, dt);
+        let past_frames: Vec<&Frame> = past.iter().map(|(frame, _)| frame).collect();
+        preview.merge(side_overlays(anchor, &past_frames, opts, PreviewSide::Past));
+    }
+    preview
 }
 
 #[cfg(test)]
@@ -1073,6 +1238,13 @@ mod tests {
     use super::*;
     use crate::{Camera, Camera2D, SpriteLayer, SpriteSampling, TextureDescription};
     use cgmath::vec3;
+
+    /// The FUTURE side's overlays for an explicit frame sequence — the shape
+    /// these tests were written against, before the preview grew a second
+    /// direction.
+    fn preview_from_frames(anchor: &Frame, futures: &[&Frame], opts: &PreviewOptions) -> FramePreview {
+        side_overlays(anchor, futures, opts, PreviewSide::Future)
+    }
 
     fn ball_at(x: f32, y: f32) -> Scene3D {
         Scene3D::sphere().transform(Matrix4::from_translation(vec3(x, y, 0.0)))
@@ -1148,6 +1320,7 @@ mod tests {
                 copies: 2,
                 ..Default::default()
             }),
+            backward: false,
         }
     }
 
@@ -1271,8 +1444,23 @@ mod tests {
             })
             .collect();
         assert_eq!(colors.len(), 2);
-        assert_eq!(colors[0].truncate(), vec3(0.0, 1.0, 0.0));
-        assert_eq!(colors[1].truncate(), vec3(0.0, 0.0, 1.0));
+        // Each copy still carries ITS OWN future frame's material — but tinted
+        // toward the side color, which dominates (`STROBE_TINT_WEIGHT`), so the
+        // direction is legible before the object is. The residual fraction of
+        // the source color is what keeps the green and blue copies distinct.
+        let tinted = |c: [f32; 3]| {
+            let w = STROBE_TINT_WEIGHT;
+            let f = FUTURE_COLOR;
+            vec3(
+                c[0] + (f[0] - c[0]) * w,
+                c[1] + (f[1] - c[1]) * w,
+                c[2] + (f[2] - c[2]) * w,
+            )
+        };
+        assert_eq!(colors[0].truncate(), tinted([0.0, 1.0, 0.0]));
+        assert_eq!(colors[1].truncate(), tinted([0.0, 0.0, 1.0]));
+        assert_ne!(colors[0].truncate(), colors[1].truncate());
+        // Alpha still carries the age fade, untouched by the tint.
         assert!((colors[0].w - 0.8).abs() < 1e-4);
         assert!((colors[1].w - 0.2).abs() < 1e-4);
     }
@@ -1286,7 +1474,7 @@ mod tests {
             sampling: SpriteSampling::Nearest,
         };
 
-        match alpha_faded_material(Some(&material), 0.25) {
+        match alpha_faded_material(Some(&material), 0.25, None) {
             Some(MaterialDescription::SpriteTexture {
                 color,
                 texture,
@@ -1651,6 +1839,7 @@ mod tests {
                 copies: 2,
                 fade_to: [0.0, 0.0, 0.0],
                 fade: (0.8, 0.2),
+                tint: None,
             },
         )
         .expect("a strobe");
@@ -1691,7 +1880,7 @@ mod tests {
             copies: 2,
             ..Default::default()
         };
-        let trail = trail_from_tracks(&tracks, Some(&opts), TRAIL_RADIUS_3D, TrailSpace::Scene3D).expect("a trail");
+        let trail = trail_from_tracks(&tracks, Some(&opts), TRAIL_RADIUS_3D, TrailSpace::Scene3D, PreviewSide::Future).expect("a trail");
         match trail.obj {
             SceneObject::Group(dots) => {
                 assert_eq!(dots.len(), 3, "anchor + the two non-copy samples")
@@ -1718,7 +1907,7 @@ mod tests {
         assert!(!tracks[0].translated);
         assert!(strobe_overlay(&tracks, &StrobeOptions::default()).is_some());
         assert!(
-            trail_from_tracks(&tracks, None, TRAIL_RADIUS_3D, TrailSpace::Scene3D).is_none(),
+            trail_from_tracks(&tracks, None, TRAIL_RADIUS_3D, TrailSpace::Scene3D, PreviewSide::Future).is_none(),
             "no dots for pure rotation"
         );
     }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -922,7 +922,7 @@ impl Scrubber {
                                             // resize together. `sign` is -1 on
                                             // the backward cap: dragging LEFT
                                             // grows the window there.
-                                            let mut cap = |ui: &mut egui::Ui,
+                                            let cap = |ui: &mut egui::Ui,
                                                            x: f32,
                                                            id: &'static str,
                                                            sign: f32,

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -1055,14 +1055,29 @@ impl Scrubber {
                                 .unwrap_or_else(|| strip.center().x);
                             let font = egui::FontId::monospace(UI_FONT_SIZE - 6.0);
                             let weak = ui.visuals().weak_text_color();
+                            // Same two colors as the rail's bands: cyan for
+                            // the recorded past, pink for the projected
+                            // future.
                             let cyan =
                                 egui::Color32::from_rgba_unmultiplied(64, 217, 255, 190);
+                            let pink =
+                                egui::Color32::from_rgba_unmultiplied(232, 88, 184, 190);
                             let mut segments: Vec<(String, egui::Color32)> = Vec::new();
                             match state.range {
-                                Some((_, hi)) => {
+                                Some((lo, hi)) => {
+                                    if future_frames > 0 {
+                                        // The window is symmetric, but the PAST
+                                        // half clips at the oldest recorded
+                                        // frame — report what actually exists,
+                                        // matching where the rail's cyan band
+                                        // stops.
+                                        let past_frames = future_frames
+                                            .min(state.frame.saturating_sub(lo));
+                                        segments.push((format!("-{past_frames} "), cyan));
+                                    }
                                     segments.push((format!("{}", state.frame), weak));
                                     if future_frames > 0 {
-                                        segments.push((format!(" +{future_frames}"), cyan));
+                                        segments.push((format!(" +{future_frames}"), pink));
                                     }
                                     segments.push((format!(" / {hi}"), weak));
                                 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -879,14 +879,21 @@ impl Scrubber {
                                         }
                                         rail = Some((slider.rect.left(), slider.rect.right()));
                                         if future_frames > 0 {
-                                            // The cyan future segment, painted
-                                            // ON the rail at track height
-                                            // (trail-cyan: it IS the preview's
-                                            // future). The handle's center
-                                            // travels an INSET range (≈ its
-                                            // half-size) inside the slider
-                                            // rect — map through that so the
-                                            // segment meets the handle.
+                                            // The preview's TWO segments,
+                                            // painted ON the rail at track
+                                            // height around the handle: pink
+                                            // ahead (the projected future),
+                                            // cyan behind (the recorded past) —
+                                            // the same two colors the trail
+                                            // marks use, so the rail and the
+                                            // scene agree on which direction is
+                                            // which. ONE symmetric window sizes
+                                            // both, and either end cap drags
+                                            // it. The handle's center travels
+                                            // an INSET range (≈ its half-size)
+                                            // inside the slider rect — map
+                                            // through that so the segments meet
+                                            // the handle.
                                             let y = slider.rect.center().y;
                                             let inset = slider.rect.height() * 0.5;
                                             let travel =
@@ -897,58 +904,124 @@ impl Scrubber {
                                                     + inset
                                                     + (frame - lo) as f32 / domain * travel
                                             };
-                                            // Start at the handle's RIGHT edge
-                                            // so the cyan never paints over the
-                                            // handle or the traversed track.
-                                            let x0 = x_of(f) + 5.0;
-                                            let x1 = x_of((f + future_frames).min(max)).max(x0);
-                                            ui.painter().rect_filled(
-                                                egui::Rect::from_min_max(
-                                                    egui::pos2(x0, y - 2.5),
-                                                    egui::pos2(x1, y + 2.5),
-                                                ),
-                                                2.0,
+                                            let band = |ui: &mut egui::Ui,
+                                                        x0: f32,
+                                                        x1: f32,
+                                                        color: egui::Color32| {
+                                                ui.painter().rect_filled(
+                                                    egui::Rect::from_min_max(
+                                                        egui::pos2(x0, y - 2.5),
+                                                        egui::pos2(x1, y + 2.5),
+                                                    ),
+                                                    2.0,
+                                                    color,
+                                                );
+                                            };
+                                            // A drag on either cap sets the ONE
+                                            // shared window, so both sides
+                                            // resize together. `sign` is -1 on
+                                            // the backward cap: dragging LEFT
+                                            // grows the window there.
+                                            let mut cap = |ui: &mut egui::Ui,
+                                                           x: f32,
+                                                           id: &'static str,
+                                                           sign: f32,
+                                                           color: egui::Color32,
+                                                           hot: egui::Color32| {
+                                                // Offset BELOW the track so it
+                                                // never fights the seek handle.
+                                                let rect = egui::Rect::from_min_max(
+                                                    egui::pos2(x - 4.0, y + 3.0),
+                                                    egui::pos2(x + 4.0, y + 11.0),
+                                                );
+                                                let resp = ui.interact(
+                                                    rect,
+                                                    ui.id().with(id),
+                                                    egui::Sense::drag(),
+                                                );
+                                                ui.painter().rect_filled(
+                                                    rect,
+                                                    1.5,
+                                                    if resp.hovered() || resp.dragged() {
+                                                        hot
+                                                    } else {
+                                                        color
+                                                    },
+                                                );
+                                                if resp.dragged() {
+                                                    let frames_per_px = domain / travel;
+                                                    let dw = sign
+                                                        * resp.drag_delta().x
+                                                        * frames_per_px
+                                                        / 60.0;
+                                                    let w = (state.preview_window + dw)
+                                                        .clamp(0.5, 5.0);
+                                                    if (w - state.preview_window).abs() > 1e-4 {
+                                                        return Some(
+                                                            ScrubberAction::SetPreviewWindow(w),
+                                                        );
+                                                    }
+                                                }
+                                                None
+                                            };
+                                            // Pink = future, cyan = past —
+                                            // the trail's own two colors.
+                                            let future_band =
+                                                egui::Color32::from_rgba_unmultiplied(
+                                                    232, 88, 184, 200,
+                                                );
+                                            let future_cap =
+                                                egui::Color32::from_rgba_unmultiplied(
+                                                    232, 88, 184, 230,
+                                                );
+                                            let future_hot =
+                                                egui::Color32::from_rgb(255, 208, 238);
+                                            let past_band =
                                                 egui::Color32::from_rgba_unmultiplied(
                                                     64, 217, 255, 200,
-                                                ),
-                                            );
-                                            // The segment's END CAP: a small
-                                            // grabber hanging under the window
-                                            // end — drag to resize the forward
-                                            // window in place (the only way to
-                                            // set it from the UI).
-                                            // Offset BELOW the track so it
-                                            // never fights the seek handle.
-                                            let cap = egui::Rect::from_min_max(
-                                                egui::pos2(x1 - 4.0, y + 3.0),
-                                                egui::pos2(x1 + 4.0, y + 11.0),
-                                            );
-                                            let cap_resp = ui.interact(
-                                                cap,
-                                                ui.id().with("preview_window_cap"),
-                                                egui::Sense::drag(),
-                                            );
-                                            let cap_color =
-                                                if cap_resp.hovered() || cap_resp.dragged() {
-                                                    egui::Color32::from_rgb(150, 236, 255)
-                                                } else {
-                                                    egui::Color32::from_rgba_unmultiplied(
-                                                        64, 217, 255, 230,
-                                                    )
-                                                };
-                                            ui.painter().rect_filled(cap, 1.5, cap_color);
-                                            if cap_resp.dragged() {
-                                                let frames_per_px = domain / travel;
-                                                let dw = cap_resp.drag_delta().x
-                                                    * frames_per_px
-                                                    / 60.0;
-                                                let w = (state.preview_window + dw)
-                                                    .clamp(0.5, 5.0);
-                                                if (w - state.preview_window).abs() > 1e-4 {
-                                                    action = Some(
-                                                        ScrubberAction::SetPreviewWindow(w),
-                                                    );
-                                                }
+                                                );
+                                            let past_cap =
+                                                egui::Color32::from_rgba_unmultiplied(
+                                                    64, 217, 255, 230,
+                                                );
+                                            let past_hot =
+                                                egui::Color32::from_rgb(150, 236, 255);
+                                            // Start at the handle's edges so
+                                            // neither band paints over the
+                                            // handle itself.
+                                            let x0 = x_of(f) + 5.0;
+                                            let x1 = x_of((f + future_frames).min(max)).max(x0);
+                                            band(ui, x0, x1, future_band);
+                                            // The backward band CLIPS at `lo`:
+                                            // there is no recorded history
+                                            // before the ring's floor, so the
+                                            // band is simply shorter there
+                                            // (the trail clips the same way).
+                                            let back_x1 = x_of(f) - 5.0;
+                                            let back_x0 = x_of(
+                                                f.saturating_sub(future_frames).max(lo),
+                                            )
+                                            .min(back_x1);
+                                            band(ui, back_x0, back_x1, past_band);
+                                            if let Some(a) = cap(
+                                                ui,
+                                                x1,
+                                                "preview_window_cap",
+                                                1.0,
+                                                future_cap,
+                                                future_hot,
+                                            ) {
+                                                action = Some(a);
+                                            }
+                                            if let Some(a) = cap(
+                                                ui,
+                                                back_x0,
+                                                "preview_window_cap_back",
+                                                -1.0,
+                                                past_cap,
+                                                past_hot,
+                                            ) {
+                                                action = Some(a);
                                             }
                                         }
                                     }

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -994,6 +994,20 @@ impl Game for FunctorLangGame {
         )
     }
 
+    /// Backward-trailing (docs/time-travel.md T6e) — the recorded mirror of
+    /// `ghost_frames`, delegated to the same shared producer body so both
+    /// shells reconstruct the past through one impl.
+    fn history_frames(&self, divisions: usize, dt: f32) -> Vec<(Frame, FrameTime)> {
+        functor_runtime_common::functor_lang_producer::history_frames(
+            &self.session,
+            &self.recorder,
+            &self.physics_rt,
+            self.has_physics,
+            divisions,
+            dt,
+        )
+    }
+
     /// Non-destructive scrub — delegated to the shared [`SceneRecorder`]
     /// (docs/time-travel.md T3): restore model + world for display without
     /// truncating, so the draggable bar can seek back and forth.
@@ -3116,6 +3130,116 @@ mod tests {
         assert!(
             (game.last_frame.scene.xform.w.y - paused_y).abs() < 1e-6,
             "live frame untouched by ghosting"
+        );
+
+        physics::remove_world(physics::DEFAULT_WORLD);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The BACKWARD trail on a PHYSICS game (docs/time-travel.md T6e), the
+    /// mirror of the ghost test above. Nothing is simulated: every returned
+    /// frame must reproduce a RECORDED frame byte-for-byte — the recorded
+    /// model, drawn at that frame's recorded `tts`, against that frame's
+    /// recorded physics world. So the ball's `Physics.transformed` y in each
+    /// past frame must equal EXACTLY the y that frame rendered when it was
+    /// live, and the window must clip at the ring's floor instead of inventing
+    /// history. The live world and model stay untouched.
+    #[test]
+    fn history_frames_replay_recorded_models_and_physics_poses() {
+        physics::remove_world(physics::DEFAULT_WORLD);
+
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-hist-phys-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        std::fs::write(
+            dir.join("game.fun"),
+            "let init = { n: 0.0 }\n\
+             let tick = (m, dt, tts) => m\n\
+             let physics = (m) => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
+             \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(Vec3.make(0.0, -0.2, 0.0)),\n\
+             \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 4.0, 0.0))])\n\
+             let draw = (m, tts) => Frame.create(\n\
+               Camera.lookAt(Vec3.make(tts, 2.0, -6.0), Vec3.make(tts, 0.0, 0.0)),\n\
+               Scene.sphere() |> Physics.transformed(\"ball\"))\n",
+        )
+        .expect("write game");
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
+
+        // Drive the fall, keeping the y each frame ACTUALLY rendered — the
+        // oracle the reconstruction has to match bit-for-bit.
+        const SUB_DT: f32 = 1.0 / 60.0;
+        const K: usize = 20;
+        let mut tts = 0.0f32;
+        let mut live_ys: Vec<(f32, f32)> = Vec::new();
+        for _ in 0..K {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+            game.render(FrameTime { tts, dts: SUB_DT });
+            live_ys.push((tts, game.last_frame.scene.xform.w.y));
+        }
+        let paused_y = game.last_frame.scene.xform.w.y;
+        let live_world_before = physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot());
+
+        const DIVISIONS: usize = 4;
+        const DT: f32 = 2.0 / 60.0;
+        let past = game.history_frames(DIVISIONS, DT);
+        assert_eq!(past.len(), DIVISIONS, "one frame per division");
+
+        for (i, (frame, ft)) in past.iter().enumerate() {
+            assert_eq!(ft.dts, 0.0, "a past frame is a still of the past");
+            // Every frame must BE a recorded frame — same tts, and the exact
+            // same rendered pose. A live-world draw would put them all at
+            // `paused_y`; a re-simulated one would drift off the recorded
+            // float.
+            let (rec_tts, rec_y) = live_ys
+                .iter()
+                .find(|(t, _)| (t - ft.tts).abs() < 1e-9)
+                .copied()
+                .unwrap_or_else(|| panic!("frame {i} tts {} is not a recorded tts", ft.tts));
+            assert_eq!(
+                frame.scene.xform.w.y, rec_y,
+                "past frame {i} (tts {rec_tts}) must reproduce the recorded pose exactly"
+            );
+            // The authored camera is drawn from the RECORDED tts too.
+            assert!((frame.camera.eye[0] - ft.tts).abs() < 1e-6);
+        }
+
+        // Nearest-past-FIRST, walking away from the anchor: a falling ball was
+        // HIGHER the further back you look.
+        let ys: Vec<f32> = past.iter().map(|(f, _)| f.scene.xform.w.y).collect();
+        assert!(ys[0] > paused_y, "the nearest past is above the live pose");
+        for pair in ys.windows(2) {
+            assert!(pair[1] > pair[0], "further back = higher: {ys:?}");
+        }
+
+        // The window CLIPS at the ring's floor rather than inventing history:
+        // 60 divisions of 2 frames each reaches far past the 20 recorded
+        // frames, so the walk stops at `lo`.
+        let (lo, _hi) = game.scene_frame_range().expect("a recorded range");
+        let clipped = game.history_frames(60, DT);
+        assert!(
+            clipped.len() < 60 && clipped.len() <= K,
+            "a window longer than history clips: {} frames",
+            clipped.len()
+        );
+        let oldest = clipped.last().expect("at least one past frame").1.tts;
+        let lo_tts = live_ys[lo as usize].0;
+        assert!(
+            (oldest - lo_tts).abs() < 1e-6,
+            "the oldest reconstructed frame is the ring floor: {oldest} vs {lo_tts}"
+        );
+
+        // Reconstruction is READ-ONLY: the live world and live frame are
+        // exactly as they were.
+        assert_eq!(
+            physics::with_world(physics::DEFAULT_WORLD, |w| w.snapshot()),
+            live_world_before,
+            "live world untouched by history reconstruction"
+        );
+        assert_eq!(
+            game.last_frame.scene.xform.w.y, paused_y,
+            "live frame untouched by history reconstruction"
         );
 
         physics::remove_world(physics::DEFAULT_WORLD);

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -3160,7 +3160,7 @@ mod tests {
              \x20 Physics.fixed(\"ground\", Physics.box(10.0, 0.4, 10.0)) |> Physics.at(Vec3.make(0.0, -0.2, 0.0)),\n\
              \x20 Physics.dynamic(\"ball\", Physics.sphere(0.5)) |> Physics.at(Vec3.make(0.0, 4.0, 0.0))])\n\
              let draw = (m, tts) => Frame.create(\n\
-               Camera.lookAt(Vec3.make(tts, 2.0, -6.0), Vec3.make(tts, 0.0, 0.0)),\n\
+               Camera3D.lookAt(Vec3.make(tts, 2.0, -6.0), Vec3.make(tts, 0.0, 0.0)),\n\
                Scene.sphere() |> Physics.transformed(\"ball\"))\n",
         )
         .expect("write game");

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -942,6 +942,17 @@ impl Game for FunctorLangGame {
         self.recorder.scene_frame_range()
     }
 
+    /// The recording generation, which bumps whenever existing recorded frames
+    /// may have been REPLACED (a destructive rewind, a reload that resets the
+    /// rings). Without this the trait's default `0` made the preview cache's
+    /// generation term dead on native: an in-place branch commit — same
+    /// selected frame, same tts, same program revision, rewritten history —
+    /// would keep serving the pre-branch backward trail, showing a past that
+    /// no longer exists.
+    fn scene_timeline_generation(&self) -> u64 {
+        self.recorder.generation()
+    }
+
     fn scene_program_revision(&self) -> u64 {
         self.recorder.program_revision()
     }
@@ -1000,6 +1011,7 @@ impl Game for FunctorLangGame {
     fn history_frames(&self, divisions: usize, dt: f32) -> Vec<(Frame, FrameTime)> {
         functor_runtime_common::functor_lang_producer::history_frames(
             &self.session,
+            &self.names,
             &self.recorder,
             &self.physics_rt,
             self.has_physics,
@@ -3258,6 +3270,132 @@ mod tests {
         );
 
         physics::remove_world(physics::DEFAULT_WORLD);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A MULTI-ENTRY role must reconstruct its past through the ROLE's entry
+    /// names. `history_frames` used to call a hardcoded `draw`, which a
+    /// `client`-prefixed project does not define — and because a failed draw is
+    /// deliberately skipped rather than fatal, the backward trail came back
+    /// EMPTY with no error at all. The regression is silent, so this test
+    /// asserts frames actually come back.
+    #[test]
+    fn history_frames_resolve_draw_through_prefixed_entry_names() {
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-hist-entry-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        // Every entry carries the `client` prefix, exactly as a multi-entry
+        // project's role does.
+        std::fs::write(
+            dir.join("game.fun"),
+            "let clientInit = { n: 0.0 }\n\
+             let clientTick = (m, dt, tts) => { n: m.n + 1.0 }\n\
+             let clientDraw = (m, tts) => Frame.create(\n\
+               Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.cube() |> Scene.translate(Vec3.make(m.n, 0.0, 0.0)))\n",
+        )
+        .expect("write game");
+        let mut game = FunctorLangGame::create_with_prefix(
+            dir.join("game.fun").to_str().expect("utf-8 path"),
+            "client",
+        );
+
+        const SUB_DT: f32 = 1.0 / 60.0;
+        let mut tts = 0.0f32;
+        for _ in 0..12 {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+            game.render(FrameTime { tts, dts: SUB_DT });
+        }
+
+        let past = game.history_frames(3, 2.0 / 60.0);
+        assert_eq!(past.len(), 3, "the prefixed role's past must reconstruct");
+        // Each past frame is a real recorded pose: the cube walked +x, so
+        // further back is a SMALLER x.
+        let xs: Vec<f32> = past.iter().map(|(f, _)| f.scene.xform.w.x).collect();
+        let live_x = game.last_frame.scene.xform.w.x;
+        assert!(
+            xs[0] < live_x,
+            "the nearest past is behind the live pose: {xs:?}"
+        );
+        for pair in xs.windows(2) {
+            assert!(pair[1] < pair[0], "further back = smaller x: {xs:?}");
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The preview cache keys on `scene_timeline_generation` so a rewritten
+    /// timeline invalidates it. The native producer used to inherit the trait's
+    /// constant `0`, making that term dead here: an in-place destructive
+    /// rewind — same selected frame, same tts, same program revision, but the
+    /// recorded future discarded — left every other key term identical, so a
+    /// cached backward trail would keep showing a past that no longer exists.
+    #[test]
+    fn a_destructive_rewind_bumps_the_timeline_generation_on_native() {
+        let dir =
+            std::env::temp_dir().join(format!("functor-lang-hist-gen-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        std::fs::write(
+            dir.join("game.fun"),
+            "let init = { n: 0.0 }\n\
+             let tick = (m, dt, tts) => { n: m.n + 1.0 }\n\
+             let draw = (m, tts) => Frame.create(\n\
+               Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.cube() |> Scene.translate(Vec3.make(m.n, 0.0, 0.0)))\n",
+        )
+        .expect("write game");
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().expect("utf-8 path"));
+
+        const SUB_DT: f32 = 1.0 / 60.0;
+        let mut tts = 0.0f32;
+        for _ in 0..12 {
+            tts += SUB_DT;
+            game.tick(FrameTime { tts, dts: SUB_DT });
+            game.render(FrameTime { tts, dts: SUB_DT });
+        }
+
+        // The producer must report the recorder's real generation, not the
+        // trait default.
+        let gen_before = game.scene_timeline_generation();
+
+        // A non-destructive scrub is exactly what the cache is meant to serve:
+        // it changes the selected frame but NOT the generation.
+        game.seek_scene_to(6).expect("seek to an earlier frame");
+        let key_before = (
+            game.current_scene_frame(),
+            game.scene_program_revision(),
+            game.scene_timeline_generation(),
+        );
+        assert_eq!(
+            key_before.2, gen_before,
+            "a non-destructive scrub must not invalidate the preview cache"
+        );
+
+        // Resuming from the scrubbed frame COMMITS a branch in place: the
+        // program is unchanged, so the generation is the only term that can
+        // carry the invalidation.
+        game.tick(FrameTime {
+            tts: tts + SUB_DT,
+            dts: SUB_DT,
+        });
+        let key_after = (
+            game.current_scene_frame(),
+            game.scene_program_revision(),
+            game.scene_timeline_generation(),
+        );
+        assert_eq!(
+            key_before.1, key_after.1,
+            "the program did not change, so the revision term cannot catch this"
+        );
+        assert_ne!(
+            key_before.2, key_after.2,
+            "a destructive rewind must bump the generation so the cache drops \
+             its now-stale backward trail"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -3230,6 +3230,21 @@ mod tests {
             "the oldest reconstructed frame is the ring floor: {oldest} vs {lo_tts}"
         );
 
+        // A window FINER than the recording cadence (dt below one rendered
+        // frame) must not emit the same frame twice: divisions that resolve to
+        // an already-emitted frame are skipped, so the marks stay spread over
+        // distinct recorded moments instead of stacking.
+        let dense = game.history_frames(16, SUB_DT / 4.0);
+        let mut seen: Vec<f32> = dense.iter().map(|(_, ft)| ft.tts).collect();
+        let before = seen.len();
+        seen.dedup();
+        assert_eq!(seen.len(), before, "no duplicate frames: {seen:?}");
+        assert!(
+            dense.len() < 16,
+            "a sub-frame window dedupes down: {} frames",
+            dense.len()
+        );
+
         // Reconstruction is READ-ONLY: the live world and live frame are
         // exactly as they were.
         assert_eq!(

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1539,7 +1539,7 @@ Escape releases while captured"
         const PAUSED_PREVIEW_REUSE_FRAMES: u32 = 30;
         const LIVE_PREVIEW_INTERVAL_SECONDS: f32 = 0.1;
         let mut trail_cache: Option<(
-            (Option<u64>, u32, bool, u64, bool, bool, usize, u32),
+            (Option<u64>, u32, bool, u64, bool, bool, usize, u32, u64),
             functor_runtime_common::FramePreview,
         )> = None;
         let mut trail_refresh: u32 = 0;
@@ -2498,6 +2498,10 @@ Escape again to quit"
                     strobe_wanted,
                     divisions,
                     window.to_bits(),
+                    // The BACKWARD side reads recorded history, so a branch or
+                    // a reload that rewrites the rings invalidates it even
+                    // when frame + program are unchanged.
+                    game.scene_timeline_generation(),
                 );
                 let interactive_live = scrubber_visible && !clock.is_paused();
                 let cache_hit = trail_cache.as_ref().is_some_and(|(k, _)| {
@@ -2510,6 +2514,7 @@ Escape again to quit"
                             && k.5 == key.5
                             && k.6 == key.6
                             && k.7 == key.7
+                            && k.8 == key.8
                     } else {
                         trail_refresh > 0 && *k == key
                     }
@@ -2557,6 +2562,13 @@ Escape again to quit"
                                 copies: strobe_copies,
                                 ..Default::default()
                             }),
+                            // One SYMMETRIC window: `window` seconds of recorded
+                            // past as well as projected future
+                            // (docs/time-travel.md T6e). The past side costs one
+                            // draw per division with no simulation, and shares
+                            // this cache — so live play redraws it on the same
+                            // ~10 Hz cadence as the forward sim, never per frame.
+                            backward: true,
                         },
                     );
                     if interactive_live {

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -94,6 +94,13 @@ const STYLE = `
 #scrub-recorded { fill: rgba(65, 216, 230, 0.30); }
 #scrub-played { fill: var(--sb-accent); opacity: 0.62; }
 #scrub-future { fill: var(--sb-future); opacity: 0.9; }
+/* The BACKWARD window is RECORDED FACT, not progress — so it reads as a
+   translucent pane with a bright edge rather than a solid filled bar like the
+   played track. Cyan, matching the past trail's marks. */
+#scrub-past {
+  fill: rgba(65, 216, 230, 0.20);
+  stroke: #8ff2fa; stroke-width: 1; stroke-opacity: 0.9;
+}
 .scrub-event { pointer-events: none; }
 .scrub-event.input { fill: #ffd166; fill-opacity: 0.75; }
 .scrub-event.reload { fill: #b994ff; }
@@ -111,8 +118,13 @@ const STYLE = `
 .scrub-handle:focus-visible { outline: 2px solid white; outline-offset: 2px; }
 #scrubber #scrub-playhead { background: var(--sb-accent); border-color: #b9f8ff; }
 #scrubber #scrub-preview-handle { background: var(--sb-future); border-color: #ffd0ee; }
+#scrubber #scrub-past-handle { background: var(--sb-accent); border-color: #b9f8ff; }
 #scrub-preview-handle.clipped { border-radius: 3px 0 0 3px !important; }
-#scrub-preview-handle.fully-clipped {
+/* Mirrored: the backward handle squares the LEFT corners when its window runs
+   past the oldest recorded frame. */
+#scrub-past-handle.clipped { border-radius: 0 3px 3px 0 !important; }
+#scrub-preview-handle.fully-clipped,
+#scrub-past-handle.fully-clipped {
   top: 0; z-index: 5; height: 12px;
 }
 #scrub-playhead.outside { box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.55); }
@@ -120,6 +132,12 @@ const STYLE = `
   position: absolute; right: 0; top: -5px; z-index: 4; display: none;
   padding: 2px 4px; border: 1px solid var(--sb-future); border-radius: 5px;
   color: #ffd0ee; background: rgba(30, 24, 51, 0.96); font-size: 9px;
+  pointer-events: none;
+}
+#scrub-underflow {
+  position: absolute; left: 0; top: -5px; z-index: 4; display: none;
+  padding: 2px 4px; border: 1px solid var(--sb-accent); border-radius: 5px;
+  color: #b9f8ff; background: rgba(30, 24, 51, 0.96); font-size: 9px;
   pointer-events: none;
 }
 #scrub-event-detail {
@@ -200,6 +218,7 @@ const HTML = `
       <rect id="scrub-unavailable-after" class="scrub-unavailable" x="1000" y="12" width="0" height="6" rx="3" aria-hidden="true" />
       <rect id="scrub-recorded" x="0" y="12" width="1000" height="6" rx="3" aria-hidden="true" />
       <rect id="scrub-played" x="0" y="12" width="0" height="6" rx="3" aria-hidden="true" />
+      <rect id="scrub-past" x="0" y="11" width="0" height="8" rx="3" aria-hidden="true" />
       <rect id="scrub-future" x="0" y="11" width="0" height="8" rx="3" aria-hidden="true" />
       <g id="scrub-ticks" aria-hidden="true"></g>
       <g id="scrub-events" aria-label="Recorded events"></g>
@@ -208,7 +227,10 @@ const HTML = `
       aria-label="Selected frame" aria-orientation="horizontal"></button>
     <button id="scrub-preview-handle" class="scrub-handle" role="slider"
       aria-label="Extrapolation endpoint" aria-orientation="horizontal"></button>
+    <button id="scrub-past-handle" class="scrub-handle" role="slider"
+      aria-label="History endpoint" aria-orientation="horizontal"></button>
     <span id="scrub-overflow"></span>
+    <span id="scrub-underflow"></span>
     <span id="scrub-event-detail" role="status"></span>
     <span id="scrub-label"><span id="scrub-count"></span></span>
     </span>
@@ -281,9 +303,12 @@ export function mountScrubber({ hidden = false } = {}) {
   const recorded = $("scrub-recorded");
   const played = $("scrub-played");
   const future = $("scrub-future");
+  const past = $("scrub-past");
   const playhead = $("scrub-playhead");
   const previewHandle = $("scrub-preview-handle");
   const overflow = $("scrub-overflow");
+  const pastHandle = $("scrub-past-handle");
+  const underflow = $("scrub-underflow");
   const eventDetail = $("scrub-event-detail");
   const eventLayer = $("scrub-events");
   const extrapolate = $("scrub-extrapolate");
@@ -540,6 +565,13 @@ export function mountScrubber({ hidden = false } = {}) {
     );
     future.setAttribute("x", String(current.playheadUnit * 1000));
     future.setAttribute("width", String(previewVisible ? futureWidth * 10 : 0));
+    // The BACKWARD half of the same window, mirrored about the playhead. Its
+    // left edge moves (it grows leftward and clips at the oldest recorded
+    // frame), so both `x` and `width` are driven.
+    const backwardPct = current.backwardStartUnit * 100;
+    const backwardWidth = Math.max(playheadPct - backwardPct, 0);
+    past.setAttribute("x", String(current.backwardStartUnit * 1000));
+    past.setAttribute("width", String(previewVisible ? backwardWidth * 10 : 0));
     previewHandle.style.left = `${previewPct}%`;
     previewHandle.style.display = previewVisible ? "block" : "none";
     previewHandle.classList.toggle("clipped", current.previewClippedFrames > 0);
@@ -554,6 +586,17 @@ export function mountScrubber({ hidden = false } = {}) {
 
     overflow.style.display = previewVisible && current.previewClippedFrames > 0 ? "block" : "none";
     overflow.textContent = `+${current.previewClippedFrames}`;
+
+    pastHandle.style.left = `${backwardPct}%`;
+    pastHandle.style.display = previewVisible ? "block" : "none";
+    pastHandle.classList.toggle("clipped", current.backwardClippedFrames > 0);
+    pastHandle.classList.toggle(
+      "fully-clipped",
+      previewVisible && current.backwardFrames > 0 && backwardPct >= playheadPct
+    );
+    underflow.style.display =
+      previewVisible && current.backwardClippedFrames > 0 ? "block" : "none";
+    underflow.textContent = `-${current.backwardClippedFrames}`;
 
     playhead.setAttribute("aria-valuemin", String(current.recorded.lo));
     playhead.setAttribute(
@@ -584,6 +627,24 @@ export function mountScrubber({ hidden = false } = {}) {
       "aria-valuetext",
       `${state.preview.seconds} seconds ahead` +
         (current.previewClippedFrames ? `, ${current.previewClippedFrames} frames clipped` : "")
+    );
+    // The backward handle's range runs the other way, so valuemin/valuemax
+    // mirror: the LARGEST window is the smallest frame.
+    pastHandle.setAttribute(
+      "aria-valuemin",
+      String(current.selectedFrame - Math.round(PREVIEW_SECONDS_MAX * TIMELINE_FPS))
+    );
+    pastHandle.setAttribute(
+      "aria-valuemax",
+      String(current.selectedFrame - Math.round(PREVIEW_SECONDS_MIN * TIMELINE_FPS))
+    );
+    pastHandle.setAttribute("aria-valuenow", String(current.backwardStartFrame));
+    pastHandle.setAttribute(
+      "aria-valuetext",
+      `${state.preview.seconds} seconds back` +
+        (current.backwardClippedFrames
+          ? `, ${current.backwardClippedFrames} frames unavailable`
+          : "")
     );
 
     label.innerHTML =
@@ -678,6 +739,35 @@ export function mountScrubber({ hidden = false } = {}) {
   previewHandle.addEventListener("pointercancel", endPreviewDrag);
   previewHandle.addEventListener("lostpointercapture", endPreviewDrag);
 
+  // The BACKWARD endpoint drags the SAME window — identical to the forward
+  // handle but for the sign: here dragging LEFT (away from the playhead) grows
+  // it. Both sides then resize together, because there is only one `seconds`.
+  let pastDrag = null;
+  pastHandle.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    pastHandle.setPointerCapture(event.pointerId);
+    pastDrag = { x: event.clientX, seconds: state.preview.seconds };
+  });
+  pastHandle.addEventListener("pointermove", (event) => {
+    if (!pastDrag || !pastHandle.hasPointerCapture(event.pointerId)) return;
+    const current = view();
+    const width = rail.getBoundingClientRect().width;
+    const span = current ? current.viewport.hi - current.viewport.lo : 0;
+    if (width <= 0 || span <= 0) return;
+    const deltaFrames = ((event.clientX - pastDrag.x) / width) * span;
+    dispatch({
+      type: "preview-changed",
+      preview: { seconds: pastDrag.seconds - deltaFrames / TIMELINE_FPS },
+    });
+    pushConfig();
+  });
+  const endPastDrag = () => (pastDrag = null);
+  pastHandle.addEventListener("pointerup", endPastDrag);
+  pastHandle.addEventListener("pointercancel", endPastDrag);
+  pastHandle.addEventListener("lostpointercapture", endPastDrag);
+
   rail.addEventListener("pointerdown", (event) => {
     if (event.button !== 0) return;
     if (event.target.closest(".scrub-handle")) return;
@@ -708,7 +798,11 @@ export function mountScrubber({ hidden = false } = {}) {
   };
   playhead.addEventListener("keydown", seekKey);
 
-  previewHandle.addEventListener("keydown", (event) => {
+  // Keyboard resize for an endpoint handle. `sign` is -1 on the BACKWARD
+  // handle, where "away from the playhead" is left — so on both handles an
+  // arrow pointing away from the playhead grows the shared window. Home/End
+  // are semantic (smallest/largest), so they do not mirror.
+  const endpointKeydown = (sign) => (event) => {
     const steps = event.shiftKey ? TIMELINE_FPS : Math.round(TIMELINE_FPS / 2);
     const deltas = {
       ArrowLeft: -steps,
@@ -726,12 +820,14 @@ export function mountScrubber({ hidden = false } = {}) {
       });
     } else if (event.key in deltas) {
       event.preventDefault();
-      dispatch({ type: "preview-delta-requested", frames: deltas[event.key] });
+      dispatch({ type: "preview-delta-requested", frames: sign * deltas[event.key] });
     } else {
       return;
     }
     pushConfig();
-  });
+  };
+  previewHandle.addEventListener("keydown", endpointKeydown(1));
+  pastHandle.addEventListener("keydown", endpointKeydown(-1));
 
   pause.addEventListener("click", () => functor_lang_scrub_toggle_pause());
   const queueDetachedToggle = () => {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1405,7 +1405,7 @@ async fn run_async() -> Result<(), JsValue> {
         const PAUSED_PREVIEW_REUSE_FRAMES: u32 = 30;
         const LIVE_PREVIEW_INTERVAL_MS: f32 = 100.0;
         let mut preview_cache: Option<(
-            (Option<u64>, u32, bool, u64, bool, bool, usize, u32),
+            (Option<u64>, u32, bool, u64, bool, bool, usize, u32, u64),
             functor_runtime_common::FramePreview,
         )> = None;
         let mut preview_refresh: u32 = 0;
@@ -1668,6 +1668,10 @@ async fn run_async() -> Result<(), JsValue> {
                     strobe_wanted,
                     preview_rate,
                     preview_window.to_bits(),
+                    // The BACKWARD side reads recorded history, so a branch or
+                    // a reload that rewrites the rings invalidates it even
+                    // when frame + program are unchanged.
+                    game.scene_timeline_generation(),
                 );
                 let cache_hit = preview_cache.as_ref().is_some_and(|(k, _)| {
                     if clock.is_paused() {
@@ -1681,6 +1685,7 @@ async fn run_async() -> Result<(), JsValue> {
                             && k.5 == key.5
                             && k.6 == key.6
                             && k.7 == key.7
+                            && k.8 == key.8
                     }
                 });
                 if cache_hit {
@@ -1714,6 +1719,13 @@ async fn run_async() -> Result<(), JsValue> {
                                 copies,
                                 ..Default::default()
                             }),
+                            // One SYMMETRIC window: `preview_window` seconds of
+                            // recorded past as well as projected future
+                            // (docs/time-travel.md T6e). The past side costs one
+                            // draw per division with no simulation, and shares
+                            // this cache — so live play redraws it on the same
+                            // ~10 Hz cadence as the forward sim, never per frame.
+                            backward: true,
                         },
                     );
                     if clock.is_paused() {

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -178,18 +178,6 @@ export function reduceTimeline(state, action) {
       };
     }
 
-    // The BACKWARD endpoint's absolute mirror: the window is symmetric, so a
-    // start frame BEHIND the playhead sets the same `seconds` its forward twin
-    // would (docs/time-travel.md T6e).
-    case "preview-start-requested": {
-      if (state.selectedFrame === null || !Number.isFinite(action.frame)) return state;
-      const seconds = (state.selectedFrame - action.frame) / TIMELINE_FPS;
-      return {
-        ...state,
-        preview: normalizePreviewConfig({ seconds }, state.preview),
-      };
-    }
-
     case "preview-delta-requested": {
       if (!Number.isFinite(action.frames)) return state;
       const seconds = state.preview.seconds + action.frames / TIMELINE_FPS;

--- a/runtime/functor-runtime-web/timeline-model.js
+++ b/runtime/functor-runtime-web/timeline-model.js
@@ -178,6 +178,18 @@ export function reduceTimeline(state, action) {
       };
     }
 
+    // The BACKWARD endpoint's absolute mirror: the window is symmetric, so a
+    // start frame BEHIND the playhead sets the same `seconds` its forward twin
+    // would (docs/time-travel.md T6e).
+    case "preview-start-requested": {
+      if (state.selectedFrame === null || !Number.isFinite(action.frame)) return state;
+      const seconds = (state.selectedFrame - action.frame) / TIMELINE_FPS;
+      return {
+        ...state,
+        preview: normalizePreviewConfig({ seconds }, state.preview),
+      };
+    }
+
     case "preview-delta-requested": {
       if (!Number.isFinite(action.frames)) return state;
       const seconds = state.preview.seconds + action.frames / TIMELINE_FPS;
@@ -218,6 +230,20 @@ export function deriveTimelineView(state) {
     state.viewport.lo,
     state.viewport.hi
   );
+  // The BACKWARD half of the same symmetric window (docs/time-travel.md T6e).
+  // Its floor is where recorded history actually STARTS — the later of the
+  // viewport's edge and the recorded range's `lo`, so the window stops at the
+  // striped post-reload region instead of pretending to cover it. With no
+  // recording available at all there is no past to show, so the floor collapses
+  // onto the playhead and the whole window reads as clipped.
+  const historyFloor = state.recordingAvailable
+    ? clamp(Math.max(state.viewport.lo, state.runtime.lo), state.viewport.lo, state.viewport.hi)
+    : selectedFrame;
+  const backwardStartFrame = selectedFrame - previewFrames;
+  const visibleBackwardStartFrame = clamp(backwardStartFrame, historyFloor, selectedFrame);
+  const backwardClippedFrames = previewFrames
+    ? Math.max(historyFloor - backwardStartFrame, 0)
+    : 0;
   const eventMarkers = clusterTimelineEvents(state.events, state.viewport);
   const recordedStartFrame = state.recordingAvailable
     ? clamp(state.runtime.lo, state.viewport.lo, state.viewport.hi)
@@ -259,6 +285,13 @@ export function deriveTimelineView(state) {
     visiblePreviewEndFrame,
     previewEndUnit: frameToUnit(visiblePreviewEndFrame, state.viewport),
     previewClippedFrames: Math.max(previewEndFrame - state.viewport.hi, 0),
+    // The backward side of the SAME window — one `seconds` drives both, so
+    // `backwardFrames === previewFrames` by construction.
+    backwardFrames: previewFrames,
+    backwardStartFrame,
+    visibleBackwardStartFrame,
+    backwardStartUnit: frameToUnit(visibleBackwardStartFrame, state.viewport),
+    backwardClippedFrames,
     eventMarkers,
     activeEvent,
     selectedEventId: state.selectedEventId,

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -251,3 +251,75 @@ test("hover takes precedence over persistent marker selection", () => {
   state = reduceTimeline(state, { type: "event-hovered", id: null });
   assert.equal(deriveTimelineView(state).activeEvent.id, 1);
 });
+
+test("one window covers the same span on both sides of the playhead", () => {
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
+  state = reduceTimeline(state, { type: "seek-requested", frame: 200 });
+  const view = deriveTimelineView(state);
+  // 2s * 60fps = 120 frames each way, from the same `seconds`.
+  assert.equal(view.backwardFrames, view.previewFrames);
+  assert.equal(view.backwardStartFrame, 80);
+  assert.equal(view.previewEndFrame, 320);
+  assert.equal(view.backwardStartUnit, 80 / 300);
+  assert.equal(view.backwardClippedFrames, 0);
+});
+
+test("the backward window clips at the oldest recorded frame", () => {
+  // Recording starts at frame 100; the playhead sits 40 frames into it, so a
+  // 120-frame window can only show 40 and the other 80 are clipped.
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true, 100);
+  state = reduceTimeline(state, { type: "seek-requested", frame: 140 });
+  const view = deriveTimelineView(state);
+  assert.equal(view.backwardFrames, 120);
+  assert.equal(view.backwardStartFrame, 20, "the logical window stays full length");
+  assert.equal(view.visibleBackwardStartFrame, 100, "the drawn band stops at lo");
+  assert.equal(view.backwardClippedFrames, 80);
+});
+
+test("unavailable post-reload history leaves no backward window at all", () => {
+  // An unsafe reload strands the playhead with nothing recorded behind it.
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
+  state = publish(state, 300, 300, true, 300, 1);
+  const view = deriveTimelineView(state);
+  assert.equal(view.visibleBackwardStartFrame, 300, "the band collapses onto the playhead");
+  assert.equal(view.backwardStartUnit, view.playheadUnit);
+  assert.equal(view.backwardClippedFrames, 120, "the whole window is unavailable");
+});
+
+test("a disabled preview has no window on either side", () => {
+  const state = publish(createTimelineState({ enabled: false, seconds: 2 }), 300, 300, true);
+  const view = deriveTimelineView(state);
+  assert.equal(view.previewFrames, 0);
+  assert.equal(view.backwardFrames, 0);
+  assert.equal(view.backwardClippedFrames, 0);
+  assert.equal(view.backwardStartFrame, 300);
+});
+
+test("dragging either endpoint resizes the one shared window", () => {
+  const base = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
+  // The forward handle drags right by 60 frames (+1s); the backward handle
+  // drags LEFT by 60, which its handler negates into the same +1s. Both land
+  // on the same symmetric window.
+  const forward = reduceTimeline(base, { type: "preview-delta-requested", frames: 60 });
+  const backward = reduceTimeline(base, { type: "preview-delta-requested", frames: 60 });
+  assert.equal(forward.preview.seconds, 3);
+  assert.equal(backward.preview.seconds, 3);
+  const view = deriveTimelineView(backward);
+  assert.equal(view.previewFrames, 180);
+  assert.equal(view.backwardFrames, 180);
+  assert.equal(
+    view.previewEndFrame - view.selectedFrame,
+    view.selectedFrame - view.backwardStartFrame
+  );
+});
+
+test("an absolute backward endpoint sets the window from its distance to the playhead", () => {
+  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
+  state = reduceTimeline(state, { type: "seek-requested", frame: 200 });
+  // Dropping the backward handle on frame 140 means a 1s window each way.
+  state = reduceTimeline(state, { type: "preview-start-requested", frame: 140 });
+  assert.equal(state.preview.seconds, 1);
+  const view = deriveTimelineView(state);
+  assert.equal(view.backwardStartFrame, 140);
+  assert.equal(view.previewEndFrame, 260);
+});

--- a/runtime/functor-runtime-web/timeline-model.test.js
+++ b/runtime/functor-runtime-web/timeline-model.test.js
@@ -295,31 +295,30 @@ test("a disabled preview has no window on either side", () => {
   assert.equal(view.backwardStartFrame, 300);
 });
 
-test("dragging either endpoint resizes the one shared window", () => {
+test("either endpoint grows the one shared window when dragged away from the playhead", () => {
   const base = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
-  // The forward handle drags right by 60 frames (+1s); the backward handle
-  // drags LEFT by 60, which its handler negates into the same +1s. Both land
-  // on the same symmetric window.
-  const forward = reduceTimeline(base, { type: "preview-delta-requested", frames: 60 });
-  const backward = reduceTimeline(base, { type: "preview-delta-requested", frames: 60 });
-  assert.equal(forward.preview.seconds, 3);
-  assert.equal(backward.preview.seconds, 3);
+  // "Away from the playhead" is +x on the forward handle and -x on the
+  // backward one, so the scrubber applies the sign (`endpointKeydown(sign)` /
+  // `pastDrag.seconds - delta`) before dispatching. Model the two handles by
+  // their raw pointer deltas and the sign each applies, so this test fails if
+  // either sign flips.
+  const drag = (rawFrames, sign) =>
+    reduceTimeline(base, { type: "preview-delta-requested", frames: sign * rawFrames });
+  const forward = drag(60, 1);
+  const backward = drag(-60, -1);
+  assert.equal(forward.preview.seconds, 3, "forward handle dragged right grows the window");
+  assert.equal(backward.preview.seconds, 3, "backward handle dragged left grows it the same");
+
+  // Dragging either handle TOWARD the playhead shrinks it, symmetrically.
+  assert.equal(drag(-60, 1).preview.seconds, 1);
+  assert.equal(drag(60, -1).preview.seconds, 1);
+
   const view = deriveTimelineView(backward);
   assert.equal(view.previewFrames, 180);
   assert.equal(view.backwardFrames, 180);
   assert.equal(
     view.previewEndFrame - view.selectedFrame,
-    view.selectedFrame - view.backwardStartFrame
+    view.selectedFrame - view.backwardStartFrame,
+    "one window, mirrored"
   );
-});
-
-test("an absolute backward endpoint sets the window from its distance to the playhead", () => {
-  let state = publish(createTimelineState({ enabled: true, seconds: 2 }), 300, 300, true);
-  state = reduceTimeline(state, { type: "seek-requested", frame: 200 });
-  // Dropping the backward handle on frame 140 means a 1s window each way.
-  state = reduceTimeline(state, { type: "preview-start-requested", frame: 140 });
-  assert.equal(state.preview.seconds, 1);
-  const view = deriveTimelineView(state);
-  assert.equal(view.backwardStartFrame, 140);
-  assert.equal(view.previewEndFrame, 260);
 });


### PR DESCRIPTION
## What

PR 3, the capstone of the bidirectional-extrapolation arc (stacked on #602). When 🔮 extrapolation is on, the preview now shows **both directions of time** around the playhead with **one symmetric window**:

- **Backward trail = recorded fact, reconstructed — never simulated.** `history_frames` (the sibling of `ghost_frames`) walks the recorder's rings back from the selected frame and re-`draw`s each recorded model at its own recorded `tts`, with that frame's recorded physics snapshot restored into a throwaway world scoped active for the draw (`TimelineLog::restore_into` / `SteppedPhysics::restore_recorded_into` — read-only extraction; the live world is untouched and byte-identical afterward).
- **Color = epistemics.** Past marks/strobe copies are cyan (matches the rail accent); future are pink (matches the rail's future segment — the forward trail flips cyan→pink accordingly). Strobe tint (weight 0.8) is applied before the age-fade so the direction reads even as copies fade.
- **Past arrows point along travel** (toward the playhead), so the two trails read as one continuous flow through the present rather than diverging from it.
- **One window, handle-driven.** The web scrubber gains a mirrored `#scrub-past` window pane + endpoint handle left of the playhead; dragging (or keyboarding) *either* endpoint sets the shared window. Backward clips at the recorded floor / unavailable post-reload history with an underflow badge. The native egui rail gets the mirrored band + cap. The `setPreview({enabled, seconds, rate, mode})` seam shape is unchanged — `seconds` is now the per-side window.
- Caching: the past half shares the forward preview cache (plus `scene_timeline_generation()` in the key, since a branch/reload can rewrite history without changing frame or program revision). Paused scrubbing — the hot case — recomputes only on key change.

## Verification

- `functor_runtime_common` 618 + 11 · `functor-runtime-desktop` 81 + 6 · timeline-model `node --test` 24. All green (re-run after review fixes).
- Oracle test `history_frames_replay_recorded_models_and_physics_poses`: records each frame's actually-rendered ball `y` and asserts every reconstructed frame reproduces it exactly (`assert_eq!` on f32) — a live-world draw would fail it; also covers ordering, ring-floor clipping, and live-state preservation.
- **frame_bench**: `allocs/frame` / `bytes/frame` byte-identical to base at all three grids; wall-clock min within noise (preview is off in the bench).
- Captures below (pr-visuals).

## Review

xreview ran **single-engine** (Claude/Opus): Codex lost scope into a sibling worktree on run 1 (discarded wholesale) and stalled on run 2. A fresh second-opinion Codex review of the final state is being run before this merges. dupfinder: no duplication signals — `history_frames` mirrors `ghost_frames`'s shape but shares no copied body.

Findings fixed in-branch:
- **Real bug**: a frame can outlive its physics frame near the ring floor; that path drew with no world scoped and silently presented the **live** pose as recorded fact. Now refuses and clips (the legitimate "nothing stepped after this frame" live-append case still draws).
- Anchor sample was marked by both sides (coplanar cyan+pink z-fighting at the playhead); speculative reducer action deleted; tautological test fixed; sub-frame dedupe coverage added; native frame counter now colors future pink / past cyan (it still said cyan-future).

Dispositioned, not fixed:
| Finding | Why |
|---|---|
| Backward restore replays from the nearest keyframe (up to 29 fixed steps per division) | Paused scrubbing (the hot case) is fully cached; the forward-walk optimization trades real complexity for a cost the cache hides. Recorded as a follow-up. |
| Textured strobe copies (e.g. mario's sprite) hue-shift toward the side color rather than becoming it | The tint is a multiply over the texture; making it dominate would discard the copy's art. Directions stay clearly distinguishable and the flat-color arrows are authoritative. Documented limitation. |


## Visuals

**Cyan = recorded past (fact) · pink = predicted future.** All frames rendered headlessly and
deterministically via `--input-script` + `--capture-at-frame` (fixed `--script-dt`; `--fixed-time`
can't be used here — it pins dt to 0, so nothing animates).

### `examples/physics` — trail (`--trajectory`)

![physics bidirectional trail](https://gist.githubusercontent.com/tommy-xr/9448401822878d33ca258c1be2dae6dd/raw/physics-trail.gif)

<sub>Cyan history grows behind each body as it falls while the pink prediction projects ahead and bends at impact; after landing only the cyan past remains. 31 frames, sim frames 4–124 step 4, empty input script (pure physics playback).</sub>

### `examples/mario` — trail through the jump arc (`jump.script`)

![mario bidirectional trail](https://gist.githubusercontent.com/tommy-xr/9448401822878d33ca258c1be2dae6dd/raw/mario-trail.gif)

<sub>The recorded run-up and takeoff trail cyan behind the character while the predicted landing arcs pink ahead — one continuous flow through the playhead. 32 frames, sim frames 3–96 step 3.</sub>

### Stills

![physics strobe, both directions](https://gist.githubusercontent.com/tommy-xr/9448401822878d33ca258c1be2dae6dd/raw/physics-strobe-both.png)

<sub>`--trajectory --strobe` at sim frame 44: tinted scene copies on **both** sides of the moment — cyan-tinted recorded poses above, pink-tinted predicted poses below.</sub>

![mario mid-jump](https://gist.githubusercontent.com/tommy-xr/9448401822878d33ca258c1be2dae6dd/raw/mario-midjump.png)

<sub>Sim frame 42: cyan arrows point along travel toward the playhead; pink arrows continue past it onto the right platform.</sub>

### Before → after

Base ref `feat/remove-ghost-mode` vs. this branch, same scene and same sim frame.

![mario before/after](https://gist.githubusercontent.com/tommy-xr/9448401822878d33ca258c1be2dae6dd/raw/beforeafter-mario.png)

![physics before/after](https://gist.githubusercontent.com/tommy-xr/9448401822878d33ca258c1be2dae6dd/raw/beforeafter-physics.png)

<sub>Before: forward-only, all cyan — the past is invisible. After: the symmetric window shows the recorded past in cyan and the predicted future in pink.</sub>
