### PR TITLE
feat(docs): categorize the API reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,10 @@ standard library (`functor-lang/stdlib/`, rendered as its own group) — and rec
 gitignored local Markdown + JSON artifacts; it does not build the GL-linked CLI or
 the wasm runtime. The check command validates both renderers without requiring
 generated files to exist. Generation and checking fails if a module, type, or
-signature lacks explicit `//!` / `///` public documentation:
+signature lacks explicit `//!` / `///` public documentation — or if a module is
+missing from `CATEGORIES` in `tools/functor-docgen`, the one table that says
+which category ("Scene & rendering", "Collections", …) each module renders
+under, so a new module cannot land uncategorized:
 
 ```sh
 npm run generate:docs

--- a/site/src/api-docs.ts
+++ b/site/src/api-docs.ts
@@ -16,9 +16,11 @@ const filterReference = (): void => {
   const query = search.value.trim().toLowerCase();
   let visibleItems = 0;
   let visibleModules = 0;
-  // Modules still showing per group ("engine" / "stdlib"), so a group's
-  // divider and nav block disappear along with its last module.
+  // Modules still showing per group ("engine" / "stdlib") and per category
+  // (group-qualified, e.g. "stdlib:Input"), so a heading and its nav block
+  // disappear along with the last module under it.
   const perGroup = new Map<string, number>();
+  const perCategory = new Map<string, number>();
 
   for (const section of referenceRoot.querySelectorAll<HTMLElement>(".api-module")) {
     const moduleMatches = query && section.dataset.search!.includes(query);
@@ -38,6 +40,8 @@ const filterReference = (): void => {
       visibleItems += moduleItems;
       const group = section.dataset.group ?? "engine";
       perGroup.set(group, (perGroup.get(group) ?? 0) + 1);
+      const category = section.dataset.category ?? "";
+      perCategory.set(category, (perCategory.get(category) ?? 0) + 1);
     }
   }
 
@@ -45,6 +49,12 @@ const filterReference = (): void => {
     ".api-group-divider, .api-nav-group"
   )) {
     element.hidden = (perGroup.get(element.dataset.group ?? "engine") ?? 0) === 0;
+  }
+
+  for (const element of document.querySelectorAll<HTMLElement>(
+    ".api-category-divider, .api-nav-category"
+  )) {
+    element.hidden = (perCategory.get(element.dataset.category ?? "") ?? 0) === 0;
   }
 
   results.textContent = query

--- a/site/src/api-reference-html.mjs
+++ b/site/src/api-reference-html.mjs
@@ -56,7 +56,7 @@ const module_ = (module) => {
   const id = slug(module.name);
   const entries = `${module.items.length} ${module.items.length === 1 ? "entry" : "entries"}`;
   return [
-    `<section class="api-module" id="${escapeAttr(id)}" data-group="${escapeAttr(module.group ?? "engine")}" data-category="${escapeAttr(categoryKey(module))}" data-search="${escapeAttr(`${module.name} ${module.docs}`.toLowerCase())}">`,
+    `<section class="api-module" id="${escapeAttr(id)}" data-group="${escapeAttr(module.group ?? "engine")}" data-category="${escapeAttr(categoryKey(module))}" data-search="${escapeAttr(`${module.name} ${module.category ?? ""} ${module.docs}`.toLowerCase())}">`,
     `<h2><span>${escapeText(module.name)}</span><span class="api-module-count">${entries}</span></h2>`,
     prose(module.docs),
     `<div class="api-items">`,
@@ -142,9 +142,9 @@ const sections = (modules) => {
     const moduleGroup = module.group ?? "engine";
     if (moduleGroup !== group) {
       group = moduleGroup;
-      category = undefined;
       out.push(divider(group));
     }
+    // The key carries the group, so a group change always opens a category too.
     if (categoryKey(module) !== category) {
       category = categoryKey(module);
       out.push(categoryHeading(module));

--- a/site/src/api-reference-html.mjs
+++ b/site/src/api-reference-html.mjs
@@ -48,11 +48,15 @@ const item = (entry) => {
   ].join("\n");
 };
 
+// A category label repeats across groups (both halves have an "Input"), so
+// everything the filter keys on is the group-qualified pair, not the label.
+const categoryKey = (module) => `${module.group ?? "engine"}:${module.category ?? ""}`;
+
 const module_ = (module) => {
   const id = slug(module.name);
   const entries = `${module.items.length} ${module.items.length === 1 ? "entry" : "entries"}`;
   return [
-    `<section class="api-module" id="${escapeAttr(id)}" data-group="${escapeAttr(module.group ?? "engine")}" data-search="${escapeAttr(`${module.name} ${module.docs}`.toLowerCase())}">`,
+    `<section class="api-module" id="${escapeAttr(id)}" data-group="${escapeAttr(module.group ?? "engine")}" data-category="${escapeAttr(categoryKey(module))}" data-search="${escapeAttr(`${module.name} ${module.docs}`.toLowerCase())}">`,
     `<h2><span>${escapeText(module.name)}</span><span class="api-module-count">${entries}</span></h2>`,
     prose(module.docs),
     `<div class="api-items">`,
@@ -68,21 +72,36 @@ const navLink = (module) =>
   `<a href="#${escapeAttr(slug(module.name))}" data-module="${escapeAttr(module.name.toLowerCase())}">${escapeText(module.name)}</a>`;
 
 // The nav is grouped so the two halves of the API — what the game runner
-// provides, and what the language itself ships — are visibly distinct. Each
-// group is one element so the search filter can hide a whole empty group.
+// provides, and what the language itself ships — are visibly distinct, and
+// each group is subdivided by category so a 37-module list reads as a handful
+// of topics. Both levels are single elements so the search filter can hide a
+// whole empty category, and a whole empty group.
 const navGroups = (modules) => {
   const groups = [];
   for (const module of modules) {
     const group = module.group ?? "engine";
-    if (groups.at(-1)?.group !== group) groups.push({ group, modules: [] });
-    groups.at(-1).modules.push(module);
+    if (groups.at(-1)?.group !== group) groups.push({ group, categories: [] });
+    const categories = groups.at(-1).categories;
+    const key = categoryKey(module);
+    if (categories.at(-1)?.key !== key)
+      categories.push({ key, label: module.category ?? "", modules: [] });
+    categories.at(-1).modules.push(module);
   }
   return groups
     .map((entry) =>
       [
         `<div class="api-nav-group" data-group="${escapeAttr(entry.group)}">`,
         `<div class="api-nav-group-label">${escapeText(GROUP_LABELS[entry.group] ?? entry.group)}</div>`,
-        entry.modules.map(navLink).join("\n"),
+        entry.categories
+          .map((category) =>
+            [
+              `<div class="api-nav-category" data-group="${escapeAttr(entry.group)}" data-category="${escapeAttr(category.key)}">`,
+              `<div class="api-nav-category-label">${escapeText(category.label)}</div>`,
+              category.modules.map(navLink).join("\n"),
+              `</div>`,
+            ].join("\n"),
+          )
+          .join("\n"),
         `</div>`,
       ].join("\n"),
     )
@@ -106,14 +125,29 @@ const divider = (group) =>
     `</div>`,
   ].join("\n");
 
+// Inside a group, each category announces itself the same way — one level
+// quieter, and hidden by the filter when its last module goes.
+const categoryHeading = (module) =>
+  [
+    `<div class="api-category-divider" data-group="${escapeAttr(module.group ?? "engine")}" data-category="${escapeAttr(categoryKey(module))}">`,
+    `<h2>${escapeText(module.category ?? "")}</h2>`,
+    `</div>`,
+  ].join("\n");
+
 const sections = (modules) => {
   const out = [];
   let group;
+  let category;
   for (const module of modules) {
     const moduleGroup = module.group ?? "engine";
     if (moduleGroup !== group) {
       group = moduleGroup;
+      category = undefined;
       out.push(divider(group));
+    }
+    if (categoryKey(module) !== category) {
+      category = categoryKey(module);
+      out.push(categoryHeading(module));
     }
     out.push(module_(module));
   }

--- a/site/styles.css
+++ b/site/styles.css
@@ -1605,7 +1605,7 @@ a:hover {
 .api-nav-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 10px;
 }
 
 .api-nav-group-label {
@@ -1614,6 +1614,23 @@ a:hover {
   font-size: 0.58rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+/* Categories are the second level of the nav: a hairline ties each topic's
+   modules together without a second uppercase shout. */
+.api-nav-category {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+}
+
+.api-nav-category-label {
+  color: var(--text-dim);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  opacity: 0.85;
 }
 
 .api-intro {
@@ -1765,7 +1782,9 @@ a:hover {
 .api-module[hidden],
 .api-item[hidden],
 .api-group-divider[hidden],
+.api-category-divider[hidden],
 .api-nav-group[hidden],
+.api-nav-category[hidden],
 .api-nav a[hidden] {
   display: none;
 }
@@ -1796,6 +1815,48 @@ a:hover {
   margin: 6px 0 0;
   color: var(--text-dim);
   font-size: 0.8rem;
+}
+
+/* And within a half, a category names the topic the next few modules share —
+   quieter than the group, marked by a short cyan tick rather than color. */
+.api-category-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 40px 0 18px;
+}
+
+.api-group-divider + .api-category-divider {
+  margin-top: 26px;
+}
+
+.api-category-divider::after {
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+  content: "";
+}
+
+.api-category-divider h2 {
+  /* `.docs-main h2` gives every heading a rule above it; the divider draws its
+     own, so this one resets that. */
+  margin: 0;
+  padding-top: 0;
+  border-top: 0;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.api-category-divider h2::before {
+  display: inline-block;
+  width: 14px;
+  margin-right: 10px;
+  border-top: 2px solid var(--cyan);
+  content: "";
+  vertical-align: middle;
 }
 
 .api-module > h2 {
@@ -1935,17 +1996,27 @@ a:hover {
     padding-bottom: 6px;
   }
 
-  /* On narrow screens the nav is one scrolling chip row, so each group
-     inlines its label with its own chips instead of stacking. */
-  .api-nav-group {
+  /* On narrow screens the nav is one scrolling chip row, so each group and
+     category inlines its label with its own chips instead of stacking. */
+  .api-nav-group,
+  .api-nav-category {
     flex: 0 0 auto;
     flex-direction: row;
     align-items: center;
     gap: 8px;
   }
 
-  .api-nav-group-label {
+  .api-nav-category {
+    padding-left: 8px;
+  }
+
+  .api-nav-group-label,
+  .api-nav-category-label {
     flex: 0 0 auto;
+  }
+
+  .api-category-divider {
+    margin: 30px 0 14px;
   }
 
   .api-nav a {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1630,7 +1630,6 @@ a:hover {
   color: var(--text-dim);
   font-size: 0.62rem;
   letter-spacing: 0.04em;
-  opacity: 0.85;
 }
 
 .api-intro {
@@ -1848,6 +1847,14 @@ a:hover {
   font-size: 0.66rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
+}
+
+/* The first module under a category belongs to it, so it drops the separating
+   rule `.docs-main h2` gives every other module heading. */
+.api-category-divider + .api-module > h2 {
+  margin-top: 22px;
+  padding-top: 0;
+  border-top: 0;
 }
 
 .api-category-divider h2::before {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1609,15 +1609,16 @@ a:hover {
 }
 
 .api-nav-group-label {
-  color: var(--text-dim);
+  color: rgba(65, 216, 230, 0.78);
   font-family: var(--font-display);
   font-size: 0.58rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
-/* Categories are the second level of the nav: a hairline ties each topic's
-   modules together without a second uppercase shout. */
+/* Categories are the second level of the nav, in the same color language as
+   the content dividers — cyan names a group, pink names a category — muted so
+   the column stays quiet. The hairline ties each topic's modules together. */
 .api-nav-category {
   display: flex;
   flex-direction: column;
@@ -1627,9 +1628,11 @@ a:hover {
 }
 
 .api-nav-category-label {
-  color: var(--text-dim);
-  font-size: 0.62rem;
-  letter-spacing: 0.04em;
+  color: rgba(232, 88, 184, 0.72);
+  font-family: var(--font-display);
+  font-size: 0.54rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
 .api-intro {
@@ -1817,12 +1820,13 @@ a:hover {
 }
 
 /* And within a half, a category names the topic the next few modules share —
-   quieter than the group, marked by a short cyan tick rather than color. */
+   one level down from the group, encoded by color role: cyan names a group,
+   pink names a category. The rule fades out from the label's own pink. */
 .api-category-divider {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin: 40px 0 18px;
+  gap: 14px;
+  margin: 44px 0 16px;
 }
 
 .api-group-divider + .api-category-divider {
@@ -1832,7 +1836,7 @@ a:hover {
 .api-category-divider::after {
   flex: 1;
   height: 1px;
-  background: var(--line);
+  background: linear-gradient(90deg, rgba(232, 88, 184, 0.35), var(--line) 30%);
   content: "";
 }
 
@@ -1842,10 +1846,10 @@ a:hover {
   margin: 0;
   padding-top: 0;
   border-top: 0;
-  color: var(--text);
+  color: var(--pink);
   font-family: var(--font-display);
-  font-size: 0.66rem;
-  letter-spacing: 0.16em;
+  font-size: 0.64rem;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
@@ -1855,15 +1859,6 @@ a:hover {
   margin-top: 22px;
   padding-top: 0;
   border-top: 0;
-}
-
-.api-category-divider h2::before {
-  display: inline-block;
-  width: 14px;
-  margin-right: 10px;
-  border-top: 2px solid var(--cyan);
-  content: "";
-  vertical-align: middle;
 }
 
 .api-module > h2 {

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -5,6 +5,10 @@
 //! The two are the same extraction — module `//!` prose, then a `///` block
 //! above each type or value — over different sources, and they stay separate
 //! only in the rendered output, as the [`ApiGroup`] each module carries.
+//!
+//! Within a group, modules are further sorted into categories ("Scene &
+//! rendering", "Collections", …) by [`CATEGORIES`] — the one place the
+//! reference's shape is declared.
 
 use functor_lang::ast::{ExprKind, Item, TypeName};
 use functor_lang::project::stdlib_documentation_modules;
@@ -26,9 +30,63 @@ pub struct ApiReference {
 pub struct ApiModule {
     pub name: String,
     pub group: ApiGroup,
+    /// The category heading this module renders under, within its group.
+    pub category: String,
     pub docs: Option<String>,
     pub items: Vec<ApiItem>,
 }
+
+/// The reference's shape, declared ONCE: every documented module, in the order
+/// it renders, under the group and category it belongs to.
+///
+/// This is the only place a module's category is stated, and it is
+/// drift-proof in both directions — [`generate`] fails if an entry here names
+/// a module that is not documented, if it claims the wrong group, or if a
+/// documented module has no entry at all. A new prelude or standard-library
+/// module therefore cannot land uncategorized.
+const CATEGORIES: &[(ApiGroup, &str, &[&str])] = &[
+    (
+        ApiGroup::Engine,
+        "Scene & rendering",
+        &[
+            "Scene",
+            "Frame",
+            "Camera3D",
+            "Camera2D",
+            "Sprite",
+            "Light",
+            "Skybox",
+            "Texture",
+            "Fog",
+            "RenderTarget",
+        ],
+    ),
+    (
+        ApiGroup::Engine,
+        "Math & geometry",
+        &["Vec3", "Angle", "Color"],
+    ),
+    (
+        ApiGroup::Engine,
+        "Simulation",
+        &["Physics", "Anim", "Terrain", "Time"],
+    ),
+    (ApiGroup::Engine, "Input", &["Input"]),
+    (ApiGroup::Engine, "Effects & messaging", &["Effect", "Sub"]),
+    (ApiGroup::Engine, "Audio", &["AudioScene", "AudioSource"]),
+    (ApiGroup::Engine, "UI", &["Ui", "Html", "Attr", "Style"]),
+    (ApiGroup::Engine, "Assets", &["Asset"]),
+    (ApiGroup::Stdlib, "Collections", &["List", "Map"]),
+    (ApiGroup::Stdlib, "Text", &["Text"]),
+    (
+        ApiGroup::Stdlib,
+        "Numbers & randomness",
+        &["Math", "Random"],
+    ),
+    (ApiGroup::Stdlib, "Fallibility", &["Option", "Result"]),
+    (ApiGroup::Stdlib, "Input", &["Key", "Mouse"]),
+    (ApiGroup::Stdlib, "Diagnostics", &["Debug"]),
+];
 
 /// Which half of the API a module belongs to. Engine modules exist only under
 /// a game runner; standard-library modules ship with the language and are
@@ -177,22 +235,93 @@ pub fn generate() -> Result<ApiReference, GenerateError> {
         }
     }
     Ok(ApiReference {
-        schema_version: 2,
-        modules,
+        schema_version: 3,
+        modules: categorize(modules, CATEGORIES)?,
     })
 }
 
+/// Sort the documented modules into [`CATEGORIES`] order, stamping each with
+/// its category.
+///
+/// Both directions are errors, so the table and the sources cannot drift: a
+/// table entry naming a module that is not documented (or documented in the
+/// other group), and a documented module with no table entry at all.
+fn categorize(
+    mut modules: Vec<ApiModule>,
+    categories: &[(ApiGroup, &str, &[&str])],
+) -> Result<Vec<ApiModule>, GenerateError> {
+    let mut ordered = Vec::with_capacity(modules.len());
+    for (group, category, names) in categories {
+        for name in *names {
+            // Removed as it is placed, so listing a module twice in the table
+            // reports as "not documented" on the second mention rather than
+            // duplicating it into the page.
+            let Some(index) = modules.iter().position(|module| module.name == *name) else {
+                return Err(categorization_error(
+                    name,
+                    format!(
+                        "`{name}` is listed under \"{category}\" but no such module is \
+                         documented — fix or remove its entry in CATEGORIES \
+                         (tools/functor-docgen)"
+                    ),
+                ));
+            };
+            if modules[index].group != *group {
+                return Err(categorization_error(
+                    name,
+                    format!(
+                        "`{name}` is listed under \"{category}\" as {group:?}, but it is \
+                         documented as {:?} — fix its entry in CATEGORIES \
+                         (tools/functor-docgen)",
+                        modules[index].group
+                    ),
+                ));
+            }
+            let mut module = modules.remove(index);
+            module.category = (*category).to_string();
+            ordered.push(module);
+        }
+    }
+    if let Some(module) = modules.first() {
+        return Err(categorization_error(
+            &module.name,
+            format!(
+                "`{}` has no category — add it to CATEGORIES (tools/functor-docgen) so it \
+                 renders under a heading",
+                module.name
+            ),
+        ));
+    }
+    Ok(ordered)
+}
+
+fn categorization_error(module: &str, message: String) -> GenerateError {
+    GenerateError {
+        module: module.to_string(),
+        extension: "funi",
+        line: 1,
+        col: 1,
+        message,
+    }
+}
+
 /// Generate a reference from `(module name, .funi source)` pairs — the
-/// interface-only shape, used by tests.
+/// interface-only shape, used by tests. The synthetic modules are not part of
+/// the real inventory, so they all render under one category.
 pub fn generate_from_modules(
     modules: impl IntoIterator<Item = (String, String)>,
 ) -> Result<ApiReference, GenerateError> {
     let modules = modules
         .into_iter()
-        .map(|(name, source)| extract_module(name, source, ApiGroup::Engine, Parse::Interface))
+        .map(|(name, source)| {
+            extract_module(name, source, ApiGroup::Engine, Parse::Interface).map(|mut module| {
+                module.category = "Reference".to_string();
+                module
+            })
+        })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(ApiReference {
-        schema_version: 2,
+        schema_version: 3,
         modules,
     })
 }
@@ -248,16 +377,24 @@ pub fn render_markdown(reference: &ApiReference) -> String {
          the host runtime's `.funi` prelude and the language's own standard library.\n",
     );
     let mut group = None;
+    let mut category = None;
     for module in &reference.modules {
         if group != Some(module.group) {
             group = Some(module.group);
+            category = None;
             out.push_str("\n## ");
             out.push_str(module.group.title());
             out.push_str("\n\n");
             out.push_str(module.group.summary());
             out.push('\n');
         }
-        out.push_str("\n### ");
+        if category.is_none_or(|current| current != module.category.as_str()) {
+            category = Some(module.category.as_str());
+            out.push_str("\n### ");
+            out.push_str(&module.category);
+            out.push('\n');
+        }
+        out.push_str("\n#### ");
         out.push_str(&module.name);
         out.push('\n');
         if let Some(docs) = &module.docs {
@@ -266,7 +403,7 @@ pub fn render_markdown(reference: &ApiReference) -> String {
             out.push('\n');
         }
         for item in &module.items {
-            out.push_str("\n#### `");
+            out.push_str("\n##### `");
             out.push_str(&item.qualified_name);
             out.push_str("`\n\n```functor\n");
             out.push_str(&item.declaration);
@@ -339,6 +476,8 @@ fn extract_module(
     Ok(ApiModule {
         name,
         group,
+        // Stamped by `categorize` once the whole inventory is known.
+        category: String::new(),
         docs: module_doc(&source),
         items,
     })
@@ -453,8 +592,8 @@ mod tests {
         assert_eq!(module.items[1].docs.as_deref(), Some("Make one."));
 
         let markdown = render_markdown(&reference);
-        assert!(markdown.contains("### Widget"));
-        assert!(markdown.contains("#### `Widget.make`"));
+        assert!(markdown.contains("#### Widget"));
+        assert!(markdown.contains("##### `Widget.make`"));
     }
 
     /// Both halves of the embedded API are complete and fully documented. The
@@ -507,9 +646,75 @@ mod tests {
         assert_eq!(
             stdlib,
             [
-                "List", "Map", "Text", "Math", "Random", "Debug", "Option", "Result", "Key",
-                "Mouse"
+                "List", "Map", "Text", "Math", "Random", "Option", "Result", "Key", "Mouse",
+                "Debug"
             ]
+        );
+    }
+
+    /// Every module renders under a category, categories stay contiguous
+    /// within their group, and the taxonomy is the one in `CATEGORIES`.
+    #[test]
+    fn every_module_lands_in_a_category() {
+        let reference = generate().unwrap();
+        assert!(
+            reference
+                .modules
+                .iter()
+                .all(|module| !module.category.is_empty()),
+            "every module carries a category"
+        );
+
+        let mut seen: Vec<(ApiGroup, &str)> = Vec::new();
+        for module in &reference.modules {
+            let key = (module.group, module.category.as_str());
+            if seen.last() != Some(&key) {
+                assert!(
+                    !seen.contains(&key),
+                    "{key:?} is split across the page — categories must be contiguous"
+                );
+                seen.push(key);
+            }
+        }
+        assert_eq!(
+            seen,
+            super::CATEGORIES
+                .iter()
+                .map(|(group, category, _)| (*group, *category))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// A module the taxonomy does not mention is a hard generation error, so
+    /// a new module cannot silently land uncategorized.
+    #[test]
+    fn an_uncategorized_module_fails_generation() {
+        let widget = super::extract_module(
+            "Widget".to_string(),
+            "//! Widgets.\n/// An opaque widget.\ntype t\n".to_string(),
+            ApiGroup::Engine,
+            super::Parse::Interface,
+        )
+        .unwrap();
+        let error = super::categorize(vec![widget], &[]).expect_err("Widget has no category");
+        assert!(
+            error.to_string().contains("`Widget` has no category"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// And the table cannot outlive its modules either: a category naming a
+    /// module that is no longer documented fails just as loudly.
+    #[test]
+    fn a_category_naming_a_missing_module_fails_generation() {
+        let error = super::categorize(
+            Vec::new(),
+            &[(ApiGroup::Engine, "Scene & rendering", &["Scene"])],
+        )
+        .expect_err("Scene is not documented");
+        assert!(
+            error.to_string().contains("no such module is documented"),
+            "unexpected error: {error}"
         );
     }
 

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -32,6 +32,11 @@ pub struct ApiModule {
     pub group: ApiGroup,
     /// The category heading this module renders under, within its group.
     pub category: String,
+    /// The extension this module's source carries on disk, so an error about
+    /// it names a plausible file. Presentation-neutral output does not need
+    /// it.
+    #[serde(skip)]
+    pub extension: &'static str,
     pub docs: Option<String>,
     pub items: Vec<ApiItem>,
 }
@@ -245,30 +250,54 @@ pub fn generate() -> Result<ApiReference, GenerateError> {
 ///
 /// Both directions are errors, so the table and the sources cannot drift: a
 /// table entry naming a module that is not documented (or documented in the
-/// other group), and a documented module with no table entry at all.
+/// other group), and a documented module with no table entry at all. A group's
+/// categories also have to be contiguous, since both renderers announce a
+/// group once and then walk its categories.
 fn categorize(
     mut modules: Vec<ApiModule>,
     categories: &[(ApiGroup, &str, &[&str])],
 ) -> Result<Vec<ApiModule>, GenerateError> {
-    let mut ordered = Vec::with_capacity(modules.len());
+    let mut ordered: Vec<ApiModule> = Vec::with_capacity(modules.len());
+    let mut groups: Vec<ApiGroup> = Vec::new();
     for (group, category, names) in categories {
-        for name in *names {
-            // Removed as it is placed, so listing a module twice in the table
-            // reports as "not documented" on the second mention rather than
-            // duplicating it into the page.
-            let Some(index) = modules.iter().position(|module| module.name == *name) else {
+        if groups.last() != Some(group) {
+            if groups.contains(group) {
                 return Err(categorization_error(
-                    name,
+                    names.first().unwrap_or(&""),
+                    "funi",
+                    format!(
+                        "{group:?} categories are split around another group's — a group's \
+                         categories must be contiguous in CATEGORIES (tools/functor-docgen), \
+                         so \"{category}\" has to move next to the others"
+                    ),
+                ));
+            }
+            groups.push(*group);
+        }
+        for name in *names {
+            // Modules are removed as they are placed, so a second mention would
+            // otherwise report as "not documented" and point at the prelude
+            // instead of at the table.
+            let Some(index) = modules.iter().position(|module| module.name == *name) else {
+                let message = if let Some(placed) = ordered.iter().find(|m| m.name == *name) {
+                    format!(
+                        "`{name}` is listed twice in CATEGORIES (tools/functor-docgen) — \
+                         under \"{}\" and again under \"{category}\"",
+                        placed.category
+                    )
+                } else {
                     format!(
                         "`{name}` is listed under \"{category}\" but no such module is \
                          documented — fix or remove its entry in CATEGORIES \
                          (tools/functor-docgen)"
-                    ),
-                ));
+                    )
+                };
+                return Err(categorization_error(name, "funi", message));
             };
             if modules[index].group != *group {
                 return Err(categorization_error(
                     name,
+                    modules[index].extension,
                     format!(
                         "`{name}` is listed under \"{category}\" as {group:?}, but it is \
                          documented as {:?} — fix its entry in CATEGORIES \
@@ -285,6 +314,7 @@ fn categorize(
     if let Some(module) = modules.first() {
         return Err(categorization_error(
             &module.name,
+            module.extension,
             format!(
                 "`{}` has no category — add it to CATEGORIES (tools/functor-docgen) so it \
                  renders under a heading",
@@ -295,10 +325,10 @@ fn categorize(
     Ok(ordered)
 }
 
-fn categorization_error(module: &str, message: String) -> GenerateError {
+fn categorization_error(module: &str, extension: &'static str, message: String) -> GenerateError {
     GenerateError {
         module: module.to_string(),
-        extension: "funi",
+        extension,
         line: 1,
         col: 1,
         message,
@@ -478,6 +508,10 @@ fn extract_module(
         group,
         // Stamped by `categorize` once the whole inventory is known.
         category: String::new(),
+        extension: match parse_as {
+            Parse::Interface => "funi",
+            Parse::Implementation => "fun",
+        },
         docs: module_doc(&source),
         items,
     })
@@ -699,6 +733,49 @@ mod tests {
         let error = super::categorize(vec![widget], &[]).expect_err("Widget has no category");
         assert!(
             error.to_string().contains("`Widget` has no category"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// A group announces itself once, so its categories cannot be split
+    /// around another group's.
+    #[test]
+    fn a_group_split_across_the_table_fails_generation() {
+        let error = super::categorize(
+            Vec::new(),
+            &[
+                (ApiGroup::Engine, "Scene & rendering", &[]),
+                (ApiGroup::Stdlib, "Collections", &[]),
+                (ApiGroup::Engine, "Audio", &[]),
+            ],
+        )
+        .expect_err("Engine is split around Stdlib");
+        assert!(
+            error.to_string().contains("must be contiguous"),
+            "unexpected error: {error}"
+        );
+    }
+
+    /// A module named twice says so, instead of pointing at the prelude.
+    #[test]
+    fn a_module_listed_twice_fails_generation() {
+        let widget = super::extract_module(
+            "Widget".to_string(),
+            "//! Widgets.\n/// An opaque widget.\ntype t\n".to_string(),
+            ApiGroup::Engine,
+            super::Parse::Interface,
+        )
+        .unwrap();
+        let error = super::categorize(
+            vec![widget],
+            &[
+                (ApiGroup::Engine, "Scene & rendering", &["Widget"]),
+                (ApiGroup::Engine, "Audio", &["Widget"]),
+            ],
+        )
+        .expect_err("Widget is listed twice");
+        assert!(
+            error.to_string().contains("listed twice"),
             "unexpected error: {error}"
         );
     }


### PR DESCRIPTION
**Stacked on #606** (`stdlib-api-docs`) — review that first; this PR's base branch is `stdlib-api-docs`, not `main`.

#606 split the reference into two groups, **Engine modules** and **Language standard library**. That left 27 and 10 modules of flat list under them — `Scene`, `Terrain`, `Anim`, `Asset`, `Angle`, `Color`, `Vec3`, … in registration order, with no answer to "where do I look for the camera?"

Each group now renders as a handful of named **categories**, in the Markdown, the JSON, and the docs page.

## The taxonomy

Declared once, in `CATEGORIES` (`tools/functor-docgen/src/lib.rs`), which also fixes the render order:

| Group | Category | Modules |
| --- | --- | --- |
| Engine | Scene & rendering | `Scene` `Frame` `Camera3D` `Camera2D` `Sprite` `Light` `Skybox` `Texture` `Fog` `RenderTarget` |
| Engine | Math & geometry | `Vec3` `Angle` `Color` |
| Engine | Simulation | `Physics` `Anim` `Terrain` `Time` |
| Engine | Input | `Input` |
| Engine | Effects & messaging | `Effect` `Sub` |
| Engine | Audio | `AudioScene` `AudioSource` |
| Engine | UI | `Ui` `Html` `Attr` `Style` |
| Engine | Assets | `Asset` |
| Standard library | Collections | `List` `Map` |
| Standard library | Text | `Text` |
| Standard library | Numbers & randomness | `Math` `Random` |
| Standard library | Fallibility | `Option` `Result` |
| Standard library | Input | `Key` `Mouse` |
| Standard library | Diagnostics | `Debug` |

Two placements were judgment calls, flagged for the maintainer:

- **`Key` / `Mouse` → Standard library ▸ Input.** The approved taxonomy put them under the engine's "Input" *if they were listed engine-side*. #606 documents them as language modules (`functor-lang/stdlib/key.fun` / `mouse.fun`), and a group's categories have to stay contiguous, so they get an "Input" category of their own inside the standard library. The label repeats across the two groups; everything the page keys on is the **group-qualified** pair (`stdlib:Input`), so nothing collides.
- **`Time` → Simulation.** It is the engine's clock/duration type, and it sits with the things that consume it.

## Drift-proofing (the same shape as #606's)

Generation is a hard error in **both** directions, so the table and the sources cannot drift apart:

- a documented module with no entry — `` `Sprite` has no category — add it to CATEGORIES (tools/functor-docgen) so it renders under a heading ``
- an entry naming a module that is not documented, or claiming the wrong group
- a module listed twice
- a group whose categories are split around another group's (both renderers announce a group once)

A new prelude or standard-library module therefore cannot silently land uncategorized. Tests cover each failure, and `every_module_lands_in_a_category` pins the rendered shape to the table.

## The three outputs

- **Markdown** — `## Group` → `### Category` → `#### Module` → `##### Declaration`.
- **JSON** — `schema_version` 2 → 3, with `category` beside `group` per module. No in-repo consumer pins the version.
- **The page** — a category heading in the scrolling reference, and a nav sub-group under each group label. The search filter hides a category (heading + nav block) when its last module goes, exactly as #606 does for groups; a module's search index now includes its category, so "collections" and "fallibility" find what the page shows.

## Screenshots (desktop + mobile, before/after)

Built normally (`npm install`, the existing `runtime/functor-runtime-web/pkg`, `npm run site:build`) and captured headlessly at 1440px and 390px; "before" is the same build at the base ref (#606's head).

|  | before | after |
| --- | --- | --- |
| desktop, top | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-before-desktop-top.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-after-desktop-top.png" width="420"> |
| desktop, the standard-library boundary | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-before-desktop-stdlib.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-after-desktop-stdlib.png" width="420"> |
| desktop, filtered by "audio" | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-before-desktop-filtered.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-after-desktop-filtered.png" width="420"> |
| mobile, top | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-before-mobile-top.png" width="220"> | <img src="https://gist.githubusercontent.com/tommy-xr/da0ff37a6ad0d854d99846a8fdbc6716/raw/apiA-after-mobile-top.png" width="220"> |

On mobile the nav stays one horizontally scrolling row; each category inlines its label with its own chips, the same way #606's group labels do.

## Verification

- `npm run generate:docs` / `npm run check:docs` — pass.
- `cargo test -p functor-docgen` (14 tests, incl. the four new negative paths) and `cargo test -p functor-lang` (all suites, incl. #606's stdlib drift pin) — pass.
- `functor docs --check docs/api-reference.md` — agrees with the generated file (binary rebuilt after the review fixes).
- `npm run check:site` (tsc) and `npm run site:build` — pass; the filter's category hiding verified in the built page headlessly (query "audio" leaves only the Audio category, in nav and body).
- `cargo fmt --check` / `cargo clippy` clean on the changed crate.

## Review dispositions (`/xreview`: Claude subagent + Codex, in parallel, both with the screenshots)

**No Critical or High findings from either engine.** Both independently confirmed the escaping, the group-qualified filter key, and that no in-repo consumer pins `schema_version`. Fixed in `60c5350` unless marked otherwise.

| Finding | Engine | Disposition |
| --- | --- | --- |
| `CATEGORIES` group contiguity unguarded — a category appended at the end of the table would emit a second group heading and nav block | Claude (Medium) | Fixed: contiguity is now a generation error, with a test |
| Category labels missing from the module search index, so searching "fallibility"/"diagnostics" returned nothing | Codex (Medium) | Fixed: `data-search` includes the category |
| A module listed twice reports as "not documented", pointing at the prelude instead of the table | Claude (Low) | Fixed: distinct "listed twice" error, with a test |
| Categorization errors always said `.funi`, wrong for `Key.fun` / `Option.fun` | Codex (Low) | Fixed: the module carries its extension |
| Dead `category = undefined` reset in `sections()` | Claude (Low) | Fixed: removed (the key carries the group) |
| Empty band + stray hairline between a category heading and its first module | Claude (Low) | Fixed: the first module under a category drops the separating rule |
| `.api-nav-category-label` dimmed twice (color + opacity), landing at the AA floor | Claude (note) | Fixed: opacity dropped |
| Presentational `<h2>`s flatten the heading outline for screen readers | Claude (Low) | **Won't fix here** — the group divider established this shape in #606 and its own comment already calls itself presentational; demoting both (and the module/item headings under them) is a page-wide change, not something to do to half the page in this PR |
| The mobile nav row is ~14 labels longer to swipe | Claude (Low) | **Won't fix** — deliberate: the labels are the feature, and the suggested alternative (hiding them on mobile) removes exactly what a mobile reader needs most |
| Duplication scan | dupfinder | No duplication signals touching the change |
