### PR TITLE
feat(lang): unit-suffix literals — 90deg, 0.5s, and user-declared units

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -41,7 +41,8 @@ The habits that break first, in one place. Each is expanded below.
   (`module Server { … }`, one level deep) — see Modules below.
 - **The engine prelude (`Scene.*`, `Camera3D.*`, `Frame.*`, `Physics.*`) exists
   only under the runner host**, not in plain `functor-lang run`. Its branded
-  values refuse bare numbers: `Angle.degrees(60.0)`, `Time.seconds(0.5)`.
+  values refuse bare numbers: `Angle.degrees(60.0)`, `Time.seconds(0.5)` — or
+  their **unit-suffix literals**, `60deg` / `0.5s` (see `unit` below).
 - **A game is `init` / `tick` / `draw`** plus optional hooks — see The game
   contract below.
 
@@ -118,6 +119,10 @@ let grade = (n: float): string =>             // `else if` chains — just an `i
   else "C"
 
 let threshold = 10                            // top-level let; ints/floats are all float (f64)
+type Px = | Px(value: float)                  // a single-ctor brand…
+unit px = Px                                  // …with a literal SUFFIX: `16px` == `Px(16.0)`
+let width = 16px                              //   the suffix must TOUCH the digits (`16 px` is
+                                              //   two tokens); `-2.5px` == `Px(-2.5)`
 let origin: Position = { x: 0.0, y: 0.0 }     // OPTIONAL binding annotation `let name: Type = …`
                                               //   (checked against the value; also on `let … in`)
 let scores = [1.0, 2.0, 3.0]                  // list literal; [x, ..xs] prepends
@@ -570,6 +575,45 @@ that's what `functor test` is for.
   assert on numbers/records you derive instead. The highest-value tests
   are pure logic anyway: model/`tick`/`update` math.
 
+## Unit-suffix literals (`unit`)
+
+A numeric literal may carry a **unit suffix** — `90deg`, `0.5s`, `16px` — which
+is exactly the call the suffix's `unit` declaration names. Design and the
+Phase 2 (operators) plan: `docs/functor-lang-units.md`.
+
+```functor
+unit deg = Angle.degrees            // a top-level ITEM, in `.fun` and `.funi`
+unit px = Px                        // target: any (float) => 't function OR constructor
+
+let turn = Scene.rotateY(90deg)     // == Scene.rotateY(Angle.degrees(90.0))
+let beat = Sub.every(0.5s, Tick)    // == Sub.every(Time.seconds(0.5), Tick)
+```
+
+- **Adjacency is the rule**: the suffix must touch the digits. `90 deg` is
+  still a number and a name; `16px2` is one suffix (`px2`), never a split.
+- **A prefix minus folds in**: `-90deg` is `Angle.degrees(-90.0)`, not a
+  negation of the branded value (branded values have no arithmetic — that is
+  Phase 2). Binary subtraction is untouched.
+- **Units are project-wide**, like constructors: a suffix declared in ANY
+  module means the same thing in every module, and declaring one twice
+  anywhere in the project is an error.
+- **The target is typechecked as exactly `(float) => 't`** at the
+  declaration, and it is a NAME (`Angle.degrees`, `Px`, `Utils.Meters`), never
+  an expression.
+- **It desugars at load**: the IR holds the ordinary call, so hover, inlay,
+  go-to-definition, typechecking, and runtime teaching errors all see
+  `Angle.degrees(90.0)` — and there is no per-frame cost.
+- **An undeclared suffix is a load/check error** listing the declared units,
+  and a bare number in a branded position now teaches both spellings
+  (``expected Angle.t, got float — write `90deg` or `Angle.degrees(90.0)` ``).
+- **Built-in suffixes (engine prelude only)**: `deg` / `rad` (`Angle.degrees`
+  / `Angle.radians`) and `s` / `ms` / `us` / `min` / `hr` (`Time.seconds` /
+  `millis` / `micros` / `minutes` / `hours`). They are declared in
+  `angle.funi` / `time.funi`, so — like every prelude name — they exist only
+  under the runner host, not in a plain `functor-lang run`.
+- **`unit` is contextual** (the `open` / `expect` / `module` rule): only item
+  position declares one, so the name stays usable everywhere else.
+
 ## Semantics rules that WILL bite you
 
 - **Pipelines append (thread-last)**: `x |> f(a)` is `f(a, x)`. Every
@@ -788,8 +832,8 @@ The generated modules:
 | `Skybox` | six-face cubemaps |
 | `Color` | `Color.rgb` — the ONE color type across 3D, lighting, fog, and UI |
 | `Vec3` | branded 3D vectors and their arithmetic |
-| `Angle` | branded angles (`degrees` / `radians`) |
-| `Time` | branded durations (`seconds` / `millis`) |
+| `Angle` | branded angles (`degrees` / `radians`; suffixes `deg` / `rad`) |
+| `Time` | branded durations (`seconds` / `millis` / `micros` / `minutes` / `hours`; suffixes `s` / `ms` / `us` / `min` / `hr`) |
 | `Texture` | `Texture.file` — a texture value from a path (a plain string, not an asset locator) |
 | `RenderTarget` | named offscreen targets for render-to-texture |
 | `Asset` | branded model / texture / sound locators, and `whilePending` placeholders |
@@ -831,6 +875,13 @@ Declare the identity-shaped ones (`RenderTarget.named`, `Physics.tag`) ONCE as a
 top-level `let` and use that value at every site. `Scene.animate` takes an
 `Anim` value, never a bare clip-name string; `Sub.every` takes a `Time`, never
 `0.5`; `Style` values, not CSS strings, go into `Attr.styles`.
+
+**Angles and durations also have literal SUFFIXES** (see "Unit-suffix literals"
+above): `90deg` / `0.5rad` are `Angle.degrees(90.0)` / `Angle.radians(0.5)`,
+and `0.5s` / `500ms` / `250us` / `2min` / `1hr` are the matching `Time.*`
+calls. They are the same value by a shorter name — the brand is not weakened,
+and a bare `90.0` is still an error (one that now names the suffix in its fix).
+Declare `unit` suffixes for your own brands the same way.
 
 **Everything pipes subject-last**, like the stdlib: `scene |> Scene.color(c)`,
 `body |> Physics.at(v)`, `sprite |> Sprite.move(x, y)`,

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -1,0 +1,171 @@
+# Unit-suffix literals
+
+Functor Lang lets a numeric literal carry a **unit suffix** — `90deg`, `0.5s`,
+`16px` — where a `unit` declaration says what the suffix means. This document
+covers what shipped (Phase 1) and the design for operators on branded units
+(Phase 2), which is **not** implemented.
+
+Syntax and semantics for day-to-day use live in the `functor-lang` skill; the
+prelude's own suffixes are documented at their source
+(`functor-prelude/prelude/angle.funi`, `time.funi`) and appear in the generated
+API reference.
+
+## Why
+
+The engine's branded values (`Angle.t`, `Time.t`, and the user's own single
+constructor brands) exist so that degrees cannot be passed where radians
+belong, or milliseconds where seconds do. That safety costs a call at every
+site — `Scene.rotateY(Angle.degrees(90.0))`, `Sub.every(Time.seconds(0.5), …)`
+— and the noise is what pushes people toward bare numbers, which is exactly the
+mistake the brand exists to prevent. A suffix keeps the brand and removes the
+ceremony: `Scene.rotateY(90deg)`.
+
+## Phase 1 (shipped)
+
+### The literal
+
+A numeric literal (`digits` or `digits.digits`) immediately followed by
+identifier characters lexes as ONE token carrying the value and the suffix
+spelling. Adjacency is the whole rule — `90 deg` is still a number and a name.
+The lexer deliberately does **not** know which units exist; there is no
+scientific notation in Functor Lang, so no `1e5` ambiguity, and `90deg` was
+previously a parse error, so the syntax was unclaimed.
+
+A prefix minus folds into the literal (`-90deg` is `Angle.degrees(-90.0)`,
+never a negation of the branded value), matching how number patterns already
+absorb a leading `-`. Binary subtraction is untouched.
+
+### The declaration
+
+```functor
+unit deg = Angle.degrees          // a `.funi` signature
+unit px = Px                      // a single-constructor brand: type Px = | Px(value: float)
+unit turns = fullTurns            // any (float) => 't function
+```
+
+`unit <suffix> = <name>` is a top-level item in both `.fun` and `.funi` files.
+The target is a NAME (never an arbitrary expression) resolved in the declaring
+module's scope, and it is typechecked as exactly `(float) => 't`.
+
+- **Units are project-wide.** `file = module` makes them behave like
+  constructors: a suffix declared in any module means the same thing in every
+  module, and declaring one twice anywhere in a project is an error.
+- **Resolution happens once**, in the declaring module, before any file lowers
+  — so a use site may precede its declaration, or live in a different file.
+- **`unit` is contextual**, like `open` / `expect` / `module`: it only means a
+  declaration in item position, so `unit` stays usable as an ordinary name.
+
+### Desugaring
+
+Lowering rewrites each suffixed literal to exactly the call the unit names:
+`90deg` becomes `Angle.degrees(90.0)`, with no unit node in the IR. Hover,
+inlay hints, go-to-definition, typechecking, the interpreter, and the host's
+teaching errors therefore all see an ordinary call — there is no second code
+path to keep honest, and no per-frame cost (the desugar happens at load).
+
+An undeclared suffix is a load/check-time error listing the units that ARE
+declared. A branded-value type error now teaches both spellings:
+
+```
+expected Angle.t, got float — `Angle.t` is a branded value: write `90deg` or `Angle.degrees(90.0)`
+```
+
+### The built-in units
+
+Declared in the prelude interfaces they belong to, not in a lexer table:
+
+| Suffix | Expands to | Home |
+| --- | --- | --- |
+| `deg` | `Angle.degrees` | `angle.funi` |
+| `rad` | `Angle.radians` | `angle.funi` |
+| `s` | `Time.seconds` | `time.funi` |
+| `ms` | `Time.millis` | `time.funi` |
+| `us` | `Time.micros` | `time.funi` |
+| `min` | `Time.minutes` | `time.funi` |
+| `hr` | `Time.hours` | `time.funi` |
+
+They resolve only where the engine prelude does (a runner-hosted project, or
+the headless test seam), like every other prelude name. A project declares its
+own units for its own brands.
+
+## Phase 2 (designed, not implemented): operators on units
+
+Phase 1 gives a brand a cheap way IN from a number. What it does not give is
+arithmetic: `90deg + 45deg` does not typecheck, because `+` is `(float, float)
+=> float`. Today the answer is to unwrap, add, and rebrand — which is exactly
+the ceremony the suffix removed.
+
+### The declaration
+
+A unit may declare operator implementations beside itself:
+
+```functor
+type Px = | Px(value: float)
+
+unit px = Px {
+  (+) = addPx        // (Px, Px) => Px
+  (-) = subPx        // (Px, Px) => Px
+  (*) = scalePx      // (Px, float) => Px   — the scalar form
+  (/) = dividePx     // (Px, float) => Px
+}
+```
+
+- `+` and `-` take `('t, 't) => 't`: adding two lengths gives a length.
+- `*` and `/` take `('t, float) => 't`: scaling a length by a number gives a
+  length. A brand-by-brand product would be a *different* type (an area), which
+  is dimensional analysis — see the non-goal below.
+- Every implementation is an ordinary named function, typechecked against the
+  shape above at the declaration, exactly as Phase 1 typechecks the constructor.
+- Comparisons (`<`, `>`, `==`) are deliberately out of this list for now: `==`
+  is already structural for plain-data brands, and ordering wants its own
+  design pass.
+
+### Resolution: ad-hoc overloading, after inference
+
+Operator selection happens **after** ordinary Hindley–Milner inference has run
+and the operand types are zonked — never during unification, which would make
+inference order-dependent:
+
+1. Infer the whole program as today, with `+` constrained as usual.
+2. Post-zonk, walk each arithmetic node. If an operand's solved type is a brand
+   that declares that operator, replace the node with a call to the declared
+   implementation.
+3. If neither operand is a declaring brand, the node stays the float operator
+   and its ordinary `float` constraint applies.
+
+The critical rule is what happens when the operand type is still an **unsolved
+type variable** at that point: that is a *teaching error* asking for an
+annotation, never a silent guess.
+
+```
+`+` here could be float addition or `Px` addition — annotate the operand
+(e.g. `(a: Px)`) so the operator can be resolved
+```
+
+This keeps two properties: a program either resolves every operator
+deterministically or says so, and code that never uses a unit operator infers
+and runs exactly as it does today.
+
+Because resolution is a post-pass rewrite, the IR again ends up with an
+ordinary call — the Phase 1 property that there is no second evaluation path is
+preserved, so the interpreter is untouched and there is no per-frame cost.
+
+### Open questions for Phase 2
+
+- **Mixed literals.** `90deg + 45` — is the bare number an error, or is it
+  lifted through the unit's constructor? Erroring is the conservative start.
+- **Prefix minus.** `-(someAngle)` would want a `negate` in the same block, or
+  to derive from `(-)` with a zero the brand cannot supply.
+- **Where the implementations live** for prelude brands: `Angle` and `Time` are
+  host types, so their operator impls are host externals, not Functor Lang
+  functions. The declaration form is the same; only the target is.
+
+### Explicit non-goal: dimensional analysis
+
+Functor Lang will **not** track dimensions — no `m/s` derived from `m` and `s`,
+no compile-time algebra over unit exponents, no rule that `Px * Px` is an area.
+A unit here is a brand with a convenient literal and (Phase 2) arithmetic that
+stays inside the brand. Games want "these two numbers are not the same kind of
+thing", which brands already deliver; full dimensional analysis is a
+substantially larger type-system commitment with a much worse error-message
+story, and it is not on the roadmap.

--- a/functor-lang/examples/functions.ir
+++ b/functor-lang/examples/functions.ir
@@ -571,4 +571,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/inline_modules.ir
+++ b/functor-lang/examples/inline_modules.ir
@@ -432,4 +432,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/lists.ir
+++ b/functor-lang/examples/lists.ir
@@ -577,4 +577,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/pure_pipeline.ir
+++ b/functor-lang/examples/pure_pipeline.ir
@@ -360,4 +360,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/records.ir
+++ b/functor-lang/examples/records.ir
@@ -744,4 +744,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/shapes.ir
+++ b/functor-lang/examples/shapes.ir
@@ -846,4 +846,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/strings.ir
+++ b/functor-lang/examples/strings.ir
@@ -750,4 +750,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/examples/tuples.ir
+++ b/functor-lang/examples/tuples.ir
@@ -809,4 +809,5 @@ Module {
     ],
     signatures: [],
     expects: [],
+    units: [],
 }

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -23,6 +23,28 @@ pub enum Item {
     Sig(SigDecl),
     Expect(ExpectDecl),
     Module(ModuleDecl),
+    /// `unit deg = Angle.degrees` — declares the literal suffix `deg`, so
+    /// `90deg` desugars to `Angle.degrees(90.0)` (see [`UnitDecl`]).
+    Unit(UnitDecl),
+}
+
+/// `unit <suffix> = <name>` — a unit-suffixed literal's meaning: which
+/// `(float) => 't` function or constructor a suffixed numeric literal calls.
+/// Units are project-wide (file = module, like constructors), so a suffix may
+/// be declared exactly once across the whole project. Resolution and
+/// desugaring happen in lowering: `90deg` becomes exactly the call
+/// `Angle.degrees(90.0)`, so hover, inlay, typechecking, and the host's
+/// teaching errors all see an ordinary call.
+#[derive(Debug)]
+pub struct UnitDecl {
+    /// The literal suffix, as spelled (`deg`, `s`, `px`).
+    pub suffix: String,
+    /// The target's name, one segment per `.` (`["Angle", "degrees"]`).
+    pub target: Vec<String>,
+    /// The target name's own span (what a resolution error points at).
+    pub target_span: Span,
+    /// The whole declaration.
+    pub span: Span,
 }
 
 /// `module Server { … }` — an INLINE module inside a `.fun` file: a named
@@ -145,6 +167,11 @@ pub struct Expr {
 pub enum ExprKind {
     /// Ints and floats both parse to f64 (Functor Lang has one number type for now).
     Number(f64),
+    /// `90deg` / `0.5s` — a numeric literal with a unit suffix. Lowering
+    /// resolves the suffix against the project's `unit` declarations and
+    /// desugars it to the plain call (`Angle.degrees(90.0)`); the IR has no
+    /// unit-literal node.
+    NumberUnit { value: f64, suffix: String },
     String(String),
     /// `$"score: {score}"` — text and full expression holes, evaluated
     /// left-to-right. `{{` / `}}` produce literal braces.

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -79,6 +79,22 @@ pub struct Module {
     /// evaluates them — only test tooling does
     /// ([`crate::eval::run_expects`]).
     pub expects: Vec<ExpectDef>,
+    /// `unit deg = Angle.degrees` declarations, in file order. Uses are
+    /// already desugared (a suffixed literal lowers to the plain call), so
+    /// these exist only so the CHECKER can verify each target really is a
+    /// `(float) => 't` function and can teach the suffix form in
+    /// branded-value errors. Evaluation ignores them.
+    pub units: Vec<UnitDef>,
+}
+
+/// One lowered `unit <suffix> = <name>` declaration: the suffix, and the
+/// already-resolved target as an expression (an `External` / `Global` /
+/// `Ctor` node — exactly what a use site calls).
+#[derive(Debug)]
+pub struct UnitDef {
+    pub suffix: String,
+    pub target: Expr,
+    pub span: Span,
 }
 
 /// One lowered `expect <expr>` test. `module` is the owning module's

--- a/functor-lang/src/lexer.rs
+++ b/functor-lang/src/lexer.rs
@@ -347,7 +347,18 @@ fn lex_with_interpolation_depth(
                     while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
                         i += 1;
                     }
-                    TokenKind::NumberUnit(n, src[suffix_start..i].to_string())
+                    let suffix = &src[suffix_start..i];
+                    // A KEYWORD abutting a number is not a unit: `1else 2` has
+                    // always lexed as `1` then `else`, and a keyword could
+                    // never be declared as a suffix anyway (`unit else = …`
+                    // does not parse). Give the digits back and let the
+                    // keyword lex on its own.
+                    if keyword(suffix).is_some() {
+                        i = suffix_start;
+                        TokenKind::Number(n)
+                    } else {
+                        TokenKind::NumberUnit(n, suffix.to_string())
+                    }
                 } else {
                     TokenKind::Number(n)
                 }
@@ -356,21 +367,8 @@ fn lex_with_interpolation_depth(
                 while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
                     i += 1;
                 }
-                match &src[start..i] {
-                    "let" => TokenKind::Let,
-                    "type" => TokenKind::Type,
-                    "true" => TokenKind::True,
-                    "false" => TokenKind::False,
-                    "mut" => TokenKind::Mut,
-                    "with" => TokenKind::With,
-                    "in" => TokenKind::In,
-                    "match" => TokenKind::Match,
-                    "if" => TokenKind::If,
-                    "then" => TokenKind::Then,
-                    "else" => TokenKind::Else,
-                    "not" => TokenKind::Not,
-                    name => TokenKind::Ident(name.to_string()),
-                }
+                let word = &src[start..i];
+                keyword(word).unwrap_or_else(|| TokenKind::Ident(word.to_string()))
             }
             _ => {
                 let c = src[i..].chars().next().expect("lex is on a char boundary");
@@ -390,6 +388,27 @@ fn lex_with_interpolation_depth(
         span: Span::new(base + src.len(), base + src.len()),
     });
     Ok(tokens)
+}
+
+/// The reserved word `word` spells, if any. The one list — used both when an
+/// identifier is lexed and when deciding that a numeric literal's trailing
+/// word is a keyword rather than a unit suffix.
+fn keyword(word: &str) -> Option<TokenKind> {
+    Some(match word {
+        "let" => TokenKind::Let,
+        "type" => TokenKind::Type,
+        "true" => TokenKind::True,
+        "false" => TokenKind::False,
+        "mut" => TokenKind::Mut,
+        "with" => TokenKind::With,
+        "in" => TokenKind::In,
+        "match" => TokenKind::Match,
+        "if" => TokenKind::If,
+        "then" => TokenKind::Then,
+        "else" => TokenKind::Else,
+        "not" => TokenKind::Not,
+        _ => return None,
+    })
 }
 
 /// Lex a string literal starting at its opening quote. Escapes: `\"`, `\\`,

--- a/functor-lang/src/lexer.rs
+++ b/functor-lang/src/lexer.rs
@@ -8,6 +8,12 @@ use crate::ParseError;
 #[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
     Number(f64),
+    /// A numeric literal immediately followed by identifier characters:
+    /// `90deg`, `0.5s`, `16px`. The lexer is deliberately DUMB here — it does
+    /// not know which units exist, only that the source spelled one; the
+    /// suffix resolves against the project's `unit` declarations in lowering
+    /// (see [`crate::lower`]). Adjacency is required: `90 deg` is two tokens.
+    NumberUnit(f64, String),
     Str(String),
     InterpolatedStart,
     InterpolatedText(String),
@@ -72,6 +78,7 @@ pub fn describe(kind: &TokenKind) -> String {
     use TokenKind::*;
     match kind {
         Number(n) => format!("number `{n}`"),
+        NumberUnit(n, suffix) => format!("number `{n}{suffix}`"),
         Str(_) => "a string".to_string(),
         InterpolatedStart => "an interpolated string".to_string(),
         InterpolatedText(_) => "interpolated string text".to_string(),
@@ -329,7 +336,21 @@ fn lex_with_interpolation_depth(
                     }
                 }
                 let n = src[start..i].parse().expect("digit runs parse as f64");
-                TokenKind::Number(n)
+                // A unit SUFFIX: identifier chars touching the digits
+                // (`90deg`, `0.5s`). There is no scientific notation, so no
+                // `1e5` ambiguity, and `90deg` is currently a parse error —
+                // the syntax is unclaimed. The lexer records the spelling
+                // and nothing more; lowering resolves it against the
+                // declared units.
+                if i < bytes.len() && (bytes[i].is_ascii_alphabetic() || bytes[i] == b'_') {
+                    let suffix_start = i;
+                    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                        i += 1;
+                    }
+                    TokenKind::NumberUnit(n, src[suffix_start..i].to_string())
+                } else {
+                    TokenKind::Number(n)
+                }
             }
             b'a'..=b'z' | b'A'..=b'Z' | b'_' => {
                 while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -148,6 +148,9 @@ pub(crate) fn exports_of(items: &[ast::Item]) -> Exports {
             ast::Item::Open(_) => {}
             // An expect binds nothing.
             ast::Item::Expect(_) => {}
+            // A unit declares a literal SUFFIX, not a name — units are
+            // project-wide and collected separately (see `unit_decls`).
+            ast::Item::Unit(_) => {}
             // An inline module's members belong to ITS namespace, not the
             // file's: the caller calls `exports_of` again on its own items.
             ast::Item::Module(_) => {}
@@ -163,6 +166,70 @@ pub(crate) struct ProjectEnv<'a> {
     pub name: &'a str,
     pub entry: &'a str,
     pub modules: &'a HashMap<String, Exports>,
+    /// Every `unit` declared anywhere in the project, already resolved
+    /// against its DECLARING module (units are project-wide, like
+    /// constructors — see [`resolve_units`]).
+    pub units: &'a HashMap<String, UnitTarget>,
+}
+
+/// What a declared unit suffix expands to: the resolved callee a suffixed
+/// literal calls. Resolved once, in the declaring module's scope, and then
+/// used verbatim from every module.
+#[derive(Clone, Debug)]
+pub(crate) enum UnitTarget {
+    Global(String),
+    Ctor { name: String, arity: usize },
+    External(Vec<String>),
+}
+
+impl UnitTarget {
+    fn kind(&self) -> ExprKind {
+        match self {
+            UnitTarget::Global(name) => ExprKind::Global(name.clone()),
+            UnitTarget::Ctor { name, arity } => ExprKind::Ctor {
+                name: name.clone(),
+                arity: *arity,
+            },
+            UnitTarget::External(path) => ExprKind::External(path.clone()),
+        }
+    }
+}
+
+/// A module's `unit` declarations, in file order.
+pub(crate) fn unit_decls(items: &[ast::Item]) -> Vec<&ast::UnitDecl> {
+    items
+        .iter()
+        .filter_map(|item| match item {
+            ast::Item::Unit(decl) => Some(decl),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Resolve one module's `unit` targets in ITS scope, so the whole project can
+/// share the result (a suffix means the same thing in every file). Runs
+/// before any module is lowered, because a use site may precede — or live in
+/// a different file from — the declaration.
+pub(crate) fn resolve_units(
+    items: &[ast::Item],
+    project: Option<&ProjectEnv>,
+) -> Result<Vec<(String, UnitTarget, Span)>, LowerError> {
+    let decls = unit_decls(items);
+    if decls.is_empty() {
+        return Ok(Vec::new());
+    }
+    // A throwaway lowerer: same name environment as the real pass, its own ID
+    // space (nothing it builds is kept).
+    let mut lowerer = prepare(items, project, IdBases::default())?;
+    let mut resolved = Vec::with_capacity(decls.len());
+    for decl in decls {
+        resolved.push((
+            decl.suffix.clone(),
+            lowerer.unit_target(decl)?,
+            decl.span,
+        ));
+    }
+    Ok(resolved)
 }
 
 /// Starting IDs for a module's lowering: a project threads these across its
@@ -232,6 +299,8 @@ fn collect_names(items: &[ast::Item]) -> Result<Names, LowerError> {
             ast::Item::Open(_) => {}
             // An expect declares no names.
             ast::Item::Expect(_) => {}
+            // A unit declares a suffix, not a name (no namespace collision).
+            ast::Item::Unit(_) => {}
             // Inline modules are their own namespaces, collected separately
             // (and checked against these names by the caller).
             ast::Item::Module(_) => {}
@@ -314,19 +383,92 @@ fn lower_module(
     project: Option<&ProjectEnv>,
     bases: IdBases,
 ) -> Result<(Module, IdBases, HashSet<String>), LowerError> {
+    let mut lowerer = prepare(&program.items, project, bases)?;
+    // Single-file lowering has no project to collect units from, so the
+    // file's own declarations are its whole unit table (a project resolves
+    // them across every module, before any file lowers — see
+    // `crate::project`).
+    if project.is_none() {
+        for (suffix, target, span) in resolve_units(&program.items, None)? {
+            if lowerer.units.insert(suffix.clone(), target).is_some() {
+                return Err(LowerError {
+                    message: format!("duplicate unit `{suffix}`"),
+                    span,
+                });
+            }
+        }
+    }
+    let mut out = Lowered {
+        next_def: bases.def,
+        types: Vec::new(),
+        defs: Vec::new(),
+        signatures: Vec::new(),
+        expects: Vec::new(),
+        units: Vec::new(),
+    };
+    for item in program.items {
+        match item {
+            // An inline module: lower its items in ITS namespace (its own
+            // names shadow the file's, and canonical names gain the extra
+            // segment).
+            ast::Item::Module(decl) => {
+                lowerer.inline = Some(decl.name);
+                for item in decl.items {
+                    lowerer.lower_item(item, &mut out)?;
+                }
+                lowerer.inline = None;
+            }
+            item => lowerer.lower_item(item, &mut out)?,
+        }
+    }
+    let Lowered {
+        next_def,
+        types,
+        defs,
+        signatures,
+        expects,
+        units,
+    } = out;
+    let bases = IdBases {
+        def: next_def,
+        binding: lowerer.next_binding,
+        expr: lowerer.next_expr,
+    };
+    Ok((
+        Module {
+            types,
+            defs,
+            signatures,
+            expects,
+            units,
+        },
+        bases,
+        lowerer.deps,
+    ))
+}
+
+/// Build the name environment a module lowers in: its own names, its inline
+/// `module` blocks, and its `open`s (pass 1 of [`lower_module`]). Shared with
+/// the unit pre-pass ([`resolve_units`]), which needs the same scope but
+/// none of the lowered output.
+fn prepare<'p>(
+    items: &[ast::Item],
+    project: Option<&'p ProjectEnv<'p>>,
+    bases: IdBases,
+) -> Result<Lowerer<'p>, LowerError> {
     let Names {
         globals,
         ctors,
         types: type_names,
         ctor_types,
-    } = collect_names(&program.items)?;
+    } = collect_names(items)?;
 
     // Pass 1a: the file's inline `module` blocks. Their names live in the
     // file's value AND type namespaces (so `Server.step` always resolves to
     // the module, never to field access on a `let Server`), and each block's
     // own names are collected the same way.
     let mut inline_names: HashMap<String, Exports> = HashMap::new();
-    for item in &program.items {
+    for item in items {
         let ast::Item::Module(decl) = item else {
             continue;
         };
@@ -362,7 +504,7 @@ fn lower_module(
     let mut open_values: HashMap<String, OpenedName> = HashMap::new();
     let mut open_types: HashMap<String, String> = HashMap::new();
     let mut deps: HashSet<String> = HashSet::new();
-    for item in &program.items {
+    for item in items {
         let ast::Item::Open(decl) = item else {
             continue;
         };
@@ -485,8 +627,7 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
         }
     }
 
-    // Pass 2: lower items in file order.
-    let mut lowerer = Lowerer {
+    Ok(Lowerer {
         globals,
         ctors,
         types: type_names,
@@ -494,57 +635,14 @@ qualify uses (`{prev}.{name}` / `{}.{name}`)",
         local_modules: inline_names,
         inline: None,
         project,
+        units: project.map(|env| env.units.clone()).unwrap_or_default(),
         open_values,
         open_types,
         deps,
         scopes: Vec::new(),
         next_binding: bases.binding,
         next_expr: bases.expr,
-    };
-    let mut out = Lowered {
-        next_def: bases.def,
-        types: Vec::new(),
-        defs: Vec::new(),
-        signatures: Vec::new(),
-        expects: Vec::new(),
-    };
-    for item in program.items {
-        match item {
-            // An inline module: lower its items in ITS namespace (its own
-            // names shadow the file's, and canonical names gain the extra
-            // segment).
-            ast::Item::Module(decl) => {
-                lowerer.inline = Some(decl.name);
-                for item in decl.items {
-                    lowerer.lower_item(item, &mut out)?;
-                }
-                lowerer.inline = None;
-            }
-            item => lowerer.lower_item(item, &mut out)?,
-        }
-    }
-    let Lowered {
-        next_def,
-        types,
-        defs,
-        signatures,
-        expects,
-    } = out;
-    let bases = IdBases {
-        def: next_def,
-        binding: lowerer.next_binding,
-        expr: lowerer.next_expr,
-    };
-    Ok((
-        Module {
-            types,
-            defs,
-            signatures,
-            expects,
-        },
-        bases,
-        lowerer.deps,
-    ))
+    })
 }
 
 /// The IR a namespace's items lower into — one accumulator shared by the
@@ -555,6 +653,7 @@ struct Lowered {
     defs: Vec<Def>,
     signatures: Vec<Signature>,
     expects: Vec<ExpectDef>,
+    units: Vec<UnitDef>,
 }
 
 /// Which module a dotted reference's leading segments named.
@@ -617,6 +716,10 @@ struct Lowerer<'p> {
     inline: Option<String>,
     /// The project context, when lowering as part of one (B8 modules).
     project: Option<&'p ProjectEnv<'p>>,
+    /// Every declared unit suffix, already resolved (see [`UnitTarget`]).
+    /// Project-wide: a suffix declared in ANY module expands the same way
+    /// here.
+    units: HashMap<String, UnitTarget>,
     /// Names brought into scope by `open`s (collision-free by pass 1b).
     open_values: HashMap<String, OpenedName>,
     /// Type names brought into scope by `open`s: name → providing module.
@@ -781,6 +884,48 @@ impl Lowerer<'_> {
         None
     }
 
+    /// The teaching error for a literal whose suffix no `unit` declares.
+    fn unknown_unit(&self, suffix: &str) -> String {
+        let mut known: Vec<&str> = self.units.keys().map(String::as_str).collect();
+        known.sort_unstable();
+        if known.is_empty() {
+            format!(
+                "unknown unit `{suffix}` in `…{suffix}` — no units are declared; declare one \
+with `unit {suffix} = SomeFn` (a `(float) => 't` function), or write the call itself"
+            )
+        } else {
+            format!(
+                "unknown unit `{suffix}` in `…{suffix}` — declared units: {}",
+                known
+                    .iter()
+                    .map(|u| format!("`{u}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        }
+    }
+
+    /// Resolve a `unit` declaration's target in THIS module's scope — the
+    /// ordinary identifier rules, restricted to the three callable shapes.
+    /// (Item position has no locals, so this is exactly a top-level
+    /// reference.)
+    fn unit_target(&mut self, decl: &ast::UnitDecl) -> Result<UnitTarget, LowerError> {
+        let resolved = self.ident(decl.target.clone(), decl.target_span)?;
+        match resolved.kind {
+            ExprKind::Global(name) => Ok(UnitTarget::Global(name)),
+            ExprKind::Ctor { name, arity } => Ok(UnitTarget::Ctor { name, arity }),
+            ExprKind::External(path) => Ok(UnitTarget::External(path)),
+            _ => Err(LowerError {
+                message: format!(
+                    "`unit {}` needs a function or constructor name — `{}` is not one",
+                    decl.suffix,
+                    decl.target.join(".")
+                ),
+                span: decl.target_span,
+            }),
+        }
+    }
+
     /// Lower one item into `out`, in the current namespace.
     fn lower_item(&mut self, item: ast::Item, out: &mut Lowered) -> Result<(), LowerError> {
         match item {
@@ -818,6 +963,18 @@ impl Lowerer<'_> {
                 out.signatures.push(Signature {
                     name: self.self_qualify(&decl.name),
                     ty: self.canon_type(decl.ty)?,
+                    span: decl.span,
+                });
+            }
+            // A unit: no name, no DefId. Uses are already desugared to the
+            // plain call; the resolved target is kept only so the CHECKER can
+            // verify it really is a `(float) => 't` function (and teach the
+            // suffix in branded-value errors).
+            ast::Item::Unit(decl) => {
+                let target = self.ident(decl.target.clone(), decl.target_span)?;
+                out.units.push(UnitDef {
+                    suffix: decl.suffix,
+                    target,
                     span: decl.span,
                 });
             }
@@ -967,6 +1124,32 @@ impl Lowerer<'_> {
                 return Ok(piped);
             }
             ast::ExprKind::Number(n) => ExprKind::Number(n),
+            // `90deg` → exactly `Angle.degrees(90.0)`: the declared unit's
+            // target applied to the literal. Everything downstream (hover,
+            // inlay, the checker, the host's teaching errors) sees an
+            // ordinary call.
+            ast::ExprKind::NumberUnit { value, suffix } => {
+                let Some(target) = self.units.get(&suffix).cloned() else {
+                    return Err(LowerError {
+                        message: self.unknown_unit(&suffix),
+                        span,
+                    });
+                };
+                let callee = Expr {
+                    id: self.expr_id(),
+                    kind: target.kind(),
+                    span,
+                };
+                let arg = Expr {
+                    id: self.expr_id(),
+                    kind: ExprKind::Number(value),
+                    span,
+                };
+                ExprKind::Call {
+                    callee: Box::new(callee),
+                    args: vec![arg],
+                }
+            }
             ast::ExprKind::String(s) => ExprKind::String(s),
             ast::ExprKind::InterpolatedString(parts) => {
                 let mut lowered = Vec::with_capacity(parts.len());

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -173,10 +173,21 @@ pub(crate) struct ProjectEnv<'a> {
 }
 
 /// What a declared unit suffix expands to: the resolved callee a suffixed
-/// literal calls. Resolved once, in the declaring module's scope, and then
-/// used verbatim from every module.
+/// literal calls, plus the module that OWNS it. Resolved once, in the
+/// declaring module's scope, and then used verbatim from every module — so
+/// the owner travels with it, because a use site's dependency edge is on the
+/// target's module, not on whoever declared the unit.
 #[derive(Clone, Debug)]
-pub(crate) enum UnitTarget {
+pub(crate) struct UnitTarget {
+    kind: UnitKind,
+    /// The module path providing the target (`"Utils"`, `"Angle"`, or the
+    /// declaring module itself). A use site records this as a dependency,
+    /// exactly as writing the call by hand would.
+    owner: String,
+}
+
+#[derive(Clone, Debug)]
+enum UnitKind {
     Global(String),
     Ctor { name: String, arity: usize },
     External(Vec<String>),
@@ -184,13 +195,13 @@ pub(crate) enum UnitTarget {
 
 impl UnitTarget {
     fn kind(&self) -> ExprKind {
-        match self {
-            UnitTarget::Global(name) => ExprKind::Global(name.clone()),
-            UnitTarget::Ctor { name, arity } => ExprKind::Ctor {
+        match &self.kind {
+            UnitKind::Global(name) => ExprKind::Global(name.clone()),
+            UnitKind::Ctor { name, arity } => ExprKind::Ctor {
                 name: name.clone(),
                 arity: *arity,
             },
-            UnitTarget::External(path) => ExprKind::External(path.clone()),
+            UnitKind::External(path) => ExprKind::External(path.clone()),
         }
     }
 }
@@ -389,10 +400,15 @@ fn lower_module(
     // them across every module, before any file lowers — see
     // `crate::project`).
     if project.is_none() {
-        for (suffix, target, span) in resolve_units(&program.items, None)? {
+        for decl in unit_decls(&program.items) {
+            let (suffix, span) = (decl.suffix.clone(), decl.span);
+            let target = lowerer.unit_target(decl)?;
             if lowerer.units.insert(suffix.clone(), target).is_some() {
                 return Err(LowerError {
-                    message: format!("duplicate unit `{suffix}`"),
+                    message: format!(
+                        "duplicate unit `{suffix}` — it is already declared in this file (units \
+are project-wide, like constructors)"
+                    ),
                     span,
                 });
             }
@@ -886,6 +902,11 @@ impl Lowerer<'_> {
 
     /// The teaching error for a literal whose suffix no `unit` declares.
     fn unknown_unit(&self, suffix: &str) -> String {
+        // `1_000` is a digit separator, not a unit — say so rather than
+        // reporting the separator as an undeclared suffix.
+        if suffix.starts_with('_') {
+            return "numeric literals have no digit separators — write `1000`".to_string();
+        }
         let mut known: Vec<&str> = self.units.keys().map(String::as_str).collect();
         known.sort_unstable();
         if known.is_empty() {
@@ -910,20 +931,43 @@ with `unit {suffix} = SomeFn` (a `(float) => 't` function), or write the call it
     /// (Item position has no locals, so this is exactly a top-level
     /// reference.)
     fn unit_target(&mut self, decl: &ast::UnitDecl) -> Result<UnitTarget, LowerError> {
+        // `ident` records a dependency when the target lives in ANOTHER
+        // module; that module is the owner a use site must depend on. A
+        // target in the declaring module records none, so the owner is this
+        // module itself.
+        let before: HashSet<String> = self.deps.clone();
         let resolved = self.ident(decl.target.clone(), decl.target_span)?;
-        match resolved.kind {
-            ExprKind::Global(name) => Ok(UnitTarget::Global(name)),
-            ExprKind::Ctor { name, arity } => Ok(UnitTarget::Ctor { name, arity }),
-            ExprKind::External(path) => Ok(UnitTarget::External(path)),
-            _ => Err(LowerError {
-                message: format!(
-                    "`unit {}` needs a function or constructor name — `{}` is not one",
-                    decl.suffix,
-                    decl.target.join(".")
-                ),
-                span: decl.target_span,
-            }),
-        }
+        let owner = self
+            .deps
+            .difference(&before)
+            .next()
+            .cloned()
+            .or_else(|| self.current_path())
+            .unwrap_or_default();
+        let kind = match resolved.kind {
+            ExprKind::Global(name) => UnitKind::Global(name),
+            ExprKind::Ctor { name, arity } => UnitKind::Ctor { name, arity },
+            // An external's own path names its module (`Angle.degrees`), which
+            // may be a bundled interface rather than a project file.
+            ExprKind::External(path) => {
+                let module = path.first().cloned().unwrap_or_default();
+                return Ok(UnitTarget {
+                    kind: UnitKind::External(path),
+                    owner: module,
+                });
+            }
+            _ => {
+                return Err(LowerError {
+                    message: format!(
+                        "`unit {}` needs a function or constructor name — `{}` is not one",
+                        decl.suffix,
+                        decl.target.join(".")
+                    ),
+                    span: decl.target_span,
+                })
+            }
+        };
+        Ok(UnitTarget { kind, owner })
     }
 
     /// Lower one item into `out`, in the current namespace.
@@ -1135,15 +1179,28 @@ with `unit {suffix} = SomeFn` (a `(float) => 't` function), or write the call it
                         span,
                     });
                 };
+                // The literal calls another module's function, so it carries
+                // that module's dependency edge — exactly as writing the call
+                // by hand would (evaluation order and cycle detection both
+                // depend on it).
+                self.dep(&target.owner);
+                // Split the literal's span between its halves — the digits
+                // ARE the argument and the suffix IS the call — so hovering
+                // `90deg` reports `Angle.degrees : (float) => Angle.t` on the
+                // suffix and `float` on the number, instead of three nodes
+                // fighting over one span. (Suffixes are ASCII, so subtracting
+                // its byte length stays on a char boundary.)
+                let digits = Span::new(span.start, span.end.saturating_sub(suffix.len()));
+                let suffix_span = Span::new(digits.end, span.end);
                 let callee = Expr {
                     id: self.expr_id(),
                     kind: target.kind(),
-                    span,
+                    span: suffix_span,
                 };
                 let arg = Expr {
                     id: self.expr_id(),
                     kind: ExprKind::Number(value),
-                    span,
+                    span: digits,
                 };
                 ExprKind::Call {
                     callee: Box::new(callee),

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -231,8 +231,14 @@ impl Parser {
                 TokenKind::Ident(name) if name == "module" => {
                     items.push(Item::Module(self.module_decl()?))
                 }
+                // …and `unit` (a literal-suffix declaration). Contextual too:
+                // `unit` stays usable as an ordinary name.
+                TokenKind::Ident(name) if name == "unit" => {
+                    items.push(Item::Unit(self.unit_decl()?))
+                }
                 _ => {
-                    return self.error("`let`, `type`, `open`, `expect`, or `module` at top level")
+                    return self
+                        .error("`let`, `type`, `open`, `expect`, `unit`, or `module` at top level")
                 }
             }
         }
@@ -296,6 +302,51 @@ the top level of the file"
             items,
             span: kw.span.to(name_span),
             block: kw.span.to(close.span),
+        })
+    }
+
+    /// `unit deg = Angle.degrees` — a literal-suffix declaration. The target
+    /// is a possibly module-qualified NAME (never an arbitrary expression):
+    /// the function or constructor a suffixed literal calls.
+    fn unit_decl(&mut self) -> Result<UnitDecl, ParseError> {
+        let kw = self.bump();
+        let (suffix, suffix_span) = match self.peek_kind() {
+            TokenKind::Ident(name) => {
+                let name = name.clone();
+                (name, self.bump().span)
+            }
+            _ => {
+                return self
+                    .error("a unit suffix after `unit` (e.g. `unit deg = Angle.degrees`)")
+            }
+        };
+        // The suffix has to be able to follow digits: `90deg` must lex back to
+        // this same suffix. Identifiers always do, so only the `_`-led case
+        // needs teaching — it reads as a name, not a unit.
+        if suffix.starts_with('_') {
+            return Err(ParseError {
+                message: format!(
+                    "a unit suffix starts with a letter: `{suffix}` cannot follow a number"
+                ),
+                span: suffix_span,
+            });
+        }
+        self.expect(TokenKind::Eq, "`=` after the unit suffix")?;
+        let (mut segment, mut span) =
+            self.expect_ident("the name a unit literal calls (e.g. `Angle.degrees`)")?;
+        let mut target = vec![segment];
+        while self.peek_kind() == &TokenKind::Dot {
+            self.bump();
+            let (next, next_span) = self.expect_ident("a name after `.`")?;
+            segment = next;
+            span = span.to(next_span);
+            target.push(segment);
+        }
+        Ok(UnitDecl {
+            suffix,
+            target,
+            target_span: span,
+            span: kw.span.to(span),
         })
     }
 
@@ -1299,6 +1350,21 @@ and an `else` branch)",
     // Iterative (not recursive) so `----x` chains can't grow the stack past
     // the `expr` depth guard.
     fn unary(&mut self) -> Result<Expr, ParseError> {
+        // A minus directly on a UNIT LITERAL folds into the literal, as it
+        // does in number patterns: `-90deg` is `Angle.degrees(-90.0)`, not a
+        // negation of the branded value it would build (branded values have
+        // no arithmetic — see `docs/functor-lang-units.md`).
+        if self.peek_kind() == &TokenKind::Minus {
+            if let TokenKind::NumberUnit(value, suffix) = self.nth_kind(1) {
+                let (value, suffix) = (-*value, suffix.clone());
+                let minus = self.bump();
+                let literal = self.bump();
+                return Ok(Expr {
+                    kind: ExprKind::NumberUnit { value, suffix },
+                    span: minus.span.to(literal.span),
+                });
+            }
+        }
         let mut minus_spans = Vec::new();
         while self.peek_kind() == &TokenKind::Minus {
             minus_spans.push(self.bump().span);
@@ -1364,6 +1430,17 @@ and an `else` branch)",
                 self.bump();
                 Ok(Expr {
                     kind: ExprKind::Number(n),
+                    span,
+                })
+            }
+            // `90deg` — a unit-suffixed literal. Which units exist is a
+            // lowering question (see `ast::UnitDecl`); the parser only
+            // carries the spelling through.
+            TokenKind::NumberUnit(n, suffix) => {
+                let (value, suffix) = (*n, suffix.clone());
+                self.bump();
+                Ok(Expr {
+                    kind: ExprKind::NumberUnit { value, suffix },
                     span,
                 })
             }

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -293,6 +293,17 @@ the top level of the file"
                         span: self.peek().span,
                     })
                 }
+                // Units are project-wide, so an inline module is never their
+                // scope — declare them at the file's top level.
+                TokenKind::Ident(kw) if kw == "unit" => {
+                    return Err(ParseError {
+                        message: format!(
+                            "`unit` inside `module {name}` is not supported — units are \
+project-wide, so declare them at the top level of the file"
+                        ),
+                        span: self.peek().span,
+                    })
+                }
                 _ => return self.error("`let`, `type`, `expect`, or `}` inside a module"),
             }
         }

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -35,8 +35,8 @@ use std::path::{Path, PathBuf};
 use crate::ast;
 use crate::ir::Module;
 use crate::lower::{
-    exports_of, lower_in_project, open_module_path, resolve_units, Exports, IdBases, ProjectEnv,
-    UnitTarget,
+    exports_of, lower_in_project, open_module_path, resolve_units, unit_decls, Exports, IdBases,
+    ProjectEnv, UnitTarget,
 };
 use crate::parser::{capitalize, parse_interface_with_base, parse_with_base};
 use crate::span::line_col;
@@ -866,8 +866,29 @@ rename it"
     // resolve every module's `unit` declarations — each in its own scope —
     // before any file lowers: a suffixed literal may precede, or live in a
     // different file from, its declaration. A suffix may be declared once.
+    // Duplicate suffixes are caught FIRST, on names alone: a redeclaration
+    // should report as a duplicate even when the second declaration's target
+    // is also broken.
+    let mut declared_in: HashMap<&str, usize> = HashMap::new();
+    for (index, program) in programs.iter().enumerate() {
+        for decl in unit_decls(&program.items) {
+            if let Some(&previous) = declared_in.get(decl.suffix.as_str()) {
+                return Err(render_span(
+                    &files,
+                    index,
+                    decl.span,
+                    &format!(
+                        "duplicate unit `{}` — it is already declared in {} (units are \
+project-wide, like constructors)",
+                        decl.suffix,
+                        files[previous].path.display()
+                    ),
+                ));
+            }
+            declared_in.insert(&decl.suffix, index);
+        }
+    }
     let mut units: HashMap<String, UnitTarget> = HashMap::new();
-    let mut unit_origin: HashMap<String, usize> = HashMap::new();
     for (index, (file, program)) in files.iter().zip(&programs).enumerate() {
         let env = ProjectEnv {
             name: &file.module,
@@ -877,24 +898,10 @@ rename it"
         };
         let resolved = resolve_units(&program.items, Some(&env))
             .map_err(|e| render_span(&files, index, e.span, &e.message))?;
-        for (suffix, target, span) in resolved {
-            if let Some(&previous) = unit_origin.get(&suffix) {
-                return Err(render_span(
-                    &files,
-                    index,
-                    span,
-                    &format!(
-                        "duplicate unit `{suffix}` — it is already declared in {} (units are \
-project-wide, like constructors)",
-                        files[previous].path.display()
-                    ),
-                ));
-            }
-            unit_origin.insert(suffix.clone(), index);
+        for (suffix, target, _) in resolved {
             units.insert(suffix, target);
         }
     }
-    let units = units;
 
     // Lower each file with the project environment, threading ID bases so
     // the merged module is one ID space. Collect dependency edges.

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -35,7 +35,8 @@ use std::path::{Path, PathBuf};
 use crate::ast;
 use crate::ir::Module;
 use crate::lower::{
-    exports_of, lower_in_project, open_module_path, Exports, IdBases, ProjectEnv,
+    exports_of, lower_in_project, open_module_path, resolve_units, Exports, IdBases, ProjectEnv,
+    UnitTarget,
 };
 use crate::parser::{capitalize, parse_interface_with_base, parse_with_base};
 use crate::span::line_col;
@@ -861,6 +862,40 @@ rename it"
     }
     let exports = exports;
 
+    // Units are PROJECT-WIDE (file = module makes them like constructors), so
+    // resolve every module's `unit` declarations — each in its own scope —
+    // before any file lowers: a suffixed literal may precede, or live in a
+    // different file from, its declaration. A suffix may be declared once.
+    let mut units: HashMap<String, UnitTarget> = HashMap::new();
+    let mut unit_origin: HashMap<String, usize> = HashMap::new();
+    for (index, (file, program)) in files.iter().zip(&programs).enumerate() {
+        let env = ProjectEnv {
+            name: &file.module,
+            entry: &entry,
+            modules: &exports,
+            units: &HashMap::new(),
+        };
+        let resolved = resolve_units(&program.items, Some(&env))
+            .map_err(|e| render_span(&files, index, e.span, &e.message))?;
+        for (suffix, target, span) in resolved {
+            if let Some(&previous) = unit_origin.get(&suffix) {
+                return Err(render_span(
+                    &files,
+                    index,
+                    span,
+                    &format!(
+                        "duplicate unit `{suffix}` — it is already declared in {} (units are \
+project-wide, like constructors)",
+                        files[previous].path.display()
+                    ),
+                ));
+            }
+            unit_origin.insert(suffix.clone(), index);
+            units.insert(suffix, target);
+        }
+    }
+    let units = units;
+
     // Lower each file with the project environment, threading ID bases so
     // the merged module is one ID space. Collect dependency edges.
     let mut bases = IdBases::default();
@@ -938,6 +973,7 @@ rename it"
             name: &file.module,
             entry: &entry,
             modules: &exports,
+            units: &units,
         };
         let (module, next, module_deps) = lower_in_project(program, &env, bases)
             .map_err(|e| render_span(&files, index, e.span, &e.message))?;
@@ -984,6 +1020,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         defs: Vec::new(),
         signatures: Vec::new(),
         expects: Vec::new(),
+        units: Vec::new(),
     };
     let mut by_module: HashMap<String, Module> = files
         .iter()
@@ -996,6 +1033,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         merged.defs.extend(module.defs);
         merged.signatures.extend(module.signatures);
         merged.expects.extend(module.expects);
+        merged.units.extend(module.units);
     }
 
     Ok(Project {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -1834,18 +1834,21 @@ if this position is deliberately untyped"
             self.unify(&got, expected, expr.span, what);
             return;
         }
-        match (&expr.kind, expected) {
-            // A bare number where a branded value belongs — the mistake the
-            // unit suffixes exist for, so name the literal in the fix.
-            (ExprKind::Number(value), Type::Variant(name, _) | Type::Record(name, _))
-                if self.unit_hint_for(name, *value).is_some() =>
-            {
-                let hint = self
-                    .unit_hint_for(name, *value)
-                    .expect("checked by the guard");
-                self.diag(expr.span, format!("{what}: expected {expected}, got float{hint}"));
+        // A bare number where a branded value belongs — the mistake the unit
+        // suffixes exist for, so name the literal the source wrote in the fix.
+        if let (ExprKind::Number(value), Type::Variant(name, _) | Type::Record(name, _)) =
+            (&expr.kind, expected)
+        {
+            if let Some(hint) = self.unit_hint_for(name, *value) {
+                self.diag(
+                    expr.span,
+                    format!("{what}: expected {expected}, got float{hint}"),
+                );
                 self.expr_types.insert(expr.id.raw(), Type::Float);
+                return;
             }
+        }
+        match (&expr.kind, expected) {
             (ExprKind::Record(fields), Type::Record(name, targs)) => {
                 let targs = targs.clone();
                 self.check_record_literal(fields, name, &targs, expr.span);

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -784,6 +784,7 @@ fn check_impl(
         def_param_names: HashMap::new(),
         ctor_param_names: HashMap::new(),
         match_scrutinees: Vec::new(),
+        unit_hints: HashMap::new(),
     };
 
     // Record type names first (nominal references may be forward), then
@@ -915,6 +916,43 @@ fn check_impl(
         checker.globals.insert(def.name.clone(), ty);
     }
 
+    // Declared units, indexed by the branded type they build — available
+    // before any def is inferred, so every branded-value mismatch below can
+    // teach the suffix form. Derived from what is already known (a `.funi`
+    // signature's return type, or a constructor's owning type); the units
+    // themselves are TYPE-CHECKED after inference, once their targets have
+    // real types.
+    for unit in &module.units {
+        let (result, call) = match &unit.target.kind {
+            ExprKind::External(path) => {
+                let call = path.join(".");
+                match checker.signatures.get(&call).map(|s| s.ty.clone()) {
+                    Some(Type::Fn(_, ret)) => (Some(*ret), call),
+                    _ => (None, call),
+                }
+            }
+            ExprKind::Ctor { name, .. } => (
+                checker
+                    .ctors
+                    .get(name)
+                    .map(|(owner, params, _)| Type::Variant(owner.clone(), vec![Type::Unknown; *params])),
+                name.clone(),
+            ),
+            ExprKind::Global(name) => match checker.globals.get(name) {
+                Some(Type::Fn(_, ret)) => (Some((**ret).clone()), name.clone()),
+                _ => (None, name.clone()),
+            },
+            _ => (None, String::new()),
+        };
+        if let Some(Type::Variant(name, _) | Type::Record(name, _)) = result {
+            checker
+                .unit_hints
+                .entry(name)
+                .or_default()
+                .push((unit.suffix.clone(), call));
+        }
+    }
+
     // Infer in dependency order, one strongly-connected component at a
     // time: within a group (mutual recursion) uses are monomorphic — the
     // standard HM letrec rule — and each def GENERALIZES as its group
@@ -962,6 +1000,24 @@ fn check_impl(
             let scheme = checker.generalize(&ty);
             checker.schemes.insert(def.name.clone(), scheme);
         }
+    }
+
+    // `unit` declarations: the target must be exactly a `(float) => 't`
+    // function or constructor, since that is what a suffixed literal calls.
+    // Checked after inference, so a target defined in Functor Lang has its
+    // real type.
+    for unit in &module.units {
+        checker.annot_vars.clear();
+        checker.current_module = String::new();
+        let got = checker.infer(&unit.target);
+        let result = checker.fresh();
+        let want = Type::Fn(vec![Type::Float], Box::new(result));
+        checker.unify(
+            &got,
+            &want,
+            unit.target.span,
+            &format!("`unit {}`", unit.suffix),
+        );
     }
 
     // `expect` tests: each must be a bool. Checked after every def has
@@ -1152,6 +1208,11 @@ struct Checker<'s> {
     /// entry is that match's scrutinee type plus the ctor names it already
     /// has arms for (an arm it still has cannot have been stolen).
     match_scrutinees: Vec<(Type, HashSet<String>)>,
+    /// Declared units, indexed by the BRANDED TYPE they produce: `"Angle.t"`
+    /// → `[("deg", "Angle.degrees"), ("rad", "Angle.radians")]`. Purely a
+    /// diagnostic side channel — it turns "expected Angle.t, got float" into
+    /// a message that teaches both spellings.
+    unit_hints: HashMap<String, Vec<(String, String)>>,
 }
 
 /// An under-applied call's provenance: enough to say `` `shift` is applied to
@@ -1310,7 +1371,51 @@ impl Checker<'_> {
     /// expectation came from ("argument 2 of `f`", "return value", "list
     /// element") — the legible-error contract.
     fn mismatch(&mut self, expected: &Type, got: &Type, span: Span, what: &str) {
-        self.diag(span, format!("{what}: expected {expected}, got {got}"));
+        let hint = match (expected, got) {
+            (Type::Variant(name, _) | Type::Record(name, _), Type::Float) => self.unit_hint(name),
+            _ => String::new(),
+        };
+        self.diag(span, format!("{what}: expected {expected}, got {got}{hint}"));
+    }
+
+    /// The suffix half of a branded-value teaching error: how to build a
+    /// `name` value from a number, in both spellings. Empty when no `unit`
+    /// produces that type.
+    fn unit_hint(&self, name: &str) -> String {
+        let units = self.unit_hints.get(name).filter(|u| !u.is_empty());
+        let Some(units) = units else {
+            return String::new();
+        };
+        let (_, call) = &units[0];
+        let suffixes = units
+            .iter()
+            .map(|(suffix, _)| format!("`45{suffix}`"))
+            .collect::<Vec<_>>()
+            .join(" / ");
+        format!(
+            " — `{name}` is a branded value: build one with `{call}(…)`, or write a \
+unit-suffixed literal ({suffixes})"
+        )
+    }
+
+    /// The same teaching error, for a NUMBER LITERAL in a branded position —
+    /// so the message can quote the value the source actually wrote
+    /// (`write 45deg or Angle.degrees(45.0)`).
+    fn unit_hint_for(&self, name: &str, value: f64) -> Option<String> {
+        let (suffix, call) = self.unit_hints.get(name)?.first()?;
+        let bare = if value.fract() == 0.0 && value.is_finite() {
+            format!("{}", value as i64)
+        } else {
+            format!("{value}")
+        };
+        let call_arg = if value.fract() == 0.0 && value.is_finite() {
+            format!("{bare}.0")
+        } else {
+            bare.clone()
+        };
+        Some(format!(
+            " — `{name}` is a branded value: write `{bare}{suffix}` or `{call}({call_arg})`"
+        ))
     }
 
     /// Enforce Map's deliberately bounded key domain when a direct builtin
@@ -1730,6 +1835,17 @@ if this position is deliberately untyped"
             return;
         }
         match (&expr.kind, expected) {
+            // A bare number where a branded value belongs — the mistake the
+            // unit suffixes exist for, so name the literal in the fix.
+            (ExprKind::Number(value), Type::Variant(name, _) | Type::Record(name, _))
+                if self.unit_hint_for(name, *value).is_some() =>
+            {
+                let hint = self
+                    .unit_hint_for(name, *value)
+                    .expect("checked by the guard");
+                self.diag(expr.span, format!("{what}: expected {expected}, got float{hint}"));
+                self.expr_types.insert(expr.id.raw(), Type::Float);
+            }
             (ExprKind::Record(fields), Type::Record(name, targs)) => {
                 let targs = targs.clone();
                 self.check_record_literal(fields, name, &targs, expr.span);

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -923,28 +923,35 @@ fn check_impl(
     // themselves are TYPE-CHECKED after inference, once their targets have
     // real types.
     for unit in &module.units {
+        // Only the branded type's NAME is needed (the hint keys on it), so
+        // this reads the declared shape rather than inferring anything.
+        let named = |ty: &Type| match ty {
+            Type::Variant(name, _) | Type::Record(name, _) => Some(name.clone()),
+            _ => None,
+        };
         let (result, call) = match &unit.target.kind {
             ExprKind::External(path) => {
                 let call = path.join(".");
-                match checker.signatures.get(&call).map(|s| s.ty.clone()) {
-                    Some(Type::Fn(_, ret)) => (Some(*ret), call),
-                    _ => (None, call),
-                }
+                let result = match checker.signatures.get(&call).map(|s| &s.ty) {
+                    Some(Type::Fn(_, ret)) => named(ret),
+                    _ => None,
+                };
+                (result, call)
             }
             ExprKind::Ctor { name, .. } => (
-                checker
-                    .ctors
-                    .get(name)
-                    .map(|(owner, params, _)| Type::Variant(owner.clone(), vec![Type::Unknown; *params])),
+                checker.ctors.get(name).map(|(owner, _, _)| owner.clone()),
                 name.clone(),
             ),
-            ExprKind::Global(name) => match checker.globals.get(name) {
-                Some(Type::Fn(_, ret)) => (Some((**ret).clone()), name.clone()),
-                _ => (None, name.clone()),
-            },
+            ExprKind::Global(name) => {
+                let result = match checker.globals.get(name) {
+                    Some(Type::Fn(_, ret)) => named(ret),
+                    _ => None,
+                };
+                (result, name.clone())
+            }
             _ => (None, String::new()),
         };
-        if let Some(Type::Variant(name, _) | Type::Record(name, _)) = result {
+        if let Some(name) = result {
             checker
                 .unit_hints
                 .entry(name)
@@ -1372,50 +1379,56 @@ impl Checker<'_> {
     /// element") — the legible-error contract.
     fn mismatch(&mut self, expected: &Type, got: &Type, span: Span, what: &str) {
         let hint = match (expected, got) {
-            (Type::Variant(name, _) | Type::Record(name, _), Type::Float) => self.unit_hint(name),
+            (Type::Variant(name, _) | Type::Record(name, _), Type::Float) => {
+                self.unit_hint(name, None).unwrap_or_default()
+            }
             _ => String::new(),
         };
         self.diag(span, format!("{what}: expected {expected}, got {got}{hint}"));
     }
 
     /// The suffix half of a branded-value teaching error: how to build a
-    /// `name` value from a number, in both spellings. Empty when no `unit`
-    /// produces that type.
-    fn unit_hint(&self, name: &str) -> String {
-        let units = self.unit_hints.get(name).filter(|u| !u.is_empty());
-        let Some(units) = units else {
-            return String::new();
-        };
-        let (_, call) = &units[0];
-        let suffixes = units
-            .iter()
-            .map(|(suffix, _)| format!("`45{suffix}`"))
-            .collect::<Vec<_>>()
-            .join(" / ");
-        format!(
-            " — `{name}` is a branded value: build one with `{call}(…)`, or write a \
+    /// `name` value from a number, in both spellings. `None` when no `unit`
+    /// produces that type. With the offending literal in hand
+    /// (`value: Some(45.0)`) the message quotes it — ``write `45deg` or
+    /// `Angle.degrees(45.0)` `` — otherwise it lists the declared suffixes.
+    fn unit_hint(&self, name: &str, value: Option<f64>) -> Option<String> {
+        let units = self.unit_hints.get(name).filter(|u| !u.is_empty())?;
+        let (first, call) = &units[0];
+        Some(match value {
+            Some(value) => {
+                // `90` for a whole number (as the literal would be written
+                // with a suffix), `90.0` for the call it desugars to.
+                let bare = if value.fract() == 0.0 && value.is_finite() {
+                    format!("{}", value as i64)
+                } else {
+                    format!("{value}")
+                };
+                let call_arg = if value.fract() == 0.0 && value.is_finite() {
+                    format!("{bare}.0")
+                } else {
+                    bare.clone()
+                };
+                format!(
+                    " — `{name}` is a branded value: write `{bare}{first}` or \
+`{call}({call_arg})`"
+                )
+            }
+            // No literal to quote (the value is computed): name the
+            // constructor, and at most two suffixes as the shorthand.
+            None => {
+                let suffixes = units
+                    .iter()
+                    .take(2)
+                    .map(|(suffix, _)| format!("`45{suffix}`"))
+                    .collect::<Vec<_>>()
+                    .join(" / ");
+                format!(
+                    " — `{name}` is a branded value: build one with `{call}(…)`, or write a \
 unit-suffixed literal ({suffixes})"
-        )
-    }
-
-    /// The same teaching error, for a NUMBER LITERAL in a branded position —
-    /// so the message can quote the value the source actually wrote
-    /// (`write 45deg or Angle.degrees(45.0)`).
-    fn unit_hint_for(&self, name: &str, value: f64) -> Option<String> {
-        let (suffix, call) = self.unit_hints.get(name)?.first()?;
-        let bare = if value.fract() == 0.0 && value.is_finite() {
-            format!("{}", value as i64)
-        } else {
-            format!("{value}")
-        };
-        let call_arg = if value.fract() == 0.0 && value.is_finite() {
-            format!("{bare}.0")
-        } else {
-            bare.clone()
-        };
-        Some(format!(
-            " — `{name}` is a branded value: write `{bare}{suffix}` or `{call}({call_arg})`"
-        ))
+                )
+            }
+        })
     }
 
     /// Enforce Map's deliberately bounded key domain when a direct builtin
@@ -1839,7 +1852,7 @@ if this position is deliberately untyped"
         if let (ExprKind::Number(value), Type::Variant(name, _) | Type::Record(name, _)) =
             (&expr.kind, expected)
         {
-            if let Some(hint) = self.unit_hint_for(name, *value) {
+            if let Some(hint) = self.unit_hint(name, Some(*value)) {
                 self.diag(
                     expr.span,
                     format!("{what}: expected {expected}, got float{hint}"),

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -2098,3 +2098,57 @@ fn stored_closure_from_an_inline_module_rebinds_across_reload() {
         .expect("apply");
     assert_eq!(number(&result), 21.0);
 }
+
+// ── Units across files ───────────────────────────────────────────────────
+
+/// A `unit` declared in one module, used in another: the suffixed literal is
+/// the cross-module call, dependency edge included — so the target module's
+/// globals evaluate FIRST, exactly as writing `Helper.scale(16.0)` by hand
+/// would. (Without the edge, a top-level initializer using the literal died
+/// with "global `Helper.scale` used before its definition".)
+#[test]
+fn a_unit_literal_carries_its_targets_dependency_edge() {
+    let value = run_main(
+        "unit-cross-file",
+        &[
+            ("game.fun", "let width = 16px\nlet main = () => width\n"),
+            (
+                "helper.fun",
+                "unit px = scale\nlet factor = 2.0\nlet scale = (n) => n * factor\n",
+            ),
+        ],
+    );
+    assert_eq!(number(&value), 32.0);
+}
+
+/// The same for a constructor target declared in a sibling: the literal
+/// builds that module's variant, with its canonical tag.
+#[test]
+fn a_unit_literal_builds_a_siblings_constructor() {
+    let value = run_main(
+        "unit-cross-file-ctor",
+        &[
+            ("game.fun", "let main = () => 16px\n"),
+            ("helper.fun", "type Px = | Px(value: float)\nunit px = Px\n"),
+        ],
+    );
+    assert_eq!(value.to_string(), "Helper.Px(16)");
+}
+
+/// A suffix may be declared once per PROJECT — the second declaration names
+/// the file that already has it, even when its own target is broken.
+#[test]
+fn a_duplicate_unit_across_files_names_both() {
+    let message = load_err(
+        "unit-duplicate-cross-file",
+        &[
+            (
+                "game.fun",
+                "type Px = | Px(value: float)\nunit px = Px\nlet main = () => 1.0\n",
+            ),
+            ("helper.fun", "unit px = Nope\n"),
+        ],
+    );
+    assert!(message.contains("duplicate unit `px`"), "{message}");
+    assert!(message.contains("game.fun"), "{message}");
+}

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -332,6 +332,48 @@ fn unary_minus_negates_a_suffixed_literal_argument() {
     assert_eq!(main_result(src), "-2.5");
 }
 
+/// The desugared call splits the literal's span between its halves, so the
+/// editor teaches instead of showing three nodes fighting over one span:
+/// the digits hover as `float`, the suffix as the function it calls.
+#[test]
+fn hovering_a_suffixed_literal_shows_both_halves() {
+    let src = "type Px = | Px(value: float)\nunit px = Px\nlet width = 16px\n";
+    let program = functor_lang::parse(src).expect("parses");
+    let module = functor_lang::lower(program).expect("lowers");
+    let (_diags, types) = functor_lang::check_with_types(&module);
+    let literal = src.find("16px").expect("the literal");
+    let hover = |offset: usize| {
+        functor_lang::hover::hover_text(&module, &types, offset).map(|(_, text)| text)
+    };
+    assert_eq!(hover(literal).as_deref(), Some("float"), "the digits");
+    assert_eq!(
+        hover(literal + 2).as_deref(),
+        Some("Px : (float) => Px"),
+        "the suffix"
+    );
+}
+
+/// A keyword touching a number is NOT a unit: `1else 2` lexes as it always
+/// has. (A keyword could never be declared as a suffix anyway.)
+#[test]
+fn a_keyword_touching_a_number_is_not_a_suffix() {
+    let tokens = lex("1else", 0).expect("lexes");
+    assert_eq!(tokens[0].kind, TokenKind::Number(1.0));
+    assert_eq!(tokens[1].kind, TokenKind::Else);
+    let src = "let pick = (c: bool): float => if c then 1else 2.0\n";
+    assert!(functor_lang::parse(src).is_ok(), "`1else 2.0` still parses");
+}
+
+/// `1_000` is a digit-separator attempt, not a unit — say so.
+#[test]
+fn a_digit_separator_is_taught_not_reported_as_a_unit() {
+    let message = lower_err("let a = 1_000\n");
+    assert!(
+        message.contains("no digit separators"),
+        "{message}"
+    );
+}
+
 /// A plain function target works too — nothing about units is brand-specific.
 #[test]
 fn a_plain_function_target_works() {

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -1,0 +1,342 @@
+//! Unit-suffix literals (`90deg`, `0.5s`, `16px`) and the `unit` declaration
+//! that gives a suffix its meaning: lexing, parsing, resolution, checking,
+//! and evaluation.
+//!
+//! The design is deliberately layered: the LEXER is dumb (it knows a literal
+//! carries identifier characters, never which units exist), and LOWERING
+//! desugars each suffixed literal to exactly the call the `unit` names — so
+//! everything downstream sees an ordinary call.
+
+use functor_lang::ast::{ExprKind, Item};
+use functor_lang::lexer::{lex, TokenKind};
+use functor_lang::{RunOutcome, Tracing};
+
+// ------------------------------------------------------------------- lexing
+
+/// Identifier characters TOUCHING a numeric literal are one token carrying
+/// the value and the spelled suffix — integers and decimals alike.
+#[test]
+fn digits_followed_by_identifier_chars_lex_as_one_token() {
+    let tokens = lex("90deg 0.5rad 16px", 0).expect("lexes");
+    let kinds: Vec<&TokenKind> = tokens.iter().map(|t| &t.kind).collect();
+    assert_eq!(
+        kinds[..3],
+        [
+            &TokenKind::NumberUnit(90.0, "deg".to_string()),
+            &TokenKind::NumberUnit(0.5, "rad".to_string()),
+            &TokenKind::NumberUnit(16.0, "px".to_string()),
+        ]
+    );
+}
+
+/// Adjacency is the whole rule: a space makes it a number and a name again,
+/// exactly as before this feature existed.
+#[test]
+fn a_space_keeps_the_number_and_the_name_apart() {
+    let tokens = lex("90 deg", 0).expect("lexes");
+    assert_eq!(tokens[0].kind, TokenKind::Number(90.0));
+    assert_eq!(tokens[1].kind, TokenKind::Ident("deg".to_string()));
+}
+
+/// A plain literal is untouched — including one followed by a non-identifier
+/// character (there is no scientific notation, so nothing else is ambiguous).
+#[test]
+fn plain_literals_are_unchanged() {
+    let tokens = lex("1.5 + 2", 0).expect("lexes");
+    assert_eq!(tokens[0].kind, TokenKind::Number(1.5));
+    assert_eq!(tokens[2].kind, TokenKind::Number(2.0));
+}
+
+/// The suffix spans the whole identifier, digits included (`16px2`), so a
+/// typo can never silently split into "number, suffix, stray name".
+#[test]
+fn a_suffix_runs_to_the_end_of_the_identifier() {
+    let tokens = lex("16px2", 0).expect("lexes");
+    assert_eq!(tokens[0].kind, TokenKind::NumberUnit(16.0, "px2".to_string()));
+}
+
+/// The lexer never produces a negative literal (as for plain numbers) — the
+/// minus is a separate token, and the PARSER folds it into the literal.
+#[test]
+fn unary_minus_is_a_separate_token() {
+    let tokens = lex("-2.5px", 0).expect("lexes");
+    assert_eq!(tokens[0].kind, TokenKind::Minus);
+    assert_eq!(
+        tokens[1].kind,
+        TokenKind::NumberUnit(2.5, "px".to_string())
+    );
+}
+
+/// A prefix minus folds INTO the literal (the number-pattern precedent), so
+/// `-90deg` is `Angle.degrees(-90.0)` rather than a negation of the branded
+/// value — which would have no meaning.
+#[test]
+fn a_prefix_minus_folds_into_the_literal() {
+    let program = functor_lang::parse("let a = -2.5px\n").expect("parses");
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let");
+    };
+    match &decl.value.kind {
+        ExprKind::NumberUnit { value, suffix } => {
+            assert_eq!((*value, suffix.as_str()), (-2.5, "px"))
+        }
+        other => panic!("expected a negative unit literal, got {other:?}"),
+    }
+}
+
+/// Subtraction is untouched: the minus between two operands stays binary.
+#[test]
+fn subtraction_of_suffixed_literals_still_parses_as_binary() {
+    let src = "type Px = | Px(value: float)\n\
+               unit px = Px\n\
+               let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+               let main = () => unwrap(5px) - unwrap(2px)\n";
+    assert_eq!(main_result(src), "3");
+}
+
+// ------------------------------------------------------------------ parsing
+
+#[test]
+fn a_unit_item_parses_with_a_qualified_target() {
+    let program = functor_lang::parse("unit deg = Angle.degrees\n").expect("parses");
+    let Item::Unit(decl) = &program.items[0] else {
+        panic!("expected a unit item, got {:?}", program.items[0]);
+    };
+    assert_eq!(decl.suffix, "deg");
+    assert_eq!(decl.target, vec!["Angle".to_string(), "degrees".to_string()]);
+}
+
+#[test]
+fn a_unit_item_parses_with_a_bare_constructor_target() {
+    let program =
+        functor_lang::parse("type Px = | Px(value: float)\nunit px = Px\n").expect("parses");
+    let Item::Unit(decl) = &program.items[1] else {
+        panic!("expected a unit item");
+    };
+    assert_eq!((decl.suffix.as_str(), decl.target.len()), ("px", 1));
+}
+
+/// A suffixed literal reaches the AST with both halves intact (the parser
+/// does not resolve it — that is lowering's job).
+#[test]
+fn a_suffixed_literal_parses_as_a_literal_with_its_suffix() {
+    let program = functor_lang::parse("let a = 90deg\n").expect("parses");
+    let Item::Let(decl) = &program.items[0] else {
+        panic!("expected a let");
+    };
+    match &decl.value.kind {
+        ExprKind::NumberUnit { value, suffix } => {
+            assert_eq!((*value, suffix.as_str()), (90.0, "deg"))
+        }
+        other => panic!("expected a unit literal, got {other:?}"),
+    }
+}
+
+fn parse_err(src: &str) -> String {
+    functor_lang::parse(src)
+        .err()
+        .unwrap_or_else(|| panic!("`{src}` should not parse"))
+        .message
+}
+
+#[test]
+fn malformed_unit_declarations_are_targeted_parse_errors() {
+    assert!(
+        parse_err("unit = Angle.degrees\n").contains("a unit suffix after `unit`"),
+        "{}",
+        parse_err("unit = Angle.degrees\n")
+    );
+    assert!(
+        parse_err("unit deg\n").contains("`=` after the unit suffix"),
+        "{}",
+        parse_err("unit deg\n")
+    );
+    assert!(
+        parse_err("unit deg =\n").contains("the name a unit literal calls"),
+        "{}",
+        parse_err("unit deg =\n")
+    );
+    // A leading underscore could never follow digits, so it is refused where
+    // it is written rather than becoming an undeclarable suffix.
+    assert!(
+        parse_err("unit _px = Px\n").contains("starts with a letter"),
+        "{}",
+        parse_err("unit _px = Px\n")
+    );
+}
+
+/// `unit` is contextual, like `open` / `expect` / `module`: it only means a
+/// declaration in item position, so the name stays ordinary everywhere else.
+#[test]
+fn unit_is_still_usable_as_a_name() {
+    let program = functor_lang::parse("let unit = 1.0\nlet main = () => unit\n").expect("parses");
+    assert_eq!(program.items.len(), 2);
+}
+
+// --------------------------------------------------------- lowering + check
+
+fn check_src(src: &str) -> Vec<String> {
+    let program = functor_lang::parse(src).expect("source should parse");
+    let module = functor_lang::lower(program).expect("source should lower");
+    functor_lang::check(&module)
+        .into_iter()
+        .map(|d| d.message)
+        .collect()
+}
+
+fn lower_err(src: &str) -> String {
+    let program = functor_lang::parse(src).expect("source should parse");
+    functor_lang::lower(program)
+        .err()
+        .expect("source should not lower")
+        .message
+}
+
+/// An undeclared suffix names the units that DO exist — the teaching error.
+#[test]
+fn an_unknown_suffix_lists_the_declared_units() {
+    let message = lower_err(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let a = 90deg\n",
+    );
+    assert!(message.contains("unknown unit `deg`"), "{message}");
+    assert!(message.contains("declared units: `px`"), "{message}");
+}
+
+/// …and with no units at all, it says how to declare one.
+#[test]
+fn an_unknown_suffix_without_units_teaches_the_declaration() {
+    let message = lower_err("let a = 90deg\n");
+    assert!(message.contains("no units are declared"), "{message}");
+    assert!(message.contains("unit deg = SomeFn"), "{message}");
+}
+
+/// A suffix is declared once — units are project-wide, like constructors.
+#[test]
+fn a_duplicate_suffix_is_an_error() {
+    let message = lower_err(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         unit px = Px\n",
+    );
+    assert!(message.contains("duplicate unit `px`"), "{message}");
+}
+
+/// The target must be exactly a one-float function; anything else is a check
+/// error at the DECLARATION, not a puzzle at every use site.
+#[test]
+fn a_target_that_is_not_a_float_function_is_a_check_error() {
+    let diags = check_src("let two = 2.0\nunit x = two\n");
+    assert!(
+        diags.iter().any(|d| d.contains("`unit x`") && d.contains("got float")),
+        "{diags:?}"
+    );
+
+    let diags = check_src(
+        "let pair = (a: float, b: float): float => a + b\n\
+         unit x = pair\n",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("`unit x`") && d.contains("(float, float) => float")),
+        "{diags:?}"
+    );
+}
+
+/// An unknown target name fails at the declaration, like any other name.
+#[test]
+fn an_unknown_target_is_a_lowering_error() {
+    let message = lower_err("unit px = Nope\n");
+    assert!(message.contains("unknown name `Nope`"), "{message}");
+}
+
+/// A declared unit types exactly as the call it desugars to.
+#[test]
+fn a_suffixed_literal_checks_as_its_target_type() {
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let width: Px = 16px\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let width: float = 16px\n",
+    );
+    assert!(
+        diags.iter().any(|d| d.contains("expected float, got Px")),
+        "{diags:?}"
+    );
+}
+
+/// A bare number where a branded value belongs now teaches BOTH spellings,
+/// quoting the literal the source actually wrote.
+#[test]
+fn a_bare_number_in_a_branded_position_teaches_the_suffix() {
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let width: Px = 16.0\n",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("write `16px` or `Px(16.0)`")),
+        "{diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------- evaluation
+
+fn main_result(src: &str) -> String {
+    let program = functor_lang::parse(src).expect("source should parse");
+    let module = functor_lang::lower(program).expect("source should lower");
+    match functor_lang::run(&module, Tracing::Off) {
+        Ok(record) => match record.outcome {
+            RunOutcome::Main(value) => value.to_string(),
+            RunOutcome::Bindings(_) => panic!("expected a main result"),
+        },
+        Err(failure) => panic!("run failed: {}", failure.error.message),
+    }
+}
+
+/// A user brand, end to end: the literal builds the same value the
+/// handwritten call does.
+#[test]
+fn a_user_declared_unit_evaluates_as_the_handwritten_call() {
+    let src = "type Px = | Px(value: float)\n\
+               unit px = Px\n\
+               let main = () => 16px\n";
+    assert_eq!(main_result(src), "Px(16)");
+    assert_eq!(
+        main_result(src),
+        main_result(
+            "type Px = | Px(value: float)\n\
+             unit px = Px\n\
+             let main = () => Px(16.0)\n"
+        )
+    );
+}
+
+/// Unary minus applies to the built value, so a brand can hold a negative.
+#[test]
+fn unary_minus_negates_a_suffixed_literal_argument() {
+    let src = "type Px = | Px(value: float)\n\
+               unit px = Px\n\
+               let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+               let main = () => unwrap(-2.5px)\n";
+    assert_eq!(main_result(src), "-2.5");
+}
+
+/// A plain function target works too — nothing about units is brand-specific.
+#[test]
+fn a_plain_function_target_works() {
+    let src = "let twice = (n: float): float => n * 2.0\n\
+               unit x = twice\n\
+               let main = () => 21x\n";
+    assert_eq!(main_result(src), "42");
+}

--- a/functor-prelude/prelude/angle.funi
+++ b/functor-prelude/prelude/angle.funi
@@ -11,3 +11,8 @@ type t
 let degrees : (float) => t
 /// Construct an angle from radians.
 let radians : (float) => t
+
+/// Degrees as a literal suffix: `90deg` is exactly `Angle.degrees(90.0)`.
+unit deg = Angle.degrees
+/// Radians as a literal suffix: `0.5rad` is exactly `Angle.radians(0.5)`.
+unit rad = Angle.radians

--- a/functor-prelude/prelude/time.funi
+++ b/functor-prelude/prelude/time.funi
@@ -10,3 +10,20 @@ type t
 let seconds : (float) => t
 /// Construct a duration from milliseconds.
 let millis : (float) => t
+/// Construct a duration from microseconds.
+let micros : (float) => t
+/// Construct a duration from minutes.
+let minutes : (float) => t
+/// Construct a duration from hours.
+let hours : (float) => t
+
+/// Seconds as a literal suffix: `0.5s` is exactly `Time.seconds(0.5)`.
+unit s = Time.seconds
+/// Milliseconds as a literal suffix: `500ms` is exactly `Time.millis(500.0)`.
+unit ms = Time.millis
+/// Microseconds as a literal suffix: `250us` is exactly `Time.micros(250.0)`.
+unit us = Time.micros
+/// Minutes as a literal suffix: `2min` is exactly `Time.minutes(2.0)`.
+unit min = Time.minutes
+/// Hours as a literal suffix: `1hr` is exactly `Time.hours(1.0)`.
+unit hr = Time.hours

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5496,6 +5496,39 @@ mod tests {
             .clone()
     }
 
+    // Drift guard: the branded-value teaching errors name unit SUFFIXES
+    // (`90deg`, `0.5s`), but the suffixes themselves are declared in the
+    // `.funi` prelude, which this crate cannot read at runtime. Pin the two
+    // together so renaming or dropping a `unit` fails here instead of leaving
+    // a message that teaches a suffix nobody can write.
+    #[test]
+    fn prelude_units_match_the_teaching_errors() {
+        use std::collections::BTreeSet;
+        let mut suffixes: BTreeSet<String> = BTreeSet::new();
+        for (module, src) in functor_prelude::modules() {
+            let program = functor_lang::parse_interface(&src)
+                .unwrap_or_else(|e| panic!("prelude module `{module}` must parse: {}", e.message));
+            for item in &program.items {
+                if let functor_lang::ast::Item::Unit(decl) = item {
+                    assert!(
+                        suffixes.insert(decl.suffix.clone()),
+                        "unit `{}` is declared more than once in the prelude",
+                        decl.suffix
+                    );
+                }
+            }
+        }
+        let expected: BTreeSet<String> = ["deg", "rad", "s", "ms", "us", "min", "hr"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(
+            suffixes, expected,
+            "the prelude's unit suffixes changed — update the Angle/Duration teaching errors \
+in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list together"
+        );
+    }
+
     // Drift guard: a HARD BIJECTION between the `functor-prelude` `.funi`
     // signatures and the registered externals. Every `.funi` `val`/`let`
     // signature must name a real host external, AND every host external must

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -1477,6 +1477,15 @@ fn register_branded_constructors(reg: &mut crate::host_registry::Registry) {
     reg.fn1("Time.millis", "Time.millis(n)", |n: f64| {
         FunctorLangDuration(n / 1000.0)
     });
+    reg.fn1("Time.micros", "Time.micros(n)", |n: f64| {
+        FunctorLangDuration(n / 1_000_000.0)
+    });
+    reg.fn1("Time.minutes", "Time.minutes(n)", |n: f64| {
+        FunctorLangDuration(n * 60.0)
+    });
+    reg.fn1("Time.hours", "Time.hours(n)", |n: f64| {
+        FunctorLangDuration(n * 3600.0)
+    });
     reg.fn3("Color.rgb", "Color.rgb(r, g, b)", |r: f64, g: f64, b: f64| {
         FunctorLangColor((r as f32, g as f32, b as f32))
     });
@@ -4046,7 +4055,7 @@ fn angle_of(value: &Value, what: &str, span: Span) -> Result<Angle, RunError> {
         Value::Number(_) => Err(RunError {
             message: format!(
                 "{what}: expected an Angle, got a bare number — say which unit: \
-Angle.degrees(…) or Angle.radians(…)"
+`90deg` / `1.5rad`, or Angle.degrees(…) / Angle.radians(…)"
             ),
             span,
         }),
@@ -4127,7 +4136,7 @@ fn duration_of(value: &Value, what: &str, span: Span) -> Result<f64, RunError> {
         Value::Number(_) => Err(RunError {
             message: format!(
                 "{what}: expected a Duration, got a bare number — say which unit: \
-Time.seconds(…) or Time.millis(…)"
+`0.5s` / `500ms`, or Time.seconds(…) / Time.millis(…)"
             ),
             span,
         }),
@@ -6812,7 +6821,7 @@ texture placeholder for a model asset; construct it with Asset.model(…)",
         assert_eq!(
             failure.error.message,
             "Scene.rotateY: expected an Angle, got a bare number — say which unit: \
-Angle.degrees(…) or Angle.radians(…)"
+`90deg` / `1.5rad`, or Angle.degrees(…) / Angle.radians(…)"
         );
     }
 
@@ -7977,7 +7986,7 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
 Physics.box(4.0, 1.0, 2.0)) |> Physics.rotateY(1.57)"
             ),
             "Physics.rotateY: expected an Angle, got a bare number — say which unit: \
-Angle.degrees(…) or Angle.radians(…)"
+`90deg` / `1.5rad`, or Angle.degrees(…) / Angle.radians(…)"
         );
         assert_eq!(
             fail_message(
@@ -8684,6 +8693,29 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         assert!(fired(millis, 1.0, 1.4).is_empty());
     }
 
+    /// The whole `Time` family lands on the same canonical seconds — the
+    /// constructors the `s`/`ms`/`us`/`min`/`hr` literal suffixes call.
+    #[test]
+    fn every_time_constructor_is_canonical_seconds() {
+        let seconds = |src: &str| {
+            let value = eval(&format!("let main = () => {src}"));
+            match &value {
+                Value::HostData(data) => {
+                    data.as_any()
+                        .downcast_ref::<FunctorLangDuration>()
+                        .expect("a Duration")
+                        .0
+                }
+                other => panic!("expected a Duration, got {other}"),
+            }
+        };
+        assert_eq!(seconds("Time.seconds(0.5)"), 0.5);
+        assert_eq!(seconds("Time.millis(500.0)"), 0.5);
+        assert_eq!(seconds("Time.micros(250.0)"), 0.00025);
+        assert_eq!(seconds("Time.minutes(2.0)"), 120.0);
+        assert_eq!(seconds("Time.hours(1.5)"), 5400.0);
+    }
+
     /// Batches fire in declaration order; `Sub.none` fires nothing; the msg
     /// crosses back verbatim (here, a parameterful variant).
     #[test]
@@ -9358,7 +9390,7 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
         assert_eq!(
             failure.error.message,
             "Sub.every: expected a Duration, got a bare number — say which unit: \
-Time.seconds(…) or Time.millis(…)"
+`0.5s` / `500ms`, or Time.seconds(…) / Time.millis(…)"
         );
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_test.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_test.rs
@@ -255,6 +255,32 @@ expect List.length([Scene.cube(), Scene.sphere()]) == 2
         assert!(!err.message.is_empty());
     }
 
+    /// Unit-suffix literals under the ENGINE prelude: the built-in suffixes
+    /// evaluate to real branded values, and a project's own unit builds
+    /// exactly what the handwritten constructor call does.
+    #[test]
+    fn unit_suffix_literals_evaluate_under_the_engine_prelude() {
+        let (_dir, entry) = project(
+            "game.fun",
+            &[(
+                "game.fun",
+                r#"type Px = | Px(value: float)
+
+unit px = Px
+
+expect List.length([90deg, 1.5rad]) == 2
+expect List.length([0.5s, 500ms, 250us, 2min, 1hr]) == 5
+expect 16px == Px(16.0)
+expect -2.5px == Px(-2.5)
+expect List.length([Scene.cube() |> Scene.rotateY(90deg)]) == 1
+"#,
+            )],
+        );
+        let run = run_project_expects(&entry).expect("project runs");
+        assert_eq!(run.total(), 5);
+        assert_eq!(run.failed(), 0, "{:?}", run.cases);
+    }
+
     #[test]
     fn a_project_with_no_expects_runs_clean() {
         let (_dir, entry) = project("game.fun", &[("game.fun", "let x = 1.0\n")]);

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -6,8 +6,14 @@ use std::collections::HashMap;
 
 /// Check `src` as a single-file game with the complete engine bundle.
 fn check(src: &str) -> Vec<String> {
-    let dir =
-        std::env::temp_dir().join(format!("functor-prelude-typecheck-{}", src.len()));
+    // Unique per CALL: tests run in parallel, and two sources of the same
+    // length would otherwise share (and delete) one directory.
+    static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let id = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "functor-prelude-typecheck-{}-{id}",
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("game.fun"), src).unwrap();
@@ -237,5 +243,96 @@ fn vec3_arithmetic_rejects_unbranded_values_at_check_time() {
     assert!(
         !check("let bad: float = Vec3.make(1.0, 2.0, 3.0) |> Vec3.normalize()").is_empty(),
         "normalize returns a Vec3, not a float"
+    );
+}
+
+// ------------------------------------------------------ unit-suffix literals
+
+/// The prelude's own `unit` declarations resolve under the engine bundle: a
+/// suffixed literal IS the branded call, so it checks as the branded type.
+#[test]
+fn builtin_unit_suffixes_check_as_their_branded_types() {
+    for src in [
+        "let turn: Angle.t = 90deg",
+        "let turn: Angle.t = 0.5rad",
+        "let d: Time.t = 0.5s",
+        "let d: Time.t = 500ms",
+        "let d: Time.t = 250us",
+        "let d: Time.t = 2min",
+        "let d: Time.t = 1hr",
+    ] {
+        assert!(check(src).is_empty(), "{src}: {:?}", check(src));
+    }
+    // …and they are branded, not floats.
+    assert!(
+        check("let bad: float = 90deg")
+            .iter()
+            .any(|m| m.contains("Angle.t")),
+        "{:?}",
+        check("let bad: float = 90deg")
+    );
+}
+
+/// A suffixed literal satisfies a branded PARAMETER exactly like the
+/// handwritten call it desugars to.
+#[test]
+fn unit_suffixes_satisfy_branded_parameters() {
+    let diags = check(
+        "type Msg = | Pulse\n\
+         let subscriptions = (m) => Sub.every(0.5s, Pulse)\n\
+         let update = (m, msg) => m\n\
+         let scene = Scene.cube() |> Scene.rotateY(90deg)",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+/// A bare number in a branded position teaches BOTH spellings now — the
+/// suffix and the constructor call.
+#[test]
+fn a_bare_number_in_a_branded_position_teaches_the_suffix() {
+    let diags = check("let scene = Scene.cube() |> Scene.rotateY(90.0)");
+    assert!(
+        diags.iter().any(|m| m.contains("write `90deg`")),
+        "{diags:?}"
+    );
+}
+
+/// An undeclared suffix lists the ones the prelude does declare.
+#[test]
+fn an_unknown_suffix_lists_the_prelude_units() {
+    let diags = check("let bad = 90degrees");
+    assert!(
+        diags
+            .iter()
+            .any(|m| m.contains("unknown unit `degrees`") && m.contains("`deg`")
+                && m.contains("`ms`")),
+        "{diags:?}"
+    );
+}
+
+/// A project may declare its OWN unit beside the prelude's — units are
+/// project-wide and compose.
+#[test]
+fn a_project_unit_lives_beside_the_prelude_units() {
+    let diags = check(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let width: Px = 16px\n\
+         let turn: Angle.t = 45deg",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+/// Redeclaring a prelude suffix is refused — one meaning per suffix, project
+/// wide, exactly like a constructor name.
+#[test]
+fn redeclaring_a_prelude_suffix_is_an_error() {
+    let diags = check(
+        "type Px = | Px(value: float)\n\
+         unit deg = Px\n",
+    );
+    assert!(
+        diags.iter().any(|m| m.contains("duplicate unit `deg`")),
+        "{diags:?}"
     );
 }

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -152,7 +152,8 @@ let draw = (model, tts: float) =>
       |> Scene.rotateY(Angle.radians(tts)))</pre>
           <p>
             Angles are branded values — <code>Scene.rotateY(1.57)</code> is a teaching error, not
-            a rotation. Say <code>Angle.radians(1.57)</code> or <code>Angle.degrees(90.0)</code>.
+            a rotation. Say <code>Angle.radians(1.57)</code> or <code>Angle.degrees(90.0)</code> —
+            or their literal suffixes, <code>1.57rad</code> and <code>90deg</code>.
           </p>
 
           <h3>3 &middot; Handle input</h3>
@@ -223,7 +224,7 @@ let draw = (model, tts: float) =>
           <p>
             <code>subscriptions</code> requires <code>update</code>. Durations are branded like
             Angles, so <code>Sub.every(1.0, Beat)</code> is an error — say
-            <code>Time.seconds(1.0)</code>. The <code>ui</code> hook is the screen-space HUD,
+            <code>Time.seconds(1.0)</code> or <code>1s</code>. The <code>ui</code> hook is the screen-space HUD,
             another pure function of the model.
           </p>
 
@@ -813,7 +814,9 @@ functor docs --format json         # the machine-readable shape</pre>
             <strong>branded values</strong> rather than bare numbers or strings —
             <code>Angle.degrees(60.0)</code>, <code>Time.seconds(0.5)</code>,
             <code>Physics.tag("ball")</code>, <code>RenderTarget.named("feed")</code> — so a
-            mixed-up unit is a check-time error instead of a puzzling frame.
+            mixed-up unit is a check-time error instead of a puzzling frame. Angles and
+            durations also read as unit-suffixed literals (<code>90deg</code>,
+            <code>0.5s</code>), which build exactly the same branded values.
           </p>
         </section>
 
@@ -824,7 +827,7 @@ functor docs --format json         # the machine-readable shape</pre>
             <li>Assignment is <code>:=</code> (not <code>&lt;-</code>) and must be followed by <code>;</code> and a continuation.</li>
             <li><code>if</code> is an expression: both branches are required, and chains use <code>else if</code> rather than <code>elif</code>.</li>
             <li>Captured game mouse input defaults on when captured hooks exist. <code>"mouseCapture":false</code> opts out; <code>"cursor":"visible"</code> selects absolute pointer input instead. Held buttons are force-released on focus loss.</li>
-            <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors.</li>
+            <li>Angles, Durations, and render targets are branded <em>values</em> — <code>Sub.every(0.5, …)</code> and <code>Scene.rotateY(1.57)</code> are errors. Angles and durations also take literal suffixes: <code>90deg</code>, <code>1.57rad</code>, <code>0.5s</code>, <code>500ms</code> — the suffix must touch the digits, and <code>unit px = Px</code> declares one for your own brand.</li>
             <li>Constructor names are global to the file's value namespace; nullary constructors never take parens. Module variants are the exception — <code>Option.Some</code>, never bare <code>Some</code>.</li>
             <li>Piping into <code>Text.concat</code> <em>prepends</em>: <code>s |> Text.concat(p)</code> is <code>p</code> then <code>s</code>. And <code>Text.fixed(n, decimals)</code> takes its number first, so it can't be piped on.</li>
             <li><code>Math</code> is only what the <a href="../docs/#api-math">reference</a> lists — there is still no <code>sinh</code> or <code>hypot</code>. <code>Math.round</code> goes half <em>away from zero</em>, not to even.</li>

--- a/site/src/docs.ts
+++ b/site/src/docs.ts
@@ -21,7 +21,9 @@ const KEYWORDS = new Set([
 const ATOMS = new Set(["true", "false"]);
 
 const CODE_TOKEN =
-  /^(?:\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|&&|\|\||[+\-*/<>=|])/;
+  // A number may carry a unit suffix touching its digits (`90deg`) — one
+  // token, as the lexer sees it.
+  /^(?:\d+(?:\.\d+)?[A-Za-z_]?[A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*|\|>|=>|:=|&&|\|\||[+\-*/<>=|])/;
 
 const escapeHtml = (s: string): string =>
   s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/site/src/functor-lang.ts
+++ b/site/src/functor-lang.ts
@@ -101,7 +101,9 @@ export const functorLangLanguage = StreamLanguage.define<State>({
         return "bracket";
       }
     }
-    if (stream.match(/^\d+(\.\d+)?/)) return "number";
+    // A number, with an optional unit suffix touching the digits (`90deg`) —
+    // one token, as the lexer sees it.
+    if (stream.match(/^\d+(\.\d+)?([A-Za-z_][A-Za-z0-9_]*)?/)) return "number";
     // Uppercase head: constructors and prelude namespaces (Scene, Math, …).
     if (stream.match(/^[A-Z][A-Za-z0-9_]*/)) return "typeName";
     if (stream.match(/^[a-z_][A-Za-z0-9_]*/)) {

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -142,6 +142,9 @@ pub struct ApiItem {
 pub enum ApiItemKind {
     Type,
     Value,
+    /// A `unit` declaration: the literal suffix a number may carry
+    /// (`90deg` → `Angle.degrees(90.0)`).
+    Unit,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -493,6 +496,14 @@ fn extract_module(
                     signature_of(&source, &decl).map_err(|message| error_at(decl.span, message))?;
                 (decl.name, ApiItemKind::Value, decl.span, declaration)
             }
+            // A `unit` is public API: it is what makes `90deg` mean
+            // `Angle.degrees(90.0)`, so it documents beside the function it
+            // calls, quoted verbatim from the source.
+            Item::Unit(decl) => {
+                let declaration = declaration_at(&source, decl.span)
+                    .ok_or_else(|| error_at(decl.span, invalid_span(&decl.suffix)))?;
+                (decl.suffix, ApiItemKind::Unit, decl.span, declaration)
+            }
             Item::Let(_) | Item::Open(_) | Item::Expect(_) | Item::Module(_) => continue,
         };
         items.push(ApiItem {
@@ -645,7 +656,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 272));
+        assert_eq!(count(ApiGroup::Engine), (27, 282));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules

--- a/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
+++ b/tools/functor-lang-vscode/syntaxes/functor-lang.tmLanguage.json
@@ -108,7 +108,8 @@
     },
     "number": {
       "name": "constant.numeric.functor",
-      "match": "\\b[0-9]+(\\.[0-9]+)?\\b"
+      "comment": "Numbers, including a unit suffix touching the digits (`90deg`)",
+      "match": "\\b[0-9]+(\\.[0-9]+)?([A-Za-z_][A-Za-z0-9_]*)?\\b"
     },
     "qualified-name": {
       "comment": "Module access like `List.map` / `Text.concat`",


### PR DESCRIPTION
Phase 1 of unit-suffix literals: a numeric literal may carry a **unit suffix** — `90deg`, `0.5s`, `16px` — and a new top-level `unit <suffix> = <name>` item says what a suffix means.

```functor
Scene.cube() |> Scene.rotateY(90deg)      // == Scene.rotateY(Angle.degrees(90.0))
Sub.every(0.5s, Beat)                     // == Sub.every(Time.seconds(0.5), Beat)

type Px = | Px(value: float)
unit px = Px
let width = 16px                          // == Px(16.0)
```

The brand is not weakened — `90deg` *is* `Angle.degrees(90.0)` — only the ceremony is gone. `docs/functor-lang-units.md` carries the design (Phase 1 as shipped, Phase 2 as designed).

## How it works

- **Lexing is dumb.** A numeric literal (`digits` / `digits.digits`) immediately followed by identifier characters lexes as ONE token carrying `(value, suffix)`. The lexer never knows which units exist. Adjacency is the rule (`90 deg` is unchanged); there is no scientific notation, so no `1e5` ambiguity, and `90deg` was previously a parse error — the syntax was unclaimed. A **keyword** touching a number is deliberately not a suffix, so `1else 2` lexes exactly as it always has.
- **`unit` declarations resolve semantically.** The target is a NAME (function or constructor) resolved in the declaring module's scope and typechecked as exactly `(float) => 't`. Units are **project-wide** (file = module, like constructors): resolved once, before any file lowers, so a use site may precede — or live in a different file from — its declaration, and a suffix may be declared once per project.
- **Lowering desugars to the plain call.** The IR has no unit node, so hover, inlay, go-to-definition, the typechecker, the interpreter, and the host's teaching errors all see an ordinary `Angle.degrees(90.0)` — one code path, and zero per-frame cost. The literal's span splits between its halves, so the digits hover as `float` and the suffix as the function it calls.
- **Built-ins are prelude declarations, not a lexer table.** `deg`/`rad` live in `angle.funi`, `s`/`ms`/`us`/`min`/`hr` in `time.funi`, each with `///` docs that docgen renders beside their module. `Time.micros`/`minutes`/`hours` are new, registered in the typed external registry (the `.funi` ≡ registry drift test passes), and a new drift test pins the prelude's suffix set to the teaching strings that quote it.
- **Teaching errors upgraded.** A bare number in a branded position now names both spellings, quoting the literal the source wrote:
  ```
  argument 1 of `Scene.rotateY`: expected Angle.t, got float — `Angle.t` is a branded
  value: write `90deg` or `Angle.degrees(90.0)`
  ```
  An undeclared suffix lists the declared units; `1_000` is taught as "no digit separators".

Explicitly **out of scope**: operator declarations on units and any dimensional analysis. `docs/functor-lang-units.md` designs Phase 2 (per-unit operator impls typed `('t,'t) => 't` plus scalar `('t,float) => 't`, resolved by ad-hoc overloading *after* inference — an unsolved type variable at that point is a teaching error asking for an annotation, never a silent guess) and states dimensional analysis as a non-goal.

## Design deviations

One, small: **a prefix minus folds into the literal** (`-90deg` is `Angle.degrees(-90.0)`), matching how number *patterns* already absorb a leading `-`. Without it `-90deg` is a negation of a branded value, which has no meaning and made `Scene.rotateY(-90deg)` a runtime error — unacceptable for the feature's main use. Binary subtraction is untouched (`a - 2px` still parses as subtraction).

## Verification

- `cargo test -p functor-lang -p functor-docgen -p functor_runtime_common` — all green (new: `functor-lang/tests/units.rs`, 3 cross-file cases in `tests/project.rs`, 6 engine-prelude cases in `prelude_typecheck.rs`, an engine-host expect run, the Time-constructor conversions, and the prelude-unit pin).
- `npm run generate:docs` + `npm run check:docs` — clean (docgen inventory pin 272 → 282: 3 new signatures + 7 units).
- `npm run build:cli:debug`, then `functor -d examples/counter test` (3/3 expects) and `functor build` on `examples/primitives`, `physics`, `orbs`, `counter` — all clean. A scratch game using `500ms`, `90deg`, `-45deg`, and a user `unit px` builds, tests, and renders through the real desktop runtime (headless capture).
- Golden IR files regenerated (one `units: []` line each).

### frame_bench (release, interleaved A/B in one window)

Both binaries built, then run **alternating** base/branch back-to-back, because the machine is shared and wall-clock drifts with ambient load (an earlier non-interleaved pass was unusable for exactly that reason). `us/frame(min)`:

| cells | base (3 runs) | branch (3 runs) | best base | best branch | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- | --- | --- |
| 400 | 687.5 / 682.6 / 693.1 | 684.6 / 691.4 / 684.6 | 682.6 | 684.6 | 13877 = 13877 | 843393 = 843393 |
| 1600 | 2691.8 / 2705.1 / 2736.2 | 2720.2 / 2724.7 / 2993.2 | 2691.8 | 2720.2 | 54717 = 54717 | 3307233 = 3307233 |
| 3136 | 5357.2 / 5353.3 / 5305.7 | 5303.5 / 5302.2 / 5307.8 | 5305.7 | 5302.2 | 106973 = 106973 | 6460257 = 6460257 |

**`allocs/frame` and `bytes/frame` are byte-identical** at every size — the deterministic number, and the expected result for a desugar that happens at load time. Wall-clock deltas (−0.1% to +1.1%) sit inside the run-to-run spread on a loaded machine.

## Review dispositions (`/xreview`: Claude subagent + Codex, plus a de-dup pass)

**High — [AGREED by both engines] — FIXED.** A suffixed literal did not record the dependency edge on its target's module, so a cross-file `16px` in a top-level initializer died with "global `Helper.scale` used before its definition" where the handwritten call worked. `UnitTarget` now carries its owner and each use site records the edge; three new `tests/project.rs` cases cover it (this was also Claude's finding #2 — "no cross-file test at all").

**Medium — FIXED**
- Duplicate suffixes are now detected on names alone, before any target resolves, so a redeclaration reports as a duplicate even when its own target is broken (Codex).
- The desugar splits the literal's span, so hovering the suffix reports `Angle.degrees : (float) => Angle.t` instead of three nodes tying on one span and the number winning (Codex; verified by test).
- A keyword touching a number is no longer a suffix — `1else 2` lexes as before, and the asymmetry (a keyword suffix could never be *declared*) is gone (Claude).
- `1_000` teaches "numeric literals have no digit separators" instead of "unknown unit `_000`" (Claude).
- `unit` inside an inline `module` gets a targeted parse error (Claude).
- De-dup: the two branded-hint builders merged into one; the hint no longer lists five suffixes; the single-file path no longer runs name/`open` resolution twice; the `unit_hints` derivation reads only the type NAME, removing the divergence with `infer`; the duplicate-unit bookkeeping is one map; a new drift test pins the prelude's suffixes to the runtime teaching strings that quote them.

**Medium — WON'T FIX, justified.** `unit px = Unknown.host` passes validation because an unresolved external is `Unknown`, which absorbs anything (Codex). That is the language's existing gradual seam — `Unknown.host(1.0)` is equally unchecked today — and under the engine host an unknown member of a KNOWN module is already a load error. Special-casing units here would be the only place an external is required to have a signature.

**Low — accepted as-is.** The unit pre-pass can change which file reports first when an unrelated later file declares a `unit` (Claude): diagnostics stay correct, only ordering shifts, and the pre-pass is what makes units project-wide. The prefix-minus-folding idiom now appears three times in the parser (de-dup pass): the token and AST types differ in each, and the pre-existing pair was already a clone.

De-dup coverage: all four strategies ran (S1 lexical 31 queries / 7002 candidates, S2 clones 242 lines with no pair intersecting the change, S3 index 3500 lines grepped, S4 full read); no duplication finding survived beyond the ones fixed above.

## Docs

`docs/functor-lang-units.md` (new), the `functor-lang` skill (syntax section, the branded-values rule, a `unit` section, the suffix list), and `site/manual/index.html` (the Angle mention, the `Sub.every` duration line, and the sharp-edges bullet — three inline text additions, no layout change).

### Manual, before / after

Built at the base ref and at this change, served locally and screenshotted with headless chromium at 1440px and 390px.

**Sharp edges bullet — desktop**

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/before-sharp-desktop.png" width="470"> | <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/after-sharp-desktop.png" width="470"> |

**"Angles are branded values" — desktop**

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/before-angle-desktop.png" width="470"> | <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/after-angle-desktop.png" width="470"> |

**Durations (`subscriptions`) — desktop**

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/before-duration-desktop.png" width="470"> | <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/after-duration-desktop.png" width="470"> |

**Mobile (390px)** — the same two spots, confirming the added text reflows without layout change:

| before (angle) | after (angle) | before (sharp) | after (sharp) |
| --- | --- | --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/before-angle-mobile.png" width="200"> | <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/after-angle-mobile.png" width="200"> | <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/before-sharp-mobile.png" width="200"> | <img src="https://gist.githubusercontent.com/tommy-xr/0edc8ac89bcc229e3b66c8e499a44bed/raw/after-sharp-mobile.png" width="200"> |
