### PR TITLE
test(e2e): make net-coordinator assertions join-order independent

### DIFF
--- a/e2e/net-coordinator.mjs
+++ b/e2e/net-coordinator.mjs
@@ -160,6 +160,11 @@ try {
     "a keydown in client 1 sends to the server, and only from client 1",
     `client 1 ${before.c1}->${after.c1}, client 2 ${before.c2}->${after.c2}`
   );
+  // Release the key: the held `w` is a velocity, and the server integrates and
+  // WRAPS it at the arena edge, so a mover left running would eventually wrap
+  // back past its spawn lane. The release pins its z for 5b below.
+  await page.evaluate(() => window.__netHost.key("client 1", "KeyW", false));
+  await sleep(200);
 
   // 4. Model state, read from each pane's paused inspector trace.
   await page.evaluate((ids) => ids.forEach((id) => window.__netHost.pause(id)), PANES);
@@ -188,9 +193,17 @@ try {
     models["server"]
   );
   // 5b. Cross-client propagation. Each client's world must hold BOTH rows,
-  // and the row for the player that pressed `w` (pid 0, spawned at z = -1.8)
-  // must have moved in z in the OTHER client's copy — client 1's input
-  // reached client 2 through the server.
+  // and the row for the player that pressed `w` must have moved in z in the
+  // OTHER client's copy — client 1's input reached client 2 through the
+  // server.
+  //
+  // Which pid that is depends on JOIN ORDER, which nothing here sequences:
+  // the three panes boot as independent iframes, the coordinator hands out
+  // connection ids in arrival order (site/src/net-coordinator.ts), and the
+  // server assigns `pid = nextPid` per Joined (examples/mp/server.fun). So
+  // client 1 is pid 0 only when it wins the boot race. Read the mover's
+  // identity out of the data instead: the coordinator's log says which
+  // connection is client 1's, and the server's model maps that cid to a pid.
   const rowsOf = (text) =>
     [...text.matchAll(/\{ pid: (-?[\d.]+), x: (-?[\d.]+), z: (-?[\d.]+) \}/g)].map((m) => ({
       pid: Number(m[1]),
@@ -198,17 +211,38 @@ try {
       z: Number(m[3]),
     }));
   const worlds = { 1: rowsOf(models["client 1"]), 2: rowsOf(models["client 2"]) };
+  // The two joiners are pids 0 and 1 whichever pane won the race — join order
+  // decides WHO owns which, not which pids exist.
+  const pidsOf = (rows) => [...rows.map((r) => r.pid)].sort().join(",");
   check(
-    worlds[1].length === 2 && worlds[2].length === 2,
+    pidsOf(worlds[1]) === "0,1" && pidsOf(worlds[2]) === "0,1",
     "each client's world contains both players",
-    `client 1: ${worlds[1].length} rows, client 2: ${worlds[2].length} rows`
+    `client 1: [${pidsOf(worlds[1])}], client 2: [${pidsOf(worlds[2])}]`
   );
-  const moved = worlds[2].find((r) => r.pid === 0);
-  const untouched = worlds[2].find((r) => r.pid === 1);
+  // Client 1's connection id, then the pid the server gave that cid.
+  const connOfClient1 = connected.find((p) => p.to === "client 1")?.conn;
+  const serverPlayers = [...models["server"].matchAll(/cid: (-?[\d.]+), pid: (-?[\d.]+)/g)].map(
+    (m) => ({ cid: Number(m[1]), pid: Number(m[2]) })
+  );
+  const moverPid = serverPlayers.find((p) => p.cid === connOfClient1)?.pid;
+  // Each player spawns on its own z-lane: `z = pid * 1.8 - 1.8` (server.fun).
+  // The other player never moves in z (its auto-move is +x only, and the
+  // server's integration of a zero velocity is exact), so its z is its spawn.
+  const spawnZ = (pid) => pid * 1.8 - 1.8;
+  const moved = worlds[2].find((r) => r.pid === moverPid);
+  const untouched = worlds[2].find((r) => r.pid !== moverPid);
   check(
-    !!moved && moved.z > -1.8 && !!untouched && untouched.z === 0,
+    moverPid !== undefined &&
+      !!moved &&
+      moved.z > spawnZ(moverPid) &&
+      !!untouched &&
+      untouched.z === spawnZ(untouched.pid),
     "client 1's `w` moved its player in CLIENT 2's world (client -> server -> client)",
-    JSON.stringify(worlds[2])
+    `client 1 is conn ${connOfClient1} = pid ${moverPid} (spawn z ${spawnZ(
+      moverPid
+    )}); client 2's world ${JSON.stringify(worlds[2])}; server players ${JSON.stringify(
+      serverPlayers
+    )}`
   );
 
   // 6. Teardown: reloading a pane closes its connection at BOTH ends — proved


### PR DESCRIPTION
## The race

`e2e/net-coordinator.mjs:190-212` asserted "client 1's `w` moved its player in CLIENT 2's world"
by **hardcoding that pane `client 1` owns pid 0** (and that pid 1's z stays exactly `0`).

But pids are assigned in **join order**, and nothing in the fixture sequences the joins:

- `examples/mp/server.fun:53` — `pid: m.nextPid`, spawning at `z = m.nextPid * 1.8 - 1.8`,
  per `Joined` in arrival order.
- `site/src/net-coordinator.ts:142` (`const conn = this.nextConn++`) and `:304` — connection ids
  are handed out in arrival order.
- `e2e/fixtures/net-host.html:71-73` — the three panes boot as **independent iframes**; nothing
  waits for one to connect before mounting the next.

So when client 2 wins the boot race, client 1 is pid 1 and the check fails spuriously: pid 0's z
is its untouched spawn `-1.8` (not `> -1.8`), and pid 1's z is the mover's (not `0`).

Precedent that this is a flake and not a regression: the **identical failure on `main` @ 61caba1**
— an LSP-only commit that cannot touch this path — in run **30709492377**.

## The fix (test-only)

Derive the mover's identity from the data instead of assuming it:

- client 1's connection id comes from the coordinator's own `connected` log
  (`connected.find((p) => p.to === "client 1")?.conn`), the same idiom the file already uses for
  client 2's teardown check;
- the server's model maps that `cid` to its `pid`;
- the moved row is asserted against **that** pid's spawn lane (`spawnZ(pid) = pid * 1.8 - 1.8`),
  and the other row against **its own** spawn lane rather than a literal `0`.

The check's name and meaning are unchanged. Also in the same spirit:

- the failure message now prints which conn/pid client 1 turned out to be, its spawn z, client 2's
  world, and the server's cid→pid table;
- "each client's world contains both players" now asserts the pid **set** is `{0, 1}` (true in
  either join order) instead of just counting rows — restoring the strictness the literal pids
  used to give;
- the held `w` is now **released** before the panes pause. The server integrates a held velocity
  and *wraps* it at the arena edge (`server.fun:41-45`, `arena = 4.0`), and the pid-1 lane
  (spawn `z = 0`) has less headroom than the pid-0 lane — which this change makes a passing path
  for the first time. Releasing pins the mover's z, so both lanes are equally immune to timing.

No runtime or `examples/` change.

## Verification

Run the way `.github/workflows/wasm-smoke.yml` does (`npm run test:net-coordinator`, against a
built `runtime/functor-runtime-web/pkg`):

| Run | Order | Result |
| --- | --- | --- |
| 1-4 (pre-review fix) | natural (client 1 won each time → pid 0) | ALL CHECKS PASSED |
| forced | temporary 2s delay on client 1's iframe boot → **client 1 = pid 1** | ALL CHECKS PASSED |
| 5-7 (post-review fix) | natural ×2 + forced-losing-order ×1 | ALL CHECKS PASSED |

The forced-order run is the one that reproduces the CI flake: it prints
`client 1 is conn 2 = pid 1 (spawn z 0)` and passes, where the old assertion would have failed on
both halves. The artificial delay was only ever local — it is **not** committed (the fixture is
untouched in this diff).

## Review

`/xreview` (Claude subagent + Codex CLI). One **[AGREED]** finding — both engines flagged reading
client 1's conn id by regex over the rendered model text instead of the structured `connected`
packet log; applied. Three Low findings from the Claude reviewer also applied (drop an unnecessary
epsilon, drop a dead ternary in the failure string, release the held key). No Critical/High
findings. All checks re-run green afterwards.
