### PR TITLE
fix(site): selecting a pane hands it the real keyboard

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -141,6 +141,45 @@ try {
     const clientsControl = await page.inputValue("#client-count");
     check(clientsControl === "1", "the CLIENTS control counts clients only", clientsControl);
 
+    // Selecting a pane hands it the BROWSER keyboard, not just the chrome —
+    // the regression was "⌨ you" showing while WASD still landed in the host
+    // page until a second click inside the canvas. A REAL click matters:
+    // mousedown's default action re-points focus after the handler, which a
+    // synthetic dispatchEvent (no default action) can never catch.
+    await page.click(".mp-pane .mp-pane-hd");
+    await sleep(150);
+    const keyboardOwner = await page.evaluate(() => {
+      const active = document.activeElement;
+      const shell = document.querySelector(".mp-pane");
+      return { isPaneIframe: active === shell?.querySelector("iframe"), tag: active?.tagName };
+    });
+    check(
+      keyboardOwner.isPaneIframe,
+      "a real header click gives the pane the real keyboard (activeElement is its iframe)",
+      keyboardOwner.tag ?? "null"
+    );
+    // The picker survives a claimed keyboard: with the pane's iframe focused,
+    // `f` (typed INTO the pane's document) must still cycle the layout —
+    // the pane documents carry the same picker handler as the host window.
+    const viewBefore = await page.evaluate(
+      () => document.querySelector(".mp-grid")?.getAttribute("data-view") ?? null
+    );
+    await page.keyboard.press("f");
+    await sleep(200);
+    const viewAfter = await page.evaluate(
+      () => document.querySelector(".mp-grid")?.getAttribute("data-view") ?? null
+    );
+    check(
+      viewBefore !== null && viewAfter !== null && viewAfter !== viewBefore,
+      "picker keys still work while a pane owns the keyboard (f cycled the layout)",
+      `${viewBefore} -> ${viewAfter}`
+    );
+    // Reset the layout so the geometry checks below see the default.
+    if (viewAfter !== viewBefore) {
+      await page.evaluate(() => document.querySelector("#mp-view-tiled")?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+      await sleep(200);
+    }
+
     // Grid with a LONE client: no peer to match, so it takes the whole row
     // rather than sitting beside an empty cell — the server strip below it.
     await page.click("#mp-view-grid");

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -416,7 +416,16 @@ export function initMultiplayerPanes({
     // is selectable by click — but it never joins the KEYBOARD client cycle
     // (digits / `[` / `]`) and never claims "⌨ you": game input belongs to a
     // client, and the authority has no player to drive.
-    const select = () => focusPane(allPanes().indexOf(pane));
+    // preventDefault: mousedown's default action re-points focus at the
+    // nearest focusable ancestor (body) AFTER this handler runs, silently
+    // undoing the iframe.focus() — a synthetic dispatch never shows this.
+    // Only a CLIENT claims the keyboard; selecting the server (tabs mode
+    // needs it) is selection, not input.
+    const select = (event?: Event) => {
+      if (event?.target && (event.target as HTMLElement).closest?.(".mp-link-host")) return;
+      event?.preventDefault();
+      focusPane(allPanes().indexOf(pane), client);
+    };
     shell.querySelector(".mp-pane-hd")!.addEventListener("mousedown", select);
     tab.addEventListener("click", select);
     if (client) {
@@ -424,6 +433,7 @@ export function initMultiplayerPanes({
       panes.push(pane);
     }
     net.addPane(id, iframe, pane.scope.signal);
+    attachPickerKeys(pane);
     return pane;
   };
 
@@ -527,7 +537,12 @@ export function initMultiplayerPanes({
   // selection onto a different pane.
   let focusedPane: Pane | null = null;
   const focusedIndex = () => (focusedPane ? allPanes().indexOf(focusedPane) : 0);
-  function focusPane(index: number) {
+  // claimKeyboard: user-intent callers (header click, tab click, digits,
+  // `[` `]`) also hand the pane the BROWSER's keyboard — the chrome must
+  // never say "⌨ you" while keys still land in the host page (the bug: WASD
+  // only worked after a second click inside the canvas). Reconcile/boot
+  // callers pass false so loading a session never steals the editor's caret.
+  function focusPane(index: number, claimKeyboard = false) {
     const current = allPanes();
     const next = current[index] ?? current[0] ?? null;
     if (next !== focusedPane && focusedPane && seamOf(focusedPane.iframe)?.detached()) {
@@ -541,6 +556,7 @@ export function initMultiplayerPanes({
       const you = pane.shell.querySelector(".mp-you") as HTMLElement | null;
       if (you) you.hidden = !on;
     });
+    if (claimKeyboard && focusedPane) focusedPane.iframe.focus();
   }
   focusPane(0);
 
@@ -568,7 +584,15 @@ export function initMultiplayerPanes({
 
   // Digits jump panes, [ ] cycle, f toggles tiled/tabs — but never while the
   // caret is in an editor or input (digits are text there, no exceptions).
-  window.addEventListener("keydown", (event) => {
+  //
+  // Attached to the host window AND to every pane's contentDocument (same
+  // origin) — once a pane owns the real keyboard, its document is where
+  // these keys land, and the picker must keep working (not one-shot). The
+  // pane's GAME still receives the key too (we never stop propagation):
+  // a game that binds Num/bracket keys sees a spurious press when the user
+  // works the picker — accepted for now, resolved properly when host-routed
+  // input lands (coordinator arc, input inversion).
+  function pickerKeys(event: KeyboardEvent) {
     const target = event.target as HTMLElement;
     if (event.key === "Escape") {
       closePopovers();
@@ -581,18 +605,34 @@ export function initMultiplayerPanes({
     // it, which is what tabs mode needs to show it at all.)
     if (/^[1-9]$/.test(event.key)) {
       const index = Number(event.key) - 1;
-      if (index < panes.length) focusPane(index);
+      if (index < panes.length) focusPane(index, true);
     } else if (event.key === "[" || event.key === "]") {
       const delta = event.key === "]" ? 1 : -1;
       const from = focusedIndex();
       // From the server pane (which sits past the clients), the cycle re-enters
       // the client set at whichever end the direction implies.
-      if (from >= panes.length) focusPane(delta === 1 ? 0 : panes.length - 1);
-      else focusPane((from + delta + panes.length) % panes.length);
+      if (from >= panes.length) focusPane(delta === 1 ? 0 : panes.length - 1, true);
+      else focusPane((from + delta + panes.length) % panes.length, true);
     } else if (event.key === "f") {
       setView(VIEWS[(VIEWS.indexOf(grid.dataset.view as PaneView) + 1) % VIEWS.length]);
     }
-  }, { signal: moduleScope.signal });
+  }
+  window.addEventListener("keydown", pickerKeys, { signal: moduleScope.signal });
+  // Every pane's contentDocument gets the same picker (wired at creation;
+  // re-wired on every load since navigation replaces the document).
+  function attachPickerKeys(pane: Pane) {
+    const wire = () => {
+      try {
+        pane.iframe.contentDocument?.addEventListener("keydown", pickerKeys, {
+          signal: pane.scope.signal,
+        });
+      } catch {
+        // A cross-origin or torn-down document has no picker to serve.
+      }
+    };
+    wire();
+    pane.iframe.addEventListener("load", wire, { signal: pane.scope.signal });
+  }
 
   // ------------------------------------------------ tiled / grid / tabs view
   // Switching layout is a CLASS CHANGE ONLY — `data-view` on the one grid, and


### PR DESCRIPTION
Found by iterating on the shipped #604/#611 UX: *"wasd doesn't seem to do anything… oh, i have to click the header **and then** in the canvas."*

The focus chrome (glow, `⌨ you`) followed `focusPane()` but nothing gave the iframe the **browser's** keyboard — header clicks and the digit picker updated chrome only, so game keys landed in the host page until a second click inside the canvas. The comment above the blur-follow handler promises *"who has my keys" never lies*; it lied on every selection gesture.

**The fix**: `focusPane(index, claimKeyboard)` — user-intent callers (header/tab click, digits, `[` `]`) focus the pane's iframe for real; boot/reconcile callers pass false so loading a session never steals the editor's caret.

**Cross-engine review (Claude + Codex) — and the first cut failed it, usefully.** The Claude engine *empirically disproved* the naive version with a Chromium probe: a **real** header click runs mousedown's default action *after* the handler, re-pointing focus at `<body>` and undoing `iframe.focus()` — while synthetic `dispatchEvent` (what the original e2e used) shows it working. All findings applied:
- `select()` now `preventDefault()`s ([Claude, High] — the real-click path).
- Only a **client** claims the keyboard; selecting the server is selection, not input ([AGREED, Medium] — the authority has no player, and it has no `⌨ you` chrome to even show).
- Link-chip clicks inside the header never claim ([Codex, Medium] — the menu's numeric inputs must keep focus).
- The picker keys (digits, `[` `]`, `f`, `Escape`) attach to every pane's `contentDocument` as well as the host window ([AGREED, Medium] — otherwise a claimed keyboard makes the picker one-shot, since iframe keydowns never bubble to the parent). The pane's game still receives those keys (propagation untouched); a game binding Num/bracket keys sees a spurious press while the user works the picker — a stated tradeoff, resolved properly when host-routed input lands (coordinator arc, input inversion).
- The e2e now uses a **real** `page.click` (the default action *is* the bug surface) and additionally asserts `f` still cycles the layout while a pane owns the keyboard.

**Verification:** `tsc -p site --noEmit` clean; `e2e/sandbox-mp.mjs` ALL CHECKS PASSED (26 checks, including both new regressions, exercised with real interactions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
