### PR TITLE
fix(physics): resilient hook — degrade on error, uniform read timing, primed cold start

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -994,7 +994,8 @@ frame and it lands on the next one). Reads and writes both live in `tick`.
 
 Note the rule this example obeys: a local `let` needs `in`. It needs no
 first-frame gate — the world is primed from `init` before frame 1, so the
-pre-step reads answer from the very first tick.
+pre-step reads answer from the very first tick. (The `probe` cast is the one
+exception: ray queries need a step, so frame 1 reads "not grounded".)
 
 ⚠️ The sketch above is the LOOP SHAPE, not a usable controller — it has no
 coyote time, jump buffering, or post-jump lockout. See the next section.
@@ -1217,11 +1218,13 @@ Three rules follow from that one:
   runtime evaluates the hook once on `init` and reconciles it with ZERO steps,
   so frame 1's `tick`/hook reads answer with the initial declared poses. A
   `started: bool` guard is no longer needed — `examples/terrain` and
-  `examples/physics-controller` deleted theirs. Two footnotes: priming re-runs
-  at a RESTART but not at a hot reload (there the world survives with the
-  model), and inside the prime evaluation itself — the one call with no stepped
-  world behind it — a body read answers the identity pose (origin, zero
-  velocity) instead of raising.
+  `examples/physics-controller` deleted theirs. Three footnotes: priming re-runs
+  at a RESTART (and at a reload that ADDS the hook) but not at an ordinary hot
+  reload, where the world survives with the model; inside the prime evaluation
+  itself — the one call with no stepped world behind it — a body read answers
+  the identity pose (origin, zero velocity) instead of raising; and priming
+  answers BODY reads only — `Physics.cast` needs a step (rapier ingests
+  colliders there), so a grounding probe still answers from frame 2.
 - **A hook error degrades, loudly.** An error inside the hook (or a
   non-`Physics.scene` return) keeps the previous frame's declaration, keeps
   stepping the world, and reports the teaching error ONCE — the hot-reload

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -907,9 +907,12 @@ Prose docs: `docs/ui-interaction.md` (widget interaction and headless driving),
 `Physics.position` / `Physics.linearVelocity` / `Physics.cast` /
 `Physics.castExcluding` / `Physics.transformed` read the live stepped world
 (Functor Lang runs in the shell's process — no boundary). They work in **any**
-entry point, `tick` included: in `tick` they see the previous step (physics runs
-after `tick`), in `draw` this frame's. That one step of read latency is inherent
-to read → decide → step. A tag not in the world is
+entry point, `tick` and the `physics` hook included, under one rule: a read
+answers the LAST STEPPED world. Every pre-step caller (`tick`, `input`, the
+hook) sees the previous step; only `draw` (and post-step `update`s) sees this
+frame's. That one step of read latency is inherent
+to read → decide → step. The world is primed from `init` before frame 1, so
+even the first frame's reads answer. A tag not in the world is
 a **spanned runtime error** (there is no Option-shaped return to match on),
 so only read tags your `physics` hook declares. The tag is cross-frame
 identity: same tag = same body; drop a body by not declaring it.
@@ -974,17 +977,14 @@ let probe = (p) =>
   Physics.castExcluding(playerTag, Vec3.make(p.x, p.y - 0.9, p.z),
                         Vec3.make(0.0, -1.0, 0.0), 0.2)
 let tick = (m, dt, tts) =>
-  match m.started with          // guard the FIRST frame: nothing has been
-  | false => { m with started: true }   //   reconciled yet, so the reads below
-  | true =>                             //   would raise `no body tagged …`
-    let pos = Physics.position(playerTag) in
-    let vel = Physics.linearVelocity(playerTag) in
-    let onGround = probe(pos).hit in
-    // Steer the horizontal plane only — the solver owns `y`.
-    (m, if onGround && m.jump then
-          Effect.batch([Physics.setVelocityXZ(playerTag, vel.x, vel.z),
-                        Physics.setVelocityY(playerTag, 6.0)])
-        else Physics.setVelocityXZ(playerTag, vel.x, vel.z))
+  let pos = Physics.position(playerTag) in    // frame 1 included: the world is
+  let vel = Physics.linearVelocity(playerTag) in  //   primed from `init`
+  let onGround = probe(pos).hit in
+  // Steer the horizontal plane only — the solver owns `y`.
+  (m, if onGround && m.jump then
+        Effect.batch([Physics.setVelocityXZ(playerTag, vel.x, vel.z),
+                      Physics.setVelocityY(playerTag, 6.0)])
+      else Physics.setVelocityXZ(playerTag, vel.x, vel.z))
 ```
 
 The read happens in `tick`, the command drains immediately after `tick` (no
@@ -992,9 +992,9 @@ The read happens in `tick`, the command drains immediately after `tick` (no
 (when the 60 Hz accumulator is short of a full step, no step runs at all that
 frame and it lands on the next one). Reads and writes both live in `tick`.
 
-Note the two rules this example obeys: local `let` needs `in`, and the
-pre-step readers raise on the first frame, before the `physics` hook's
-declaration has been reconciled and stepped — so gate them.
+Note the rule this example obeys: a local `let` needs `in`. It needs no
+first-frame gate — the world is primed from `init` before frame 1, so the
+pre-step reads answer from the very first tick.
 
 ⚠️ The sketch above is the LOOP SHAPE, not a usable controller — it has no
 coyote time, jump buffering, or post-jump lockout. See the next section.
@@ -1205,21 +1205,28 @@ not uniformly pre-step — when it is handling a `Physics.raycast` tagger or a
 `Physics.events` message it runs POST-step, and its reads see the current
 frame's world.
 
-Two real constraints:
+Three rules follow from that one:
 
-- **Never read inside the `physics` hook.** It is not merely stale — it is a
-  DEADLOCK. The read raises before the hook returns its scene, so the world
-  is never declared, so the body never exists, so the read raises again:
-  every frame, forever — and it takes `draw`'s `Physics.transformed` down
-  with it. The hook is a pure DECLARATION of the world; derive positions
-  from the model instead.
-- **The first frame**, for the pre-step readers: nothing has stepped yet, so
-  the read is a spanned error — `` no body tagged "ball" in the physics world
-  (bodies exist after the frame's `physics` declaration has been reconciled
-  and stepped) ``. Unlike the hook case this is self-correcting: it is logged
-  as a `<hook> error` (`tick error`, `draw error`, …), that hook's call is
-  skipped, and every later frame reads fine. Guard it (a `started` flag, or a
-  `Sub`/`update` gate) or do that particular read in `draw`.
+- **The `physics` hook is a pre-step reader like any other.** Reading inside
+  it is allowed and answers with the LAST stepped world — the same pose `tick`
+  saw that frame. (It used to be a DEADLOCK: the read raised, so the world was
+  never declared, so it raised again, forever. It no longer is.) The hook is
+  still a DECLARATION, so keep it cheap; a read there is for deriving one
+  body's declared pose from another's.
+- **The first frame is primed, so it reads.** Before the first frame the
+  runtime evaluates the hook once on `init` and reconciles it with ZERO steps,
+  so frame 1's `tick`/hook reads answer with the initial declared poses. A
+  `started: bool` guard is no longer needed — `examples/terrain` and
+  `examples/physics-controller` deleted theirs. Two footnotes: priming re-runs
+  at a RESTART but not at a hot reload (there the world survives with the
+  model), and inside the prime evaluation itself — the one call with no stepped
+  world behind it — a body read answers the identity pose (origin, zero
+  velocity) instead of raising.
+- **A hook error degrades, loudly.** An error inside the hook (or a
+  non-`Physics.scene` return) keeps the previous frame's declaration, keeps
+  stepping the world, and reports the teaching error ONCE — the hot-reload
+  broken-edit discipline. An unknown tag is still a spanned error everywhere
+  else: `` no body tagged "ball" in the physics world ``.
 
 The physics world survives hot reload (like the model); deleting the
 `physics` hook drops it. Gotcha: `--fixed-time T` pins the clock with

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -167,8 +167,15 @@ engine one-for-one); an F# surface would need that data-crossing `DrawContext`
 plumbing and is deferred indefinitely.
 
 Because these are direct reads and not a `draw`-only view, they are valid in
-**any** entry point. In `tick` they answer against the previous step (physics
-runs after `tick`); in `draw`, against this frame's. Alongside `position` the
+**any** entry point — the `physics` hook included. One rule covers all of
+them: **a physics read answers with the LAST stepped world**. Everything that
+runs before this frame's step — `tick`, `input`, a pre-step `update`, and the
+`physics` hook itself — sees the previous step; only `draw` (and the post-step
+`update`s driven by a `Physics.raycast` tagger or a `Physics.events` message)
+sees the world this frame just stepped. That one step of read latency is
+inherent to read → decide → step.
+
+Alongside `position` the
 same class provides `Physics.linearVelocity(tag)` and the synchronous ray
 queries `Physics.cast` / `Physics.castExcluding` — together the
 read-decide-write triple a character controller needs, all inside one frame:
@@ -181,6 +188,45 @@ Read semantics worth knowing: physics reads of a missing tag are **loud
 spanned errors** — games read only tags their `physics` hook declares. (An
 Option-shaped variant return is possible now that Functor Lang has `match`; loud
 remains the default because a missing declared body is a bug, not a case.)
+
+### Cold start: the world is primed from `init`
+
+At session start — and at every model reset (restart), but **not** on hot
+reload, where the world survives with the model — the runtime evaluates the
+`physics` hook once on the INITIAL model and reconciles that declaration with
+**zero simulation steps**. So frame 1's pre-step readers (`tick`, and the hook
+itself) answer with the initial declared poses instead of raising against a
+world nothing has declared yet. This is what games used to hand-roll as a
+`started: bool` first-frame guard; those guards are now dead weight
+(`examples/terrain` and `examples/physics-controller` lost theirs).
+
+The prime is the ONE hook evaluation with no stepped world behind it, so it has
+its own small rule: **inside the prime, a body read answers the identity pose**
+(the origin, zero velocity) rather than raising — a hook that derives one
+body's declaration from another's pose can therefore bootstrap, at the cost of
+that derived body sitting at its identity pose for the single primed
+declaration. From frame 1 on, reads answer the real world and an unknown tag
+(a typo, an undeclared body) raises exactly as it always did.
+
+Priming is deterministic — a pure function of `init` — and it lands *before*
+the timeline records anything, so the frame-0 keyframe already contains the
+primed world: rewind, seek, and replay reproduce it byte-identically, with **no
+new entry in the recording format** (`physics/driver.rs`'s
+`SteppedPhysics::prime`).
+
+### When the hook errors: degrade, don't wedge
+
+An error raised inside the `physics` hook (or a return value that is not a
+`Physics.scene`) used to stop reconciliation permanently: zero steps, so the
+declaration was never reconciled, so the next frame's read raised the same way
+— forever, taking `draw`'s `Physics.transformed` down with it.
+
+Now the frame **degrades**: the world KEEPS the previous frame's declaration
+and keeps stepping (the frame records no `DeclareScene`, which replays exactly
+as it ran), and the teaching error is surfaced ONCE — the same discipline as
+hot reload's broken edit, which keeps the old program running. A hook that is
+broken from the very first evaluation has no previous declaration to keep, so
+its world stays empty; it is still loud, and the rest of the game still runs.
 
 Capture gotcha: `--fixed-time` pins the clock with `dts = 0`, so physics never
 steps under it — a physics golden captures a *settled* scene via plain
@@ -647,6 +693,8 @@ resume still **branches** (`TimelineLog::truncate_from` discards the old
 future). History is bounded (~15s at 60Hz, pruned each frame); rewind clamps
 to it. Frame 0's pre-step state is the empty world, so the rewind floor is
 frame 1 (the world's first stepped state) — reads never hit an empty world.
+(Frame 0's keyframe is snapshotted after the cold-start prime, so it is the
+*primed* world, not an empty one; priming adds no `Command` of its own.)
 
 ## Debug visualization (wireframes via Rapier's debug renderer)
 

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -203,10 +203,23 @@ world nothing has declared yet. This is what games used to hand-roll as a
 The prime is the ONE hook evaluation with no stepped world behind it, so it has
 its own small rule: **inside the prime, a body read answers the identity pose**
 (the origin, zero velocity) rather than raising — a hook that derives one
-body's declaration from another's pose can therefore bootstrap, at the cost of
-that derived body sitting at its identity pose for the single primed
-declaration. From frame 1 on, reads answer the real world and an unknown tag
-(a typo, an undeclared body) raises exactly as it always did.
+body's declaration from another's pose can therefore bootstrap. The hook is
+then evaluated a SECOND time, outside that rule, so a derived pose is declared
+at its real value before the first frame (otherwise it would be primed at the
+origin and jump on frame 1, which the divergence rule would turn into a
+teleport). Both passes are declaration-only and neither reports: a hook broken
+at startup surfaces on frame 1 through the degraded path below. From frame 1 on
+reads answer the real world, and an unknown tag (a typo, an undeclared body)
+raises exactly as it always did.
+
+⚠️ **Priming answers body reads, not ray queries.** `Physics.position` /
+`linearVelocity` / `transformed` read the primed poses on frame 1, but rapier's
+broad phase ingests colliders **at the step**, so `Physics.cast` /
+`castExcluding` still report a miss until the first substep has run — a
+grounding probe therefore answers from frame 2. That is one frame of "not
+grounded" at spawn, which is what a character in the air reads anyway; forcing
+a broad-phase update outside the pipeline would risk the determinism the
+Timeline depends on, so priming deliberately does not.
 
 Priming is deterministic — a pure function of `init` — and it lands *before*
 the timeline records anything, so the frame-0 keyframe already contains the

--- a/examples/physics-controller/control.fun
+++ b/examples/physics-controller/control.fun
@@ -29,9 +29,6 @@ let landHardness = 6.0
 // The controller's own state. Everything here is plain data, so it snapshots,
 // hot-reloads, and time-travels with the rest of the model.
 type Ctl = {
-  // Gate for the first frame: the physics reads raise before the `physics`
-  // hook's declaration has been reconciled and stepped.
-  started: bool,
   // Grounded as of the last observation.
   grounded: bool,
   // Seconds of jump grace remaining after leaving the ground.
@@ -50,7 +47,6 @@ type Ctl = {
 }
 
 let zero: Ctl = {
-  started: false,
   grounded: false,
   coyote: 0.0,
   buffer: 0.0,
@@ -61,10 +57,8 @@ let zero: Ctl = {
   wishZ: 0.0,
 }
 
-// Clear the transient feel state after a respawn, but KEEP `started` — that is
-// the "the physics world has been reconciled" gate, not controller state, and
-// clearing it would make the character free-fall one uncommanded frame. The
-// steering wish is kept too: it belongs to the keys currently held down.
+// Clear the transient feel state after a respawn. The steering wish is kept:
+// it belongs to the keys currently held down.
 let respawned = (c) =>
   { c with grounded: false, coyote: 0.0, buffer: 0.0, squash: 0.0, lock: 0.0, landImpact: 0.0 }
 

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -157,71 +157,67 @@ let surfaceVelocity = (probe) =>
 
 let tick = (model, dt, tts) =>
   let m = { model with clock: model.clock + dt, frame: model.frame + 1.0 } in
-  // The pre-step physics reads raise on the very first frame: the `physics`
-  // hook's declaration has not been reconciled and stepped yet.
-  if not m.ctl.started then { m with ctl: { m.ctl with started: true } }
-  else
-    let pos = Physics.position(playerTag) in
-    let vel = Physics.linearVelocity(playerTag) in
-    let probe = groundProbe(pos) in
-    // The observation handed to the pure controller. It needs no probe
-    // distance and no rest height: the controller never writes the vertical
-    // axis, so it has no standing height to hold. `vy` is here only so a
-    // landing's impact can scale the squash.
-    let obs = {
-      grounded: probe.hit,
-      vx: vel.x, vy: vel.y, vz: vel.z,
+  let pos = Physics.position(playerTag) in
+  let vel = Physics.linearVelocity(playerTag) in
+  let probe = groundProbe(pos) in
+  // The observation handed to the pure controller. It needs no probe
+  // distance and no rest height: the controller never writes the vertical
+  // axis, so it has no standing height to hold. `vy` is here only so a
+  // landing's impact can scale the squash.
+  let obs = {
+    grounded: probe.hit,
+    vx: vel.x, vy: vel.y, vz: vel.z,
+  } in
+  let carry = surfaceVelocity(probe) in
+  let sensed = Control.sense(dt, obs, m.jumpEdge, m.ctl) in
+  let want = Control.desiredVelocity(dt, obs, carry, sensed) in
+  let ctl = if Control.jumpNow(sensed) then Control.consumeJump(sensed) else sensed in
+  let next =
+    { m with
+      ctl: ctl,
+      jumpEdge: false,
+      onDeck: probe.hit && probe.tag == deckTag,
+      carryX: carry.x,
     } in
-    let carry = surfaceVelocity(probe) in
-    let sensed = Control.sense(dt, obs, m.jumpEdge, m.ctl) in
-    let want = Control.desiredVelocity(dt, obs, carry, sensed) in
-    let ctl = if Control.jumpNow(sensed) then Control.consumeJump(sensed) else sensed in
-    let next =
-      { m with
-        ctl: ctl,
-        jumpEdge: false,
-        onDeck: probe.hit && probe.tag == deckTag,
-        carryX: carry.x,
-      } in
-    // Respawn — either because the character fell out of the world, or because
-    // ENTER asked for one. Both go through `tick`, and both return `respawn`
-    // INSTEAD of this frame's velocity command, never alongside it: commands
-    // apply in queue order, so a `setVelocity` issued after the respawn's would
-    // win and hand the body back its pre-teleport fall speed.
-    //
-    // The body is put back with a command rather than by re-declaring its
-    // spawn: a changed declaration would teleport it, but then every later
-    // frame's declaration would be a change back again.
-    let fellOut = pos.y < World.voidY in
-    if fellOut || m.respawnPending then
-      ({ next with
-         falls: if fellOut then next.falls + 1.0 else next.falls,
-         respawnPending: false,
-         ctl: Control.respawned(next.ctl) },
-       respawn)
-    else
-      // Built lazily: under the default `traceOn = false` the record — and the
-      // `Math.cos` inside `World.deckVx` — is never constructed, because `if`
-      // only evaluates the branch it takes. (The closure itself is still
-      // allocated each frame; only its body is skipped.)
-      let row = () => {
-        f: next.frame,
-        x: pos.x, y: pos.y, z: pos.z, vy: vel.y,
-        g: obs.grounded, deck: next.onDeck,
-        carry: carry.x, deckVx: World.deckVx(m.clock),
-        coy: ctl.coyote, sq: ctl.squash, impact: ctl.landImpact,
-      } in
-      // Steer the horizontal plane and leave the vertical axis to the solver,
-      // which owns the ground contact, the landing impulse, and gravity. The
-      // ONLY frame that writes vy is the one a jump fires on — `Control.
-      // verticalCommand` is `Some` exactly then, and its expects pin that.
-      // The two writes touch disjoint axes, so the pair applies as one
-      // whole-vector write without either clobbering the other.
-      let steer = Physics.setVelocityXZ(playerTag, want.x, want.z) in
-      (trace(row, next),
-       match Control.verticalCommand(carry, sensed) with
-       | Option.Some(vy) => Effect.batch([steer, Physics.setVelocityY(playerTag, vy)])
-       | Option.None => steer)
+  // Respawn — either because the character fell out of the world, or because
+  // ENTER asked for one. Both go through `tick`, and both return `respawn`
+  // INSTEAD of this frame's velocity command, never alongside it: commands
+  // apply in queue order, so a `setVelocity` issued after the respawn's would
+  // win and hand the body back its pre-teleport fall speed.
+  //
+  // The body is put back with a command rather than by re-declaring its
+  // spawn: a changed declaration would teleport it, but then every later
+  // frame's declaration would be a change back again.
+  let fellOut = pos.y < World.voidY in
+  if fellOut || m.respawnPending then
+    ({ next with
+       falls: if fellOut then next.falls + 1.0 else next.falls,
+       respawnPending: false,
+       ctl: Control.respawned(next.ctl) },
+     respawn)
+  else
+    // Built lazily: under the default `traceOn = false` the record — and the
+    // `Math.cos` inside `World.deckVx` — is never constructed, because `if`
+    // only evaluates the branch it takes. (The closure itself is still
+    // allocated each frame; only its body is skipped.)
+    let row = () => {
+      f: next.frame,
+      x: pos.x, y: pos.y, z: pos.z, vy: vel.y,
+      g: obs.grounded, deck: next.onDeck,
+      carry: carry.x, deckVx: World.deckVx(m.clock),
+      coy: ctl.coyote, sq: ctl.squash, impact: ctl.landImpact,
+    } in
+    // Steer the horizontal plane and leave the vertical axis to the solver,
+    // which owns the ground contact, the landing impulse, and gravity. The
+    // ONLY frame that writes vy is the one a jump fires on — `Control.
+    // verticalCommand` is `Some` exactly then, and its expects pin that.
+    // The two writes touch disjoint axes, so the pair applies as one
+    // whole-vector write without either clobbering the other.
+    let steer = Physics.setVelocityXZ(playerTag, want.x, want.z) in
+    (trace(row, next),
+     match Control.verticalCommand(carry, sensed) with
+     | Option.Some(vy) => Effect.batch([steer, Physics.setVelocityY(playerTag, vy)])
+     | Option.None => steer)
 
 let input = (model, key, isDown) =>
   match key with

--- a/examples/terrain/game.fun
+++ b/examples/terrain/game.fun
@@ -74,9 +74,6 @@ let init = {
   lastMouse: NoMouse,
   eye: { x: 0.0 - 650.0, y: 192.0, z: 0.0 - 1200.0 },
   grounded: false,
-  // The pre-step physics reads raise on the very first frame: the `physics`
-  // hook's declaration has not been reconciled and stepped yet.
-  started: false,
   balls: [],
   nextBall: 0.0,
 }
@@ -158,8 +155,6 @@ let groundProbe = (pos) =>
 // read -> decide -> write, all in one frame. The reads see the previous step
 // (physics runs after `tick`) and the command applies at the next one.
 let tick = (model, dt, tts) =>
-  if not model.started then { model with started: true }
-  else
   let pos = Physics.position(walkerTag) in
   let probe = groundProbe(pos) in
   let forward = axis(model.held.down, model.held.up) in

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -10,19 +10,24 @@
 //! its declared position or rotation drives that field — a dynamic or fixed
 //! body teleports immediately, and a kinematic body takes the new pose as its
 //! next-step target, so it carries velocity into contacts. Reading a tag that
-//! is not in the live world — never declared, or declared but not yet
-//! reconciled and stepped — is a runtime error rather than an empty answer, so
-//! read only bodies your hook has already declared. Like the model, the world
-//! survives hot reload for as long as the hook does; deleting the hook drops
-//! it.
+//! is not in the live world is a runtime error rather than an empty answer, so
+//! read only bodies your hook has declared. Like the model, the world survives
+//! hot reload for as long as the hook does; deleting the hook drops it. An
+//! error raised inside the hook does NOT stop the world: the previous frame's
+//! declaration is kept and stepped, and the error is reported once.
 //!
 //! Reads are SYNCHRONOUS and writes are QUEUED. `Physics.position`,
-//! `Physics.linearVelocity`, and `Physics.cast` answer in place from the last
-//! stepped world, while every mutation returns an `Effect.t` that applies at
-//! the next physics step after it queues — after reconcile, on that step's
-//! first substep. A command issued from `tick` therefore normally lands in
-//! time for the same frame's `draw`; on a frame that takes no substep at all
-//! (normal above 60fps) it waits for the next simulated frame.
+//! `Physics.linearVelocity`, and `Physics.cast` answer in place from the LAST
+//! STEPPED world — in any entry point, the `physics` hook included. Everything
+//! that runs before the step (`tick`, `input`, a pre-step `update`, the hook)
+//! sees the previous step; only `draw` and the post-step `update`s see the
+//! world this frame just stepped. The world is primed from `init` before the
+//! first frame, so frame 1's reads answer with the initial declared poses.
+//! Every mutation instead returns an `Effect.t` that applies at the next
+//! physics step after it queues — after reconcile, on that step's first
+//! substep. A command issued from `tick` therefore normally lands in time for
+//! the same frame's `draw`; on a frame that takes no substep at all (normal
+//! above 60fps) it waits for the next simulated frame.
 
 /// An opaque collision shape.
 type shape
@@ -126,6 +131,9 @@ let upright : (body) => body
 let scene : (Vec3.t, List<body>) => world
 
 /// Read a body's live, stepped world position.
+///
+/// Answers with the LAST stepped world, so a pre-step caller (`tick`, the
+/// `physics` hook) sees the previous step and `draw` sees this frame's.
 let position : (tag) => position
 
 /// Read a body's live, stepped linear velocity.

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -366,6 +366,10 @@ impl FunctorLangEmbeddedGame {
         };
         // Cold start (docs/physics.md): declare the initial world before the
         // first frame, so frame 1's physics reads answer instead of raising.
+        // The world is a thread-local, so drop whatever an earlier producer on
+        // this thread left behind first — otherwise a same-tag body from the
+        // previous session would answer this session's priming reads.
+        physics::remove_world(physics::DEFAULT_WORLD);
         game.ctx().prime_physics();
         Ok(game)
     }
@@ -413,9 +417,17 @@ impl FunctorLangEmbeddedGame {
         self.has_mouse_wheel = loaded.has_mouse_wheel;
         self.has_mouse_button = loaded.has_mouse_button;
         self.has_subscriptions = loaded.has_subscriptions;
+        let had_physics = self.has_physics;
         self.has_physics = loaded.has_physics;
         if !self.has_physics {
             physics::remove_world(physics::DEFAULT_WORLD);
+        } else if !had_physics {
+            // The edit ADDED the hook: there is no surviving world to keep, so
+            // this reload is a cold start for physics and must prime like one
+            // (docs/physics.md). Without it the very next frame's reads face an
+            // empty world — the cold-start hole this PR closes, reopened by the
+            // most common way to reach it.
+            self.ctx().prime_physics();
         }
         self.has_soundscape = loaded.has_soundscape;
         if !self.has_soundscape {

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -320,7 +320,7 @@ impl FunctorLangEmbeddedGame {
         journal_arm();
         let source_hashes = inspector_sources(&loaded.sources);
         let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
-        Ok(FunctorLangEmbeddedGame {
+        let mut game = FunctorLangEmbeddedGame {
             reporter: Reporter::new(SpanSource::Project(loaded.sources), report_to_log),
             last_frame_journal: Vec::new(),
             journal_ring: std::collections::VecDeque::new(),
@@ -363,7 +363,11 @@ impl FunctorLangEmbeddedGame {
             webview_handlers: Vec::new(),
             last_frame: empty_frame(),
             platform,
-        })
+        };
+        // Cold start (docs/physics.md): declare the initial world before the
+        // first frame, so frame 1's physics reads answer instead of raising.
+        game.ctx().prime_physics();
+        Ok(game)
     }
 
     /// Swap in a freshly loaded program, KEEPING THE MODEL — the desktop
@@ -523,6 +527,10 @@ impl FunctorLangEmbeddedGame {
         self.input_buf.clear();
         self.last_frame = empty_frame();
         self.reporter.reset();
+        // A reset is a cold start: the model is `init` again and the world was
+        // removed, so re-prime it (a hot reload deliberately does NOT — there
+        // the world, like the model, survives).
+        self.ctx().prime_physics();
         self.platform.on_reload();
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5368,19 +5368,55 @@ Fog.linear(near, far, color) or Fog.exp(density, color)"
     }
 }
 
+thread_local! {
+    /// Set only while the producer evaluates the `physics` hook to PRIME the
+    /// world (docs/physics.md, "Cold start"). See [`PrimingScope`].
+    static PRIMING: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// RAII scope marking the COLD prime evaluation of the `physics` hook — the
+/// one call with no stepped world behind it, because nothing has ever been
+/// declared. Inside it a body read answers the IDENTITY pose (the origin, zero
+/// velocity) instead of raising, so a hook that derives one body's declaration
+/// from another's pose can bootstrap. Every later evaluation (frame 1 onward)
+/// reads the real world, where a genuinely unknown tag raises exactly as
+/// before — including a tag misspelled here, one frame later.
+pub struct PrimingScope;
+
+impl PrimingScope {
+    pub fn enter() -> PrimingScope {
+        PRIMING.with(|p| p.set(true));
+        PrimingScope
+    }
+}
+
+impl Drop for PrimingScope {
+    fn drop(&mut self) {
+        PRIMING.with(|p| p.set(false));
+    }
+}
+
 /// Live pose of a body in the ACTIVE world (normally the singleton world the
 /// shell steps — same process, same crate statics as this prelude; under a
 /// dry-run forward-step scope, the throwaway projected world, so ghost draws
 /// read the stepped poses — docs/time-travel.md T6b).
 fn live_transform(tag: &str) -> Option<([f32; 3], [f32; 4])> {
-    physics::with_world(physics::active_world(), |w| w.body_transform(tag)).flatten()
+    physics::with_world(physics::active_world(), |w| w.body_transform(tag))
+        .flatten()
+        .or_else(|| {
+            PRIMING
+                .with(|p| p.get())
+                .then(|| ([0.0; 3], [0.0, 0.0, 0.0, 1.0]))
+        })
 }
 
 /// Live linear velocity of a body in the ACTIVE world — the read counterpart
 /// of `Physics.setVelocity`, on the same world-scope rules as
 /// [`live_transform`].
 fn live_velocity(tag: &str) -> Option<[f32; 3]> {
-    physics::with_world(physics::active_world(), |w| w.body_velocity(tag)).flatten()
+    physics::with_world(physics::active_world(), |w| w.body_velocity(tag))
+        .flatten()
+        .or_else(|| PRIMING.with(|p| p.get()).then_some([0.0; 3]))
 }
 
 /// A synchronous ray query against the ACTIVE world, shared by `Physics.cast`

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5385,6 +5385,12 @@ pub struct PrimingScope;
 
 impl PrimingScope {
     pub fn enter() -> PrimingScope {
+        // Set/clear rather than save/restore: priming is a single, top-level
+        // producer call that never nests (the hook cannot prime the world).
+        debug_assert!(
+            !PRIMING.with(|p| p.get()),
+            "PrimingScope does not nest — it clears the flag on drop"
+        );
         PRIMING.with(|p| p.set(true));
         PrimingScope
     }
@@ -5465,8 +5471,9 @@ fn sync_cast(
 
 fn no_body(tag: &str) -> String {
     format!(
-        "no body tagged \"{tag}\" in the physics world (bodies exist after the \
-         frame's `physics` declaration has been reconciled and stepped)"
+        "no body tagged \"{tag}\" in the physics world (bodies exist once the \
+         `physics` hook has declared them — the world is declared from `init` \
+         before the first frame, so this is a tag your hook never declares)"
     )
 }
 

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -36,7 +36,7 @@ use crate::functor_lang_prelude::{
     perform_deferred_queries, physics_event_taggers, physics_scene_value, split_model_effect,
     sub_messages_for_frame, take_audio_completion, take_http_tagger, take_preload_completion,
     take_ui_handlers, DryRunEffects, EffectLog, EffectRunner, EffectTree, FunctorHost,
-    NetEventKind, UiHandler,
+    NetEventKind, PrimingScope, UiHandler,
 };
 use crate::input::RecordedInput;
 use crate::net::{push_conn_command, ConnCommand, HttpResult};
@@ -1290,14 +1290,22 @@ to receive their messages; dropping them",
     /// fixed substeps. Runs after `tick` so declarations come from the settled
     /// model, and before `render` so `Physics.position`/`Physics.transformed`
     /// in `draw` read the just-stepped world. Returns the number of fixed
-    /// substeps taken (0 when there is no `physics` hook, the hook errored, or
-    /// the accumulator hasn't reached a full step yet).
+    /// substeps taken (0 when there is no `physics` hook or the accumulator
+    /// hasn't reached a full step yet).
+    ///
+    /// A hook that ERRORS (or returns something that is not a `Physics.scene`)
+    /// DEGRADES rather than wedging the game: the world keeps the previous
+    /// frame's declaration and keeps stepping, and the teaching error is
+    /// surfaced once — the same discipline as hot-reload's broken edit, which
+    /// keeps the old program running. Wedging is the alternative this replaces:
+    /// zero steps means the declaration is never reconciled, so every later
+    /// read raises too, forever.
     fn step_physics(&mut self, dts: f32) -> u32 {
         if !self.has_physics {
             return 0;
         }
         let args = vec![self.model.clone()];
-        match self
+        let degraded = match self
             .session
             .call(self.names.physics, args, &mut FunctorHost)
         {
@@ -1306,19 +1314,66 @@ to receive their messages; dropping them",
                     // The recorded drive (Phase 6): every fixed frame goes
                     // through the Timeline, so pause/rewind/replay work.
                     let advanced = self.physics_rt.advance(scene, dts);
-                    *self.pending_events = advanced.events;
-                    *self.physics_frame = advanced.frame;
-                    let steps = advanced.steps;
-                    let warnings = advanced.warnings;
-                    // Command effects apply asynchronously (queued at perform
-                    // time, applied at the step), so their problems — unknown
-                    // tag, queue overflow — surface here, deduped.
-                    for warning in warnings {
-                        self.reporter
-                            .report_once(format!("[functor-lang] {warning}"));
-                    }
-                    return steps;
+                    return self.absorb_advance(advanced);
                 }
+                None => format!(
+                    "[functor-lang] physics must return Physics.scene(gravity, [body, …]), got {}",
+                    value.kind_name()
+                ),
+            },
+            Err(err) => self.reporter.render_frame_error(self.names.physics, &err),
+        };
+        self.reporter.report_once(format!(
+            "{degraded} — keeping the previous frame's declared world and stepping it. \
+The `physics` hook is a pure DECLARATION; physics reads inside it answer with the \
+LAST stepped world, so a read of a tag this hook has never declared still raises."
+        ));
+        let advanced = self.physics_rt.advance_undeclared(dts);
+        self.absorb_advance(advanced)
+    }
+
+    /// Take one [`physics::Advanced`]'s outputs into per-frame state, returning
+    /// the substeps simulated. Command effects apply asynchronously (queued at
+    /// perform time, applied at the step), so their problems — unknown tag,
+    /// queue overflow — surface here, deduped.
+    fn absorb_advance(&mut self, advanced: physics::Advanced) -> u32 {
+        *self.pending_events = advanced.events;
+        *self.physics_frame = advanced.frame;
+        for warning in advanced.warnings {
+            self.reporter
+                .report_once(format!("[functor-lang] {warning}"));
+        }
+        advanced.steps
+    }
+
+    /// Prime the world from the INITIAL model — once, at session start and at
+    /// every model reset (restart), never on hot reload (where the world, like
+    /// the model, survives). The `physics` hook is evaluated on the current
+    /// model and its declaration reconciled with ZERO simulation steps, so the
+    /// first frame's `tick` / hook reads answer with the initial declared poses
+    /// instead of raising against a world nothing has declared yet.
+    ///
+    /// This is the ONE hook evaluation with no stepped world behind it, so it
+    /// runs under a [`PrimingScope`]: a body read answers the identity pose
+    /// rather than raising, letting a hook that derives one body's declaration
+    /// from another's pose bootstrap. From frame 1 on, reads answer the real
+    /// world and an unknown tag raises as it always did.
+    ///
+    /// Deterministic: priming is a pure function of `init`, and it lands before
+    /// the timeline's frame-0 keyframe is taken, so replays and rewinds
+    /// reproduce it byte-identically with no change to the recording format.
+    pub fn prime_physics(&mut self) {
+        if !self.has_physics {
+            return;
+        }
+        let args = vec![self.model.clone()];
+        let _priming = PrimingScope::enter();
+        match self
+            .session
+            .call(self.names.physics, args, &mut FunctorHost)
+        {
+            Ok(value) => match physics_scene_value(&value) {
+                Some(scene) => self.physics_rt.prime(scene),
                 None => self.reporter.report_once(format!(
                     "[functor-lang] physics must return Physics.scene(gravity, [body, …]), got {}",
                     value.kind_name()
@@ -1326,7 +1381,6 @@ to receive their messages; dropping them",
             },
             Err(err) => self.reporter.frame_error(self.names.physics, &err),
         }
-        0
     }
 
     /// Close every connection this producer still has open (a reload that
@@ -2980,6 +3034,319 @@ mod tests {
         assert!(
             journal_swap().is_none(),
             "journaling must stay off until explicitly armed"
+        );
+    }
+
+    // ---- The `physics` hook: degradation, read timing, primed cold start ----
+    //
+    // The three rules of docs/physics.md's "Reading inside the hook" section,
+    // driven headlessly through the same `FrameCtx` the shells use.
+
+    /// The reporter sink for the physics-hook tests: `Reporter::emit` is a
+    /// plain `fn(&str)`, so collect into a thread-local (each test thread has
+    /// its own — as it does its own physics world).
+    thread_local! {
+        static PHYSICS_REPORTS: std::cell::RefCell<Vec<String>> =
+            const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    fn collect_emit(message: &str) {
+        PHYSICS_REPORTS.with(|r| r.borrow_mut().push(message.to_string()));
+    }
+
+    /// A game driven one fixed frame at a time through the real frame body,
+    /// with a physics hook and a collecting reporter.
+    struct PhysicsHarness {
+        session: Session,
+        model: Value,
+        physics_rt: SteppedPhysics,
+        physics_frame: u64,
+        recorder: SceneRecorder,
+        effect_runner: crate::functor_lang_prelude::FakeEffects,
+        effect_log: EffectLog,
+        deferred_queries: Vec<EffectTree>,
+        pending_events: Vec<PhysicsEvent>,
+        live_conn_keys: HashSet<String>,
+        prev_tts: Option<f64>,
+        input_buf: Vec<RecordedInput>,
+        delivered_asset_progress: Option<AssetProgress>,
+        reporter: Reporter,
+        tts: f32,
+    }
+
+    impl PhysicsHarness {
+        fn new(src: &str) -> PhysicsHarness {
+            physics::remove_world(physics::DEFAULT_WORLD);
+            PHYSICS_REPORTS.with(|r| r.borrow_mut().clear());
+            let project = functor_lang::project::load_single_source("game", src)
+                .unwrap_or_else(|e| panic!("load: {}", e.render()));
+            let session = Session::load(&project.module, &mut FunctorHost)
+                .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+            let model = session.global("init").expect("init");
+            PhysicsHarness {
+                session,
+                model,
+                physics_rt: SteppedPhysics::new(),
+                physics_frame: 0,
+                recorder: SceneRecorder::new(),
+                effect_runner: crate::functor_lang_prelude::FakeEffects::new(0.0, vec![0.0]),
+                effect_log: EffectLog::new(),
+                deferred_queries: Vec::new(),
+                pending_events: Vec::new(),
+                live_conn_keys: HashSet::new(),
+                prev_tts: None,
+                input_buf: Vec::new(),
+                delivered_asset_progress: None,
+                reporter: Reporter::new(
+                    SpanSource::Single {
+                        src: src.to_string(),
+                        path: "game.fun".to_string(),
+                    },
+                    collect_emit,
+                ),
+                tts: 0.0,
+            }
+        }
+
+        fn ctx(&mut self) -> FrameCtx<'_> {
+            FrameCtx {
+                session: &self.session,
+                names: &EntryNames::UNPREFIXED,
+                model: &mut self.model,
+                physics_rt: &mut self.physics_rt,
+                physics_frame: &mut self.physics_frame,
+                recorder: &mut self.recorder,
+                effect_runner: &mut self.effect_runner as &mut dyn EffectRunner,
+                effect_log: &mut self.effect_log,
+                deferred_queries: &mut self.deferred_queries,
+                pending_events: &mut self.pending_events,
+                live_conn_keys: &mut self.live_conn_keys,
+                prev_tts: &mut self.prev_tts,
+                input_buf: &mut self.input_buf,
+                has_physics: true,
+                has_subscriptions: false,
+                asset_progress: None,
+                delivered_asset_progress: &mut self.delivered_asset_progress,
+                suppress_outbound: false,
+                reporter: &mut self.reporter,
+            }
+        }
+
+        /// One rendered frame at exactly one fixed substep.
+        fn frame(&mut self) {
+            self.tts += physics::FIXED_DT;
+            let frame_time = FrameTime {
+                dts: physics::FIXED_DT,
+                tts: self.tts,
+            };
+            self.ctx().run_frame(frame_time, None);
+        }
+
+        /// A body's live world-space height, `None` when no such body exists.
+        fn height(&self, tag: &str) -> Option<f32> {
+            physics::with_world(physics::DEFAULT_WORLD, |w| {
+                w.body_transform(tag).map(|(pos, _)| pos[1])
+            })
+            .flatten()
+        }
+
+        fn reports() -> Vec<String> {
+            PHYSICS_REPORTS.with(|r| r.borrow().clone())
+        }
+    }
+
+    /// A ball falling in vacuum, plus:
+    ///
+    /// * `probe` — a body the HOOK parks at whatever height its own
+    ///   `Physics.position(ballTag)` read answered, so the probe's height after
+    ///   frame N is exactly what the in-hook read saw on frame N;
+    /// * `seen` in the model — what a `tick` read answered, so the same rule
+    ///   can be checked from the pre-step side.
+    ///
+    /// Both reads are UNGUARDED — this is the program shape that used to wedge
+    /// the runtime forever (the hook's read raised, so nothing was ever
+    /// declared, so it raised again).
+    const HOOK_READ_SRC: &str = "\
+        let ballTag = Physics.tag(\"ball\")\n\
+        let probeTag = Physics.tag(\"probe\")\n\
+        let init = { n: 0.0, seen: 0.0 }\n\
+        let tick = (m, dt, tts) =>\n\
+        \x20 { n: m.n + 1.0, seen: Physics.position(ballTag).y }\n\
+        let physics = (m) =>\n\
+        \x20 Physics.scene(Vec3.make(0.0, 0.0 - 10.0, 0.0),\n\
+        \x20   [ Physics.dynamic(ballTag, Physics.sphere(0.5))\n\
+        \x20       |> Physics.at(Vec3.make(0.0, 10.0, 0.0)),\n\
+        \x20     Physics.fixed(probeTag, Physics.box(0.2, 0.2, 0.2))\n\
+        \x20       |> Physics.at(Vec3.make(0.0, Physics.position(ballTag).y, 0.0)) ])\n\
+        let draw = (m, tts) =>\n\
+        \x20 Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 0.0 - 5.0),\n\
+        \x20                              Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
+
+    /// Cold start: the hook is evaluated once on `init` — declaration only,
+    /// zero simulation steps — so the very first frame's reads (in `tick`, and
+    /// in the hook) answer with the INITIAL DECLARED poses instead of raising.
+    /// This is what the examples' `started` flags used to work around.
+    #[test]
+    fn the_hook_is_primed_at_init_so_the_first_frames_reads_answer() {
+        let mut h = PhysicsHarness::new(HOOK_READ_SRC);
+        h.ctx().prime_physics();
+        // Priming declares, it does not simulate: the ball is exactly where
+        // `init`'s declaration put it and no fixed frame has been recorded.
+        assert_eq!(h.height("ball"), Some(10.0));
+        assert_eq!(h.physics_frame, 0);
+        assert_eq!(h.physics_rt.seekable_range(), None);
+        // The prime evaluation has no stepped world behind it, so its own read
+        // answered the identity pose — the probe sits at the origin for
+        // exactly this one declaration, instead of the hook raising.
+        assert_eq!(h.height("probe"), Some(0.0));
+
+        h.frame();
+        // `tick` ran BEFORE this frame's step, so its read is the primed pose.
+        assert_eq!(field(&h.model, "seen"), 10.0);
+        // …and so is the hook's, which runs after `tick` and before the step.
+        assert_eq!(
+            h.height("probe"),
+            Some(10.0),
+            "frame 1's in-hook read must see the primed initial pose"
+        );
+        assert!(
+            PhysicsHarness::reports().is_empty(),
+            "{:?}",
+            PhysicsHarness::reports()
+        );
+    }
+
+    /// Reads inside the hook are LAST frame's stepped world — the same rule
+    /// `tick` follows, one frame of read latency, no error. Only `draw` sees
+    /// the freshly stepped world.
+    #[test]
+    fn a_read_inside_the_hook_sees_last_frames_world() {
+        let mut h = PhysicsHarness::new(HOOK_READ_SRC);
+        h.ctx().prime_physics();
+        h.frame();
+        let after_first = h.height("ball").expect("ball");
+        assert!(
+            after_first < 10.0,
+            "the ball must have fallen: {after_first}"
+        );
+
+        h.frame();
+        let probe = h.height("probe").expect("probe");
+        assert!(
+            (probe - after_first).abs() < 1e-6,
+            "the hook's read must answer with the previous frame's stepped pose \
+             (probe {probe} vs previous ball {after_first})"
+        );
+        // `tick`, the other pre-step reader, answered the same pose…
+        assert!((field(&h.model, "seen") as f32 - after_first).abs() < 1e-6);
+        // …and the world `draw` reads has already moved on.
+        assert!(h.height("ball").expect("ball") < after_first);
+        assert!(
+            PhysicsHarness::reports().is_empty(),
+            "{:?}",
+            PhysicsHarness::reports()
+        );
+    }
+
+    /// The prime's identity-pose read is scoped to the prime ALONE: a tag the
+    /// hook never declares (a typo) still raises from frame 1 on — loudly,
+    /// once, with the world kept and stepping.
+    #[test]
+    fn an_undeclared_tag_still_raises_after_the_prime() {
+        const SRC: &str = "\
+            let ballTag = Physics.tag(\"ball\")\n\
+            let init = { n: 0.0 }\n\
+            let tick = (m, dt, tts) => { n: m.n + 1.0 }\n\
+            let physics = (m) =>\n\
+            \x20 Physics.scene(Vec3.make(0.0, 0.0 - 10.0, 0.0),\n\
+            \x20   [ Physics.dynamic(ballTag, Physics.sphere(0.5))\n\
+            \x20       |> Physics.at(Vec3.make(0.0, 10.0 + Physics.position(Physics.tag(\"bal\")).y, 0.0)) ])\n\
+            let draw = (m, tts) =>\n\
+            \x20 Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 0.0 - 5.0),\n\
+            \x20                              Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
+        let mut h = PhysicsHarness::new(SRC);
+        h.ctx().prime_physics();
+        assert!(
+            PhysicsHarness::reports().is_empty(),
+            "the prime read answers"
+        );
+        assert_eq!(h.height("ball"), Some(10.0));
+
+        h.frame();
+        h.frame();
+        let reports = PhysicsHarness::reports();
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert!(reports[0].contains("no body tagged \"bal\""), "{reports:?}");
+        // Degraded, not wedged: the primed declaration is kept and stepping.
+        assert!(h.height("ball").expect("ball") < 10.0);
+    }
+
+    /// One number field out of a record model.
+    fn field(model: &Value, name: &str) -> f64 {
+        match model {
+            Value::Record(fields) => match fields.iter().find(|(f, _)| f == name) {
+                Some((_, Value::Number(n))) => *n,
+                _ => panic!("no number field `{name}` in {model}"),
+            },
+            other => panic!("not a record: {other}"),
+        }
+    }
+
+    /// A hook that starts erroring must not wedge the world: the previous
+    /// frame's declaration is kept, the world keeps stepping, and the teaching
+    /// error is surfaced ONCE.
+    #[test]
+    fn a_hook_error_degrades_loudly_instead_of_wedging_the_world() {
+        const SRC: &str = "\
+            let ballTag = Physics.tag(\"ball\")\n\
+            let ghostTag = Physics.tag(\"ghost\")\n\
+            let init = { n: 0.0 }\n\
+            let tick = (m, dt, tts) => { n: m.n + 1.0 }\n\
+            let world = (m) =>\n\
+            \x20 Physics.scene(Vec3.make(0.0, 0.0 - 10.0, 0.0),\n\
+            \x20   [ Physics.dynamic(ballTag, Physics.sphere(0.5))\n\
+            \x20       |> Physics.at(Vec3.make(0.0, 10.0, 0.0)) ])\n\
+            let physics = (m) =>\n\
+            \x20 if m.n > 2.0 then\n\
+            \x20   let boom = Physics.position(ghostTag) in\n\
+            \x20   world(m)\n\
+            \x20 else world(m)\n\
+            let draw = (m, tts) =>\n\
+            \x20 Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 0.0 - 5.0),\n\
+            \x20                              Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
+        let mut h = PhysicsHarness::new(SRC);
+        h.ctx().prime_physics();
+        // Two healthy frames, then the hook starts raising on every call.
+        h.frame();
+        h.frame();
+        assert!(PhysicsHarness::reports().is_empty());
+        let healthy = h.height("ball").expect("ball");
+        let healthy_frame = h.physics_frame;
+
+        let mut last = healthy;
+        for _ in 0..5 {
+            h.frame();
+            let now = h
+                .height("ball")
+                .expect("the world must survive the hook error");
+            assert!(
+                now < last,
+                "the world must keep stepping through a broken hook ({now} vs {last})"
+            );
+            last = now;
+        }
+        assert!(
+            h.physics_frame > healthy_frame + 4,
+            "every frame must still simulate: {} -> {}",
+            healthy_frame,
+            h.physics_frame
+        );
+        let reports = PhysicsHarness::reports();
+        assert_eq!(reports.len(), 1, "the error must surface ONCE: {reports:?}");
+        assert!(reports[0].contains("physics error"), "{reports:?}");
+        assert!(
+            reports[0].contains("keeping the previous frame"),
+            "the error must teach what the runtime did instead: {reports:?}"
         );
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -25,7 +25,7 @@
 //! differently); live input still funnels through [`FrameCtx::absorb`], so the
 //! frame body begins at the scrub-commit and never absorbs live input itself.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use functor_lang::{line_col, project::SourceMap, RunError, Session, Span, Value};
 
@@ -589,6 +589,11 @@ impl SpanSource {
 /// ([`SpanSource`]).
 pub struct Reporter {
     last_error: Option<String>,
+    /// Per-CHANNEL dedupe slots ([`Reporter::report_keyed`]) for a persistent
+    /// condition that co-occurs with other errors — the single `last_error`
+    /// slot only suppresses a repeat of the message that printed LAST, so two
+    /// persistent messages alternating would both re-emit every frame.
+    keyed: HashMap<&'static str, String>,
     source: SpanSource,
     emit: fn(&str),
 }
@@ -597,6 +602,7 @@ impl Reporter {
     pub fn new(source: SpanSource, emit: fn(&str)) -> Reporter {
         Reporter {
             last_error: None,
+            keyed: HashMap::new(),
             source,
             emit,
         }
@@ -607,9 +613,10 @@ impl Reporter {
         self.source = source;
     }
 
-    /// Clear the dedupe slot: a reload starts a fresh error stream.
+    /// Clear the dedupe slots: a reload starts a fresh error stream.
     pub fn reset(&mut self) {
         self.last_error = None;
+        self.keyed.clear();
     }
 
     fn last_error(&self) -> Option<String> {
@@ -622,6 +629,18 @@ impl Reporter {
         if self.last_error.as_deref() != Some(message.as_str()) {
             (self.emit)(&message);
             self.last_error = Some(message);
+        }
+    }
+
+    /// Print a message once per distinct string ON ITS OWN CHANNEL — for a
+    /// persistent condition that co-occurs with other reported errors (the
+    /// degraded `physics` hook, whose broken declaration also provokes
+    /// per-frame command warnings). Sharing the single `report_once` slot would
+    /// make the two alternate and re-emit at 60 Hz.
+    pub fn report_keyed(&mut self, channel: &'static str, message: String) {
+        if self.keyed.get(channel).map(String::as_str) != Some(message.as_str()) {
+            (self.emit)(&message);
+            self.keyed.insert(channel, message);
         }
     }
 
@@ -1304,32 +1323,60 @@ to receive their messages; dropping them",
         if !self.has_physics {
             return 0;
         }
+        let mut steps = None;
+        let problem = self.with_physics_scene(|ctx, scene| {
+            // The recorded drive (Phase 6): every fixed frame goes through the
+            // Timeline, so pause/rewind/replay work.
+            let advanced = ctx.physics_rt.advance(scene, dts);
+            steps = Some(advanced);
+        });
+        if let Some(advanced) = steps {
+            return self.absorb_advance(advanced);
+        }
+        // Degraded: keep the previous frame's declaration and keep stepping.
+        // Reported on its OWN dedupe channel — `report_once` is a single slot,
+        // and this message co-occurs with the command warnings a broken hook
+        // provokes, which would make the pair alternate every frame.
+        self.reporter.report_keyed(
+            "physics-hook",
+            format!(
+                "{} — keeping the previous frame's declared world and stepping it. \
+The `physics` hook is a pure DECLARATION; physics reads inside it answer with the \
+LAST stepped world, so a read of a tag this hook has never declared still raises.",
+                problem.expect("a frame that did not advance has a problem to report")
+            ),
+        );
+        let advanced = self.physics_rt.advance_undeclared(dts);
+        self.absorb_advance(advanced)
+    }
+
+    /// Evaluate the `physics` hook on the current model and hand its declared
+    /// scene to `f`. Returns `None` when the hook produced one, or the rendered
+    /// problem (a raised error, or a return value that is not a
+    /// `Physics.scene`) when it did not — the CALLER decides how to report it,
+    /// so the live frame and the cold-start prime can differ without the
+    /// teaching text drifting apart.
+    fn with_physics_scene(
+        &mut self,
+        f: impl FnOnce(&mut Self, &physics::PhysicsScene),
+    ) -> Option<String> {
         let args = vec![self.model.clone()];
-        let degraded = match self
+        match self
             .session
             .call(self.names.physics, args, &mut FunctorHost)
         {
             Ok(value) => match physics_scene_value(&value) {
                 Some(scene) => {
-                    // The recorded drive (Phase 6): every fixed frame goes
-                    // through the Timeline, so pause/rewind/replay work.
-                    let advanced = self.physics_rt.advance(scene, dts);
-                    return self.absorb_advance(advanced);
+                    f(self, scene);
+                    None
                 }
-                None => format!(
+                None => Some(format!(
                     "[functor-lang] physics must return Physics.scene(gravity, [body, …]), got {}",
                     value.kind_name()
-                ),
+                )),
             },
-            Err(err) => self.reporter.render_frame_error(self.names.physics, &err),
-        };
-        self.reporter.report_once(format!(
-            "{degraded} — keeping the previous frame's declared world and stepping it. \
-The `physics` hook is a pure DECLARATION; physics reads inside it answer with the \
-LAST stepped world, so a read of a tag this hook has never declared still raises."
-        ));
-        let advanced = self.physics_rt.advance_undeclared(dts);
-        self.absorb_advance(advanced)
+            Err(err) => Some(self.reporter.render_frame_error(self.names.physics, &err)),
+        }
     }
 
     /// Take one [`physics::Advanced`]'s outputs into per-frame state, returning
@@ -1353,11 +1400,19 @@ LAST stepped world, so a read of a tag this hook has never declared still raises
     /// first frame's `tick` / hook reads answer with the initial declared poses
     /// instead of raising against a world nothing has declared yet.
     ///
-    /// This is the ONE hook evaluation with no stepped world behind it, so it
-    /// runs under a [`PrimingScope`]: a body read answers the identity pose
-    /// rather than raising, letting a hook that derives one body's declaration
-    /// from another's pose bootstrap. From frame 1 on, reads answer the real
-    /// world and an unknown tag raises as it always did.
+    /// The hook is evaluated TWICE, both times declaration-only:
+    ///
+    /// 1. under a [`PrimingScope`], where a body read answers the identity pose
+    ///    instead of raising — the only way a hook that derives one body's
+    ///    declaration from another's pose can bootstrap at all;
+    /// 2. normally, now that pass 1's bodies exist, so any derived pose is
+    ///    declared at its REAL value before the first frame. Without this a
+    ///    derived body would be primed at the origin and then jump to its true
+    ///    pose on frame 1 — which the divergence rule turns into a teleport (a
+    ///    kinematic body would carry that jump into contacts as velocity).
+    ///
+    /// Neither pass REPORTS: a hook broken at startup surfaces on frame 1
+    /// through the degraded path, with the full teaching text, exactly once.
     ///
     /// Deterministic: priming is a pure function of `init`, and it lands before
     /// the timeline's frame-0 keyframe is taken, so replays and rewinds
@@ -1366,21 +1421,11 @@ LAST stepped world, so a read of a tag this hook has never declared still raises
         if !self.has_physics {
             return;
         }
-        let args = vec![self.model.clone()];
-        let _priming = PrimingScope::enter();
-        match self
-            .session
-            .call(self.names.physics, args, &mut FunctorHost)
         {
-            Ok(value) => match physics_scene_value(&value) {
-                Some(scene) => self.physics_rt.prime(scene),
-                None => self.reporter.report_once(format!(
-                    "[functor-lang] physics must return Physics.scene(gravity, [body, …]), got {}",
-                    value.kind_name()
-                )),
-            },
-            Err(err) => self.reporter.frame_error(self.names.physics, &err),
+            let _priming = PrimingScope::enter();
+            let _ = self.with_physics_scene(|ctx, scene| ctx.physics_rt.prime(scene));
         }
+        let _ = self.with_physics_scene(|ctx, scene| ctx.physics_rt.prime(scene));
     }
 
     /// Close every connection this producer still has open (a reload that
@@ -3195,10 +3240,10 @@ mod tests {
         assert_eq!(h.height("ball"), Some(10.0));
         assert_eq!(h.physics_frame, 0);
         assert_eq!(h.physics_rt.seekable_range(), None);
-        // The prime evaluation has no stepped world behind it, so its own read
-        // answered the identity pose — the probe sits at the origin for
-        // exactly this one declaration, instead of the hook raising.
-        assert_eq!(h.height("probe"), Some(0.0));
+        // The prime's own read had no stepped world behind it, so pass 1
+        // answered the identity pose and pass 2 re-declared the derived body at
+        // the ball's primed height — either way the hook did not raise.
+        assert_eq!(h.height("probe"), Some(10.0));
 
         h.frame();
         // `tick` ran BEFORE this frame's step, so its read is the primed pose.
@@ -3246,6 +3291,105 @@ mod tests {
             "{:?}",
             PhysicsHarness::reports()
         );
+    }
+
+    /// A body whose declared pose is DERIVED from another body's is primed at
+    /// its real pose, not the identity pose pass 1 read — the prime evaluates
+    /// the hook a second time once pass 1's bodies exist. Otherwise frame 1's
+    /// first real declaration would be a pose CHANGE, which the divergence rule
+    /// turns into a teleport (and a kinematic body would carry it as velocity).
+    #[test]
+    fn a_derived_body_is_primed_at_its_real_pose() {
+        let mut h = PhysicsHarness::new(HOOK_READ_SRC);
+        h.ctx().prime_physics();
+        assert_eq!(h.height("ball"), Some(10.0));
+        assert_eq!(
+            h.height("probe"),
+            Some(10.0),
+            "the second prime pass must re-declare the derived body at the \
+             pose the first pass established"
+        );
+        assert!(PhysicsHarness::reports().is_empty());
+    }
+
+    /// Priming declares; it does not simulate — and rapier's broad phase
+    /// ingests colliders at the step, so a synchronous ray query still misses
+    /// on frame 1 while body reads answer. Pinning the caveat the docs state.
+    #[test]
+    fn a_primed_world_answers_body_reads_but_not_casts_until_it_steps() {
+        const SRC: &str = "\
+            let ballTag = Physics.tag(\"ball\")\n\
+            let init = { y: 0.0 - 1.0, hit: false }\n\
+            let tick = (m, dt, tts) =>\n\
+            \x20 { y: Physics.position(ballTag).y,\n\
+            \x20   hit: Physics.cast(Vec3.make(0.0, 12.0, 0.0),\n\
+            \x20                     Vec3.make(0.0, 0.0 - 1.0, 0.0), 20.0).hit }\n\
+            let physics = (m) =>\n\
+            \x20 Physics.scene(Vec3.make(0.0, 0.0 - 10.0, 0.0),\n\
+            \x20   [ Physics.dynamic(ballTag, Physics.sphere(0.5))\n\
+            \x20       |> Physics.at(Vec3.make(0.0, 10.0, 0.0)) ])\n\
+            let draw = (m, tts) =>\n\
+            \x20 Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 0.0 - 5.0),\n\
+            \x20                              Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
+        let mut h = PhysicsHarness::new(SRC);
+        h.ctx().prime_physics();
+        h.frame();
+        assert_eq!(field(&h.model, "y"), 10.0, "the body read answers");
+        assert_eq!(
+            h.model.to_string().contains("hit: true"),
+            false,
+            "a cast against a primed-but-unstepped world misses (documented)"
+        );
+        h.frame();
+        assert!(
+            h.model.to_string().contains("hit: true"),
+            "once a step has run the cast answers: {}",
+            h.model
+        );
+        assert!(PhysicsHarness::reports().is_empty());
+    }
+
+    /// The degraded notice has its OWN dedupe channel, so a broken hook that
+    /// also provokes a per-frame command warning does not make the two
+    /// alternate through `report_once`'s single slot and flood at 60 Hz.
+    #[test]
+    fn a_degraded_frame_does_not_flood_alongside_command_warnings() {
+        const SRC: &str = "\
+            let ballTag = Physics.tag(\"ball\")\n\
+            let ghostTag = Physics.tag(\"ghost\")\n\
+            let init = { n: 0.0 }\n\
+            let tick = (m, dt, tts) =>\n\
+            \x20 ({ n: m.n + 1.0 },\n\
+            \x20  Physics.applyImpulse(ghostTag, Vec3.make(0.0, 1.0, 0.0)))\n\
+            let physics = (m) =>\n\
+            \x20 let boom = Physics.position(ghostTag) in\n\
+            \x20 Physics.scene(Vec3.make(0.0, 0.0 - 10.0, 0.0),\n\
+            \x20   [ Physics.dynamic(ballTag, Physics.sphere(0.5))\n\
+            \x20       |> Physics.at(Vec3.make(0.0, 10.0, 0.0)) ])\n\
+            let draw = (m, tts) =>\n\
+            \x20 Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, 0.0 - 5.0),\n\
+            \x20                              Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
+        let mut h = PhysicsHarness::new(SRC);
+        // The hook reads `ghost`, which it never declares: the prime tolerates
+        // it (identity pose) and declares the ball; every later frame degrades,
+        // while `tick` commands the same unknown tag once per frame.
+        h.ctx().prime_physics();
+        for _ in 0..6 {
+            h.frame();
+        }
+        let reports = PhysicsHarness::reports();
+        assert_eq!(
+            reports.len(),
+            2,
+            "one degraded notice + one command warning, not one pair per frame: {reports:?}"
+        );
+        assert!(reports.iter().any(|r| r.contains("physics error")), "{reports:?}");
+        assert!(
+            reports.iter().any(|r| r.contains("ghost")),
+            "the command warning still surfaces: {reports:?}"
+        );
+        // …and the world the prime declared keeps stepping through all of it.
+        assert!(h.height("ball").expect("ball") < 10.0);
     }
 
     /// The prime's identity-pose read is scoped to the prime ALONE: a tag the

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -146,6 +146,14 @@ impl SteppedPhysics {
     /// frame-0 keyframe, and that snapshot is taken AFTER this reconcile — so a
     /// seek/rewind to any recorded frame restores the primed world exactly, and
     /// replay stays byte-identical without a synthetic pre-frame in the log.
+    ///
+    /// Body READS (`Physics.position` / `linearVelocity` / `transformed`)
+    /// answer from a primed world, but synchronous RAY QUERIES do not: rapier's
+    /// broad phase ingests colliders at the step, so `Physics.cast` still
+    /// reports a miss until the first substep has run (docs/physics.md). This
+    /// deliberately does not force a broad-phase update to paper over that —
+    /// hand-updating it outside the pipeline would put the determinism the
+    /// Timeline depends on at risk for one frame of probe latency.
     pub fn prime(&mut self, scene: &PhysicsScene) {
         let scene = scene.hydrated_heightfields();
         with_world(self.world, |w| {
@@ -285,7 +293,8 @@ impl SteppedPhysics {
     }
 
     /// The fixed-frame range a rewind can restore EXACTLY: the practical floor
-    /// (frame 0's pre-step is the empty pre-reconcile world, so 1 is the real
+    /// (frame 0's pre-step is the world before any STEP — empty, or the
+    /// cold-start primed declaration — so 1 is the real
     /// floor) through the newest recorded frame. `None` until something has
     /// stepped. The coupled scene rewind (docs/time-travel.md T1) uses this to
     /// refuse rather than silently clamp — a clamp would land the world on a
@@ -313,12 +322,13 @@ impl SteppedPhysics {
         };
         if hi == 0 {
             // Only the empty frame-0 exists — nothing meaningful to seek to
-            // (frame 0's pre-step state is the empty world, before any
+            // (frame 0's pre-step state is the world before any step — empty,
+            // or the cold-start primed declaration, before any
             // reconcile, which draw-reads can't use).
             warnings.push("physics rewind: no stepped frame recorded yet".to_string());
             return;
         }
-        // Pre-step of fixed frame 0 is the empty world, so the practical floor
+        // Pre-step of fixed frame 0 is the world before any step, so the floor
         // is frame 1 (= the world after its first step).
         let floor = if lo == 0 { 1 } else { lo };
         let target = frame.clamp(floor, hi);

--- a/runtime/functor-runtime-common/src/physics/driver.rs
+++ b/runtime/functor-runtime-common/src/physics/driver.rs
@@ -136,12 +136,46 @@ impl SteppedPhysics {
         .is_some()
     }
 
+    /// Reconcile `scene` into the world WITHOUT simulating — the cold-start
+    /// prime (docs/physics.md, "Priming the world at init"). Evaluating the
+    /// `physics` hook once on the initial model and declaring its result means
+    /// frame 1's reads (in `tick`, and in the hook itself) answer with the
+    /// initial declared poses instead of raising against an empty world.
+    ///
+    /// Nothing is recorded: the first `advance` snapshots the world as its
+    /// frame-0 keyframe, and that snapshot is taken AFTER this reconcile — so a
+    /// seek/rewind to any recorded frame restores the primed world exactly, and
+    /// replay stays byte-identical without a synthetic pre-frame in the log.
+    pub fn prime(&mut self, scene: &PhysicsScene) {
+        let scene = scene.hydrated_heightfields();
+        with_world(self.world, |w| {
+            w.reconcile(&scene);
+            // Reconcile is declaration only — no step runs, so nothing may
+            // observe events or warnings from it.
+            let _ = w.take_events();
+            let _ = w.take_command_warnings();
+        });
+    }
+
     /// One rendered frame's worth of recorded physics: simulate whole fixed
     /// substeps from `real_dt`, recording each through the Timeline. The
     /// declared `scene` reconciles on the frame's first recorded substep —
     /// identical semantics to `World::step_frame`, but every fixed frame is
     /// now seekable.
     pub fn advance(&mut self, scene: &PhysicsScene, real_dt: f32) -> Advanced {
+        self.advance_scene(Some(scene), real_dt)
+    }
+
+    /// Advance with NO declaration this frame — the degraded step taken when
+    /// the `physics` hook errored (docs/physics.md, "When the hook errors").
+    /// The world already holds the previous frame's declaration, so keeping it
+    /// is literally recording no `DeclareScene` for this frame: the sim keeps
+    /// running and replay reproduces it exactly.
+    pub fn advance_undeclared(&mut self, real_dt: f32) -> Advanced {
+        self.advance_scene(None, real_dt)
+    }
+
+    fn advance_scene(&mut self, scene: Option<&PhysicsScene>, real_dt: f32) -> Advanced {
         let mut out = Advanced {
             steps: 0,
             events: Vec::new(),
@@ -173,7 +207,7 @@ impl SteppedPhysics {
             // Resolve terrain once at the live shell boundary, then move that
             // exact immutable scene into the command log. Replays must never
             // consult whatever asset revision happens to be loaded later.
-            let mut scene = Some(scene.hydrated_heightfields());
+            let mut scene = scene.map(|scene| scene.hydrated_heightfields());
             let (events, warnings) = with_world(self.world, |w| {
                 let mut events = Vec::new();
                 for i in 0..steps {
@@ -183,9 +217,11 @@ impl SteppedPhysics {
                     // one DeclareScene per rendered frame keeps the log lean.
                     let mut cmds: Vec<Command> = Vec::new();
                     if i == 0 {
-                        cmds.push(Command::DeclareScene(
-                            scene.take().expect("first fixed substep owns the scene"),
-                        ));
+                        // A degraded frame (the hook errored) declares nothing
+                        // and keeps the world's existing declaration.
+                        if let Some(scene) = scene.take() {
+                            cmds.push(Command::DeclareScene(scene));
+                        }
                         for command in w.take_pending_commands() {
                             cmds.push(Command::Apply(command));
                         }
@@ -388,6 +424,71 @@ mod tests {
             snapshot() == end_a,
             "replaying identical inputs must reproduce run A"
         );
+    }
+
+    /// Priming (the cold-start declaration, no steps) is inside the frame-0
+    /// keyframe, so a rewind restores the primed world and a replay reproduces
+    /// the run byte-for-byte — no new entry in the recording format.
+    #[test]
+    fn a_primed_world_rewinds_and_replays_byte_identically() {
+        let mut sp = fresh();
+        sp.prime(&scene_at(0));
+        // Declaration only: the bodies exist, nothing has stepped.
+        assert!(with_world(DEFAULT_WORLD, |w| w.body_transform("a").is_some()).unwrap());
+        assert_eq!(with_world(DEFAULT_WORLD, |w| w.frame()), Some(0));
+        assert_eq!(sp.seekable_range(), None);
+
+        let mut snap_10 = Vec::new();
+        for t in 0..40 {
+            if t == 10 {
+                snap_10 = snapshot();
+            }
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        let end = snapshot();
+
+        let warnings = sp.rewind_to_frame(10);
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert!(snapshot() == snap_10, "a primed run must rewind byte-exact");
+        for t in 10..40 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        assert!(snapshot() == end, "a primed run must replay byte-exact");
+        remove_world(DEFAULT_WORLD);
+    }
+
+    /// The degraded frame (the `physics` hook errored): no declaration is
+    /// recorded, so the world keeps the previous frame's bodies and keeps
+    /// simulating — and that frame replays exactly as it ran.
+    #[test]
+    fn an_undeclared_advance_keeps_the_world_and_replays() {
+        let mut sp = fresh();
+        sp.prime(&scene_at(0));
+        for t in 0..10 {
+            sp.advance(&scene_at(t), FIXED_DT);
+        }
+        let before = with_world(DEFAULT_WORLD, |w| w.body_transform("a").unwrap().0[1]).unwrap();
+        let snap_10 = snapshot();
+
+        for _ in 0..10 {
+            let out = sp.advance_undeclared(FIXED_DT);
+            assert_eq!(out.steps, 1, "a degraded frame still simulates");
+        }
+        let after = with_world(DEFAULT_WORLD, |w| w.body_transform("a").unwrap().0[1]).unwrap();
+        assert!(
+            after < before,
+            "the kept world must keep falling: {before} -> {after}"
+        );
+        let end = snapshot();
+
+        let warnings = sp.rewind_to_frame(10);
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert!(snapshot() == snap_10);
+        for _ in 0..10 {
+            sp.advance_undeclared(FIXED_DT);
+        }
+        assert!(snapshot() == end, "degraded frames must replay byte-exact");
+        remove_world(DEFAULT_WORLD);
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -497,6 +497,10 @@ impl FunctorLangGame {
         };
         // Cold start (docs/physics.md): declare the initial world before the
         // first frame, so frame 1's physics reads answer instead of raising.
+        // The world is a thread-local, so drop whatever an earlier producer on
+        // this thread left behind first — otherwise a same-tag body from the
+        // previous session would answer this session's priming reads.
+        physics::remove_world(physics::DEFAULT_WORLD);
         game.ctx().prime_physics();
         game
     }
@@ -575,9 +579,17 @@ impl FunctorLangGame {
         self.has_mouse_wheel = loaded.has_mouse_wheel;
         self.has_mouse_button = loaded.has_mouse_button;
         self.has_subscriptions = loaded.has_subscriptions;
+        let had_physics = self.has_physics;
         self.has_physics = loaded.has_physics;
         if !self.has_physics {
             physics::remove_world(physics::DEFAULT_WORLD);
+        } else if !had_physics {
+            // The edit ADDED the hook: there is no surviving world to keep, so
+            // this reload is a cold start for physics and must prime like one
+            // (docs/physics.md). Without it the very next frame's reads face an
+            // empty world — the cold-start hole this PR closes, reopened by the
+            // most common way to reach it.
+            self.ctx().prime_physics();
         }
         self.has_soundscape = loaded.has_soundscape;
         if !self.has_soundscape {
@@ -1805,6 +1817,50 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
             "2",
             "a role whose module vanished keeps the old program"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A hot reload that ADDS the `physics` hook is a cold start for physics —
+    /// there is no surviving world to keep — so it must prime like one. Without
+    /// this the developer's very next frame faces an empty world, which for a
+    /// hook that reads its own bodies is the permanent wedge the priming exists
+    /// to remove. [xreview High]
+    #[test]
+    fn a_reload_that_adds_the_physics_hook_primes_the_world() {
+        let dir = std::env::temp_dir().join(format!(
+            "functor-lang-game-test-{}-adds-physics",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp project dir");
+        let entry = dir.join("game.fun");
+        std::fs::write(&entry, BASE).expect("write entry");
+        physics::remove_world(physics::DEFAULT_WORLD);
+        let mut game = FunctorLangGame::create(entry.to_str().expect("utf-8 path"));
+        assert!(!game.has_physics);
+
+        // The edit introduces a hook that READS the body it declares — the
+        // shape that used to wedge forever.
+        let with_physics = format!(
+            "{BASE}let ballTag = Physics.tag(\"ball\")\n\
+             let physics = (m) =>\n\
+             \x20 let ball = Physics.position(ballTag) in\n\
+             \x20 Physics.scene(Vec3.make(0.0, -10.0, 0.0),\n\
+             \x20   [Physics.dynamic(ballTag, Physics.sphere(0.5))\n\
+             \x20      |> Physics.at(Vec3.make(0.0, ball.y + 4.0, 0.0))])\n"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20)); // distinct mtime
+        std::fs::write(&entry, with_physics).expect("edit entry");
+        game.check_hot_reload(FrameTime { tts: 0.0, dts: 0.0 });
+        assert!(game.has_physics, "the reload must have landed");
+        assert!(
+            physics::with_world(physics::DEFAULT_WORLD, |w| w
+                .body_transform("ball")
+                .is_some())
+            .unwrap_or(false),
+            "adding the hook must prime the world before the next frame"
+        );
+        physics::remove_world(physics::DEFAULT_WORLD);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -442,7 +442,7 @@ impl FunctorLangGame {
         let source_hashes = inspector_sources(&loaded.sources);
         let sources = project_sources_of(&loaded.sources);
         let runnable = functor_lang::coverage::runnable_offsets(&loaded.module);
-        FunctorLangGame {
+        let mut game = FunctorLangGame {
             path: path.to_string(),
             role,
             names: loaded.names,
@@ -494,7 +494,11 @@ impl FunctorLangGame {
             draw_ns: 0,
             render_ns: 0,
             swap_ns: 0,
-        }
+        };
+        // Cold start (docs/physics.md): declare the initial world before the
+        // first frame, so frame 1's physics reads answer instead of raising.
+        game.ctx().prime_physics();
+        game
     }
 
     /// Bundle this producer's per-frame state into the shared [`FrameCtx`]
@@ -694,6 +698,10 @@ impl FunctorLangGame {
         self.draw_ns = 0;
         self.render_ns = 0;
         self.swap_ns = 0;
+        // A reset is a cold start: the model is `init` again and the world was
+        // removed, so re-prime it (a hot reload deliberately does NOT — there
+        // the world, like the model, survives).
+        self.ctx().prime_physics();
     }
 
     fn report_stats(&mut self) {


### PR DESCRIPTION
The `physics` hook had two failure modes that compounded into a **permanent wedge**. This makes the hook resilient, gives in-hook reads defined semantics, and primes the world at `init` — which lets two examples delete their hand-rolled first-frame guards.

## The wedge, reproduced on `main`

A scratch project whose `physics` hook reads the world it declares (a shadow puck parked at the ball's height — the shape the docs called a DEADLOCK):

```functor
let physics = (m) =>
  let ball = Physics.position(ballTag) in
  Physics.scene(gravity, [ ground, ball@6.0, shadow |> Physics.at(Vec3.make(2.5, ball.y, 0.0)) ])
```

`functor -d <scratch> run native --capture-time 1.0` on `main`:

* **114** `no body tagged "ball"` lines in one second — the `physics` and `draw` errors alternate, so `Reporter::report_once` never even dedupes them;
* the capture is an **empty blue screen**: nothing was ever declared, so `draw`'s whole scene failed too.

Headlessly (a temporary producer test, 5 frames at `FIXED_DT`) on `main`:

```
REPORT: [functor-lang] physics error at game.fun:5:14: no body tagged "ball" …
frame 1: ball y = None, physics fixed frame = 0
frame 2: ball y = None, physics fixed frame = 0
frame 3: ball y = None, physics fixed frame = 0
frame 4: ball y = None, physics fixed frame = 0
frame 5: ball y = None, physics fixed frame = 0
```

The world never advances past fixed frame 0 and the body never exists — forever.

**After this PR** the same program runs clean: zero errors, the ball falls and lands, the blue puck (the in-hook read) tracks it.

| `main` — empty frame, 114 errors/s | this PR — 0 errors |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/befb740558a79aefd31fefb5c8dfd8d4/raw/wedge-before.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/befb740558a79aefd31fefb5c8dfd8d4/raw/wedge-after2.png" width="420"> |

## What changed

1. **Hook errors degrade instead of wedging.** An error inside the hook — or a return value that isn't a `Physics.scene` — now keeps the **previous frame's declaration** and keeps stepping. The implementation is the honest one: the degraded frame records **no `DeclareScene`**, so the world simply retains what it already has, and the frame replays byte-exactly as it ran (`SteppedPhysics::advance_undeclared`). The teaching error is reported **once**, in hot reload's broken-edit style, and says what the runtime did instead.
2. **Reads inside the hook: last frame's world.** One uniform rule now covers every entry point — *a physics read answers the LAST stepped world*. Pre-step callers (`tick`, `input`, a pre-step `update`, **and the hook**) see the previous step; only `draw` and the post-step `update`s (raycast tagger, `Physics.events`) see the world this frame just stepped. Note for reviewers: the live world was *already* the active scope during the hook — the reads raised purely because of the cold start below, so this rule needed pinning with tests + docs rather than a scope change.
3. **Cold start: the world is primed at `init`.** At session start and at every model reset (restart) — **never** on hot reload, where the world survives with the model — the producer evaluates the hook once on the initial model and reconciles it with **zero simulation steps** (`FrameCtx::prime_physics` → `SteppedPhysics::prime`), wired in both producers (desktop + embedded/web).

### The one new rule, and why (please review this specifically)

The prime is the ONE hook evaluation with no stepped world behind it, so a hook that reads a body it is about to declare would still be circular — it would raise at prime, declare nothing, and stay wedged. So **inside the prime evaluation only, a body read answers the identity pose** (origin, zero velocity) instead of raising (`PrimingScope` in `functor_lang_prelude.rs`). The hook is then evaluated a **second time outside that rule**, so a body whose declared pose is *derived* from another's is primed at its real value rather than at the origin — otherwise frame 1's first real declaration would be a pose change, which the divergence rule turns into a teleport (a kinematic body would carry it into contacts as velocity). Both passes are declaration-only; neither reports. Consequences:

* a hook deriving one body's declaration from another's pose bootstraps, at its true pose, before frame 1;
* a genuinely unknown tag (a typo) is **not** silenced — it raises on frame 1 and every frame after, loudly, once (test: `an_undeclared_tag_still_raises_after_the_prime`).

This is the one piece beyond the three agreed changes; it is what makes (2) usable at frame 1. Happy to drop it if you'd rather the prime keep raising — the cost is that the wedge repro above stays broken (loudly, and with the rest of the game live, but with no world).

⚠️ **Priming answers body reads, not ray queries.** rapier's broad phase ingests colliders *at the step*, so `Physics.cast` / `castExcluding` still miss against a primed-but-unstepped world — a grounding probe answers from frame 2. Forcing a broad-phase update outside the pipeline would risk the determinism the Timeline depends on, for one frame of probe latency, so priming deliberately does not. Documented in `docs/physics.md` and the skill, and pinned by a test.

## Replay / recording implications

Priming reconciles **before** the timeline records anything, and `TimelineLog::record` always snapshots a keyframe at frame 0 — so the frame-0 keyframe *is* the primed world. Rewind, seek, and replay reproduce it byte-identically with **no new entry in the recording format** and no synthetic pre-frame in the log. Same for degraded frames: "no declaration this frame" is already representable (an empty first-substep command list). Pinned by two new driver tests (`a_primed_world_rewinds_and_replays_byte_identically`, `an_undeclared_advance_keeps_the_world_and_replays`). `docs/physics.md`'s rewind-floor paragraph notes that frame 0's keyframe is now the primed world.

## Examples that lost their workaround

Grepped `examples/*/game.fun` for first-frame guards around physics reads. Two had them, both deleted:

* **`examples/terrain`** — `started: false` in `init` + the `if not model.started then …` gate at the top of `tick`.
* **`examples/physics-controller`** — `Ctl.started` (the field, `zero`, and the `respawned` comment explaining why it must be preserved) + the gate in `tick`. The rest of that file's diff is the mechanical dedent of the freed `else` branch.

(`examples/physics` and `examples/shooting-range` do no pre-step body reads, so they had nothing to remove.)

Both built (`functor build`) and captured (`run native --capture-frame --fixed-time 3 --capture-time 3`) before and after:

* `physics-controller`: **byte-identical** PNG.
* `terrain`: visually identical, a few pixels different — the walker is now steered from frame 1 instead of frame 2. `npm run test:golden` passes (`terrain-t2` diff 0.917%, within tolerance; no goldens regenerated).

| `examples/terrain` before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/befb740558a79aefd31fefb5c8dfd8d4/raw/terrain-before.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/befb740558a79aefd31fefb5c8dfd8d4/raw/terrain-after2.png" width="420"> |

## Verification

* `cargo test -p functor_runtime_common` — **641 + 12 pass**, including four new producer tests (primed cold start, in-hook read = last frame's pose, hook-error degradation with the once-only error, unknown tag still raises) and two new driver tests (replay/rewind determinism for primed and degraded frames). All use the `FakeEffects`/`FrameCtx` test seam.
* `cargo test -p functor-lang` — untouched, all pass.
* `npm run build:cli:debug`, then `functor build` + a capture for both simplified examples; `functor -d examples/physics-controller test` → 36/36 expects pass.
* `npm run check:docs` — green (the `.funi` edits are prose-only, so the drift pins stay green).
* `npm run test:golden` — passes.

### `frame_bench` (release, 2 runs per side, min column)

Physics is a per-frame hot path; priming happens once, so steady state must be neutral — it is, exactly:

| cells | base us/frame (min) | PR us/frame (min) | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 400 | 437.8 / 447.7 | 428.4 / 432.2 | 13877 → 13877 | 843393 → 843393 |
| 1600 | 1695.6 / 1761.4 | 1686.0 / 1690.8 | 54717 → 54717 | 3307233 → 3307233 |
| 3136 | 3323.6 / 3333.0 | 3298.9 / 3307.8 | 106973 → 106973 | 6460257 → 6460257 |

`allocs/frame` and `bytes/frame` are **identical** on both sides (the deterministic numbers). Wall clock is within run-to-run spread. No Quest was attached, but nothing here touches rendering, shaders, or texture sampling.

## Docs

* `docs/physics.md` — new "Cold start: the world is primed from `init`" and "When the hook errors: degrade, don't wedge" sections; the read-timing paragraph now states the uniform rule; the rewind-floor paragraph notes the primed frame-0 keyframe.
* The **`functor-lang` skill** — the "will bite you" physics entries: "Never read inside the `physics` hook" (a DEADLOCK) → the three new rules; the character-controller sketch no longer teaches a `started` gate.
* `functor-prelude/prelude/physics.funi` — prose only (the module `//!` block + `position`'s `///`), so the signature drift pins are unaffected (`check:docs` green).

**Manual (#616):** I did **not** touch the manual — its sharp-edges physics bullet lives on the open `docs-manual-sharp-edges` branch. Once both land, that bullet needs a one-paragraph rewrite: drop "never read inside the `physics` hook / guard the first frame with a `started` flag", and replace it with "a physics read answers the last stepped world in every entry point, the hook included; the world is primed from `init` so frame 1 reads fine; a hook error keeps the previous declaration and reports once".

## Review

`/xreview` ran three reviewers (a Claude subagent, Codex, and the dedicated de-dup pass): **one High and five Medium findings**, all fixed or dispositioned — see the review comment below for the full write-up and the post-fix re-verification. The headline fix: a hot reload that ADDS the `physics` hook reopened the wedge (it never primed); it now primes, pinned by a test.

The verification numbers above are from the first push; the review comment carries the paired `frame_bench` re-run after the fixes (deterministic columns still identical) and the re-run tests, goldens, and captures.
