### PR TITLE
docs(site): group the manual nav

### DIFF
--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -27,25 +27,25 @@
     <div class="docs-layout">
       <!-- Four labelled groups, in the order a reader meets them: run something,
            understand it, drive it from a tool, then look things up. -->
-      <nav class="docs-nav" aria-label="Manual sections">
-        <div class="docs-nav-group">
-          <div class="docs-nav-group-label">Start</div>
+      <nav class="docs-nav docs-nav-grouped" aria-label="Manual sections">
+        <div class="docs-nav-group" role="group" aria-labelledby="nav-start">
+          <div class="docs-nav-group-label" id="nav-start">Start</div>
           <a href="#get-started">Get started</a>
           <a href="#tutorial">Tutorial</a>
         </div>
-        <div class="docs-nav-group">
-          <div class="docs-nav-group-label">Concepts</div>
+        <div class="docs-nav-group" role="group" aria-labelledby="nav-concepts">
+          <div class="docs-nav-group-label" id="nav-concepts">Concepts</div>
           <a href="#contract">The game contract</a>
           <a href="#debug-camera">The debug camera</a>
           <a href="#language">The language</a>
         </div>
-        <div class="docs-nav-group">
-          <div class="docs-nav-group-label">Tooling</div>
+        <div class="docs-nav-group" role="group" aria-labelledby="nav-tooling">
+          <div class="docs-nav-group-label" id="nav-tooling">Tooling</div>
           <a href="#agents">Driving with agents</a>
         </div>
-        <div class="docs-nav-group">
-          <div class="docs-nav-group-label">Reference</div>
-          <a class="docs-nav-out" href="../docs/">API reference ↗</a>
+        <div class="docs-nav-group" role="group" aria-labelledby="nav-reference">
+          <div class="docs-nav-group-label" id="nav-reference">Reference</div>
+          <a class="docs-nav-out" href="../docs/">API reference <span aria-hidden="true">↗</span></a>
           <a href="#prelude">The prelude</a>
           <a href="#builtins">Standard library</a>
           <a href="#sharp-edges">Sharp edges</a>

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -25,16 +25,31 @@
     <!--/@header-->
 
     <div class="docs-layout">
-      <nav class="docs-nav">
-        <a href="#get-started">Get started</a>
-        <a href="#tutorial">Tutorial</a>
-        <a href="#contract">The game contract</a>
-        <a href="#debug-camera">The debug camera</a>
-        <a href="#language">The language</a>
-        <a href="#prelude">The prelude</a>
-        <a href="#builtins">Standard library</a>
-        <a href="#agents">Driving with agents</a>
-        <a href="#sharp-edges">Sharp edges</a>
+      <!-- Four labelled groups, in the order a reader meets them: run something,
+           understand it, drive it from a tool, then look things up. -->
+      <nav class="docs-nav" aria-label="Manual sections">
+        <div class="docs-nav-group">
+          <div class="docs-nav-group-label">Start</div>
+          <a href="#get-started">Get started</a>
+          <a href="#tutorial">Tutorial</a>
+        </div>
+        <div class="docs-nav-group">
+          <div class="docs-nav-group-label">Concepts</div>
+          <a href="#contract">The game contract</a>
+          <a href="#debug-camera">The debug camera</a>
+          <a href="#language">The language</a>
+        </div>
+        <div class="docs-nav-group">
+          <div class="docs-nav-group-label">Tooling</div>
+          <a href="#agents">Driving with agents</a>
+        </div>
+        <div class="docs-nav-group">
+          <div class="docs-nav-group-label">Reference</div>
+          <a class="docs-nav-out" href="../docs/">API reference ↗</a>
+          <a href="#prelude">The prelude</a>
+          <a href="#builtins">Standard library</a>
+          <a href="#sharp-edges">Sharp edges</a>
+        </div>
       </nav>
 
       <main class="docs-main">

--- a/site/styles.css
+++ b/site/styles.css
@@ -1441,8 +1441,25 @@ a:hover {
   align-self: start;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 18px;
   font-size: 0.85rem;
+}
+
+/* The manual is one long page, so its nav is grouped: a label names what the
+   next few links are for. Each group is one element, so it stays intact when
+   the nav becomes a scrolling row on narrow screens. */
+.docs-nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.docs-nav-group-label {
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-size: 0.58rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .docs-nav a {
@@ -1456,6 +1473,11 @@ a:hover {
   color: var(--cyan);
   border-left-color: var(--cyan);
   text-decoration: none;
+}
+
+/* The one link that leaves the page. */
+.docs-nav a.docs-nav-out {
+  color: var(--cyan);
 }
 
 .docs-main h1 {
@@ -1910,9 +1932,23 @@ a:hover {
     position: static;
     flex-direction: row;
     flex-wrap: nowrap;
-    gap: 8px;
+    /* Wide enough that a group's label reads as belonging to the links after
+       it, not the link before it. */
+    gap: 26px;
     overflow-x: auto;
     padding-bottom: 6px;
+  }
+
+  /* One scrolling row, so a group inlines its label with its own links. */
+  .docs-nav-group {
+    flex: 0 0 auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .docs-nav-group-label {
+    flex: 0 0 auto;
   }
 
   .api-nav {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1441,13 +1441,18 @@ a:hover {
   align-self: start;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 8px;
   font-size: 0.85rem;
 }
 
 /* The manual is one long page, so its nav is grouped: a label names what the
    next few links are for. Each group is one element, so it stays intact when
-   the nav becomes a scrolling row on narrow screens. */
+   the nav becomes a scrolling row on narrow screens. The spacing lives on its
+   own class — `.docs-nav` is shared with the API reference page. */
+.docs-nav-grouped {
+  gap: 18px;
+}
+
 .docs-nav-group {
   display: flex;
   flex-direction: column;
@@ -1932,11 +1937,16 @@ a:hover {
     position: static;
     flex-direction: row;
     flex-wrap: nowrap;
-    /* Wide enough that a group's label reads as belonging to the links after
-       it, not the link before it. */
-    gap: 26px;
+    gap: 8px;
     overflow-x: auto;
     padding-bottom: 6px;
+  }
+
+  /* Wide enough that a group's label reads as belonging to the links after
+     it, not the link before it — and no wider, since every pixel here is one
+     less link reachable in the scrolling row. */
+  .docs-nav-grouped {
+    gap: 20px;
   }
 
   /* One scrolling row, so a group inlines its label with its own links. */


### PR DESCRIPTION
**Stacked on #605** (`docs-manual-tutorial`) — review that first; this PR's base branch is `docs-manual-tutorial`, not `main`. (Branched from its post-#603 head, `c56a468`.)

The manual is one very long page, and its nav was nine flat links — "Sharp edges" carried the same weight as "Get started", and nothing said which of them a first-time reader needs. The links are now four labelled groups, in the order a reader meets them:

| Group | Links |
| --- | --- |
| **Start** | Get started · Tutorial |
| **Concepts** | The game contract · The debug camera · The language |
| **Tooling** | Driving with agents |
| **Reference** | **API reference ↗** (out to `/docs/`) · The prelude · Standard library · Sharp edges |

Reference opens with the link out to the generated API reference, because that is where an exact signature actually lives — the manual's own Prelude and Standard library sections sit under it as the page-local reference material they are.

**Nav and its labels only.** No section was moved, and no section content was rewritten.

Two things worth calling out:

- **Prelude / Standard library are still here.** They exist on this base branch, so they are placed rather than removed — under Reference, where they belong until the follow-up PR deletes them.
- **Two nav links point backwards.** `#agents` (Tooling) precedes `#prelude` and `#builtins` in the DOM but follows them in the nav, so those two Reference links scroll up rather than down. Fixing it properly means moving the ~150-line Agents section, which is exactly the "don't touch section content" line this PR draws — and the mismatch disappears on its own when the follow-up removes Prelude and Standard library, leaving Tooling → Reference in document order.

## Screenshots (desktop + mobile, before/after)

Site built with `npm run site:build` and captured headlessly at 1440px and 390px; "before" is the same build at the base ref.

|  | before | after |
| --- | --- | --- |
| desktop, top | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-before-desktop-top.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-after-desktop-top.png" width="420"> |
| desktop, the nav itself | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-before-desktop-nav.png" width="200"> | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-after-desktop-nav.png" width="200"> |
| mobile, top | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-before-mobile-top.png" width="220"> | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-after-mobile-top.png" width="220"> |
| mobile, the nav strip | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-before-mobile-nav.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/ad484ef91a1679366052706a18c2130f/raw/prB-after-mobile-nav.png" width="420"> |

Styling extends the site's existing system rather than inventing one: group labels use the same Orbitron / uppercase / `--text-dim` eyebrow treatment the site already uses for labels, links keep their hairline left rule, and the single out-link is cyan (pink stays reserved for the wordmark). On mobile the nav is still one horizontally scrolling row; each group inlines its label with its own links.

## Verification

- `npm run site:build` and `npm run check:site` (tsc) — pass.
- Every nav `href` resolves: all nine `#…` targets exist as `<section id>` on the page, and `../docs/` is a real page (both reviewers checked this independently).
- `.docs-nav` is shared with the API reference page (`site/docs/index.html` uses `docs-nav api-nav`), so the new spacing lives on a `.docs-nav-grouped` class and `.docs-nav`'s own rules are byte-identical to the base ref — `/docs/` cannot reflow.
- Desktop 1440px and mobile 390px captured and inspected (above).

## Review dispositions (`/xreview`: Claude subagent + Codex, in parallel, both with the screenshots)

**No Critical findings.** Fixed in `6eeee5d` unless marked otherwise.

| Finding | Engine(s) | Disposition |
| --- | --- | --- |
| The wider `.docs-nav` gap leaked onto the API reference page, which shares the class — an out-of-scope reflow of `/docs/` | both **[AGREED]** (Claude High, Codex Low) | Fixed: the spacing moved to a `.docs-nav-grouped` class; `.docs-nav` is unchanged from the base |
| Group labels were presentational `<div>`s, so the grouping did not exist for assistive technology | both **[AGREED]** (Medium) | Fixed: each group is `role="group" aria-labelledby="…"` against its own label |
| The mobile gap (26px) cost link reachability in the scrolling strip | Claude (Low/Medium) | Partly fixed: down to 20px — enough that a label reads as belonging to the links after it, and no more. The suggested alternative (hiding the labels on mobile) removes the feature exactly where the reader is most lost |
| The `↗` glyph is read aloud and implies a new tab | Claude (Low) | Fixed: `aria-hidden` |
| Nav order contradicts document order for `#prelude` / `#builtins` | Claude (Medium) | **Won't fix here** — see above: the real fix is moving the Agents section, which this PR deliberately does not do, and the follow-up removal resolves it |
| `.docs-nav-group-label` (0.58rem/0.14em) differs from `.api-nav-heading` (0.68rem/0.12em) | Claude (Low) | **Won't fix** — `.api-nav-heading` is the title of a whole nav, not a group label. These values match the group-label role as used in #609, so the two docs pages agree |
| Duplication scan | dupfinder | No duplication signals touching the change |
