### PR TITLE
feat(site): grid layout — client cells over a server strip

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -16,7 +16,9 @@
 //      inspector trace, the same path the net-coordinator e2e uses — so the
 //      panes are one session, not three lonely sims;
 //   4. every pane header shows its coordinator link state;
-//   5. switching to a single-role example removes the server pane again.
+//   5. the GRID layout puts the clients in two columns with the server as a
+//      full-width strip below them — and switching layout reloads no pane;
+//   6. switching to a single-role example removes the server pane again.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -85,6 +87,32 @@ const installProbe = (page) =>
       headers: () => shells().map((s) => s.header),
       pill: () => document.getElementById("status").textContent.trim(),
       pauseAll: () => document.getElementById("mp-pause").click(),
+      layout: () => ({
+        view: document.querySelector(".mp-grid").dataset.view,
+        pressed: [...document.querySelectorAll(".mp-viewseg button")].map(
+          (b) => `${b.id.replace("mp-view-", "")}:${b.getAttribute("aria-pressed")}`
+        ),
+      }),
+      // Laid-out geometry per pane, plus the server's resolved grid placement.
+      boxes: () =>
+        shells().map((s) => {
+          const shell = s.frame.closest(".mp-pane");
+          const box = shell.getBoundingClientRect();
+          return {
+            role: s.role,
+            x: Math.round(box.x),
+            y: Math.round(box.y),
+            w: Math.round(box.width),
+            h: Math.round(box.height),
+            gridColumn: getComputedStyle(shell).gridColumn,
+          };
+        }),
+      // Document-lifetime markers for EVERY pane: a re-parented iframe reloads
+      // into a fresh realm and loses the flag.
+      markAll: () => {
+        for (const s of shells()) s.frame.contentWindow.__mpAlive = true;
+      },
+      allAlive: () => shells().every((s) => s.frame.contentWindow?.__mpAlive === true),
       model: (role) => {
         const trace = traces.get(role);
         const invocations = trace?.invocations ?? [];
@@ -112,6 +140,17 @@ try {
     );
     const clientsControl = await page.inputValue("#client-count");
     check(clientsControl === "1", "the CLIENTS control counts clients only", clientsControl);
+
+    // Grid with a LONE client: no peer to match, so it takes the whole row
+    // rather than sitting beside an empty cell — the server strip below it.
+    await page.click("#mp-view-grid");
+    await sleep(400);
+    const [client, server] = await page.evaluate(() => window.__mpProbe.boxes());
+    check(
+      Math.abs(client.w - server.w) < 2 && server.y >= client.y + client.h && server.h < client.h,
+      "grid with one client stacks it full-width over the server strip",
+      JSON.stringify([client, server])
+    );
     await page.close();
   }
 
@@ -231,6 +270,111 @@ try {
     await page.close();
   }
 
+  // --- 4c. GRID layout: client cells over a server strip, no pane reloaded. ---
+  // Switching layout must be a pure CSS/class change: reordering or re-parenting
+  // a pane's node would reload its iframe and wipe the model, so the same
+  // document-lifetime marker 4b uses on the server is applied to EVERY pane here.
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`${BASE}/sandbox.html?example=mp#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    const tiled = await page.evaluate(() => {
+      window.__mpProbe.markAll();
+      return window.__mpProbe.layout();
+    });
+    check(
+      tiled.view === "tiled" && tiled.pressed.join(" ") === "tiled:true grid:false tabs:false",
+      "the layout control starts on TILED with three options",
+      `${tiled.view} — ${tiled.pressed.join(" ")}`
+    );
+
+    await page.click("#mp-view-grid");
+    await sleep(400);
+    const grid = await page.evaluate(() => window.__mpProbe.layout());
+    check(
+      grid.view === "grid" && grid.pressed.join(" ") === "tiled:false grid:true tabs:false",
+      "clicking GRID switches the pane grid's layout",
+      `${grid.view} — ${grid.pressed.join(" ")}`
+    );
+
+    const boxes = await page.evaluate(() => window.__mpProbe.boxes());
+    const [c1, c2, server] = boxes;
+    check(
+      Math.abs(c1.y - c2.y) < 2 && c2.x > c1.x && Math.abs(c1.w - c2.w) < 2,
+      "the two clients sit side by side in equal columns",
+      JSON.stringify([c1, c2])
+    );
+    check(
+      server.gridColumn === "1 / -1" && server.w > c1.w * 1.8 && server.y >= c1.y + c1.h,
+      "the server pane spans every column as a strip below the clients",
+      JSON.stringify(server)
+    );
+    check(
+      server.h < c1.h,
+      "the server strip is shorter than a client cell",
+      `${server.h} vs ${c1.h}`
+    );
+    check(
+      await page.evaluate(() => window.__mpProbe.allAlive()),
+      "no pane's iframe was reloaded by the switch to grid"
+    );
+
+    // ...and back. Tiled is one row again, still the same three documents.
+    await page.click("#mp-view-tiled");
+    await sleep(400);
+    const back = await page.evaluate(() => window.__mpProbe.layout());
+    const backBoxes = await page.evaluate(() => window.__mpProbe.boxes());
+    check(
+      back.view === "tiled" &&
+        back.pressed.join(" ") === "tiled:true grid:false tabs:false" &&
+        backBoxes.every((b) => Math.abs(b.y - backBoxes[0].y) < 2),
+      "switching back to TILED restores the single row",
+      `${back.view} — ${JSON.stringify(backBoxes.map((b) => b.y))}`
+    );
+    check(
+      await page.evaluate(() => window.__mpProbe.allAlive()),
+      "no pane's iframe was reloaded by the switch back to tiled"
+    );
+
+    // `f` cycles the three layouts in the segmented control's order.
+    const cycled = [];
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press("f");
+      await sleep(250);
+      cycled.push(await page.evaluate(() => window.__mpProbe.layout().view));
+    }
+    check(
+      cycled.join(" → ") === "grid → tabs → tiled",
+      "f cycles tiled → grid → tabs → tiled",
+      cycled.join(" → ")
+    );
+    check(
+      await page.evaluate(() => window.__mpProbe.allAlive()),
+      "no pane's iframe was reloaded by the f cycle"
+    );
+
+    // A third client makes the odd row: it keeps its half-width cell (its peers
+    // are right above it, and the server strip still closes the layout below).
+    await page.selectOption("#client-count", "3");
+    await sleep(2500);
+    await page.click("#mp-view-grid");
+    await sleep(400);
+    const three = await page.evaluate(() => window.__mpProbe.boxes());
+    check(
+      three.length === 4 &&
+        Math.abs(three[2].w - three[0].w) < 2 &&
+        three[2].x === three[0].x &&
+        three[2].y >= three[0].y + three[0].h &&
+        three[3].w > three[2].w * 1.8,
+      "a third client keeps its half-width cell above the full-width strip",
+      JSON.stringify(three.map((b) => [b.role, b.x, b.y, b.w, b.h]))
+    );
+    await page.close();
+  }
+
   // --- 5. Switching away drops the server pane. -------------------------------
   {
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
@@ -249,6 +393,19 @@ try {
       .catch(() => false);
     const roles = await page.evaluate(() => window.__mpProbe.roles());
     check(gone, "switching to a single-role example removes the server pane", roles.join(", "));
+
+    // Grid with no authority: nothing closes the bottom row, so the odd last
+    // client stretches rather than leaving a whole empty quadrant.
+    await page.selectOption("#client-count", "3");
+    await sleep(2500);
+    await page.click("#mp-view-grid");
+    await sleep(400);
+    const solo = await page.evaluate(() => window.__mpProbe.boxes());
+    check(
+      solo.length === 3 && solo[2].w > solo[0].w * 1.8 && solo[2].y >= solo[0].y + solo[0].h,
+      "in a single-role example the odd last client spans the bottom row",
+      JSON.stringify(solo.map((b) => [b.role, b.x, b.y, b.w, b.h]))
+    );
     await page.close();
   }
 } finally {

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -4,7 +4,7 @@
 //
 // The preview column becomes:
 //
-//   ┌ chrono bar ─ ⏸ ⏭ ═══rail═══╪══ 🔮 | ⊞ tiled ▤ tabs ┐   (game side only —
+//   ┌ chrono bar ─ ⏸ ⏭ ══rail══╪═ 🔮 | ⊞ tiled ▦ grid ▤ tabs ┐ (game side only —
 //   ├ pane grid ──────────────────────────────────────────────┤    the editor keeps
 //   │  ╔ 1 client · cyan  ⇅ Wi-Fi ▾   #f 841 ● ╗  ┌ 2 client ┐│    its full height)
 //   │  ║             iframe                    ║  │  iframe   ││
@@ -116,6 +116,17 @@ interface LinkProfile {
 }
 
 type PaneState = PillState["state"];
+
+/**
+ * How the panes are laid out. `tiled` is one row of equal tiles; `grid` wraps
+ * the CLIENTS into two columns and gives the server its own full-width strip
+ * along the bottom (design-multiplayer-ide-frontend.md §5 — the authority reads
+ * differently from the players); `tabs` shows one pane at a time.
+ *
+ * Declaration order is the segmented control's order AND the `f` key's cycle.
+ */
+const VIEWS = ["tiled", "grid", "tabs"] as const;
+type PaneView = (typeof VIEWS)[number];
 
 /**
  * What a pane IS in the session. A `client` pane is a player: numbered, player
@@ -251,8 +262,9 @@ export function initMultiplayerPanes({
     </span>
     <button class="mp-sbtn" id="mp-extrap" title="Extrapolate: speculatively simulate forward from the parked frame">🔮</button>
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
-      <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every client visible">⊞ tiled</button>
-      <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one client full-size (f)">▤ tabs</button>
+      <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every pane in one row (f cycles)">⊞ tiled</button>
+      <button id="mp-view-grid" aria-pressed="false" title="Grid: clients in two columns over the server strip (f cycles)">▦ grid</button>
+      <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one pane full-size (f cycles)">▤ tabs</button>
     </span>`;
 
   const debugDrawer = document.createElement("section");
@@ -578,30 +590,38 @@ export function initMultiplayerPanes({
       if (from >= panes.length) focusPane(delta === 1 ? 0 : panes.length - 1);
       else focusPane((from + delta + panes.length) % panes.length);
     } else if (event.key === "f") {
-      setView(grid.dataset.view === "tiled" ? "tabs" : "tiled");
+      setView(VIEWS[(VIEWS.indexOf(grid.dataset.view as PaneView) + 1) % VIEWS.length]);
     }
   }, { signal: moduleScope.signal });
 
-  // ------------------------------------------------------- tiled / tabs view
-  const setView = (view: "tiled" | "tabs", force = false) => {
+  // ------------------------------------------------ tiled / grid / tabs view
+  // Switching layout is a CLASS CHANGE ONLY — `data-view` on the one grid, and
+  // pure CSS from there. Nothing may reorder or re-parent a pane's node: a
+  // re-appended iframe reloads and wipes its model (the same invariant that
+  // keeps pane 1, and the server pane, in place across count changes).
+  const setView = (view: PaneView, force = false) => {
     if (allPanes().length === 1 && !force) return;
     grid.dataset.view = view;
     tabsStrip.hidden = view !== "tabs";
-    $btn("mp-view-tiled").setAttribute("aria-pressed", String(view === "tiled"));
-    $btn("mp-view-tabs").setAttribute("aria-pressed", String(view === "tabs"));
+    for (const candidate of VIEWS) {
+      $btn(`mp-view-${candidate}`).setAttribute("aria-pressed", String(view === candidate));
+    }
   };
-  $btn("mp-view-tiled").addEventListener("click", () => setView("tiled"));
-  $btn("mp-view-tabs").addEventListener("click", () => setView("tabs"));
+  for (const view of VIEWS) $btn(`mp-view-${view}`).addEventListener("click", () => setView(view));
 
   // Everything on the chrono bar that depends on how many panes exist.
   // (CSS keyed on data-count hides the pane header / 🔮 / view toggle.)
   const updateChrome = () => {
     // "Single" is about TILES, not clients: one client plus a server is still
-    // a grid, so it keeps its pane headers and the tiled/tabs toggle.
+    // a grid, so it keeps its pane headers and the layout toggle.
     const single = allPanes().length === 1;
     previewPane.dataset.count = String(allPanes().length);
-    $btn("mp-view-tiled").disabled = single;
-    $btn("mp-view-tabs").disabled = single;
+    // Grid's column rules need the CLIENT count, which `data-count` (every
+    // pane, server included) cannot express: "2 panes" is one client under an
+    // authority or two peers in a single-role example, and those lay out
+    // differently.
+    grid.dataset.clients = String(panes.length);
+    for (const view of VIEWS) $btn(`mp-view-${view}`).disabled = single;
     if (single) setView("tiled", true);
   };
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -2798,6 +2798,52 @@ a:hover {
   display: none;
 }
 
+/* ---- grid view: client cells over a server strip ----
+
+   Tiled lays every pane out in one row, which at three clients plus an
+   authority is four slivers. Grid wraps the CLIENTS into two columns and hands
+   the server the full bottom row (design-multiplayer-ide-frontend.md §5): the
+   players are peers of equal size, and the one full-width band belongs to the
+   authority — the SHAPE says which is which before you read a label.
+
+   The strip is half a client row tall, expressed as spans over one set of
+   equal implicit rows rather than per-count track sizes: a client takes two
+   rows, the server one. It stays a thumbnail at every count with no CSS that
+   knows how many panes there are.
+
+   An odd LAST client under an authority (three of them: 2 + 1) keeps its
+   half-width cell instead of stretching: it has peers on the row above, and
+   equal cells are what makes two players comparable at a glance — the notch
+   beside it is small, because the server strip closes the layout below.
+
+   The two cases where a client would otherwise sit beside a HOLE rather than a
+   notch stretch instead: a lone client (no peer to match), and an odd last
+   client in a single-role example (no strip below it, so the empty cell is a
+   whole quadrant). */
+
+.mp-grid[data-view="grid"] {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mp-grid[data-view="grid"] .mp-pane {
+  grid-row: span 2;
+}
+
+.mp-grid[data-view="grid"][data-clients="1"] .mp-pane:not(.server) {
+  grid-column: 1 / -1;
+}
+
+/* Nothing follows this client — no peer beside it and no server strip below,
+   since a server pane would be the last child instead. */
+.mp-grid[data-view="grid"] .mp-pane:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}
+
+.mp-grid[data-view="grid"] .mp-pane.server {
+  grid-column: 1 / -1;
+  grid-row: span 1;
+}
+
 /* ---- pane shell ---- */
 
 .mp-pane {
@@ -2815,18 +2861,41 @@ a:hover {
      carry the rounding: the header clips its top corners, the body clips the
      iframe's bottom corners (unless the error strip is the last row). */
   background: #0b0817;
+  /* Depth in three steps — contact, lift, and a wide ambient pool — so a
+     client pane reads as a window floating over the surface rather than a
+     boxed-off region of it. The border stays a hairline; the shadow does the
+     separating. (The server tile opts out further down: see its block.) */
   box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.45),
-    0 12px 36px rgba(0, 0, 0, 0.55);
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 9px 22px rgba(0, 0, 0, 0.55),
+    0 26px 60px rgba(0, 0, 0, 0.62);
   transition: border-color 0.18s, box-shadow 0.18s;
 }
 
-.mp-pane.focus {
-  border-color: color-mix(in srgb, var(--pc) 55%, transparent);
+/* The active pane — the client holding the keyboard ("⌨ you") — is lit from
+   its own edge: a spread glow in the player's color over the depth stack, so
+   "who has my keys" is answerable from across the room, not by reading a
+   header. The SERVER is excluded by name: it never owns input, and the flat
+   dashed authority tile is the whole point of its styling. */
+.mp-pane.focus:not(.server) {
+  border-color: color-mix(in srgb, var(--pc) 60%, transparent);
   box-shadow:
-    0 0 22px color-mix(in srgb, var(--pc) 28%, transparent),
-    0 2px 6px rgba(0, 0, 0, 0.45),
-    0 12px 36px rgba(0, 0, 0, 0.55);
+    0 0 26px 5px color-mix(in srgb, var(--pc) 34%, transparent),
+    0 0 72px 14px color-mix(in srgb, var(--pc) 13%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 9px 22px rgba(0, 0, 0, 0.55),
+    0 26px 60px rgba(0, 0, 0, 0.62);
+}
+
+/* The glow itself is static — nothing to stop for reduced motion — but moving
+   focus crossfades three surfaces (the pane's shadow, its header, its tab).
+   Under reduce, focus lands instantly on all three or on none. */
+@media (prefers-reduced-motion: reduce) {
+  .mp-pane,
+  .mp-pane-hd,
+  .mp-tab {
+    transition: none;
+  }
 }
 
 .mp-pane-hd {
@@ -2952,6 +3021,9 @@ a:hover {
 .mp-pane.server {
   border-style: dashed;
   border-color: color-mix(in srgb, var(--pc) 30%, transparent);
+  /* Deliberately NOT the clients' three-step depth stack: the authority sits
+     flat against the surface while the players float over it, and it never
+     takes the focus glow (it owns no keyboard). Quiet where they are lit. */
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
 }
 
@@ -3100,7 +3172,9 @@ a:hover {
   opacity: 0.8;
 }
 
-/* Narrow columns (the sandbox's preview at laptop width): stack the panes. */
+/* Narrow columns (the sandbox's preview at laptop width): stack the panes.
+   Grid's two columns collapse here too — the server strip still spans them,
+   so the layout keeps its shape, one column wide. */
 @media (max-width: 1280px) {
   .preview-pane.mp .mp-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
![grid layout — 2 clients over the server strip](https://gist.githubusercontent.com/tommy-xr/f2fee25150a389f6d3612004ce16aab0/raw/mpgrid-2.png)

<sub>Grid mode: client cells over the full-width SERVER strip; the focused client carries its player-color glow.</sub>

![focused vs unfocused pane chrome](https://gist.githubusercontent.com/tommy-xr/f2fee25150a389f6d3612004ce16aab0/raw/mpgrid-crop.png)

<sub>2× close-up: the focused pane's player-color glow and border vs. the unfocused pane beside it.</sub>

<details>
<summary>More grid packings</summary>

![grid at 1 client](https://gist.githubusercontent.com/tommy-xr/f2fee25150a389f6d3612004ce16aab0/raw/mpgrid-1.png)

<sub>1 client: the single cell goes full-width over the server strip.</sub>

![grid at 3 clients](https://gist.githubusercontent.com/tommy-xr/f2fee25150a389f6d3612004ce16aab0/raw/mpgrid-3-check.png)

<sub>3 clients pack 2+1, the odd cell keeping the column width.</sub>

</details>

---

PR 5 of the **coordinator transport arc** (stacked on #604): a third pane layout — **TILED | GRID | TABS** — plus the pane-chrome polish round from Bryan's iteration.

**Grid**: client panes wrap into two equal columns; the SERVER pane becomes a **full-width strip along the bottom, half a client row tall** — the authority reads differently from the players (design doc §5's server-strip, arrived at via layout). The geometry is row-spans over equal implicit rows (client = 2, server = 1), so no CSS knows the pane count. 1 client goes full-width over the strip; 3 clients pack 2+1 with the odd client keeping its half-width cell (equal cells keep players comparable; a full-width client would borrow the server's signature) — except in single-role examples, where the odd last client stretches so the layout doesn't hold an empty quadrant. `f` now cycles the three layouts in control order.

**Pane polish (Bryan's feedback)**: client panes float on a three-step shadow (contact / lift / ambient pool — the site's shadow-over-border language), and the focused client — the pane that owns keyboard input — carries a spread glow in its player color, clearly stronger than the old border highlight. The server never glows: it never owns input. Static glow; `prefers-reduced-motion` drops the focus crossfade across pane, header, and tab.

**Iframe invariant held**: layout switches are pure class changes — the document-lifetime marker check now runs across every switch (`allAlive()`, the same marker that caught the parent PR's appendChild reload bug).

**Cross-engine review (Claude + Codex), findings applied**: the single-role empty-quadrant case, missing 3-client/`f`-cycle e2e coverage, the partial reduced-motion block, dead defensive code in the cycle handler, a stale comment. Kept as intended (Codex concurred): the ≤1280px one-column collapse.

**Verification** (at the post-#600-restack state, after resolving the #602 ghost-preview conflicts in main's favor): `tsc -p site --noEmit` strict clean; site rebuilt from scratch; `npm run test:site` ALL CHECKS PASSED; `e2e/sandbox-mp.mjs` grown to 24 checks (three-state control, grid geometry at 1/2/3 clients, server `1 / -1` span, single-role stretch, `f` cycling, tiled restore, no-reload markers) — all green; `e2e/net-coordinator.mjs` 15/15.

Next in the stack: the **network view** (Addendum 5, mockup-approved) — server hub, orbiting client thumbnails, packet dots at measured pace on SVG edges, pinned scrub-locked wire log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

