### PR TITLE
feat(site): network view — the server hub with live packet flow

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -93,6 +93,25 @@ const installProbe = (page) =>
           (b) => `${b.id.replace("mp-view-", "")}:${b.getAttribute("aria-pressed")}`
         ),
       }),
+      // The NETWORK view's graph layer: one measured wire per client↔server
+      // link, its mid-edge chip, and the packets currently in flight.
+      network: () => {
+        const wires = [...document.querySelectorAll(".mp-wire")];
+        return {
+          wires: wires.length,
+          drawn: wires.filter((w) => (w.getAttribute("d") ?? "").length > 0).length,
+          lengths: wires.map((w) => Math.round(w.getTotalLength())),
+          chips: [...document.querySelectorAll(".mp-edge-chip")].map((c) =>
+            c.textContent.trim()
+          ),
+          dots: document.querySelectorAll(".mp-packet").length,
+          up: document.querySelectorAll(".mp-packet.up").length,
+          down: document.querySelectorAll(".mp-packet.down").length,
+          legend: getComputedStyle(document.querySelector(".mp-legend")).display,
+          networkDisabled: document.getElementById("mp-view-network").disabled,
+          networkTitle: document.getElementById("mp-view-network").title,
+        };
+      },
       // Laid-out geometry per pane, plus the server's resolved grid placement.
       boxes: () =>
         shells().map((s) => {
@@ -113,6 +132,15 @@ const installProbe = (page) =>
         for (const s of shells()) s.frame.contentWindow.__mpAlive = true;
       },
       allAlive: () => shells().every((s) => s.frame.contentWindow?.__mpAlive === true),
+      // A keydown/keyup straight into a pane's window — the mp client only
+      // sends to the server when its input changes, so client → server traffic
+      // has to be provoked.
+      key: (role, code, down) => {
+        const win = shells().find((s) => s.role === role)?.frame.contentWindow;
+        if (!win) return false;
+        win.dispatchEvent(new win.KeyboardEvent(down ? "keydown" : "keyup", { code }));
+        return true;
+      },
       model: (role) => {
         const trace = traces.get(role);
         const invocations = trace?.invocations ?? [];
@@ -325,8 +353,9 @@ try {
       return window.__mpProbe.layout();
     });
     check(
-      tiled.view === "tiled" && tiled.pressed.join(" ") === "tiled:true grid:false tabs:false",
-      "the layout control starts on TILED with three options",
+      tiled.view === "tiled" &&
+        tiled.pressed.join(" ") === "tiled:true grid:false network:false tabs:false",
+      "the layout control starts on TILED with four options",
       `${tiled.view} — ${tiled.pressed.join(" ")}`
     );
 
@@ -334,7 +363,8 @@ try {
     await sleep(400);
     const grid = await page.evaluate(() => window.__mpProbe.layout());
     check(
-      grid.view === "grid" && grid.pressed.join(" ") === "tiled:false grid:true tabs:false",
+      grid.view === "grid" &&
+        grid.pressed.join(" ") === "tiled:false grid:true network:false tabs:false",
       "clicking GRID switches the pane grid's layout",
       `${grid.view} — ${grid.pressed.join(" ")}`
     );
@@ -368,7 +398,7 @@ try {
     const backBoxes = await page.evaluate(() => window.__mpProbe.boxes());
     check(
       back.view === "tiled" &&
-        back.pressed.join(" ") === "tiled:true grid:false tabs:false" &&
+        back.pressed.join(" ") === "tiled:true grid:false network:false tabs:false" &&
         backBoxes.every((b) => Math.abs(b.y - backBoxes[0].y) < 2),
       "switching back to TILED restores the single row",
       `${back.view} — ${JSON.stringify(backBoxes.map((b) => b.y))}`
@@ -378,16 +408,16 @@ try {
       "no pane's iframe was reloaded by the switch back to tiled"
     );
 
-    // `f` cycles the three layouts in the segmented control's order.
+    // `f` cycles the four layouts in the segmented control's order.
     const cycled = [];
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 4; i++) {
       await page.keyboard.press("f");
       await sleep(250);
       cycled.push(await page.evaluate(() => window.__mpProbe.layout().view));
     }
     check(
-      cycled.join(" → ") === "grid → tabs → tiled",
-      "f cycles tiled → grid → tabs → tiled",
+      cycled.join(" → ") === "grid → network → tabs → tiled",
+      "f cycles tiled → grid → network → tabs → tiled",
       cycled.join(" → ")
     );
     check(
@@ -414,6 +444,108 @@ try {
     await page.close();
   }
 
+  // --- 4d. NETWORK layout: the hub, its measured wires, and live packets. -----
+  // The graph is drawn from MEASURED pane boxes, so the assertions here are
+  // about geometry (who sits where, how many wires exist and that each one has
+  // a real length) rather than about hard-coded coordinates.
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`${BASE}/sandbox.html?example=mp#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    await page.evaluate(() => window.__mpProbe.markAll());
+
+    await page.click("#mp-view-network");
+    await sleep(600);
+    const layout = await page.evaluate(() => window.__mpProbe.layout());
+    check(
+      layout.view === "network" &&
+        layout.pressed.join(" ") === "tiled:false grid:false network:true tabs:false",
+      "clicking NETWORK switches the pane grid's layout",
+      `${layout.view} — ${layout.pressed.join(" ")}`
+    );
+
+    const [c1, c2, server] = await page.evaluate(() => window.__mpProbe.boxes());
+    check(
+      c1.x + c1.w <= server.x + 2 &&
+        c2.x >= server.x + server.w - 2 &&
+        server.h > c1.h &&
+        server.w > c1.w,
+      "the server is the hub between its two clients, and the biggest card",
+      JSON.stringify([c1, server, c2].map((b) => [b.role, b.x, b.y, b.w, b.h]))
+    );
+
+    const graph = await page.evaluate(() => window.__mpProbe.network());
+    check(
+      graph.wires === 2 && graph.drawn === 2 && graph.lengths.every((l) => l > 50),
+      "one measured wire per client↔server link",
+      JSON.stringify(graph.lengths)
+    );
+    check(
+      graph.chips.length === 2 && graph.chips.every((c) => c.includes("Wi-Fi")),
+      "each edge carries its client's link chip mid-wire",
+      graph.chips.join(" | ")
+    );
+    check(graph.legend === "flex", "the packet legend shows in network mode", graph.legend);
+
+    // Packets: the coordinator's live feed, sampled onto the wires. Both
+    // directions must appear — the shapes are what carry direction.
+    let flight = await page.evaluate(() => window.__mpProbe.network());
+    let flowing = false;
+    for (let i = 0; i < 40 && !flowing; i++) {
+      // Drive client 1 so it has intent to send; a dot lives 600ms, so sample
+      // faster than that.
+      await page.evaluate((down) => window.__mpProbe.key("client 1", "KeyW", down), i % 2 === 0);
+      await sleep(150);
+      flight = await page.evaluate(() => window.__mpProbe.network());
+      flowing = flight.up > 0 && flight.down > 0;
+    }
+    check(
+      flowing,
+      "packets fly both ways along the wires (circles up, snapshots down)",
+      `up=${flight.up} down=${flight.down}`
+    );
+    check(
+      flight.dots <= 40,
+      "concurrent dots stay under the cap",
+      String(flight.dots)
+    );
+    check(
+      await page.evaluate(() => window.__mpProbe.allAlive()),
+      "no pane's iframe was reloaded by the switch to network"
+    );
+
+    // Leaving the view is inert again: nothing keeps flying off-screen.
+    await page.click("#mp-view-tiled");
+    await sleep(400);
+    const parked = await page.evaluate(() => window.__mpProbe.network());
+    check(
+      parked.dots === 0 && parked.legend === "none",
+      "leaving network clears the dots and hides the legend",
+      `${parked.dots} dots, legend ${parked.legend}`
+    );
+
+    // Three clients: two flanking the hub, the third parked below it.
+    await page.click("#mp-view-network");
+    await page.selectOption("#client-count", "3");
+    await sleep(2500);
+    const three = await page.evaluate(() => window.__mpProbe.boxes());
+    const graph3 = await page.evaluate(() => window.__mpProbe.network());
+    const hub = three[3];
+    check(
+      three.length === 4 &&
+        three[0].x < hub.x &&
+        three[1].x > hub.x &&
+        three[2].y >= hub.y + hub.h - 2 &&
+        graph3.wires === 3,
+      "a third client parks below the hub, and gets its own wire",
+      `${JSON.stringify(three.map((b) => [b.role, b.x, b.y]))} — ${graph3.wires} wires`
+    );
+    await page.close();
+  }
+
   // --- 5. Switching away drops the server pane. -------------------------------
   {
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
@@ -422,6 +554,10 @@ try {
       timeout: 40000,
     });
     await installProbe(page);
+    // Enter the hub view FIRST: dropping the authority must not strand the
+    // session in a layout that no longer has a hub.
+    await page.click("#mp-view-network");
+    await sleep(400);
     await page.selectOption("#example-picker", "counter");
     await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
       timeout: 40000,
@@ -432,6 +568,33 @@ try {
       .catch(() => false);
     const roles = await page.evaluate(() => window.__mpProbe.roles());
     check(gone, "switching to a single-role example removes the server pane", roles.join(", "));
+    check(
+      (await page.evaluate(() => window.__mpProbe.layout().view)) !== "network",
+      "losing the authority falls the layout back out of NETWORK",
+      await page.evaluate(() => window.__mpProbe.layout().view)
+    );
+
+    // No authority, no hub: NETWORK is disabled with a tooltip that says why,
+    // and `f` steps over it instead of stalling the cycle.
+    await page.selectOption("#client-count", "2");
+    await sleep(2500);
+    const soloGraph = await page.evaluate(() => window.__mpProbe.network());
+    check(
+      soloGraph.networkDisabled && soloGraph.networkTitle.includes("no server role"),
+      "a single-role example disables NETWORK and explains why",
+      `disabled=${soloGraph.networkDisabled}; "${soloGraph.networkTitle}"`
+    );
+    const soloCycle = [];
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press("f");
+      await sleep(250);
+      soloCycle.push(await page.evaluate(() => window.__mpProbe.layout().view));
+    }
+    check(
+      soloCycle.join(" → ") === "grid → tabs → tiled",
+      "f skips NETWORK when there is no authority",
+      soloCycle.join(" → ")
+    );
 
     // Grid with no authority: nothing closes the bottom row, so the odd last
     // client stretches rather than leaving a whole empty quadrant.

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -681,6 +681,77 @@ try {
     await page.close();
   }
 
+  // --- 4e. A LATE-JOINED client scrubs with everyone else. --------------------
+  // Pane frame indices are boot-relative, so a client added mid-session counts
+  // from 0 while the rest are in the hundreds. A broadcast seek sent as a bare
+  // number therefore asks that client for a frame it has never reached — it
+  // clamps to the end of its recording and sits still while everyone else
+  // rewinds. The host measures each pane's OFFSET against the reference clock
+  // (the server pane) and translates every seek through it.
+  //
+  // The assertion is a differential one, and it needs no knowledge of absolute
+  // frames: park the session, seek back one second on the rail, and every pane
+  // must move back one second OF ITS OWN CLOCK — and the late client's offset
+  // to the server must be exactly what it was before the seek (the panes still
+  // correspond). Untranslated, the late client's delta is ~0: it is asked for a
+  // frame past its own end. The measured offset is asserted non-trivial first,
+  // so a session that happened to boot in lockstep cannot pass vacuously.
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await page.goto(`${BASE}/sandbox.html?example=mp`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    await page.evaluate(() => {
+      // Every pane's frame, sampled in ONE task — the same rule the host's own
+      // measurement follows.
+      window.__mpProbe.frames = () =>
+        [...document.querySelectorAll(".mp-pane")].map((shell) => {
+          const win = shell.querySelector("iframe").contentWindow;
+          return {
+            role: shell.classList.contains("server") ? "server" : "client",
+            frame: win?.__scrub?.frame() ?? null,
+          };
+        });
+    });
+    // Let the session get a few seconds ahead, THEN add the late client.
+    await page.waitForFunction(() => (window.__mpProbe.frames()[1]?.frame ?? 0) > 180, {
+      timeout: 30000,
+    });
+    await page.selectOption("#client-count", "2");
+    await sleep(4000);
+    const joined = await page.evaluate(() => window.__mpProbe.frames());
+    const [c1, c2, srv] = joined.map((p) => p.frame);
+    const offset = c2 - srv;
+    check(
+      joined.length === 3 && offset < -60,
+      "the late-joined client's clock really is offset from the reference",
+      `client 1 #${c1}, client 2 #${c2}, server #${srv} → offset ${offset}`
+    );
+
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(1200);
+    const before = (await page.evaluate(() => window.__mpProbe.frames())).map((p) => p.frame);
+    // The product path: focus the rail's playhead and page back one second.
+    await page.focus("#mp-playhead");
+    await page.keyboard.press("PageDown");
+    await sleep(1500);
+    const after = (await page.evaluate(() => window.__mpProbe.frames())).map((p) => p.frame);
+    const moved = before.map((frame, index) => frame - after[index]);
+    check(
+      moved.every((delta) => Math.abs(delta - 60) <= 8),
+      "a broadcast seek moves every pane back the same second of ITS OWN clock",
+      `${JSON.stringify(before)} → ${JSON.stringify(after)} (deltas ${JSON.stringify(moved)})`
+    );
+    check(
+      Math.abs(after[1] - after[2] - offset) <= 8,
+      "the late client and the server still correspond after the seek",
+      `offset was ${offset}, now ${after[1] - after[2]}`
+    );
+    await page.close();
+  }
+
   // --- 5. Switching away drops the server pane. -------------------------------
   {
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -85,6 +85,12 @@ const installProbe = (page) =>
     window.__mpProbe = {
       roles: () => shells().map((s) => s.role),
       headers: () => shells().map((s) => s.header),
+      // The link indicator, read as STATE rather than as prose: the dot is what
+      // survives when a thumbnail header clips the word off (see headerParts).
+      links: () =>
+        [...document.querySelectorAll(".mp-pane .mp-conn")].map(
+          (conn) => `${conn.hidden ? "hidden" : conn.dataset.linked}:${conn.title.slice(0, 20)}`
+        ),
       pill: () => document.getElementById("status").textContent.trim(),
       pauseAll: () => document.getElementById("mp-pause").click(),
       layout: () => ({
@@ -107,10 +113,53 @@ const installProbe = (page) =>
           dots: document.querySelectorAll(".mp-packet").length,
           up: document.querySelectorAll(".mp-packet.up").length,
           down: document.querySelectorAll(".mp-packet.down").length,
-          legend: getComputedStyle(document.querySelector(".mp-legend")).display,
+          // The legend + demoted pane readouts now live on the status bar's
+          // view strip: the legend only in network, the readouts in every
+          // multi-pane view (the headers clip by their own width).
+          legend: getComputedStyle(document.querySelector(".mp-vs-legend")).display,
+          stripShown: !document.querySelector(".statusbar-view").hidden,
+          strip: document.querySelector(".mp-vs-panes").innerText.replace(/\s+/g, " ").trim(),
           networkDisabled: document.getElementById("mp-view-network").disabled,
           networkTitle: document.getElementById("mp-view-network").title,
         };
+      },
+      // What a pane header still shows at its current width: the priority clip
+      // keeps identity + link state and drops the frame counter first.
+      headerParts: (index) => {
+        const shell = [...document.querySelectorAll(".mp-pane")][index];
+        const shown = (selector) => {
+          const node = shell.querySelector(selector);
+          return !!node && getComputedStyle(node).display !== "none";
+        };
+        return {
+          width: Math.round(shell.getBoundingClientRect().width),
+          digit: shown(".mp-digit"),
+          dot: shown(".mp-conn-d"),
+          word: shown(".mp-conn-t"),
+          frame: shown(".mp-pf"),
+        };
+      },
+      // The "+" affordances (tile in tiled/grid, tab in tabs).
+      addTile: () => {
+        const tile = document.querySelector(".mp-add-tile");
+        return {
+          present: !!tile,
+          hidden: !tile || tile.hidden,
+          display: tile ? getComputedStyle(tile).display : "none",
+          tag: tile?.tagName,
+          tabDisplay: getComputedStyle(document.querySelector(".mp-tab.add")).display,
+        };
+      },
+      clickAddTile: () => document.querySelector(".mp-add-tile").click(),
+      // Click a view button and read back, IN THE SAME TASK, how many pane
+      // cards are mid-animation — the FLIP has to have started before the
+      // browser has painted anything.
+      switchAndCountAnimations: (id) => {
+        document.getElementById(id).click();
+        return [...document.querySelectorAll(".mp-pane")].reduce(
+          (total, shell) => total + shell.getAnimations().length,
+          0
+        );
       },
       // Laid-out geometry per pane, plus the server's resolved grid placement.
       boxes: () =>
@@ -208,15 +257,52 @@ try {
       await sleep(200);
     }
 
-    // Grid with a LONE client: no peer to match, so it takes the whole row
-    // rather than sitting beside an empty cell — the server strip below it.
-    await page.click("#mp-view-grid");
-    await sleep(400);
-    const [client, server] = await page.evaluate(() => window.__mpProbe.boxes());
+    // The "+" tile: the spatial way to add a client, same path as the dropdown.
+    const tile = await page.evaluate(() => window.__mpProbe.addTile());
     check(
-      Math.abs(client.w - server.w) < 2 && server.y >= client.y + client.h && server.h < client.h,
-      "grid with one client stacks it full-width over the server strip",
-      JSON.stringify([client, server])
+      tile.present && !tile.hidden && tile.display !== "none" && tile.tag === "BUTTON",
+      "a + tile sits after the client panes, as a real button",
+      JSON.stringify(tile)
+    );
+    await page.evaluate(() => window.__mpProbe.clickAddTile());
+    await sleep(2500);
+    const afterAdd = await page.evaluate(() => ({
+      roles: window.__mpProbe.roles(),
+      hash: window.location.hash,
+      control: document.getElementById("client-count").value,
+    }));
+    check(
+      afterAdd.roles.join(", ") === "client 1, client 2, server" &&
+        afterAdd.control === "2" &&
+        afterAdd.hash.includes("clients=2"),
+      "clicking + adds a client through the same path as the CLIENTS dropdown",
+      JSON.stringify(afterAdd)
+    );
+    await page.selectOption("#client-count", "3");
+    await sleep(2500);
+    const atMax = await page.evaluate(() => window.__mpProbe.addTile());
+    check(atMax.hidden, "the + tile is hidden at MAX_CLIENTS", JSON.stringify(atMax));
+    await page.selectOption("#client-count", "1");
+    await sleep(1500);
+
+    // Grid with a LONE client: the open seat takes the cell beside it (at the
+    // size the new client will be), with the server strip below both.
+    await page.click("#mp-view-grid");
+    await sleep(700);
+    const [client, server] = await page.evaluate(() => window.__mpProbe.boxes());
+    const seat = await page.evaluate(() => {
+      const box = document.querySelector(".mp-add-tile").getBoundingClientRect();
+      return { x: Math.round(box.x), y: Math.round(box.y), w: Math.round(box.width) };
+    });
+    check(
+      seat.x > client.x &&
+        Math.abs(seat.w - client.w) < 2 &&
+        Math.abs(seat.y - client.y) < 2 &&
+        server.w > client.w * 1.8 &&
+        server.y >= client.y + client.h &&
+        server.h < client.h,
+      "grid puts the open seat beside the lone client, over the server strip",
+      JSON.stringify([client, seat, server])
     );
     await page.close();
   }
@@ -242,14 +328,18 @@ try {
     // The link indicator: every pane linked through the coordinator.
     const linked = await page
       .waitForFunction(
-        () => window.__mpProbe.headers().every((h) => h.includes("linked")),
+        () => window.__mpProbe.links().every((state) => state.startsWith("true")),
         null,
         { timeout: 20000 }
       )
       .then(() => true)
       .catch(() => false);
     const headers = await page.evaluate(() => window.__mpProbe.headers());
-    check(linked, "every pane header shows its coordinator link state", headers.join(" | "));
+    check(
+      linked,
+      "every pane header shows its coordinator link state",
+      (await page.evaluate(() => window.__mpProbe.links())).join(" | ")
+    );
     check(
       headers[2].startsWith("SERVER") && !headers[2].includes("⇅"),
       "the server pane is labelled SERVER in its chrome and carries no link chip",
@@ -408,6 +498,31 @@ try {
       "no pane's iframe was reloaded by the switch back to tiled"
     );
 
+    // FLIP: the switch ANIMATES the pane cards (Web Animations on the same
+    // nodes — never a re-parent), and the document-lifetime markers have to
+    // survive an animated switch exactly as they survive an instant one.
+    const running = await page.evaluate(() =>
+      window.__mpProbe.switchAndCountAnimations("mp-view-network")
+    );
+    check(running > 0, "switching view animates the pane cards in place (FLIP)", `${running} animations`);
+    check(
+      await page.evaluate(() => window.__mpProbe.allAlive()),
+      "no pane's iframe was reloaded mid-transition"
+    );
+    await sleep(700);
+    check(
+      await page.evaluate(
+        () =>
+          window.__mpProbe.allAlive() &&
+          [...document.querySelectorAll(".mp-pane")].every(
+            (shell) => getComputedStyle(shell).transform === "none"
+          )
+      ),
+      "the transition settles with every pane still alive and untransformed"
+    );
+    await page.click("#mp-view-tiled");
+    await sleep(700);
+
     // `f` cycles the four layouts in the segmented control's order.
     const cycled = [];
     for (let i = 0; i < 4; i++) {
@@ -471,9 +586,9 @@ try {
     check(
       c1.x + c1.w <= server.x + 2 &&
         c2.x >= server.x + server.w - 2 &&
-        server.h > c1.h &&
-        server.w > c1.w,
-      "the server is the hub between its two clients, and the biggest card",
+        server.h < c1.h &&
+        server.w < c1.w,
+      "the server is a compact hub between its two clients — the smallest card",
       JSON.stringify([c1, server, c2].map((b) => [b.role, b.x, b.y, b.w, b.h]))
     );
 
@@ -488,7 +603,20 @@ try {
       "each edge carries its client's link chip mid-wire",
       graph.chips.join(" | ")
     );
-    check(graph.legend === "flex", "the packet legend shows in network mode", graph.legend);
+    check(
+      graph.legend === "flex" && /1\s*#f/.test(graph.strip) && /SRV\s*#f/.test(graph.strip),
+      "the network status strip carries the legend and every pane's frame",
+      `${graph.legend} — "${graph.strip}"`
+    );
+
+    // Header priority at thumbnail width: identity + link state survive, the
+    // frame counter (now on the strip) is the first thing dropped.
+    const header = await page.evaluate(() => window.__mpProbe.headerParts(0));
+    check(
+      header.digit && header.dot && !header.frame,
+      "a thumbnail pane header keeps its digit and link dot, drops the frame counter",
+      JSON.stringify(header)
+    );
 
     // Packets: the coordinator's live feed, sampled onto the wires. Both
     // directions must appear — the shapes are what carry direction.
@@ -508,7 +636,7 @@ try {
       `up=${flight.up} down=${flight.down}`
     );
     check(
-      flight.dots <= 40,
+      flight.dots <= 260,
       "concurrent dots stay under the cap",
       String(flight.dots)
     );
@@ -525,6 +653,13 @@ try {
       parked.dots === 0 && parked.legend === "none",
       "leaving network clears the dots and hides the legend",
       `${parked.dots} dots, legend ${parked.legend}`
+    );
+    // ...but the pane readouts stay: TILED at four cells clips its headers too,
+    // so the frame counters still need somewhere to live.
+    check(
+      parked.stripShown && /1\s*#f/.test(parked.strip),
+      "the pane readouts stay on the strip outside the network view",
+      `shown=${parked.stripShown} "${parked.strip}"`
     );
 
     // Three clients: two flanking the hub, the third parked below it.

--- a/site/src/components/StatusBar.tsx
+++ b/site/src/components/StatusBar.tsx
@@ -24,6 +24,11 @@ export const StatusBar = ({ store }: { store: StatusBarStore }) => {
   const { problems, output, executions } = useSyncExternalStore(store.subscribe, store.getSnapshot);
   const [open, setOpen] = useState<TabName | null>(null);
   const outputList = useRef<HTMLDivElement>(null);
+  // The view-scoped strip (`store.viewStrip`): a node an imperative surface
+  // fills — today the pane grid's NETWORK legend and pane readouts. React
+  // mounts it and never renders into it, so its owner can repaint per frame
+  // without touching this component. See status-bar-store's note.
+  const viewHost = useRef<HTMLDivElement>(null);
   // Stick to the bottom only if the user is already there (don't yank the
   // scroll out from under them mid-read). Measured HERE, during the render
   // that carries new lines: the DOM still holds the previous ones, so this is
@@ -53,6 +58,12 @@ export const StatusBar = ({ store }: { store: StatusBarStore }) => {
     const list = outputList.current;
     if (list && open === "output") list.scrollTop = list.scrollHeight;
   }, [open]);
+
+  // `replaceChildren`, not `appendChild`: React does not manage this node, so a
+  // swapped store would otherwise leave the previous strip mounted beside it.
+  useLayoutEffect(() => {
+    viewHost.current?.replaceChildren(store.viewStrip);
+  }, [store]);
 
   const panel = (name: TabName) => ({
     className: `statusbar-list ${name}-list`,
@@ -120,6 +131,7 @@ export const StatusBar = ({ store }: { store: StatusBarStore }) => {
         {tab("problems", problemsLabel(problems.length, errors), errors > 0 ? " has-problems" : "")}
         {tab("output", "output")}
         {tab("executions", executions.length ? `⏸ ${executions.length} executions` : "executions")}
+        <div className="statusbar-view-host" ref={viewHost} />
       </div>
     </>
   );

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -1,0 +1,416 @@
+// The NETWORK view's graph layer: the wires between the client panes and the
+// server hub, and the packets travelling along them (design:
+// ~/notes/projects/functor/design-multiplayer-ide-frontend.md, "Addendum 5 —
+// the network view").
+//
+// The panes themselves are laid out by CSS (styles.css, `[data-view=network]`)
+// — this module never positions, reorders, or re-parents a pane. It only
+// MEASURES them: every edge endpoint comes from the pane cards' boxes, so the
+// wires follow whatever the grid decided at the current size and client count.
+//
+// Two rules from the addendum are load-bearing here:
+//
+//   1. SHAPE carries direction, COLOR carries identity. client → server is a
+//      small filled circle in that client's player color (intent); server →
+//      client is a chunky hollow rounded-rect in cyan (authority).
+//   2. PACE is a measurement. See FLIGHT_MS.
+//
+// The wire log (click an edge → a pinned, scrub-locked panel) is the NEXT PR.
+
+import type { NetCoordinator, Packet } from "./net-coordinator.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/**
+ * How long a packet takes to cross its edge, in ms.
+ *
+ * A FIXED value, and that is honest today: the coordinator routes on perfect
+ * links (net-coordinator.ts — no latency, no jitter, no loss), so there is no
+ * measurement to render and every edge is genuinely the same speed. The link
+ * chips are configured profiles, not observations, which is why they are
+ * labelled as such.
+ *
+ * When impairment lands, this becomes the MEASURED latency of the packet's
+ * link, per Addendum 5's "pace is a measurement": flight time is never scaled
+ * for looks, and if sub-perceptual links ever force a floor or a log scale, the
+ * UI must SAY so with a "×N" chip on the edge.
+ */
+const FLIGHT_MS = 600;
+
+/** Concurrent dots, hard cap. Oldest is dropped first, so a busy session sheds
+ * packets instead of growing the DOM without bound. */
+const MAX_DOTS = 40;
+
+/**
+ * Minimum gap between two spawned dots on the same edge in the same direction —
+ * ~10/s each way. The mp example broadcasts a snapshot per client per frame, so
+ * a 60Hz session routes far more packets than a person can see or a browser
+ * should animate. The view SAMPLES the feed rather than dropping frames, and
+ * the legend says so: these dots are traffic, not a 1:1 packet count.
+ */
+const SPAWN_GAP_MS = 100;
+
+/**
+ * Buffered packets awaiting the next frame, hard cap. rAF is throttled (or
+ * stopped) in a background tab while the panes keep routing, so the buffer
+ * needs the same discipline the coordinator's own log has: oldest out first,
+ * never unbounded.
+ */
+const INBOX_CAP = 512;
+
+/** A pane as the graph needs it: an identity, a box to measure, and its ink. */
+export interface NetworkNode {
+  /** The coordinator's routing id ("client 2", "server"). */
+  id: string;
+  /** The pane card whose box the edge anchors to. */
+  shell: HTMLElement;
+  /** The pane's player color, as a CSS value. */
+  color: string;
+  /** The client's configured link profile, as a label. Read live: the chip is a
+   * label of the CONFIGURED profile, never a claim about the wire. */
+  linkLabel: () => string;
+}
+
+export interface NetworkGraphOptions {
+  /** The stage the graph shares with the pane grid — its positioning context. */
+  stage: HTMLElement;
+  /** The pane grid inside it. The wires are inserted BEFORE it and the chips
+   * AFTER it, so wires run behind the cards and a chip is never buried under
+   * one. */
+  grid: HTMLElement;
+  net: NetCoordinator;
+  clients: () => NetworkNode[];
+  server: () => NetworkNode | null;
+}
+
+export interface NetworkGraph {
+  /** Re-measure every edge against the panes' current boxes. */
+  relayout(): void;
+  /** One frame of the graph: spawn sampled packets, advance the dots. Driven by
+   * the host's existing rAF loop rather than a second one. */
+  step(): void;
+  /** Network view on/off. Off is inert: no listeners fire work, no dots live. */
+  setActive(on: boolean): void;
+  /** Zero the per-edge packet totals — a new program is a new session, and the
+   * reduced-motion badge must not carry the previous example's traffic. */
+  resetCounts(): void;
+  destroy(): void;
+}
+
+type Direction = "up" | "down";
+
+interface Edge {
+  node: NetworkNode;
+  path: SVGPathElement;
+  chip: HTMLElement;
+  chipLabel: HTMLElement;
+  chipCount: HTMLElement;
+  length: number;
+  lastSpawn: Record<Direction, number>;
+  count: number;
+}
+
+interface Dot {
+  el: SVGElement;
+  edge: Edge;
+  dir: Direction;
+  start: number;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/** A cubic's point at t = 0.5 — where the edge chip sits. */
+const midpoint = (p0: Point, c0: Point, c1: Point, p1: Point): Point => ({
+  x: (p0.x + 3 * c0.x + 3 * c1.x + p1.x) / 8,
+  y: (p0.y + 3 * c0.y + 3 * c1.y + p1.y) / 8,
+});
+
+export function initNetworkGraph({
+  stage,
+  grid,
+  net,
+  clients,
+  server,
+}: NetworkGraphOptions): NetworkGraph {
+  const layer = document.createElement("div");
+  layer.className = "mp-net-layer";
+  stage.insertBefore(layer, grid);
+  const chips = document.createElement("div");
+  chips.className = "mp-net-chips";
+  stage.appendChild(chips);
+
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("class", "mp-wires");
+  svg.setAttribute("aria-hidden", "true");
+  const wires = document.createElementNS(SVG_NS, "g");
+  const packets = document.createElementNS(SVG_NS, "g");
+  svg.append(wires, packets);
+  layer.appendChild(svg);
+
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+  const edges = new Map<string, Edge>();
+  const dots: Dot[] = [];
+  /** Packets seen since the last frame. Routing must stay cheap, so the
+   * listener only buffers — every DOM write happens in `step`. */
+  let inbox: Packet[] = [];
+  let active = false;
+
+  const addEdge = (node: NetworkNode): Edge => {
+    const path = document.createElementNS(SVG_NS, "path");
+    path.setAttribute("class", "mp-wire");
+    // The player color rides on `color`, so the wire's stroke and the dot's
+    // fill and glow can all be one `currentColor` in the stylesheet.
+    path.style.color = node.color;
+    wires.appendChild(path);
+    const chip = document.createElement("span");
+    chip.className = "mp-edge-chip";
+    chip.innerHTML = `<b></b><i></i>`;
+    chips.appendChild(chip);
+    const edge: Edge = {
+      node,
+      path,
+      chip,
+      chipLabel: chip.querySelector("b")!,
+      chipCount: chip.querySelector("i")!,
+      length: 0,
+      lastSpawn: { up: 0, down: 0 },
+      count: 0,
+    };
+    edges.set(node.id, edge);
+    return edge;
+  };
+
+  const dropEdge = (edge: Edge, id: string) => {
+    edge.path.remove();
+    edge.chip.remove();
+    edges.delete(id);
+    for (let i = dots.length - 1; i >= 0; i--) {
+      if (dots[i].edge === edge) {
+        dots[i].el.remove();
+        dots.splice(i, 1);
+      }
+    }
+  };
+
+  const relayout = () => {
+    const hub = server();
+    const live = hub ? clients() : [];
+    // Reconcile the edge set with the current panes (a count change, or an
+    // example that mounted/removed its authority).
+    for (const [id, edge] of [...edges]) {
+      if (!live.some((node) => node.id === id)) dropEdge(edge, id);
+    }
+    if (!hub || live.length === 0) return;
+
+    // ONE read pass, then one write pass: the boxes are all measured before
+    // anything is written back, so a re-measure never thrashes layout.
+    const origin = layer.getBoundingClientRect();
+    if (origin.width === 0 || origin.height === 0) return;
+    svg.setAttribute("viewBox", `0 0 ${origin.width} ${origin.height}`);
+    const boxOf = (node: NetworkNode) => {
+      const box = node.shell.getBoundingClientRect();
+      return {
+        left: box.left - origin.left,
+        top: box.top - origin.top,
+        width: box.width,
+        height: box.height,
+        cx: box.left - origin.left + box.width / 2,
+        cy: box.top - origin.top + box.height / 2,
+      };
+    };
+    const hubBox = boxOf(hub);
+    const geometry = live.map((node) => {
+      const box = boxOf(node);
+      const dx = hubBox.cx - box.cx;
+      const dy = hubBox.cy - box.cy;
+      // Leave from whichever pair of sides actually faces the hub. Pick the
+      // axis the two cards are SEPARATED on, not simply the larger centre
+      // delta: a tall stage can make |dy| win between cards that overlap
+      // vertically, and the wire would then leave a card's bottom for a hub
+      // edge above it — running backwards behind both.
+      const apartX = Math.max(0, hubBox.left - (box.left + box.width), box.left - (hubBox.left + hubBox.width));
+      const apartY = Math.max(0, hubBox.top - (box.top + box.height), box.top - (hubBox.top + hubBox.height));
+      const horizontal = apartX === apartY ? Math.abs(dx) >= Math.abs(dy) : apartX > apartY;
+      let from: Point;
+      let to: Point;
+      let control: Point;
+      // The bow is a fraction of the GAP the wire actually crosses, not of the
+      // distance between the cards' centres: the cards nearly touch, and a
+      // bow sized off their centres would swing the whole curve out behind
+      // them — a wire (and its packets) you cannot see.
+      if (horizontal) {
+        from = { x: box.left + (dx > 0 ? box.width : 0), y: box.cy };
+        to = { x: hubBox.left + (dx > 0 ? 0 : hubBox.width), y: hubBox.cy };
+        control = { x: (to.x - from.x) * 0.5, y: 0 };
+      } else {
+        from = { x: box.cx, y: box.top + (dy > 0 ? box.height : 0) };
+        to = { x: hubBox.cx, y: hubBox.top + (dy > 0 ? 0 : hubBox.height) };
+        control = { x: 0, y: (to.y - from.y) * 0.5 };
+      }
+      const c0 = { x: from.x + control.x, y: from.y + control.y };
+      const c1 = { x: to.x - control.x, y: to.y - control.y };
+      return { node, from, c0, c1, to };
+    });
+
+    const written: Edge[] = [];
+    for (const { node, from, c0, c1, to } of geometry) {
+      const edge = edges.get(node.id) ?? addEdge(node);
+      edge.node = node;
+      edge.path.style.color = node.color;
+      edge.path.setAttribute(
+        "d",
+        `M${from.x},${from.y} C${c0.x},${c0.y} ${c1.x},${c1.y} ${to.x},${to.y}`
+      );
+      const mid = midpoint(from, c0, c1, to);
+      edge.chip.style.left = `${mid.x}px`;
+      edge.chip.style.top = `${mid.y}px`;
+      written.push(edge);
+    }
+    // Lengths last: `getTotalLength` is a geometry READ, and interleaving it
+    // with the `d` writes above would flush per edge instead of once.
+    for (const edge of written) edge.length = edge.path.getTotalLength();
+    paintChips();
+  };
+
+  // Every write is change-guarded, so this is a couple of string compares per
+  // frame — cheaper than the bookkeeping a throttle would need.
+  const paintChips = () => {
+    for (const edge of edges.values()) {
+      const label = edge.node.linkLabel();
+      if (edge.chipLabel.textContent !== label) {
+        edge.chipLabel.textContent = label;
+        // The chip labels a CONFIGURED profile — the links themselves are still
+        // perfect (net-coordinator.ts). Say that, rather than implying a
+        // measurement the coordinator cannot make yet.
+        edge.chip.title =
+          `${label} — this client's configured link profile. Impairment is ` +
+          `recorded, not applied yet, so every packet crosses at the same pace.`;
+      }
+      const count = `${edge.count} pkt`;
+      if (edge.chipCount.textContent !== count) edge.chipCount.textContent = count;
+    }
+  };
+
+  const spawn = (edge: Edge, dir: Direction, size: number, now: number) => {
+    // Dot size scales MILDLY with the payload: a snapshot should read as
+    // heavier than a keypress without a 96-byte packet becoming a balloon.
+    const weight = Math.min(1, size / 128);
+    let el: SVGElement;
+    if (dir === "up") {
+      const circle = document.createElementNS(SVG_NS, "circle");
+      circle.setAttribute("r", (2.6 + weight * 2).toFixed(2));
+      circle.style.color = edge.node.color;
+      el = circle;
+    } else {
+      const width = 11 + weight * 6;
+      const height = 8 + weight * 2;
+      const rect = document.createElementNS(SVG_NS, "rect");
+      rect.setAttribute("x", (-width / 2).toFixed(2));
+      rect.setAttribute("y", (-height / 2).toFixed(2));
+      rect.setAttribute("width", width.toFixed(2));
+      rect.setAttribute("height", height.toFixed(2));
+      rect.setAttribute("rx", "2");
+      el = rect;
+    }
+    el.setAttribute("class", `mp-packet ${dir}`);
+    if (dots.length >= MAX_DOTS) {
+      const oldest = dots.shift();
+      oldest?.el.remove();
+    }
+    packets.appendChild(el);
+    dots.push({ el, edge, dir, start: now });
+  };
+
+  const step = () => {
+    if (!active) return;
+    const now = performance.now();
+    const seen = inbox;
+    inbox = [];
+    for (const packet of seen) {
+      // Lifecycle events (connected/disconnected) are not traffic — the pane
+      // headers already say who is linked. Dots are payload.
+      if (packet.kind !== "message") continue;
+      const dir: Direction = packet.from === "server" ? "down" : "up";
+      const edge = edges.get(dir === "up" ? packet.from : packet.to);
+      if (!edge) continue;
+      edge.count += 1;
+      // Reduced motion: no flying dots at all. The edge keeps a static packet
+      // COUNT badge instead, so the traffic is still legible without animation.
+      if (reduceMotion.matches) continue;
+      if (now - edge.lastSpawn[dir] < SPAWN_GAP_MS) continue;
+      edge.lastSpawn[dir] = now;
+      spawn(edge, dir, packet.size, now);
+    }
+    // The preference can flip while the view is open; whatever is still in the
+    // air stops immediately rather than finishing its flight.
+    if (reduceMotion.matches && dots.length > 0) clearDots();
+    // Read every position first, then write every transform: `getPointAtLength`
+    // flushes pending layout, so interleaving it with the transform writes
+    // would flush once PER DOT.
+    const moved: { el: SVGElement; point: DOMPoint }[] = [];
+    for (let i = dots.length - 1; i >= 0; i--) {
+      const dot = dots[i];
+      const t = (now - dot.start) / FLIGHT_MS;
+      if (t >= 1 || dot.edge.length === 0) {
+        dot.el.remove();
+        dots.splice(i, 1);
+        continue;
+      }
+      // Authority travels the wire backwards: the path is drawn client → hub.
+      const at = dot.dir === "up" ? t : 1 - t;
+      moved.push({ el: dot.el, point: dot.edge.path.getPointAtLength(at * dot.edge.length) });
+    }
+    for (const { el, point } of moved) {
+      el.setAttribute("transform", `translate(${point.x.toFixed(2)},${point.y.toFixed(2)})`);
+    }
+    paintChips();
+  };
+
+  const clearDots = () => {
+    for (const dot of dots) dot.el.remove();
+    dots.length = 0;
+    inbox = [];
+  };
+
+  const setActive = (on: boolean) => {
+    if (on === active) return;
+    active = on;
+    if (!on) clearDots();
+    else relayout();
+  };
+
+  const unsubscribe = net.onPacket((packet) => {
+    if (!active) return;
+    if (inbox.length >= INBOX_CAP) inbox.shift();
+    inbox.push(packet);
+  });
+
+  // The clean re-measure seam: the panes are sized by the grid, so whatever
+  // changes their boxes (a window resize, the editor column dragging, a layout
+  // switch, a client arriving) resizes this layer with them.
+  const observer = new ResizeObserver(() => {
+    if (active) relayout();
+  });
+  observer.observe(layer);
+
+  return {
+    relayout,
+    step,
+    setActive,
+    resetCounts() {
+      for (const edge of edges.values()) edge.count = 0;
+      paintChips();
+    },
+    destroy() {
+      observer.disconnect();
+      unsubscribe();
+      clearDots();
+      for (const [id, edge] of [...edges]) dropEdge(edge, id);
+      layer.remove();
+      chips.remove();
+    },
+  };
+}

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -10,9 +10,11 @@
 //
 // Two rules from the addendum are load-bearing here:
 //
-//   1. SHAPE carries direction, COLOR carries identity. client → server is a
-//      small filled circle in that client's player color (intent); server →
-//      client is a chunky hollow rounded-rect in cyan (authority).
+//   1. COLOR carries identity, SIZE carries payload (Addendum 5a.1 — the
+//      hollow-cyan-square authority packet is retired). Both directions are
+//      circles: client → server is the client's player color, sized by payload;
+//      server → client is the server's slate (--scrub-server) in a TIGHT size
+//      range, so the per-frame snapshot stream never dominates the picture.
 //   2. PACE is a measurement. See FLIGHT_MS.
 //
 // The wire log (click an edge → a pinned, scrub-locked panel) is the NEXT PR.
@@ -37,18 +39,29 @@ const SVG_NS = "http://www.w3.org/2000/svg";
  */
 const FLIGHT_MS = 600;
 
-/** Concurrent dots, hard cap. Oldest is dropped first, so a busy session sheds
- * packets instead of growing the DOM without bound. */
-const MAX_DOTS = 40;
+/**
+ * Concurrent dots, hard cap. Oldest is dropped first, so a runaway session sheds
+ * packets instead of growing the DOM without bound.
+ *
+ * Sized for the honest steady state rather than for looks: with one dot per
+ * edge per direction per frame (see the batching in `step`), a 60Hz session
+ * keeps `FLIGHT_MS / 16.7 ≈ 36` dots in the air per edge per direction, so
+ * MAX_CLIENTS × 2 directions ≈ 216 at the busiest. A cap below that is not a
+ * safety valve, it is a visual bug: every dot is evicted mid-wire and the
+ * stream never reaches the far end.
+ */
+const MAX_DOTS = 260;
 
 /**
- * Minimum gap between two spawned dots on the same edge in the same direction —
- * ~10/s each way. The mp example broadcasts a snapshot per client per frame, so
- * a 60Hz session routes far more packets than a person can see or a browser
- * should animate. The view SAMPLES the feed rather than dropping frames, and
- * the legend says so: these dots are traffic, not a 1:1 packet count.
+ * Payload bytes at which a dot reaches its largest size, per direction.
+ *
+ * INTENT is a keypress-sized message, so it saturates early and its range is
+ * wide — a snapshot-sized intent should look heavy. AUTHORITY is a whole world
+ * snapshot every frame, so it saturates late and its range is tight
+ * (Addendum 5a.1): the stream is constant, and a constant stream of big dots
+ * is the thing that drowned the view out.
  */
-const SPAWN_GAP_MS = 100;
+const FULL_BYTES: Record<Direction, number> = { up: 128, down: 512 };
 
 /**
  * Buffered packets awaiting the next frame, hard cap. rAF is throttled (or
@@ -106,7 +119,6 @@ interface Edge {
   chipLabel: HTMLElement;
   chipCount: HTMLElement;
   length: number;
-  lastSpawn: Record<Direction, number>;
   count: number;
 }
 
@@ -176,7 +188,6 @@ export function initNetworkGraph({
       chipLabel: chip.querySelector("b")!,
       chipCount: chip.querySelector("i")!,
       length: 0,
-      lastSpawn: { up: 0, down: 0 },
       count: 0,
     };
     edges.set(node.id, edge);
@@ -294,27 +305,16 @@ export function initNetworkGraph({
     }
   };
 
-  const spawn = (edge: Edge, dir: Direction, size: number, now: number) => {
-    // Dot size scales MILDLY with the payload: a snapshot should read as
-    // heavier than a keypress without a 96-byte packet becoming a balloon.
-    const weight = Math.min(1, size / 128);
-    let el: SVGElement;
-    if (dir === "up") {
-      const circle = document.createElementNS(SVG_NS, "circle");
-      circle.setAttribute("r", (2.6 + weight * 2).toFixed(2));
-      circle.style.color = edge.node.color;
-      el = circle;
-    } else {
-      const width = 11 + weight * 6;
-      const height = 8 + weight * 2;
-      const rect = document.createElementNS(SVG_NS, "rect");
-      rect.setAttribute("x", (-width / 2).toFixed(2));
-      rect.setAttribute("y", (-height / 2).toFixed(2));
-      rect.setAttribute("width", width.toFixed(2));
-      rect.setAttribute("height", height.toFixed(2));
-      rect.setAttribute("rx", "2");
-      el = rect;
-    }
+  const spawn = (edge: Edge, dir: Direction, bytes: number, now: number) => {
+    // Both directions are circles; size scales MILDLY with the bytes the dot
+    // carries, over a range that differs by direction (FULL_BYTES). The
+    // client's own ink rides on `color` for intent; authority takes the
+    // server's slate from the stylesheet, since every authority packet on
+    // every wire comes from the one pane.
+    const weight = Math.min(1, bytes / FULL_BYTES[dir]);
+    const el = document.createElementNS(SVG_NS, "circle");
+    el.setAttribute("r", (dir === "up" ? 2.6 + weight * 2 : 2 + weight * 0.8).toFixed(2));
+    if (dir === "up") el.style.color = edge.node.color;
     el.setAttribute("class", `mp-packet ${dir}`);
     if (dots.length >= MAX_DOTS) {
       const oldest = dots.shift();
@@ -329,6 +329,14 @@ export function initNetworkGraph({
     const now = performance.now();
     const seen = inbox;
     inbox = [];
+    // BATCHED PER FRAME (Addendum 5a.5, retiring the old time sampling): one
+    // dot per edge per direction per frame that carried traffic, sized by the
+    // bytes that frame carried. A 60Hz session broadcasts a snapshot per client
+    // per frame, so a dot per packet is a swarm and a time sample is a lie
+    // about the rate; a dot per frame is exactly what the wire did, at the rate
+    // the screen can show. (Traffic keyed to the TIMELINE — replaying the
+    // scrubbed window's packets — arrives with the wire-log PR.)
+    const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number }>();
     for (const packet of seen) {
       // Lifecycle events (connected/disconnected) are not traffic — the pane
       // headers already say who is linked. Dots are payload.
@@ -340,10 +348,12 @@ export function initNetworkGraph({
       // Reduced motion: no flying dots at all. The edge keeps a static packet
       // COUNT badge instead, so the traffic is still legible without animation.
       if (reduceMotion.matches) continue;
-      if (now - edge.lastSpawn[dir] < SPAWN_GAP_MS) continue;
-      edge.lastSpawn[dir] = now;
-      spawn(edge, dir, packet.size, now);
+      const key = `${edge.node.id}|${dir}`;
+      const carried = batched.get(key);
+      if (carried) carried.bytes += packet.size;
+      else batched.set(key, { edge, dir, bytes: packet.size });
     }
+    for (const { edge, dir, bytes } of batched.values()) spawn(edge, dir, bytes, now);
     // The preference can flip while the view is open; whatever is still in the
     // air stops immediately rather than finishing its flight.
     if (reduceMotion.matches && dots.length > 0) clearDots();

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -41,6 +41,10 @@ import { initNetworkGraph, type NetworkNode } from "./mp-network.js";
 interface ScrubSeam {
   paused(): boolean;
   frame(): number;
+  /** The recorded window `[lo, hi]`, empty until anything is recorded. `hi` is
+   * the pane's LIVE HEAD — the newest frame it has simulated — independent of
+   * where its scrubber is currently parked (which is what `frame()` reports). */
+  range(): number[];
   seek(frame: number): void;
   togglePause(): void;
   canDetach(): boolean;
@@ -1046,8 +1050,99 @@ export function initMultiplayerPanes({
     allPanes()
       .map((pane) => seamOf(pane.iframe))
       .filter((s): s is ScrubSeam => !!s);
-  const primarySeam = () =>
-    (focusedPane ? seamOf(focusedPane.iframe) : null) ?? seams()[0] ?? null;
+  // The pane the chrono bar mirrors: the focused one, or — while that pane is
+  // reloading and has no seam — the first that has one. Resolved as a PANE, not
+  // as a seam: the bar reads its viewport AND its frame offset, and taking those
+  // two from different panes is how a reload window mislabels the rail.
+  const primaryPane = (): Pane | null => {
+    if (focusedPane && seamOf(focusedPane.iframe)) return focusedPane;
+    return allPanes().find((pane) => seamOf(pane.iframe)) ?? null;
+  };
+  const primarySeam = () => {
+    const pane = primaryPane();
+    return pane ? seamOf(pane.iframe) : null;
+  };
+
+  // ------------------------------------------------------ per-pane frame offsets
+  // A pane's frame index is BOOT-RELATIVE: it counts from 0 when that document
+  // starts running. So a client added three seconds into a session is ~180
+  // frames behind the rest for the very same instant, and a broadcast seek sent
+  // as a bare number lands somewhere else in its world (or clamps to the end of
+  // its recording, which is what you actually see: the late client refuses to
+  // move while everyone else rewinds).
+  //
+  // There is no session epoch to translate through yet, so the host MEASURES
+  // the difference, every frame, from the panes' LIVE HEADS:
+  //
+  //     offset(pane) = head(pane) - head(reference)
+  //
+  // where a head is `range()[1]` — the newest frame a pane has simulated — read
+  // for every pane in the same rAF, so the numbers describe one moment. It is
+  // deliberately the head and NOT `frame()`: `frame()` is where that pane's
+  // scrubber is currently PARKED, so measuring from it while the session sits
+  // rewound would call the parked position the present and bake the rewind into
+  // the offset. The reference clock is the SERVER pane when there is one (the
+  // only pane that outlives every client) and pane 1 otherwise.
+  //
+  // Nothing is latched, and that is what keeps this honest: a pane whose head
+  // has not appeared yet (booting — the range is empty until the first frame is
+  // recorded) is simply not measured, and one that reloads, or joins while the
+  // session is parked, or hitches behind the others, is re-measured on the next
+  // frame from whatever its head actually is. An earlier draft latched a first
+  // reading and needed reload detection, boot detection, and a reference-change
+  // rule to stay correct; measuring continuously needs none of them.
+  //
+  // Every broadcast seek, and the rail's own label, is translated through it —
+  // the chrono bar speaks reference-clock frames and each pane hears its own.
+  //
+  // The exact epoch — a frame index that means the same instant everywhere by
+  // construction — arrives with barrier stepping, when the coordinator delivers
+  // on step boundaries instead of on the host's rAF (coordinator arc).
+  const offsets = new Map<Pane, number>();
+  const referencePane = (): Pane | null => serverPane?.pane ?? panes[0] ?? null;
+
+  /** A pane's live head, or null while it has recorded nothing. */
+  const headOf = (pane: Pane): number | null => {
+    const range = seamOf(pane.iframe)?.range();
+    const head = range && range.length === 2 ? range[1] : null;
+    return typeof head === "number" && head > 0 ? head : null;
+  };
+
+  const measureClocks = () => {
+    const reference = referencePane();
+    const referenceHead = reference ? headOf(reference) : null;
+    if (!reference || referenceHead === null) return;
+    offsets.set(reference, 0);
+    const live = allPanes();
+    for (const pane of live) {
+      if (pane === reference) continue;
+      const head = headOf(pane);
+      // No head yet: keep whatever was last measured rather than claiming 0 —
+      // a booting pane is not "in step with the server".
+      if (head !== null) offsets.set(pane, head - referenceHead);
+    }
+    for (const pane of [...offsets.keys()]) if (!live.includes(pane)) offsets.delete(pane);
+  };
+
+  const offsetOf = (pane: Pane | null): number => (pane && offsets.get(pane)) || 0;
+
+  /** A frame the PRIMARY pane reported (the rail mirrors that pane), read back
+   * in reference-clock frames. */
+  const toReference = (paneFrame: number): number => paneFrame - offsetOf(primaryPane());
+
+  /**
+   * Seek every pane to one reference-clock frame, each in its own indices.
+   *
+   * A pane whose recording does not reach that instant — a client that joined
+   * after it — clamps to its own earliest frame rather than the seek being
+   * refused for everyone: rewinding to before a late client joined is a normal
+   * thing to want, and the pane's own rail says where it actually landed.
+   */
+  const seekAll = (referenceFrame: number) => {
+    for (const pane of allPanes()) {
+      seamOf(pane.iframe)?.seek(Math.max(0, Math.round(referenceFrame + offsetOf(pane))));
+    }
+  };
   let pendingDetached:
     | { seam: ScrubSeam; generation: number; iframe: HTMLIFrameElement }
     | null = null;
@@ -1272,7 +1367,9 @@ export function initMultiplayerPanes({
     const target = Math.round(
       current.viewport.lo + unit * (current.viewport.hi - current.viewport.lo)
     );
-    for (const seam of seams()) seam.seek(target);
+    // The viewport is the FOCUSED pane's, so the target is in its indices:
+    // back to the reference clock, then out to every pane in its own.
+    seekAll(toReference(target));
   };
   rail.addEventListener("pointerdown", (event) => {
     event.preventDefault();
@@ -1303,7 +1400,7 @@ export function initMultiplayerPanes({
     if (target === undefined) return;
     event.preventDefault();
     event.stopPropagation();
-    for (const seam of seams()) seam.seek(Math.round(target));
+    seekAll(toReference(Math.round(target)));
   });
 
   // The rail mirrors the FOCUSED pane (each pane is an independent sim in the
@@ -1318,8 +1415,17 @@ export function initMultiplayerPanes({
     // focused pane is loading. Navigation/removal makes that old seam unable
     // to acknowledge, so treat it as a refusal instead of stalling the bar.
     reconcilePendingCamera();
+    measureClocks();
     const primary = primarySeam();
     const current = primary?.view();
+    // The rail mirrors the focused pane, but it LABELS the reference clock:
+    // the numbers on the bar mean the same instant whichever pane you focus.
+    // (Geometry is unit fractions of that pane's own viewport, so only the
+    // numbers shift.)
+    const clockShift = offsetOf(primaryPane());
+    // Clamped at 0: a pane that booted BEFORE the reference has a positive
+    // offset, and its first second would otherwise label as negative frames.
+    const inReference = (frame: number) => Math.max(0, Math.round(frame - clockShift));
     if (!primary?.detached()) debugDrawer.hidden = true;
     chrono.classList.toggle("dormant", !current);
     if (primary && current) {
@@ -1384,32 +1490,33 @@ export function initMultiplayerPanes({
       overflow.textContent = `+${current.previewClippedFrames}`;
       $btn("mp-extrap").classList.toggle("on", previewOn);
       $btn("mp-extrap").setAttribute("aria-pressed", String(previewOn));
+      const selectedRef = inReference(current.selectedFrame);
+      const viewportHiRef = inReference(current.viewport.hi);
       const labelHtml =
-        `${current.selectedFrame}` +
+        `${selectedRef}` +
         (outside ? ` <span class="out">outside</span>` : "") +
         (previewOn ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
-        ` / ${Math.round(current.viewport.hi)}`;
+        ` / ${viewportHiRef}`;
       // The stripes' availability note is ARIA-only, but it shares the label's
-      // change guard so it repaints exactly when the label does.
-      // Mirrors timeline-model's describeRecordedAvailability exactly.
+      // change guard so it repaints exactly when the label does. It follows
+      // timeline-model's describeRecordedAvailability WORD for word, but not
+      // number for number: an in-pane bar says the pane's own frames, while
+      // this bar speaks the reference clock (see the offsets above).
       const availability = !current.recordingAvailable
         ? ", no recorded history is currently available"
         : striped
-          ? `, recorded frames ${Math.round(current.recorded.lo)} to ` +
-            `${Math.round(current.recorded.hi)}; striped history outside that range is unavailable`
+          ? `, recorded frames ${inReference(current.recorded.lo)} to ` +
+            `${inReference(current.recorded.hi)}; striped history outside that range is unavailable`
           : "";
       if (labelHtml + availability !== lastLabel) {
         lastLabel = labelHtml + availability;
         $("mp-frame").innerHTML = labelHtml;
-        playheadEl.setAttribute("aria-valuemin", String(Math.round(current.viewport.lo)));
-        playheadEl.setAttribute(
-          "aria-valuemax",
-          String(Math.max(Math.round(current.viewport.hi), current.selectedFrame))
-        );
-        playheadEl.setAttribute("aria-valuenow", String(current.selectedFrame));
+        playheadEl.setAttribute("aria-valuemin", String(inReference(current.viewport.lo)));
+        playheadEl.setAttribute("aria-valuemax", String(Math.max(viewportHiRef, selectedRef)));
+        playheadEl.setAttribute("aria-valuenow", String(selectedRef));
         playheadEl.setAttribute(
           "aria-valuetext",
-          `frame ${current.selectedFrame} of ${Math.round(current.viewport.hi)}` +
+          `frame ${selectedRef} of ${viewportHiRef}` +
             (outside ? ", outside the frozen viewport" : "") +
             availability
         );
@@ -1504,7 +1611,8 @@ export function initMultiplayerPanes({
             tick.addEventListener("click", (event) => {
               event.stopPropagation();
               primarySeam()?.selectEvent(marker.id);
-              for (const seam of seams()) seam.seek(marker.frame);
+              // The markers are the focused pane's, so its frames are too.
+              seekAll(toReference(marker.frame));
             });
             tick.addEventListener("mouseenter", () => showTip(marker.unit, detail));
             tick.addEventListener("mouseleave", hideTip);

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -155,6 +155,14 @@ interface Pane {
   frameLabels: HTMLElement[];
   dots: HTMLElement[];
   conn: HTMLElement;
+  /** The link indicator's two halves. The DOT survives every header clip (it
+   * is the pane's whole connection state at a glance); the WORD goes with the
+   * rest of the prose when the header is a thumbnail's. */
+  connDot: HTMLElement;
+  connText: HTMLElement;
+  /** This pane's frame readout on the network status strip, while that strip
+   * exists (rebuilt whenever the pane set changes). */
+  stripFrame: HTMLElement | null;
   errStrip: HTMLElement;
 }
 
@@ -166,6 +174,13 @@ export interface MultiplayerPanesOptions {
   setPill: (state: PaneState, text: string, detail: string) => void;
   /** The current editor buffer, so a mirror added mid-session catches up. */
   getSource: () => string;
+  /**
+   * Ask the PAGE for a client count — the "+" tile's one job. It routes through
+   * the host rather than calling `setCount` directly so that the spatial
+   * affordance and the CLIENTS dropdown are the same path: the same clamp, the
+   * same `#clients=` hash write, the same control re-render.
+   */
+  requestCount: (n: number) => void;
 }
 
 export interface MultiplayerPanes {
@@ -236,6 +251,7 @@ export function initMultiplayerPanes({
   statusBar,
   setPill,
   getSource,
+  requestCount,
 }: MultiplayerPanesOptions): MultiplayerPanes {
   const previewPane = frame.closest(".preview-pane") as HTMLElement;
   previewPane.classList.add("mp");
@@ -269,7 +285,7 @@ export function initMultiplayerPanes({
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
       <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every pane in one row (f cycles)">⊞ tiled</button>
       <button id="mp-view-grid" aria-pressed="false" title="Grid: clients in two columns over the server strip (f cycles)">▦ grid</button>
-      <button id="mp-view-network" aria-pressed="false" title="Network: the server as the hub, with live packet flow along each link (f cycles)">◈ network</button>
+      <button id="mp-view-network" aria-pressed="false">◈ network</button>
       <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one pane full-size (f cycles)">▤ tabs</button>
     </span>`;
 
@@ -312,24 +328,62 @@ export function initMultiplayerPanes({
   grid.className = "mp-grid";
   grid.dataset.view = "tiled";
 
-  // The stage holds the grid plus the surfaces the NETWORK view adds: the
-  // legend above it, and (mounted by the graph itself) the wire and chip
-  // layers around it. They are siblings of the grid, never children of it —
-  // the grid's cells are exactly the panes, and another child would shift the
-  // `:nth-child` rules the grid and network views lay out with.
+  // The "+" tile (Addendum 5a.7): the SPATIAL way to add a client, sitting
+  // where the client it would create is about to appear — the CLIENTS dropdown
+  // stays the numeric one, and both go through the same host call. It is a real
+  // <button>, so it is tab-reachable and answers to Enter/Space for free; it is
+  // a grid child so it takes a cell in tiled/grid, and CSS hides it in tabs
+  // (which has its own "+" tab) and in network. NETWORK gets no ghost spoke: a
+  // wire is measured between two panes that are actually talking, and drawing
+  // one to a card that is not a participant would be the one lie this view
+  // cannot afford.
+  const addTile = document.createElement("button");
+  addTile.type = "button";
+  addTile.className = "mp-add-tile";
+  addTile.title = "Add a client";
+  addTile.innerHTML = `<span class="mp-add-plus" aria-hidden="true">+</span>
+    <span class="mp-add-label">add a client</span>`;
+  grid.appendChild(addTile);
+
+  const addTab = document.createElement("button");
+  addTab.type = "button";
+  addTab.className = "mp-tab add";
+  addTab.title = "Add a client";
+  addTab.textContent = "+";
+  addTab.setAttribute("aria-label", "Add a client");
+  tabsStrip.appendChild(addTab);
+
+  // The stage holds the grid plus the layers the NETWORK view adds (mounted by
+  // the graph itself: the wires under the cards, the chips over them). They are
+  // siblings of the grid, never children of it — the grid's cells are the panes
+  // and the "+" tile, and another child would shift the `:nth-child` rules the
+  // grid and network views lay out with.
   const stage = document.createElement("div");
   stage.className = "mp-stage";
   stage.dataset.view = "tiled";
-  const legend = document.createElement("div");
-  legend.className = "mp-legend";
-  // Two legends, one per motion preference — under `reduce` nothing flies, so
-  // a legend about dot shapes would describe something that is not on screen.
-  legend.innerHTML = `
-    <span class="motion"><i class="mp-sw up"></i><b>intent</b> — client → server</span>
-    <span class="motion"><i class="mp-sw down"></i><b>authority</b> — server → client</span>
-    <span class="motion mp-legend-note">dot size = payload bytes · dots are sampled traffic, not one per packet</span>
-    <span class="still mp-legend-note">reduced motion: each link shows its packet count instead of moving dots</span>`;
-  stage.append(legend, grid);
+  stage.append(grid);
+
+  // The NETWORK view's status strip (Addendum 5a.3), homed in the status bar's
+  // view slot: the packet legend, plus the pane readouts the headers drop when
+  // they clip to thumbnail width. A thumbnail header has room for WHO and
+  // WHETHER IT IS LINKED and nothing else, so the frame counters live here —
+  // one place, aligned, instead of spilling out of four narrow headers.
+  const viewStrip = statusBar.viewStrip;
+  viewStrip.hidden = true;
+  viewStrip.innerHTML = `
+    <span class="mp-vs-legend">
+      <span class="motion"><span class="mp-vs-inks"></span><b>intent</b> — client → server</span>
+      <span class="motion"><i class="mp-sw down"></i><b>authority</b> — server → client</span>
+      <span class="motion mp-vs-note">one dot per link per direction per frame · size = bytes carried</span>
+      <span class="still mp-vs-note">reduced motion: each link shows its packet count instead of moving dots</span>
+    </span>
+    <span class="mp-vs-panes" title="Each pane's OWN frame count, which is boot-relative — a late-joined client counts from 0. The rail above counts the reference clock."></span>`;
+  const stripPanes = viewStrip.querySelector(".mp-vs-panes") as HTMLElement;
+  // The intent swatch is one dot PER CLIENT, in that client's ink: "color
+  // carries identity" is the rule the dots follow, and a single swatch would
+  // have to pick one player's color to stand for all of them — which is the
+  // cyan-means-player-1 confusion 5a.1 retired the cyan square for.
+  const stripInks = viewStrip.querySelector(".mp-vs-inks") as HTMLElement;
 
   previewPane.prepend(chrono, debugDrawer, tabsStrip);
   previewPane.appendChild(stage);
@@ -410,7 +464,7 @@ export function initMultiplayerPanes({
         }
         <span class="mp-hd-r">
           ${client ? `<span class="mp-you" hidden>⌨ you</span>` : ""}
-          <span class="mp-conn" hidden></span>
+          <span class="mp-conn" hidden><b class="mp-conn-d"></b><span class="mp-conn-t"></span></span>
           <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
           <span class="mp-st" data-state="busy"></span>
         </span>
@@ -418,12 +472,12 @@ export function initMultiplayerPanes({
       <div class="mp-pane-body"></div>
       <div class="mp-pane-err" hidden></div>`;
     shell.querySelector(".mp-pane-body")!.appendChild(iframe);
-    // A client tile is INSERTED BEFORE the server's, never appended after it:
-    // re-appending a mounted node is a remove + insert, and that reloads an
-    // iframe — the same invariant that keeps pane 1 in place would be broken
-    // for the authority, wiping the world every time the count changed.
-    const before = client && serverPane ? serverPane.pane : null;
-    grid.insertBefore(shell, before?.shell ?? null);
+    // A client tile is INSERTED BEFORE the "+" tile (and so before the server's
+    // card, which follows it), never appended after them: re-appending a
+    // mounted node is a remove + insert, and that reloads an iframe — the same
+    // invariant that keeps pane 1 in place would be broken for the authority,
+    // wiping the world every time the count changed.
+    grid.insertBefore(shell, client ? addTile : null);
 
     const tab = document.createElement("button");
     tab.className = client ? "mp-tab" : "mp-tab server";
@@ -431,7 +485,9 @@ export function initMultiplayerPanes({
     tab.innerHTML = `${client ? `<span class="mp-digit">${index + 1}</span> client` : "SERVER"}
       <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
       <span class="mp-st" data-state="busy"></span>`;
-    tabsStrip.insertBefore(tab, before?.tab ?? null);
+    // Same rule in the tab strip, with the "+" tab pinned last: a client's tab
+    // goes before the server's, and both go before the "+".
+    tabsStrip.insertBefore(tab, (client && serverPane?.pane.tab) || addTab);
 
     const pane: Pane = {
       role,
@@ -452,6 +508,9 @@ export function initMultiplayerPanes({
         tab.querySelector(".mp-st") as HTMLElement,
       ],
       conn: shell.querySelector(".mp-conn") as HTMLElement,
+      connDot: shell.querySelector(".mp-conn-d") as HTMLElement,
+      connText: shell.querySelector(".mp-conn-t") as HTMLElement,
+      stripFrame: null,
       errStrip: shell.querySelector(".mp-pane-err") as HTMLElement,
     };
 
@@ -694,12 +753,83 @@ export function initMultiplayerPanes({
   // `f` skips it, so the cycle never stalls on a view it cannot enter.
   const viewAvailable = (view: PaneView) => view !== "network" || serverPane !== null;
 
+  // FLIP (Addendum 5a.4), by hand and deliberately NOT react-spring: the panes
+  // live OUTSIDE React because a re-parented iframe reloads and wipes its model
+  // (the e2e's document-lifetime markers exist to catch exactly that), so the
+  // animation has to be one that never touches the tree. FLIP is that
+  // animation: measure First, let the class change decide Last, then Invert the
+  // delta as a transform on the SAME node and Play it back to none. Nothing is
+  // created, moved, or re-parented — a switch mid-flight simply re-measures
+  // from wherever the cards currently are.
+  const SWITCH_MS = 420;
+  /** Overshoot-free but spring-paced: quick off the mark, long settle. */
+  const SWITCH_EASING = "cubic-bezier(0.22, 1, 0.3, 1)";
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+  /** Views in flight — while any is, the wires re-measure every frame, since a
+   * transform moves a card's box without resizing anything. */
+  let animating = 0;
+  /** Our own FLIP per node, so an interrupted switch cancels exactly what it
+   * started (a pane also carries CSS transitions we must not touch). */
+  const inFlight = new Map<HTMLElement, Animation>();
+
+  const flipViews = (apply: () => void) => {
+    const nodes = [...allPanes().map((pane) => pane.shell), addTile];
+    // Reduced motion: the layout still changes, it just arrives instantly.
+    if (reduceMotion.matches) {
+      apply();
+      return;
+    }
+    // FIRST is measured WITH any running transform — a switch mid-flight has to
+    // start from where the card visibly is. OUR previous animation on that node
+    // is then cancelled before LAST is measured, or the destination box would be
+    // read through a transform still being applied (its `finished` rejection is
+    // caught below, and `animating` still settles in the `finally`). Only ours:
+    // `getAnimations()` would also return the pane's CSS focus transitions.
+    const first = nodes.map((node) => node.getBoundingClientRect());
+    for (const node of nodes) inFlight.get(node)?.cancel();
+    apply();
+    nodes.forEach((node, index) => {
+      const from = first[index];
+      const to = node.getBoundingClientRect();
+      if (from.width === 0 || to.width === 0) return;
+      const dx = from.left - to.left;
+      const dy = from.top - to.top;
+      const sx = from.width / to.width;
+      const sy = from.height / to.height;
+      if (Math.abs(dx) < 1 && Math.abs(dy) < 1 && Math.abs(sx - 1) < 0.01 && Math.abs(sy - 1) < 0.01) {
+        return;
+      }
+      const animation = node.animate(
+        [
+          { transformOrigin: "0 0", transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})` },
+          { transformOrigin: "0 0", transform: "none" },
+        ],
+        { duration: SWITCH_MS, easing: SWITCH_EASING }
+      );
+      animating += 1;
+      inFlight.set(node, animation);
+      animation.finished
+        .catch(() => {})
+        .finally(() => {
+          animating -= 1;
+          if (inFlight.get(node) === animation) inFlight.delete(node);
+          if (animating === 0 && grid.dataset.view === "network") graph.relayout();
+        });
+    });
+  };
+
   const setView = (view: PaneView, force = false) => {
     if (allPanes().length === 1 && !force) return;
     if (!viewAvailable(view)) return;
-    grid.dataset.view = view;
-    stage.dataset.view = view;
-    tabsStrip.hidden = view !== "tabs";
+    if (view === grid.dataset.view) return;
+    flipViews(() => {
+      grid.dataset.view = view;
+      stage.dataset.view = view;
+      tabsStrip.hidden = view !== "tabs";
+      // The strip's LEGEND is network-only (nothing flies in the other views);
+      // its pane readouts are not — see updateChrome.
+      viewStrip.dataset.view = view;
+    });
     for (const candidate of VIEWS) {
       $btn(`mp-view-${candidate}`).setAttribute("aria-pressed", String(view === candidate));
     }
@@ -721,16 +851,65 @@ export function initMultiplayerPanes({
     // differently.
     grid.dataset.clients = String(panes.length);
     for (const view of VIEWS) $btn(`mp-view-${view}`).disabled = single;
+    // The network button's tooltip is written here and nowhere else — it says
+    // either what the view is or why it is unavailable.
     const network = $btn("mp-view-network");
     if (!single) network.disabled = !viewAvailable("network");
     network.title = viewAvailable("network")
       ? "Network: the server as the hub, with live packet flow along each link (f cycles)"
       : "Network needs an authority — this example declares no server role, so there is no hub to arrange the clients around";
+    // The "+" affordances: hidden at MAX_CLIENTS (there is nothing to add), and
+    // hidden in the single-pane layout, which drops every other piece of
+    // multiplayer chrome with it.
+    // The strip carries the pane readouts in EVERY multi-pane view, not just
+    // network: the headers clip by their own width (a tiled row of four is
+    // thumbnails too), so the frame counters need a home wherever that happens.
+    // Only the packet legend is network-scoped, via `data-view` above.
+    viewStrip.hidden = single;
+    const canAdd = !single && panes.length < MAX_CLIENTS;
+    addTile.hidden = !canAdd;
+    addTab.hidden = !canAdd;
+    // Grid's cell rules need both of these as data, not as structure: a hidden
+    // tile is still a child, so `:last-child` cannot answer "is the bottom row
+    // closed" any more.
+    grid.dataset.seat = canAdd ? "open" : "full";
+    grid.dataset.server = serverPane ? "yes" : "no";
     if (single) setView("tiled", true);
     // An example that dropped its server pane cannot stay in the hub view.
     else if (grid.dataset.view === "network" && !viewAvailable("network")) setView("tiled");
     else if (grid.dataset.view === "network") graph.relayout();
+    rebuildStrip();
   };
+
+  // The network strip's pane readouts, rebuilt whenever the pane set changes.
+  // Each row is the identity the clipped header keeps (digit / SERVER) plus the
+  // frame counter it drops; the paint loop writes the numbers.
+  function rebuildStrip() {
+    stripInks.replaceChildren(
+      ...panes.map((pane) => {
+        const ink = document.createElement("i");
+        ink.className = "mp-sw up";
+        ink.style.setProperty("--pc", pane.color);
+        return ink;
+      })
+    );
+    stripPanes.replaceChildren(
+      ...allPanes().map((pane) => {
+        const row = document.createElement("span");
+        row.className = `mp-vs-pane${pane.role === "server" ? " server" : ""}`;
+        row.style.setProperty("--pc", pane.color);
+        row.innerHTML =
+          `${pane.role === "server" ? `<i class="mp-vs-who">SRV</i>` : `<i class="mp-digit">${panes.indexOf(pane) + 1}</i>`}` +
+          `<b>#f</b> <span class="mp-pf-n">—</span>`;
+        pane.stripFrame = row.querySelector(".mp-pf-n") as HTMLElement;
+        return row;
+      })
+    );
+  }
+
+  const requestAnotherClient = () => requestCount(panes.length + 1);
+  addTile.addEventListener("click", requestAnotherClient);
+  addTab.addEventListener("click", requestAnotherClient);
 
   // Live client-count change: grow or shrink the mirror set in place. Pane 1
   // is untouched, so its model (and the editor session) survive.
@@ -1347,17 +1526,18 @@ export function initMultiplayerPanes({
       for (const label of pane.frameLabels) {
         if (label.textContent !== text) label.textContent = text;
       }
+      // The same number the header drops when it clips (see the strip's note).
+      if (pane.stripFrame && pane.stripFrame.textContent !== text) {
+        pane.stripFrame.textContent = text;
+      }
       pane.conn.hidden = !links;
       if (!links) continue;
       const count = links.get(pane.id) ?? 0;
       const linked =
-        count > 0
-          ? pane.role === "server"
-            ? `● ${count} linked`
-            : "● linked"
-          : "○ waiting";
-      if (pane.conn.textContent !== linked) {
-        pane.conn.textContent = linked;
+        count > 0 ? (pane.role === "server" ? `${count} linked` : "linked") : "waiting";
+      if (pane.connText.textContent !== linked) {
+        pane.connDot.textContent = count > 0 ? "●" : "○";
+        pane.connText.textContent = linked;
         pane.conn.dataset.linked = String(count > 0);
         pane.conn.title =
           count > 0
@@ -1373,6 +1553,11 @@ export function initMultiplayerPanes({
   let raf = 0;
   const tickLoop = () => {
     paint();
+    // A FLIP transform moves a card's box without resizing anything, so the
+    // ResizeObserver the graph normally re-measures from never fires: while a
+    // view switch is in flight, re-measure every frame and the wires fly with
+    // the cards.
+    if (animating > 0 && grid.dataset.view === "network") graph.relayout();
     // One loop for the whole preview column: the network graph advances its
     // packets here rather than running a second rAF beside this one.
     graph.step();
@@ -1424,6 +1609,8 @@ export function initMultiplayerPanes({
     count: () => panes.length,
     destroy() {
       cancelAnimationFrame(raf);
+      viewStrip.hidden = true;
+      viewStrip.replaceChildren();
       graph.destroy();
       net.destroy();
       moduleScope.abort();

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -35,6 +35,7 @@ import { asPlayerMessage } from "./protocol.js";
 import type { StatusBar } from "./status-bar-store.js";
 import type { PillState } from "./components/StatusPill.js";
 import { NetCoordinator } from "./net-coordinator.js";
+import { initNetworkGraph, type NetworkNode } from "./mp-network.js";
 
 /** The shared scrubber's `window.__scrub` seam (runtime/functor-runtime-web/scrubber.js). */
 interface ScrubSeam {
@@ -121,11 +122,13 @@ type PaneState = PillState["state"];
  * How the panes are laid out. `tiled` is one row of equal tiles; `grid` wraps
  * the CLIENTS into two columns and gives the server its own full-width strip
  * along the bottom (design-multiplayer-ide-frontend.md §5 — the authority reads
- * differently from the players); `tabs` shows one pane at a time.
+ * differently from the players); `network` puts the server in the middle as the
+ * hub with its clients around it and draws the wires between them (Addendum 5);
+ * `tabs` shows one pane at a time.
  *
  * Declaration order is the segmented control's order AND the `f` key's cycle.
  */
-const VIEWS = ["tiled", "grid", "tabs"] as const;
+const VIEWS = ["tiled", "grid", "network", "tabs"] as const;
 type PaneView = (typeof VIEWS)[number];
 
 /**
@@ -140,6 +143,8 @@ interface Pane {
   role: PaneRole;
   /** The pane's routing identity in the coordinator ("client 2", "server"). */
   id: string;
+  /** The pane's ink — a player color, or the server's slate. */
+  color: string;
   /** Aborts every listener this pane registered outside its own subtree. */
   scope: AbortController;
   iframe: HTMLIFrameElement;
@@ -264,6 +269,7 @@ export function initMultiplayerPanes({
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
       <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every pane in one row (f cycles)">⊞ tiled</button>
       <button id="mp-view-grid" aria-pressed="false" title="Grid: clients in two columns over the server strip (f cycles)">▦ grid</button>
+      <button id="mp-view-network" aria-pressed="false" title="Network: the server as the hub, with live packet flow along each link (f cycles)">◈ network</button>
       <button id="mp-view-tabs" aria-pressed="false" title="Tabs: one pane full-size (f cycles)">▤ tabs</button>
     </span>`;
 
@@ -306,8 +312,27 @@ export function initMultiplayerPanes({
   grid.className = "mp-grid";
   grid.dataset.view = "tiled";
 
+  // The stage holds the grid plus the surfaces the NETWORK view adds: the
+  // legend above it, and (mounted by the graph itself) the wire and chip
+  // layers around it. They are siblings of the grid, never children of it —
+  // the grid's cells are exactly the panes, and another child would shift the
+  // `:nth-child` rules the grid and network views lay out with.
+  const stage = document.createElement("div");
+  stage.className = "mp-stage";
+  stage.dataset.view = "tiled";
+  const legend = document.createElement("div");
+  legend.className = "mp-legend";
+  // Two legends, one per motion preference — under `reduce` nothing flies, so
+  // a legend about dot shapes would describe something that is not on screen.
+  legend.innerHTML = `
+    <span class="motion"><i class="mp-sw up"></i><b>intent</b> — client → server</span>
+    <span class="motion"><i class="mp-sw down"></i><b>authority</b> — server → client</span>
+    <span class="motion mp-legend-note">dot size = payload bytes · dots are sampled traffic, not one per packet</span>
+    <span class="still mp-legend-note">reduced motion: each link shows its packet count instead of moving dots</span>`;
+  stage.append(legend, grid);
+
   previewPane.prepend(chrono, debugDrawer, tabsStrip);
-  previewPane.appendChild(grid);
+  previewPane.appendChild(stage);
 
   const $ = (id: string) => chrono.querySelector(`#${id}`) as HTMLElement;
   const $btn = (id: string) => chrono.querySelector(`#${id}`) as HTMLButtonElement;
@@ -343,6 +368,23 @@ export function initMultiplayerPanes({
   // with the server always LAST so client indices (and their digits) never move.
   let serverPane: { pane: Pane; bridge: PlayerBridge } | null = null;
   const allPanes = (): Pane[] => (serverPane ? [...panes, serverPane.pane] : panes);
+
+  // The NETWORK view's wires and packet dots. It measures the pane cards the
+  // CSS laid out and reads the coordinator's packet feed; it is inert until the
+  // view is switched on.
+  const asNode = (pane: Pane): NetworkNode => ({
+    id: pane.id,
+    shell: pane.shell,
+    color: pane.color,
+    linkLabel: () => `${pane.link.name} · ${pane.link.ms}ms`,
+  });
+  const graph = initNetworkGraph({
+    stage,
+    grid,
+    net,
+    clients: () => panes.map(asNode),
+    server: () => (serverPane ? asNode(serverPane.pane) : null),
+  });
 
   const makePane = (role: PaneRole, index: number, iframe: HTMLIFrameElement): Pane => {
     const client = role === "client";
@@ -394,6 +436,7 @@ export function initMultiplayerPanes({
     const pane: Pane = {
       role,
       id,
+      color,
       iframe,
       shell,
       tab,
@@ -614,7 +657,12 @@ export function initMultiplayerPanes({
       if (from >= panes.length) focusPane(delta === 1 ? 0 : panes.length - 1, true);
       else focusPane((from + delta + panes.length) % panes.length, true);
     } else if (event.key === "f") {
-      setView(VIEWS[(VIEWS.indexOf(grid.dataset.view as PaneView) + 1) % VIEWS.length]);
+      let next = VIEWS.indexOf(grid.dataset.view as PaneView);
+      for (let hop = 0; hop < VIEWS.length; hop++) {
+        next = (next + 1) % VIEWS.length;
+        if (viewAvailable(VIEWS[next])) break;
+      }
+      setView(VIEWS[next]);
     }
   }
   window.addEventListener("keydown", pickerKeys, { signal: moduleScope.signal });
@@ -639,13 +687,24 @@ export function initMultiplayerPanes({
   // pure CSS from there. Nothing may reorder or re-parent a pane's node: a
   // re-appended iframe reloads and wipes its model (the same invariant that
   // keeps pane 1, and the server pane, in place across count changes).
+  //
+  // NETWORK is the one view that can be unavailable: it is a hub-and-spoke
+  // picture, and a single-role example has no hub. Rather than inventing a ring
+  // around nothing, the option is DISABLED with a tooltip that says why — and
+  // `f` skips it, so the cycle never stalls on a view it cannot enter.
+  const viewAvailable = (view: PaneView) => view !== "network" || serverPane !== null;
+
   const setView = (view: PaneView, force = false) => {
     if (allPanes().length === 1 && !force) return;
+    if (!viewAvailable(view)) return;
     grid.dataset.view = view;
+    stage.dataset.view = view;
     tabsStrip.hidden = view !== "tabs";
     for (const candidate of VIEWS) {
       $btn(`mp-view-${candidate}`).setAttribute("aria-pressed", String(view === candidate));
     }
+    // Turning the graph on measures the boxes this class change just produced.
+    graph.setActive(view === "network");
   };
   for (const view of VIEWS) $btn(`mp-view-${view}`).addEventListener("click", () => setView(view));
 
@@ -662,7 +721,15 @@ export function initMultiplayerPanes({
     // differently.
     grid.dataset.clients = String(panes.length);
     for (const view of VIEWS) $btn(`mp-view-${view}`).disabled = single;
+    const network = $btn("mp-view-network");
+    if (!single) network.disabled = !viewAvailable("network");
+    network.title = viewAvailable("network")
+      ? "Network: the server as the hub, with live packet flow along each link (f cycles)"
+      : "Network needs an authority — this example declares no server role, so there is no hub to arrange the clients around";
     if (single) setView("tiled", true);
+    // An example that dropped its server pane cannot stay in the hub view.
+    else if (grid.dataset.view === "network" && !viewAvailable("network")) setView("tiled");
+    else if (grid.dataset.view === "network") graph.relayout();
   };
 
   // Live client-count change: grow or shrink the mirror set in place. Pane 1
@@ -1306,6 +1373,9 @@ export function initMultiplayerPanes({
   let raf = 0;
   const tickLoop = () => {
     paint();
+    // One loop for the whole preview column: the network graph advances its
+    // packets here rather than running a second rAF beside this one.
+    graph.step();
     raf = requestAnimationFrame(tickLoop);
   };
   raf = requestAnimationFrame(tickLoop);
@@ -1327,6 +1397,9 @@ export function initMultiplayerPanes({
       } else {
         mountServer(serverSrc);
       }
+      // A different program is a different session: the per-link packet totals
+      // the reduced-motion badge shows start over with it.
+      graph.resetCounts();
       updateChrome();
       paintAggregate();
     },
@@ -1351,6 +1424,7 @@ export function initMultiplayerPanes({
     count: () => panes.length,
     destroy() {
       cancelAnimationFrame(raf);
+      graph.destroy();
       net.destroy();
       moduleScope.abort();
       unmountServer();

--- a/site/src/net-coordinator.ts
+++ b/site/src/net-coordinator.ts
@@ -58,10 +58,14 @@ type DeliveredEvent =
   | { kind: "disconnected"; key: string; conn: number }
   | { kind: "error"; key: string; conn: number; message: string };
 
-/** One routed packet, as the (not yet rendered) packet-log rail will read it. */
+/** One routed packet, as the packet-log rail and the network view read it. */
 export interface Packet {
   /** The step it belongs to — always null until the barrier lands (see above). */
   tick: number | null;
+  /** When the coordinator routed it (`performance.now()`). Host-clock time, not
+   * game time: until the barrier lands a packet has no step to belong to, and
+   * the network view still has to place it on a wall-clock timeline. */
+  at: number;
   /** Pane id the packet originated from. */
   from: string;
   /** Pane id it was delivered to. */
@@ -139,6 +143,7 @@ export class NetCoordinator {
   private readonly conns = new Map<number, Conn>();
   private readonly pending: PendingConnect[] = [];
   private readonly log: Packet[] = [];
+  private readonly watchers = new Set<(packet: Packet) => void>();
   private nextConn = 1;
   private raf = 0;
   private readonly abort = new AbortController();
@@ -204,6 +209,19 @@ export class NetCoordinator {
   }
 
   /**
+   * Watch packets as they route. The log is the record; this is the live feed a
+   * view animates from, so it does not have to poll a 10k array every frame.
+   *
+   * Called synchronously from the routing path, so a watcher must be cheap and
+   * must not route anything itself — the network view buffers and spends its
+   * work on the next frame. Returns an unsubscribe.
+   */
+  onPacket(watcher: (packet: Packet) => void): () => void {
+    this.watchers.add(watcher);
+    return () => this.watchers.delete(watcher);
+  }
+
+  /**
    * How many live connections each pane holds. The coordinator is the only
    * place that knows who is actually talking to whom, so this is what a pane's
    * link indicator reads — a pane absent from the map is still waiting.
@@ -226,6 +244,7 @@ export class NetCoordinator {
     this.listeners.clear();
     this.conns.clear();
     this.pending.length = 0;
+    this.watchers.clear();
   }
 
   // ------------------------------------------------------------------ ingress
@@ -371,10 +390,20 @@ export class NetCoordinator {
     const pane = this.panes.get(to.pane);
     if (!pane) return;
     pane.outbox.push(event);
-    this.log.push({ tick: null, from, to: to.pane, conn: event.conn, kind: event.kind, size });
+    const packet: Packet = {
+      tick: null,
+      at: performance.now(),
+      from,
+      to: to.pane,
+      conn: event.conn,
+      kind: event.kind,
+      size,
+    };
+    this.log.push(packet);
     if (this.log.length > PACKET_LOG_CAP + PACKET_LOG_SLACK) {
       this.log.splice(0, this.log.length - PACKET_LOG_CAP);
     }
+    for (const watcher of this.watchers) watcher(packet);
   }
 
   /** Close everything a pane owns without deregistering the pane itself. */

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -135,6 +135,9 @@ mp = initMultiplayerPanes({
   statusBar,
   setPill: (state, text, detail) => pill.set({ state, text, detail }),
   getSource: () => view.state.doc.toString(),
+  // The pane grid's "+" tile asks for a count the same way the CLIENTS
+  // dropdown does — `selectClients` is the one path (clamp, hash, control).
+  requestCount: (n) => selectClients(n),
 });
 
 // The CLIENTS control only appears for multiplayer-structured samples (the

--- a/site/src/status-bar-store.ts
+++ b/site/src/status-bar-store.ts
@@ -38,6 +38,17 @@ export interface StatusBar {
   setProblems: (items: Problem[]) => void;
   appendOutput: (level: ConsoleLevel, text: string, frame?: number | null) => void;
   setExecutions: (items: Execution[]) => void;
+  /**
+   * A slot on the status strip for whichever surface is currently open — the
+   * pane grid's NETWORK legend and its demoted pane readouts today.
+   *
+   * It is an ELEMENT rather than store state on purpose: its owner (mp-panes)
+   * is imperative DOM outside the React islands and repaints per frame, and
+   * routing a 60Hz frame counter through the store would re-render the whole
+   * bar — output list included — once per frame. React mounts this node and
+   * never looks inside it.
+   */
+  viewStrip: HTMLElement;
 }
 
 /** One rendered output row. `time` is stamped at append, not at flush. */
@@ -74,6 +85,8 @@ export const outputPreamble = (frame: number | null, time: string): string =>
 export const createStatusBarStore = (): StatusBarStore => {
   let snapshot: StatusBarSnapshot = { problems: [], output: [], executions: [] };
   const listeners = new Set<() => void>();
+  const viewStrip = document.createElement("div");
+  viewStrip.className = "statusbar-view";
 
   const emit = (next: StatusBarSnapshot): void => {
     snapshot = next;
@@ -97,6 +110,7 @@ export const createStatusBarStore = (): StatusBarStore => {
   };
 
   return {
+    viewStrip,
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {

--- a/site/styles.css
+++ b/site/styles.css
@@ -2965,6 +2965,28 @@ a:hover {
   grid-auto-rows: minmax(0, 1fr);
 }
 
+/* TILED is one row, and says so: a flex row rather than auto-fit columns, which
+   wrapped into a second row as soon as a fourth cell existed (three clients and
+   an authority, or two and the open seat) — the one thing "tiled" promises not
+   to do. The seat rides the end of the row as a slim rail instead of taking a
+   pane's worth of it. */
+.mp-grid[data-view="tiled"] {
+  display: flex;
+}
+
+.mp-grid[data-view="tiled"] > * {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.mp-grid[data-view="tiled"] .mp-add-tile {
+  flex: 0 0 clamp(44px, 5%, 68px);
+}
+
+.mp-grid[data-view="tiled"] .mp-add-label {
+  display: none;
+}
+
 .mp-grid[data-view="tabs"] {
   grid-template-columns: 1fr;
   padding-top: 0;
@@ -3005,13 +3027,18 @@ a:hover {
   grid-row: span 2;
 }
 
-.mp-grid[data-view="grid"][data-clients="1"] .mp-pane:not(.server) {
+/* A lone client stretches only when nothing else wants the cell beside it. An
+   OPEN SEAT (the "+" tile) is not a hole — it is the picture of what pressing
+   it does — so with the seat showing, the client sits beside it at the size its
+   new peer will be. */
+.mp-grid[data-view="grid"][data-clients="1"][data-seat="full"] .mp-pane:not(.server) {
   grid-column: 1 / -1;
 }
 
-/* Nothing follows this client — no peer beside it and no server strip below,
-   since a server pane would be the last child instead. */
-.mp-grid[data-view="grid"] .mp-pane:last-child:nth-child(odd) {
+/* Three clients and no authority: nothing closes the bottom row (no server
+   strip, and the seat is full at MAX_CLIENTS), so the odd last client stretches
+   rather than leaving a whole empty quadrant. */
+.mp-grid[data-view="grid"][data-clients="3"][data-server="no"] .mp-pane:nth-child(3) {
   grid-column: 1 / -1;
 }
 
@@ -3020,80 +3047,74 @@ a:hover {
   grid-row: span 1;
 }
 
-/* ---- network view: the server as the hub, the clients around it ----
+/* ---- network view: the compact hub, the clients around it ----
 
-   design-multiplayer-ide-frontend.md, Addendum 5. Grid and tiled answer "what
-   is each pane running"; NETWORK answers "who is talking to whom" — so the
-   authority moves to the middle of the stage and the players sit around it,
+   design-multiplayer-ide-frontend.md, Addendum 5 + 5a.2. Grid and tiled answer
+   "what is each pane running"; NETWORK answers "who is talking to whom" — so
+   the authority moves to the middle of the stage and the players sit around it,
    with a measured wire per link (mp-network.ts) drawn behind the cards.
+
+   The SERVER IS THE SMALLEST WINDOW here, inverting v1. The gameplay is on the
+   clients, and a hub that outsized them spent the stage on a pane nobody
+   watches; what says "hub" is that every wire ends at it, not its acreage. So
+   the authority is a compact NODE — it opts out of its cell's stretch and takes
+   a clamped size instead — and the clients keep the real estate.
 
    The arrangement is a fixed eight-row track set, so a card's placement is a
    span rather than a computed position — the same class-change-only rule the
    other views follow, and the wires re-measure from wherever the cards land.
-   The hub outsizes its clients in BOTH axes at every count: it is the one card
-   every wire ends at, and size is what says so before any label does.
 
-     1 client  · the spoke on the left, the hub taking the rest.
-     2 clients · left and right of the hub, cascaded down a step each so the
-                 two wires leave at different angles instead of overlapping.
-     3 clients · two flanking the hub, the third parked below it — with a
-                 whole empty row between them, because that row is the channel
-                 its wire runs down. Stable at every count: client 1 never
-                 moves when client 3 arrives.
-*/
+     1 client  · the spoke on the left, the hub far right, a long wire between.
+     2 clients · left and right, full height, with the hub in the channel
+                 between them and parked ABOVE their centreline, so the two
+                 wires leave at different angles instead of forming one
+                 straight line drawn through the hub.
+     3 clients · the same two flanking cards, the third parked below the hub in
+                 the middle channel — the channel its wire runs down.
+
+   Client 1 holds column 1, rows 1–8, at EVERY count: adding or dropping a
+   client never moves the pane you are playing in. */
 
 .mp-grid[data-view="network"] {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr) minmax(0, 1fr);
+  /* The middle track is a channel, not a pane slot: it holds the hub (which is
+     smaller than the track) and the wires that cross it. */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.52fr) minmax(0, 1fr);
   grid-template-rows: repeat(8, minmax(0, 1fr));
-  /* The wide column gap is what the wires travel through — cards are pulled
-     apart here on purpose, where tiled/grid pack them together. */
-  gap: 8px 52px;
+  gap: 8px 44px;
   padding: 12px 18px;
 }
 
-.mp-grid[data-view="network"][data-clients="1"] .mp-pane:not(.server) {
+.mp-grid[data-view="network"] .mp-pane:not(.server):nth-child(1) {
   grid-column: 1;
-  grid-row: 2 / span 5;
-}
-
-.mp-grid[data-view="network"][data-clients="1"] .mp-pane.server {
-  grid-column: 2 / span 2;
   grid-row: 1 / span 8;
 }
 
-.mp-grid[data-view="network"][data-clients="2"] .mp-pane:nth-child(1) {
-  grid-column: 1;
-  grid-row: 1 / span 4;
+.mp-grid[data-view="network"] .mp-pane:not(.server):nth-child(2) {
+  grid-column: 3;
+  grid-row: 1 / span 8;
 }
 
-.mp-grid[data-view="network"][data-clients="2"] .mp-pane:nth-child(2) {
-  grid-column: 3;
+.mp-grid[data-view="network"] .mp-pane:not(.server):nth-child(3) {
+  grid-column: 2;
   grid-row: 5 / span 4;
 }
 
-.mp-grid[data-view="network"][data-clients="2"] .mp-pane.server {
+/* The hub: a compact node parked in the upper middle. `justify-self`/
+   `align-self` are what make it smaller than its cell — the clamp then keeps
+   it a node at any stage size rather than a scaled-down window. */
+.mp-grid[data-view="network"] .mp-pane.server {
   grid-column: 2;
-  grid-row: 2 / span 6;
-}
-
-.mp-grid[data-view="network"][data-clients="3"] .mp-pane:nth-child(1) {
-  grid-column: 1;
   grid-row: 1 / span 3;
+  justify-self: center;
+  align-self: center;
+  width: clamp(128px, 100%, 232px);
+  height: clamp(92px, 100%, 176px);
 }
 
-.mp-grid[data-view="network"][data-clients="3"] .mp-pane:nth-child(2) {
+/* A lone client has no second flank, so the hub crosses to the far column and
+   the wire gets the whole stage to run across. */
+.mp-grid[data-view="network"][data-clients="1"] .mp-pane.server {
   grid-column: 3;
-  grid-row: 1 / span 3;
-}
-
-.mp-grid[data-view="network"][data-clients="3"] .mp-pane:nth-child(3) {
-  grid-column: 2;
-  grid-row: 6 / span 3;
-}
-
-.mp-grid[data-view="network"][data-clients="3"] .mp-pane.server {
-  grid-column: 2;
-  grid-row: 1 / span 4;
 }
 
 /* ---- the stage: the grid, its legend, and the wire layer under the cards ---- */
@@ -3149,18 +3170,20 @@ a:hover {
   opacity: 0.42;
 }
 
-/* Shape says DIRECTION, color says WHO (Addendum 5): a small filled circle in
-   the client's player color is that client's intent travelling up to the
-   authority; a chunky hollow rounded-rect in cyan is authority coming back. */
+/* COLOR says who, SIZE says how much (Addendum 5a.1). Both directions are
+   circles: intent is the client's own player color, lit like the player's other
+   chrome; authority is the server's slate, a smaller and quieter dot, because
+   it arrives every frame on every wire and a bright badge sixty times a second
+   is not information — it is weather. (The retired hollow-cyan square also read
+   as player 1, whose color IS cyan.) */
 .mp-packet.up {
   fill: currentColor;
   filter: drop-shadow(0 0 5px currentColor);
 }
 
 .mp-packet.down {
-  fill: rgba(65, 216, 230, 0.18);
-  stroke: var(--cyan);
-  stroke-width: 1.2;
+  fill: var(--scrub-server);
+  filter: drop-shadow(0 0 3px rgba(139, 131, 173, 0.75));
 }
 
 /* The mid-edge chip: this client's CONFIGURED link profile. It is a label, not
@@ -3208,66 +3231,137 @@ a:hover {
   }
 }
 
-/* ---- the legend: what a shape and a size mean (network view only) ---- */
+/* ---- the network status strip (Addendum 5a.3) ----
 
-.mp-legend {
-  display: none;
+   The legend, and the readouts the pane headers drop when they clip to
+   thumbnail width, ride the STATUS BAR rather than the stage: the stage is the
+   topology, and a caption band above it was pushing the cards down and still
+   spilling out of the headers. The bar already is the page's line of ambient
+   state, so the view's own state belongs on it — scoped to the view, gone the
+   moment you leave it. */
+
+.statusbar-view-host {
+  margin-left: auto;
+  min-width: 0;
+}
+
+.statusbar-view {
+  display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 18px;
-  flex-wrap: wrap;
-  padding: 8px 22px 2px;
-  font: 10px/1.4 var(--font-mono);
+  min-width: 0;
+  padding: 4px 4px 4px 12px;
+  font: 10px/1 var(--font-mono);
   letter-spacing: 0.04em;
   color: var(--text-dim);
 }
 
-.mp-stage[data-view="network"] .mp-legend {
-  display: flex;
+.statusbar-view[hidden] {
+  display: none;
 }
 
-.mp-legend b {
+/* The packet legend describes dots that only fly in the NETWORK view; the pane
+   readouts beside it are carried in every multi-pane view (see mp-panes.ts). */
+.statusbar-view:not([data-view="network"]) .mp-vs-legend {
+  display: none;
+}
+
+.mp-vs-legend {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.mp-vs-legend b {
   font-weight: 400;
   color: var(--text);
 }
 
-.mp-legend .mp-sw {
+.mp-vs-note {
+  opacity: 0.72;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mp-sw {
   display: inline-block;
   vertical-align: middle;
+  border-radius: 999px;
   margin-right: 7px;
 }
 
-.mp-legend .mp-sw.up {
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: var(--scrub-p1);
-  box-shadow: 0 0 6px var(--scrub-p1);
+/* One intent swatch per live client, each in that client's ink (mp-panes.ts). */
+.mp-vs-inks {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-right: 7px;
+  vertical-align: middle;
 }
 
-.mp-legend .mp-sw.down {
-  width: 13px;
-  height: 9px;
-  border-radius: 2px;
-  background: rgba(65, 216, 230, 0.18);
-  border: 1px solid var(--cyan);
+.mp-sw.up {
+  --pc: var(--scrub-p1);
+  width: 8px;
+  height: 8px;
+  margin: 0;
+  background: var(--pc);
+  box-shadow: 0 0 6px var(--pc);
 }
 
-.mp-legend-note {
-  opacity: 0.75;
+/* The authority swatch is the authority dot: smaller, slate, unlit. */
+.mp-sw.down {
+  width: 5px;
+  height: 5px;
+  background: var(--scrub-server);
+  box-shadow: 0 0 4px rgba(139, 131, 173, 0.7);
 }
 
-/* One legend per motion preference (see the pane module): the shapes legend
-   only under motion, the counts note only under reduce. */
-.mp-legend .still {
+/* The demoted header details: one row per pane, in pane order. */
+.mp-vs-panes {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: none;
+}
+
+.mp-vs-pane {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.mp-vs-pane b {
+  font-weight: 400;
+  opacity: 0.62;
+}
+
+.mp-vs-pane .mp-digit {
+  font-style: normal;
+}
+
+.mp-vs-who {
+  font-style: normal;
+  letter-spacing: 0.12em;
+  color: var(--scrub-server);
+}
+
+/* One legend per motion preference (see the pane module): the dot legend only
+   under motion, the counts note only under reduce. */
+.statusbar-view .still {
   display: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .mp-legend .motion {
+  .statusbar-view .motion {
     display: none;
   }
 
-  .mp-legend .still {
+  .statusbar-view .still {
     display: inline;
   }
 }
@@ -3277,6 +3371,10 @@ a:hover {
 .mp-pane {
   --pc: var(--cyan);
   position: relative;
+  /* The header clips against the PANE's width, not the viewport's — a pane is
+     a thumbnail at three-up on a wide screen and full width at one-up on a
+     narrow one. See the header's priority rules. */
+  container: mp-pane / inline-size;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -3375,7 +3473,51 @@ a:hover {
   display: inline-flex;
   align-items: center;
   gap: 9px;
+  min-width: 0;
   font-variant-numeric: tabular-nums;
+}
+
+/* ---- header priority: what survives a thumbnail (Addendum 5a.3) ----
+
+   A pane header is a sentence about one pane, and at network-view widths there
+   is not room for the sentence. Rather than let it spill (it cannot clip: the
+   link menu drops OUT of this header), the header sheds it in priority order,
+   least load-bearing first:
+
+     1. the frame counter — a number that changes 60×/s, and the one the
+        status strip now carries for every pane at once;
+     2. the prose — the role word, the "authority" caption, "⌨ you" (the focus
+        glow already says which pane holds the keyboard), and the word beside
+        the link dot;
+     3. the link chip, which truncates rather than disappearing.
+
+   What NEVER goes: the DIGIT (which pane this is) and the CONNECTION DOT
+   (whether it is talking) — identity and liveness, the two things you look at
+   a thumbnail's header for at all. */
+
+@container mp-pane (max-width: 330px) {
+  .mp-pf {
+    display: none;
+  }
+}
+
+@container mp-pane (max-width: 250px) {
+  /* The SERVER keeps its word: it carries no digit, so the label is the whole
+     of its identity — the one piece of prose that is load-bearing. */
+  .mp-pane:not(.server) .mp-role,
+  .mp-authority,
+  .mp-you,
+  .mp-conn-t {
+    display: none;
+  }
+}
+
+.mp-conn-d {
+  font-weight: 400;
+}
+
+.mp-conn-t {
+  margin-left: 4px;
 }
 
 .mp-you {
@@ -3608,6 +3750,12 @@ a:hover {
     grid-template-columns: 1fr;
   }
 
+  /* Tiled's flex row becomes a flex column — the same stack the grid views
+     collapse to, with the seat as a short band at the end of it. */
+  .preview-pane.mp .mp-grid[data-view="tiled"] {
+    flex-direction: column;
+  }
+
   /* Network has no room for a hub flanked by spokes in one narrow column, so
      it collapses to the same stack — the clients over the authority, in DOM
      order. The wires re-measure and run vertically down the chain, so the
@@ -3623,10 +3771,100 @@ a:hover {
     grid-column: 1;
     grid-row: auto;
   }
+
+  /* The hub keeps its full width in a one-column stack (a centred node in a
+     list reads as a broken cell) but stays the SHORT card — still the smallest
+     window, still the thing the wires run to. */
+  .preview-pane.mp .mp-grid[data-view="network"] .mp-pane.server {
+    justify-self: stretch;
+    width: auto;
+    height: clamp(76px, 62%, 132px);
+  }
+}
+
+/* ---- the "+" tile: add a client where the client will appear ----
+
+   Addendum 5a.7. The CLIENTS dropdown is the numeric control; this is the
+   spatial one — an empty seat at the table, drawn as the dashed outline of the
+   pane it would become. It sits in the cell after the last client, so the
+   layout answers "what happens if I press this" before the tooltip does.
+   Hidden at MAX_CLIENTS, and in TABS (which has its own "+" tab) and NETWORK
+   (a topology of real participants only — see mp-panes.ts). */
+
+.mp-add-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-width: 0;
+  min-height: 0;
+  cursor: pointer;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px dashed color-mix(in srgb, var(--cyan) 22%, rgba(43, 37, 66, 0.9));
+  border-radius: 5px;
+  font: 10px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: border-color 0.18s, color 0.18s, background 0.18s;
+}
+
+.mp-add-tile:hover,
+.mp-add-tile:focus-visible {
+  color: var(--cyan);
+  border-color: color-mix(in srgb, var(--cyan) 55%, transparent);
+  background: rgba(65, 216, 230, 0.05);
+}
+
+.mp-add-plus {
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 300;
+  opacity: 0.8;
+}
+
+/* In GRID the seat is exactly the cell the next client will take — except when
+   it would be alone on its row, where it becomes a short full-width band
+   instead of a cell beside a hole. */
+.mp-grid[data-view="grid"] .mp-add-tile {
+  grid-row: span 2;
+}
+
+.mp-grid[data-view="grid"][data-clients="2"] .mp-add-tile {
+  grid-column: 1 / -1;
+  grid-row: span 1;
+  /* A band, not a cell: it opts out of the row's stretch so an empty seat
+     never outweighs the panes that are actually running. */
+  align-self: center;
+  height: clamp(64px, 100%, 116px);
+}
+
+.mp-grid[data-view="tabs"] .mp-add-tile,
+.mp-grid[data-view="network"] .mp-add-tile {
+  display: none;
+}
+
+/* The tab-strip twin: the same action, at the size the tab strip allows. */
+.mp-tab.add {
+  --pc: var(--cyan);
+  font-size: 13px;
+  line-height: 1;
+  padding: 6px 12px;
+  filter: none;
+  background: transparent;
+  border-style: dashed;
+}
+
+.mp-tab.add:hover {
+  color: var(--cyan);
+  border-color: color-mix(in srgb, var(--cyan) 55%, transparent);
 }
 
 /* `hidden` must win over the display rules above. */
 .mp-tabs[hidden],
+.mp-add-tile[hidden],
+.mp-tab.add[hidden],
 .mp-link-menu[hidden] {
   display: none;
 }

--- a/site/styles.css
+++ b/site/styles.css
@@ -3020,6 +3020,258 @@ a:hover {
   grid-row: span 1;
 }
 
+/* ---- network view: the server as the hub, the clients around it ----
+
+   design-multiplayer-ide-frontend.md, Addendum 5. Grid and tiled answer "what
+   is each pane running"; NETWORK answers "who is talking to whom" — so the
+   authority moves to the middle of the stage and the players sit around it,
+   with a measured wire per link (mp-network.ts) drawn behind the cards.
+
+   The arrangement is a fixed eight-row track set, so a card's placement is a
+   span rather than a computed position — the same class-change-only rule the
+   other views follow, and the wires re-measure from wherever the cards land.
+   The hub outsizes its clients in BOTH axes at every count: it is the one card
+   every wire ends at, and size is what says so before any label does.
+
+     1 client  · the spoke on the left, the hub taking the rest.
+     2 clients · left and right of the hub, cascaded down a step each so the
+                 two wires leave at different angles instead of overlapping.
+     3 clients · two flanking the hub, the third parked below it — with a
+                 whole empty row between them, because that row is the channel
+                 its wire runs down. Stable at every count: client 1 never
+                 moves when client 3 arrives.
+*/
+
+.mp-grid[data-view="network"] {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr) minmax(0, 1fr);
+  grid-template-rows: repeat(8, minmax(0, 1fr));
+  /* The wide column gap is what the wires travel through — cards are pulled
+     apart here on purpose, where tiled/grid pack them together. */
+  gap: 8px 52px;
+  padding: 12px 18px;
+}
+
+.mp-grid[data-view="network"][data-clients="1"] .mp-pane:not(.server) {
+  grid-column: 1;
+  grid-row: 2 / span 5;
+}
+
+.mp-grid[data-view="network"][data-clients="1"] .mp-pane.server {
+  grid-column: 2 / span 2;
+  grid-row: 1 / span 8;
+}
+
+.mp-grid[data-view="network"][data-clients="2"] .mp-pane:nth-child(1) {
+  grid-column: 1;
+  grid-row: 1 / span 4;
+}
+
+.mp-grid[data-view="network"][data-clients="2"] .mp-pane:nth-child(2) {
+  grid-column: 3;
+  grid-row: 5 / span 4;
+}
+
+.mp-grid[data-view="network"][data-clients="2"] .mp-pane.server {
+  grid-column: 2;
+  grid-row: 2 / span 6;
+}
+
+.mp-grid[data-view="network"][data-clients="3"] .mp-pane:nth-child(1) {
+  grid-column: 1;
+  grid-row: 1 / span 3;
+}
+
+.mp-grid[data-view="network"][data-clients="3"] .mp-pane:nth-child(2) {
+  grid-column: 3;
+  grid-row: 1 / span 3;
+}
+
+.mp-grid[data-view="network"][data-clients="3"] .mp-pane:nth-child(3) {
+  grid-column: 2;
+  grid-row: 6 / span 3;
+}
+
+.mp-grid[data-view="network"][data-clients="3"] .mp-pane.server {
+  grid-column: 2;
+  grid-row: 1 / span 4;
+}
+
+/* ---- the stage: the grid, its legend, and the wire layer under the cards ---- */
+
+.mp-stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  /* The containing block the wire layer measures against. */
+  position: relative;
+}
+
+.mp-stage .mp-grid {
+  /* The grid keeps its own flex sizing now that the stage is the flex item. */
+  flex: 1;
+  min-height: 0;
+}
+
+/* Two layers, one on each side of the grid in the DOM. The WIRES sit before it
+   so the pane cards (which are positioned) paint over them — wires run behind
+   the windows, like the mockup. The CHIPS sit after it, because a label buried
+   under a card is a label you cannot read. Both share the stage's box, so one
+   measurement places both. */
+.mp-net-layer,
+.mp-net-chips {
+  display: none;
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mp-stage[data-view="network"] .mp-net-layer,
+.mp-stage[data-view="network"] .mp-net-chips {
+  display: block;
+}
+
+.mp-wires {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+/* The wire itself: the client's own ink, kept quiet. It is context — the
+   packets moving along it are the thing to watch. */
+.mp-wire {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  opacity: 0.42;
+}
+
+/* Shape says DIRECTION, color says WHO (Addendum 5): a small filled circle in
+   the client's player color is that client's intent travelling up to the
+   authority; a chunky hollow rounded-rect in cyan is authority coming back. */
+.mp-packet.up {
+  fill: currentColor;
+  filter: drop-shadow(0 0 5px currentColor);
+}
+
+.mp-packet.down {
+  fill: rgba(65, 216, 230, 0.18);
+  stroke: var(--cyan);
+  stroke-width: 1.2;
+}
+
+/* The mid-edge chip: this client's CONFIGURED link profile. It is a label, not
+   a measurement — the coordinator's links are still perfect. */
+.mp-edge-chip {
+  position: absolute;
+  /* The layer is click-through; the chip is not, so its title (the note that
+     the profile is configured, not measured) is reachable on hover. */
+  pointer-events: auto;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+  font: 9.5px/1 var(--font-mono);
+  letter-spacing: 0.03em;
+  color: var(--text-dim);
+  background: rgba(15, 12, 29, 0.92);
+  border: 1px solid var(--line);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
+}
+
+.mp-edge-chip b {
+  font-weight: 400;
+  color: var(--text);
+}
+
+/* The packet counter rides the chip, and only under reduced motion — see the
+   dots' note below. */
+.mp-edge-chip i {
+  display: none;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Reduced motion: NOTHING flies. mp-network.ts stops spawning dots entirely
+   and each edge shows a static packet count instead, so the traffic is still
+   legible — a number that ticks up rather than a movement to track. */
+@media (prefers-reduced-motion: reduce) {
+  .mp-edge-chip i {
+    display: inline;
+    color: var(--cyan);
+  }
+}
+
+/* ---- the legend: what a shape and a size mean (network view only) ---- */
+
+.mp-legend {
+  display: none;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 8px 22px 2px;
+  font: 10px/1.4 var(--font-mono);
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.mp-stage[data-view="network"] .mp-legend {
+  display: flex;
+}
+
+.mp-legend b {
+  font-weight: 400;
+  color: var(--text);
+}
+
+.mp-legend .mp-sw {
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 7px;
+}
+
+.mp-legend .mp-sw.up {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--scrub-p1);
+  box-shadow: 0 0 6px var(--scrub-p1);
+}
+
+.mp-legend .mp-sw.down {
+  width: 13px;
+  height: 9px;
+  border-radius: 2px;
+  background: rgba(65, 216, 230, 0.18);
+  border: 1px solid var(--cyan);
+}
+
+.mp-legend-note {
+  opacity: 0.75;
+}
+
+/* One legend per motion preference (see the pane module): the shapes legend
+   only under motion, the counts note only under reduce. */
+.mp-legend .still {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mp-legend .motion {
+    display: none;
+  }
+
+  .mp-legend .still {
+    display: inline;
+  }
+}
+
 /* ---- pane shell ---- */
 
 .mp-pane {
@@ -3354,6 +3606,22 @@ a:hover {
 @media (max-width: 1280px) {
   .preview-pane.mp .mp-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Network has no room for a hub flanked by spokes in one narrow column, so
+     it collapses to the same stack — the clients over the authority, in DOM
+     order. The wires re-measure and run vertically down the chain, so the
+     topology still reads; only the geometry changes. */
+  .preview-pane.mp .mp-grid[data-view="network"] {
+    grid-template-rows: none;
+    grid-auto-rows: minmax(0, 1fr);
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .preview-pane.mp .mp-grid[data-view="network"] .mp-pane {
+    grid-column: 1;
+    grid-row: auto;
   }
 }
 


### PR DESCRIPTION
![network view demo](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-hero.gif)

<sub>The network view after Bryan's iteration round: compact SERVER hub, clients get the real estate, intent circles in player colors, authority as small slate circles — one dot per link per direction per frame, no sampling.</sub>

![network view still](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-2clients-network.png)

<details>
<summary>More: status strip, reduced motion, FLIP mid-transition, the + seat</summary>

![status strip legend](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-strip-legend.png)

<sub>The status strip carries the legend: intent (client → server) and authority (server → client), one dot per link per direction per frame.</sub>

![reduced motion](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-2clients-network-reduced-motion.png)

<sub>Reduced motion: each link shows its packet count badge instead of moving dots.</sub>

![FLIP mid-transition](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-flip-midtransition.png)

<sub>FLIP mid-flight: the hub caught mid-transition with a `transform: scale(0.596, 0.208)` still applied.</sub>

![grid + seat](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-grid-seat.png)

<sub>The + seat: a dashed placeholder that adds a client in place (GRID).</sub>

![tabs + seat](https://gist.githubusercontent.com/tommy-xr/16034496c2f70ddaeabf836e38da1d17/raw/mpnet2-tabs-seat.png)

<sub>The same + seat as a trailing tab in TABS.</sub>

</details>

---

The **network view** (design doc Addendum 5, mockup-approved by Bryan): a fourth pane layout — **TILED | GRID | NETWORK | TABS** — where the SERVER pane sits centered as the hub, client panes orbit as live thumbnails, and the session's actual packets flow along SVG wires between them. The topology of the running game, drawn from the coordinator's own log.

**The three approved rules, as shipped:**
- **Shape carries direction, color carries identity** — client→server intent is a small filled circle in that client's player color; server→client authority is a chunky hollow cyan square. Dot size scales mildly with payload bytes. The legend states both.
- **Pace is honest** — flight time is a fixed 600ms today and the legend says dots are *sampled traffic, not one per packet* (~10/sec per edge per direction, 40 concurrent, oldest evicted). When impairment lands, flight time becomes the measured link latency (the Addendum 5 honesty rule — any scaling gets a visible "×N" chip — is recorded at the seam).
- **The wire log is the NEXT PR** — `Packet.at` (host-clock stamp) and the new `onPacket()` subscribe seam on the coordinator land here as its foundation; the pinned scrub-locked log panel is deliberately not in this diff.

**Layout:** CSS-only (3×8 grid keyed on `data-clients`): 1 client = spoke left of the hub; 2 = flanking, cascaded so the wires leave at different angles; 3 = two flanking + one below with its wire channel row. The hub outsizes clients in both axes at every count; client 1 never moves when client 3 arrives. Below 1280px the stack collapses vertically and the wires re-measure. Single-role examples **disable** the toggle with an explanatory tooltip (no authority = no hub), `f` skips it, and losing the authority mid-view falls back to tiled.

**Mechanics:** measured bezier endpoints (`getBoundingClientRect` + a `ResizeObserver` re-measure seam — no fixed geometry), wires behind the cards / chips in front, a pooled dot layer driven from the host's existing rAF (no second loop), inert when the view is off. Link chips render mid-edge from the pane's recorded profile (labels of configured impairment — still recorded-only until the impairment PR). `prefers-reduced-motion`: no dots at all — a static per-edge packet-count badge and a legend that says so; flipping the preference mid-view clears anything in the air.

**Cross-engine review (Claude + Codex), no Critical/High; all findings applied:** [AGREED] redundant relayout removed; [AGREED] the packet inbox capped at 512 (mirrors the log's discipline); read/write passes split in the dot loop and relayout (no layout thrash); edge-chip tooltips reachable through the pointer-events layer; a dead throttle deleted; the wire-axis choice now uses actual separation (a centre-delta pick could run a wire backwards behind both cards); runtime reduced-motion flips clear in-flight dots; per-edge counts reset on example switch. Declined with reasons in-diff: `Packet.at` stays (it is the wire-log PR's stated foundation, both engines' scope-creep flag answered by naming the consumer).

**Verification:** `tsc -p site --noEmit` clean; site rebuilt from scratch; `npm run test:site` ALL CHECKS PASSED; `e2e/net-coordinator.mjs` 15/15; `e2e/sandbox-mp.mjs` extended and green — network class, 2 wires with real lengths, both chips, legend, both dot directions observed in flight, the cap, document-lifetime markers alive across every switch, the 4-way `f` cycle, the 3-client arrangement with 3 wires, the disabled-toggle fallback, and the authority-loss fallback.

---

**Iteration round (Addendum 5a — Bryan's live feedback on v1), two further commits:**

- **The hub inverted**: the server is now the SMALLEST window — a compact node between the clients, which get the real estate. Client 1's box is literally identical at 1, 2, and 3 clients (no reflow on join).
- **Authority packets are small slate circles** (`--scrub-server`, tight size range) — both directions are circles now; shape stopped carrying direction, ink does, and the cyan≈player-1 confusion is gone for good. Intent keeps player colors + payload scaling.
- **Status strip**: the legend and per-pane frame readouts moved to a view-scoped strip in the status bar (a mounted element, not store state — the bar must not re-render at 60Hz); pane headers clip by priority via container queries (digit + linked dot always survive). This fixes the header spill.
- **FLIP + Web Animations transitions between all four views** — transform animation on the same nodes, never reparenting (the document-lifetime e2e markers are asserted across an *animated* switch); wires re-measure per frame so they fly with the cards; reduced-motion is instant. Deliberately not react-spring: panes live outside React so React can never reload an iframe.
- **Dots are per-frame batched** — one dot per link per direction per frame that carried traffic, sized by that frame's bytes. The "sampled" caveat is retired; the wire-log PR next keys traffic to the timeline (scrub the rail → the wires replay).
- **A "+" seat adds clients in place** — dashed placeholder tile in tiled/grid, a "+" tab in tabs, hidden at MAX_CLIENTS, same code path as the CLIENTS control. Deliberately absent from network view: a wire is measured between two panes actually talking, and a ghost spoke to a non-participant is the one lie that view can't afford.
- **`fix(site)`: chrono broadcasts translate through per-pane frame offsets.** Pane frame indices are boot-relative, so seeks landed wrong on late-joined clients (found by Bryan). The host now measures each pane's offset against the server's clock continuously from live recording heads (review caught that a latched measurement could capture a booting reference), and every broadcast seek/label translates through it. A differential e2e proves it: after a late join, paging back one second moves *every* pane exactly 60 frames of its own clock — against the untranslated code the late client provably doesn't move. Exact session epoch still arrives with barrier stepping.

Iteration-round review (both engines): [AGREED] the offset-latching High (fixed via continuous measurement) and FLIP interrupt-safety (fixed — cancel tracked animations between First and Last); plus seven single-engine fixes applied and four declines with in-diff rationale. Full ladder re-verified at the final tree: `test:site` ALL CHECKS PASSED, `sandbox-mp` 48/48, `net-coordinator` 15/15, tsc strict clean.

Next: the pinned wire log (Addendum 5 rule 3) on this foundation — traffic keyed to the timeline; then orbs adopts the transport; then impairment makes the link chips and the dot pace real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

