### PR TITLE
feat(site): guide the paused hero — notice, pulse, reset, and camera grouping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Functor is a functional toolkit for building 3D games in **Functor Lang** — Functor's own interpreted,
+Functor is a functional toolkit for building games in **Functor Lang** — Functor's own interpreted,
 F#-inspired game-logic language (roadmap and design: `docs/functor-lang.md`; syntax/semantics source of
 truth: the **`functor-lang` skill**, `.claude/skills/functor-lang/`). You write a game as a `.fun`
 file. There is **no transpile or compile step for game logic**: the Rust runtime *interprets* the

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -442,8 +442,9 @@ trades real complexity for a cost the cache already hides.
 The bar reads left to right as **transport, then ways to look**. Left of the rail
 are the controls that move time (⏸ and ⏭); right of it are the two that change
 how you see the frame time landed on — 📷 (the debug camera) and 🔮
-(extrapolation). Both scrubbers order it that way, the web bar and the native
-egui one, so the two surfaces teach the same layout.
+(extrapolation). All three bars over the seam order it that way — the web
+scrubber, the native egui one, and the sandbox's own chrono bar — so every
+surface teaches the same layout.
 
 Two affordances answer moments the bar previously left silent:
 
@@ -468,7 +469,12 @@ swaps ⏭ for ↺ and calls the handler; passing `null` restores ⏭. The scrubb
 owns the button, never the meaning of "reset" — on the landing hero the handler
 re-parks *that* demo's staged anchor (pause, then seek), which is knowledge only
 the host has. It re-seeks the timeline and never touches the visitor's edits, so
-↺ works the same over an edited or a broken program. The sandbox and IDE pass no
+↺ works the same over an edited or a broken program. The recorded ring is
+bounded, so after a long resumed run the anchor is simply gone and `seek` would
+clamp silently onto an arbitrary late frame; the hero checks the recorded range
+first and re-records the jump when the anchor has aged out. The click latches
+while that is in flight, since a second pause toggle would leave the demo
+running. The sandbox and IDE pass no
 handler and keep ⏭ unchanged.
 
 ## Deferred follow-ups: keep and reconstruct the old future

--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -437,6 +437,40 @@ pick and walk *forward* through the picks (re-stepping only between consecutive
 picks) instead of seeking each independently — deliberately not done here, since it
 trades real complexity for a cost the cache already hides.
 
+### The bar's grammar, and what a host page may say through it
+
+The bar reads left to right as **transport, then ways to look**. Left of the rail
+are the controls that move time (⏸ and ⏭); right of it are the two that change
+how you see the frame time landed on — 📷 (the debug camera) and 🔮
+(extrapolation). Both scrubbers order it that way, the web bar and the native
+egui one, so the two surfaces teach the same layout.
+
+Two affordances answer moments the bar previously left silent:
+
+- **Paused input says so.** Pressing a game key against a paused clock used to do
+  nothing at all, which reads as a broken page rather than a stopped one. The web
+  bar raises a transient notice — *"Paused — ⏸ resume · 🔮 preview"* — naming the
+  two controls that *do* respond. It is a scrubber-level `keydown` listener, not a
+  runtime change, and it mirrors the host page's own delivery rule: a key counts
+  only when it would have reached the game, so the bar's own chrome (arrow nudges
+  on a handle, Enter on a button), focused text fields, the webview overlay, and
+  shell-owned debug-camera navigation raise nothing. A pause that began under
+  300 ms ago is silent too, so a host staging a moment programmatically doesn't
+  flash it.
+- **A host may point at 🔮 once.** `__scrub.setAttention({ extrapolate: true })`
+  breathes a soft glow on the button (a static ring under
+  `prefers-reduced-motion`). It retires permanently the first time 🔮 is used —
+  an invitation, not a nag. The landing hero enables it at exactly one moment:
+  when its staged pre-jump frame is parked and waiting for that click.
+
+**Reset is a host action, not a scrubber feature.** `__scrub.setReset(handler)`
+swaps ⏭ for ↺ and calls the handler; passing `null` restores ⏭. The scrubber
+owns the button, never the meaning of "reset" — on the landing hero the handler
+re-parks *that* demo's staged anchor (pause, then seek), which is knowledge only
+the host has. It re-seeks the timeline and never touches the visitor's edits, so
+↺ works the same over an edited or a broken program. The sandbox and IDE pass no
+handler and keep ⏭ unchanged.
+
 ## Deferred follow-ups: keep and reconstruct the old future
 
 Today's stripe after Resume has a specific meaning: the selected frame became a

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -383,18 +383,20 @@ const playerFrame = (page) => {
   // Game input against a paused clock says so instead of doing nothing — but
   // only for keys that would have reached the game. A nudge on the timeline
   // handle is chrome, not game input.
-  const pressInPlayer = (code, onPlayhead) =>
+  const pressInPlayer = (code, onPlayhead, repeat = false) =>
     heroPlayer.evaluate(
-      ([keyCode, chrome]) => {
+      ([keyCode, chrome, held]) => {
         const target = chrome ? document.getElementById("scrub-playhead") : document.body;
-        target.dispatchEvent(new KeyboardEvent("keydown", { code: keyCode, bubbles: true }));
+        target.dispatchEvent(
+          new KeyboardEvent("keydown", { code: keyCode, bubbles: true, repeat: held })
+        );
         const raised = document.getElementById("scrub-toast").classList.contains("show");
         // Release it: the host page delivers held keys to the game, and a
         // press with no matching release would leave the character running.
         target.dispatchEvent(new KeyboardEvent("keyup", { code: keyCode, bubbles: true }));
         return raised;
       },
-      [code, onPlayhead]
+      [code, onPlayhead, repeat]
     );
   // Past the staging-silence window: the notice deliberately says nothing for
   // 300ms after a pause EDGE, so the hero's own programmatic park never flashes
@@ -413,6 +415,16 @@ const playerFrame = (page) => {
     !(await heroPlayer.evaluate(() =>
       document.getElementById("scrub-toast").classList.contains("show")
     ))
+  );
+  // Auto-repeat is one held press, not a stream: it must not re-arm the notice
+  // (which would pin it open while the key is down). A letter also counts —
+  // the host router delivers every letter and digit, not just WASD/arrows.
+  const toastOnRepeat = await pressInPlayer("KeyQ", false, true);
+  const toastOnLetter = await pressInPlayer("KeyQ", false);
+  check(
+    "the paused notice ignores auto-repeat but covers any game key",
+    !toastOnRepeat && toastOnLetter,
+    JSON.stringify({ toastOnRepeat, toastOnLetter })
   );
 
   await heroPlayer.evaluate(() => document.getElementById("scrub-extrapolate").click());
@@ -579,6 +591,47 @@ const playerFrame = (page) => {
     "hero ↺ re-parks the staged moment after scrubbing away",
     afterReset.paused && afterReset.frame === staged.frame,
     JSON.stringify({ scrubbedAway, staged: staged.frame, afterReset })
+  );
+
+  // The visitor's other path: RESUME, let it run, then ↺. Reset must land
+  // paused two frames before a real takeoff — the staged anchor while it is
+  // still recorded, a freshly re-recorded one once the ring has dropped it.
+  // Either way the demo is parked and ready for 🔮, never on a stray frame.
+  await heroPlayer.evaluate(() => window.__scrub.togglePause());
+  await heroPlayer.waitForFunction(() => !window.__scrub.paused(), { timeout: 8000 });
+  await sleep(2500);
+  await heroPlayer.evaluate(() => document.getElementById("scrub-reset").click());
+  await heroPlayer
+    .waitForFunction(
+      () => {
+        if (!window.__scrub.paused()) return false;
+        const range = window.__scrub.range();
+        const jumps = window.__scrub
+          .events()
+          .filter((event) => event.label === "Up down" && event.frame >= range[0]);
+        return jumps.some((jump) => window.__scrub.frame() === Math.max(0, jump.frame - 2));
+      },
+      null,
+      { timeout: 30000 }
+    )
+    .catch(() => {});
+  const afterRunReset = await heroPlayer.evaluate(() => {
+    const range = Array.from(window.__scrub.range());
+    return {
+      frame: window.__scrub.frame(),
+      paused: window.__scrub.paused(),
+      range,
+      jumps: window.__scrub
+        .events()
+        .filter((event) => event.label === "Up down" && event.frame >= range[0])
+        .map((event) => event.frame),
+    };
+  });
+  check(
+    "hero ↺ re-parks before a recorded takeoff after the demo has run",
+    afterRunReset.paused &&
+      afterRunReset.jumps.some((jump) => afterRunReset.frame === Math.max(0, jump - 2)),
+    JSON.stringify(afterRunReset)
   );
 
   await page.close();
@@ -866,6 +919,18 @@ for (const example of examples) {
     })
   );
   check("chrono bar exposes two keyboard-focusable slider handles", customHandles);
+  // Same grammar as the in-frame scrubber: transport left of the rail, the
+  // two ways to LOOK at the parked frame right of it.
+  const chronoOrder = await page.evaluate(() => {
+    const ids = [...document.querySelectorAll(".mp-chrono > button")].map((b) => b.id);
+    return { ids, afterCamera: document.getElementById("mp-camera").nextElementSibling?.id };
+  });
+  check(
+    "chrono bar orders the debug camera immediately left of extrapolation",
+    chronoOrder.afterCamera === "mp-extrap" &&
+      chronoOrder.ids.indexOf("mp-step") < chronoOrder.ids.indexOf("mp-camera"),
+    JSON.stringify(chronoOrder)
+  );
   const handleColors = await page.evaluate(() => ({
     playhead: getComputedStyle(document.getElementById("mp-playhead")).backgroundColor,
     preview: getComputedStyle(document.getElementById("mp-preview-handle")).backgroundColor,

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -350,7 +350,79 @@ const playerFrame = (page) => {
     JSON.stringify(staged)
   );
 
+  // The bar's grammar: transport on the left of the rail, ways to LOOK at the
+  // parked frame on its right — 📷 immediately before 🔮. The hero also trades
+  // ⏭ (which reads as fast-forward here) for ↺, its re-park control.
+  const bar = await heroPlayer.evaluate(() => {
+    const camera = document.getElementById("scrub-camera");
+    const step = document.getElementById("scrub-step");
+    const reset = document.getElementById("scrub-reset");
+    return {
+      afterCamera: camera.nextElementSibling?.id,
+      cameraHidden: camera.hidden,
+      stepHidden: step.hidden,
+      resetHidden: reset.hidden,
+      resetGlyph: reset.textContent,
+      attention: document
+        .getElementById("scrub-extrapolate")
+        .classList.contains("attention"),
+    };
+  });
+  check(
+    "scrubber puts the debug camera immediately left of extrapolation",
+    !bar.cameraHidden && bar.afterCamera === "scrub-extrapolate",
+    JSON.stringify(bar)
+  );
+  check(
+    "hero bar offers ↺ reset instead of ⏭ step",
+    bar.stepHidden && !bar.resetHidden && bar.resetGlyph === "↺",
+    JSON.stringify(bar)
+  );
+  check("staged hero pulses attention on 🔮", bar.attention, JSON.stringify(bar));
+
+  // Game input against a paused clock says so instead of doing nothing — but
+  // only for keys that would have reached the game. A nudge on the timeline
+  // handle is chrome, not game input.
+  const pressInPlayer = (code, onPlayhead) =>
+    heroPlayer.evaluate(
+      ([keyCode, chrome]) => {
+        const target = chrome ? document.getElementById("scrub-playhead") : document.body;
+        target.dispatchEvent(new KeyboardEvent("keydown", { code: keyCode, bubbles: true }));
+        const raised = document.getElementById("scrub-toast").classList.contains("show");
+        // Release it: the host page delivers held keys to the game, and a
+        // press with no matching release would leave the character running.
+        target.dispatchEvent(new KeyboardEvent("keyup", { code: keyCode, bubbles: true }));
+        return raised;
+      },
+      [code, onPlayhead]
+    );
+  // Past the staging-silence window: the notice deliberately says nothing for
+  // 300ms after a pause EDGE, so the hero's own programmatic park never flashes
+  // it. Staging finished moments ago, so settle before pressing.
+  await sleep(400);
+  const toastOnChrome = await pressInPlayer("ArrowRight", true);
+  const toastOnGameKey = await pressInPlayer("ArrowRight", false);
+  check(
+    "paused game input raises the scrubber's paused notice",
+    !toastOnChrome && toastOnGameKey,
+    JSON.stringify({ toastOnChrome, toastOnGameKey })
+  );
+  await sleep(2000);
+  check(
+    "the paused notice dismisses itself",
+    !(await heroPlayer.evaluate(() =>
+      document.getElementById("scrub-toast").classList.contains("show")
+    ))
+  );
+
   await heroPlayer.evaluate(() => document.getElementById("scrub-extrapolate").click());
+  check(
+    "using 🔮 retires its attention pulse for good",
+    await heroPlayer.evaluate(() => {
+      window.__scrub.setAttention({ extrapolate: true });
+      return !document.getElementById("scrub-extrapolate").classList.contains("attention");
+    })
+  );
   await heroPlayer.waitForFunction(() => window.__scrub.model().preview.enabled, {
     timeout: 3000,
   });
@@ -477,6 +549,36 @@ const playerFrame = (page) => {
     "rejected hero input batches enqueue no partial key edges",
     !beforeRejectedBatch.accepted && afterRejectedBatch === beforeRejectedBatch.inputs,
     JSON.stringify({ beforeRejectedBatch, afterRejectedBatch })
+  );
+
+  // ↺ re-parks the demo after the visitor has scrubbed (and edited) away: it
+  // seeks back to the staged anchor, paused, over the live edited program.
+  const scrubbedAway = await heroPlayer.evaluate(() => {
+    const range = window.__scrub.range();
+    window.__scrub.seek(range[1]);
+    return range[1];
+  });
+  await heroPlayer.waitForFunction(
+    (end) => window.__scrub.frame() === end,
+    scrubbedAway,
+    { timeout: 8000 }
+  );
+  await heroPlayer.evaluate(() => document.getElementById("scrub-reset").click());
+  await heroPlayer
+    .waitForFunction(
+      (anchor) => window.__scrub.paused() && window.__scrub.frame() === anchor,
+      staged.frame,
+      { timeout: 8000 }
+    )
+    .catch(() => {});
+  const afterReset = await heroPlayer.evaluate(() => ({
+    frame: window.__scrub.frame(),
+    paused: window.__scrub.paused(),
+  }));
+  check(
+    "hero ↺ re-parks the staged moment after scrubbing away",
+    afterReset.paused && afterReset.frame === staged.frame,
+    JSON.stringify({ scrubbedAway, staged: staged.frame, afterReset })
   );
 
   await page.close();

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -835,21 +835,12 @@ impl Scrubber {
                                 {
                                     action = Some(ScrubberAction::TogglePause);
                                 }
-                                if state.camera_detachable {
-                                    let enabled =
-                                        state.camera_detached || !state.camera_catching_up;
-                                    let label = if state.camera_detached {
-                                        "Exit debug view"
-                                    } else {
-                                        "Debug camera"
-                                    };
-                                    let height = ui.spacing().interact_size.y;
-                                    let button = ui.add_enabled_ui(enabled, |ui| {
-                                        ui.add_sized([104.0, height], egui::Button::new(label))
-                                    });
-                                    if button.inner.clicked() {
-                                        action = Some(ScrubberAction::ToggleDetachedCamera);
-                                    }
+                                // Left of the rail is TRANSPORT, right of it is
+                                // ways to LOOK at the frame the transport
+                                // landed on (debug camera, extrapolation) —
+                                // the web scrubber's order, mirrored.
+                                if ui.button("Step >").clicked() {
+                                    action = Some(ScrubberAction::Step);
                                 }
                                 // The draggable timeline. When a preview is
                                 // on, the rail's DOMAIN includes the preview
@@ -1026,8 +1017,21 @@ impl Scrubber {
                                         }
                                     }
                                 }
-                                if ui.button("Step >").clicked() {
-                                    action = Some(ScrubberAction::Step);
+                                if state.camera_detachable {
+                                    let enabled =
+                                        state.camera_detached || !state.camera_catching_up;
+                                    let label = if state.camera_detached {
+                                        "Exit debug view"
+                                    } else {
+                                        "Debug camera"
+                                    };
+                                    let height = ui.spacing().interact_size.y;
+                                    let button = ui.add_enabled_ui(enabled, |ui| {
+                                        ui.add_sized([104.0, height], egui::Button::new(label))
+                                    });
+                                    if button.inner.clicked() {
+                                        action = Some(ScrubberAction::ToggleDetachedCamera);
+                                    }
                                 }
 
                                 // Future preview (docs/time-travel.md T6):

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -16,6 +16,7 @@ import {
   functor_lang_scrub_set_preview_config,
   functor_lang_timeline_events,
   functor_lang_timeline_events_gen,
+  functor_lang_ui_wants_keyboard,
   functor_lang_viewer_detached,
   functor_lang_viewer_detached_generation,
   functor_lang_viewer_authored_frustum,
@@ -86,7 +87,7 @@ const STYLE = `
   position: relative; flex: 1; min-width: 80px; height: 30px; cursor: ew-resize;
   touch-action: none; user-select: none;
   /* The handles overhang the rail ends by half their width; reserve that so a
-     fully-out playhead never crowds the step / extrapolate buttons. */
+     fully-out playhead never crowds the buttons flanking the rail. */
   margin: 0 7px;
 }
 #scrub-timeline { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
@@ -273,7 +274,9 @@ const HTML = `
     <button id="scrub-camera" title="Open the debug camera" hidden>📷</button>
     <button id="scrub-extrapolate" title="Extrapolate the game into the future">🔮</button>
   </div>
-  <span id="scrub-toast" role="status" aria-live="polite">Paused — ⏸ resume · 🔮 preview</span>
+  <!-- ▶, not ⏸: the notice only ever shows while paused, and the transport
+       button reads ▶ then. It must name the glyph actually on the bar. -->
+  <span id="scrub-toast" role="status" aria-live="polite">Paused — ▶ resume · 🔮 preview</span>
   <section id="scrub-debug" aria-label="Debug Camera controls">
     <span id="scrub-debug-title">Debug Camera</span>
     <label>View
@@ -919,6 +922,11 @@ export function mountScrubber({ hidden = false } = {}) {
       refused();
     }
   });
+  const dismissAttention = () => {
+    attentionDismissed = true;
+    extrapolate.classList.remove("attention");
+  };
+
   step.addEventListener("click", () => functor_lang_scrub_step());
   reset.addEventListener("click", () => {
     if (resetAction) resetAction();
@@ -929,11 +937,6 @@ export function mountScrubber({ hidden = false } = {}) {
     pushPreview();
   });
 
-  const dismissAttention = () => {
-    attentionDismissed = true;
-    extrapolate.classList.remove("attention");
-  };
-
   // Game input while the clock is paused does nothing, which reads as a broken
   // page. Say so, once, next to the two controls that DO respond.
   //
@@ -943,17 +946,13 @@ export function mountScrubber({ hidden = false } = {}) {
   // (arrow nudges on the handles, Enter/Space on a button), any focused text
   // field or the webview overlay that swallows keys first, modifier chords, and
   // shell-owned debug-camera navigation. Keys landing on the canvas remain.
-  const GAME_KEYS = new Set([
-    "ArrowUp",
-    "ArrowDown",
-    "ArrowLeft",
-    "ArrowRight",
-    "Space",
-    "KeyW",
-    "KeyA",
-    "KeyS",
-    "KeyD",
-  ]);
+  // The host page's `keyCode(e.code)` surface: every letter, every digit
+  // (top row and numpad), the arrows, Space and Enter. Escape is left out on
+  // purpose — the browser and the shell own it (pointer-lock exit, field
+  // blur), so it is not a key the visitor aimed at the game.
+  const GAME_KEY = /^(Key[A-Z]|Digit[0-9]|Numpad[0-9]|Arrow(Up|Down|Left|Right)|Space|Enter)$/;
+  // The host page's shell-owned debug-camera movement keys.
+  const DEBUG_KEYS = /^Key[WASDQE]$/;
   const CHROME = "input, textarea, select, button, [contenteditable], #webview";
   const showPausedToast = () => {
     toast.classList.add("show");
@@ -961,11 +960,21 @@ export function mountScrubber({ hidden = false } = {}) {
     toastTimer = setTimeout(() => toast.classList.remove("show"), 1600);
   };
   const onPausedGameKey = (event) => {
-    if (!GAME_KEYS.has(event.code)) return;
+    if (!GAME_KEY.test(event.code)) return;
+    // Auto-repeat is dropped by the host's key router too, so a held key is
+    // ONE press — and re-arming the dismiss timer on every repeat would pin
+    // the notice open for as long as the key is down.
+    if (event.repeat) return;
     if (event.ctrlKey || event.metaKey || event.altKey) return;
     const target = event.target;
     if (target instanceof Element && (el.contains(target) || target.closest(CHROME))) return;
-    if (ownsDetachedInput()) return;
+    // A focused in-game text field (Ui.textInput) lives on the CANVAS, so no
+    // DOM check can see it: the keystroke reaches the field, not the paused
+    // clock, and the notice would be a lie.
+    // The debug camera only takes its OWN movement keys; everything else still
+    // falls through to the game, so bailing on any detached state would go
+    // silent exactly where the notice is wanted.
+    if (ownsDetachedInput() && DEBUG_KEYS.test(event.code)) return;
     const current = view();
     if (!current || !current.paused) return;
     // Staging a moment programmatically (the landing hero) pauses and then

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -161,6 +161,39 @@ const STYLE = `
   border-color: var(--sb-future);
   box-shadow: 0 0 0 1px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.4);
 }
+/* Attention: the host page (the landing hero) points here once, at the moment
+   the demo is staged. A slow breath rather than a blink — it should read as
+   "this is the next thing", not as an alarm. Cleared for good on first use. */
+#scrub-extrapolate.attention {
+  border-color: var(--sb-future);
+  animation: scrub-attention 2s ease-in-out infinite;
+}
+@keyframes scrub-attention {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(232, 88, 184, 0.35), 0 0 0 rgba(232, 88, 184, 0); }
+  50% { box-shadow: 0 0 0 1px var(--sb-future), 0 0 14px 2px rgba(232, 88, 184, 0.45); }
+}
+#scrub-toast {
+  /* Docked under the bar's right edge: the frame label sits centered under the
+     rail and event details hang below the marker, so this corner is free. */
+  position: absolute; z-index: 12; top: calc(100% + 6px); right: 12px;
+  display: none; padding: 5px 9px; border: 1px solid var(--sb-accent);
+  border-radius: 6px; color: var(--sb-text); background: rgba(30, 24, 51, 0.98);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45); font-size: 10px; line-height: 1.3;
+  white-space: nowrap; pointer-events: none;
+}
+#scrub-toast.show { display: block; animation: scrub-toast-in 0.16s ease-out; }
+@keyframes scrub-toast-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* A steady ring carries the same "look here" without motion. */
+  #scrub-extrapolate.attention {
+    animation: none;
+    box-shadow: 0 0 0 2px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.35);
+  }
+  #scrub-toast.show { animation: none; }
+}
 #scrub-camera.on {
   border-color: var(--sb-accent);
   box-shadow: 0 0 0 1px var(--sb-accent), 0 2px 10px rgba(65, 216, 230, 0.35);
@@ -202,8 +235,8 @@ const STYLE = `
 const HTML = `
   <div id="scrub-main">
     <button id="scrub-pause" title="Pause / resume">⏸</button>
-    <button id="scrub-camera" title="Open the debug camera" hidden>📷</button>
     <button id="scrub-step" title="Step one frame forward">⏭</button>
+    <button id="scrub-reset" title="Reset the demo" hidden>↺</button>
     <span id="scrub-rail" aria-label="Time-travel timeline" title="Drag to seek">
     <svg id="scrub-timeline" viewBox="0 0 1000 30" preserveAspectRatio="none"
       role="group" aria-label="Timeline event markers">
@@ -235,8 +268,12 @@ const HTML = `
     <span id="scrub-event-detail" role="status"></span>
     <span id="scrub-label"><span id="scrub-count"></span></span>
     </span>
+    <!-- Left of the rail = transport (⏸ ⏭/↺); right of it = ways to LOOK at
+         the frame the transport landed on (📷 the scene, 🔮 its future). -->
+    <button id="scrub-camera" title="Open the debug camera" hidden>📷</button>
     <button id="scrub-extrapolate" title="Extrapolate the game into the future">🔮</button>
   </div>
+  <span id="scrub-toast" role="status" aria-live="polite">Paused — ⏸ resume · 🔮 preview</span>
   <section id="scrub-debug" aria-label="Debug Camera controls">
     <span id="scrub-debug-title">Debug Camera</span>
     <label>View
@@ -298,6 +335,8 @@ export function mountScrubber({ hidden = false } = {}) {
   const pause = $("scrub-pause");
   const camera = $("scrub-camera");
   const step = $("scrub-step");
+  const reset = $("scrub-reset");
+  const toast = $("scrub-toast");
   const label = $("scrub-count");
   const unavailable = $("scrub-unavailable");
   const unavailableAfter = $("scrub-unavailable-after");
@@ -344,6 +383,15 @@ export function mountScrubber({ hidden = false } = {}) {
   let pendingDetachedGeneration = null;
   let pendingPointerLock = false;
   let raf = 0;
+  // Host-supplied "re-park the demo" action. When set, it REPLACES ⏭ with ↺:
+  // the staging knowledge lives with the host (the landing hero), never here.
+  let resetAction = null;
+  // The 🔮 attention pulse is a one-shot invitation: once the button has been
+  // used (or the host withdraws it), it never pulses again for this mount.
+  let attentionDismissed = false;
+  let wasPaused = false;
+  let pausedAt = 0;
+  let toastTimer = 0;
   const markerNodes = new Map();
 
   const dispatch = (action) => {
@@ -872,10 +920,60 @@ export function mountScrubber({ hidden = false } = {}) {
     }
   });
   step.addEventListener("click", () => functor_lang_scrub_step());
+  reset.addEventListener("click", () => {
+    if (resetAction) resetAction();
+  });
   extrapolate.addEventListener("click", () => {
+    dismissAttention();
     dispatch({ type: "preview-changed", preview: { enabled: !state.preview.enabled } });
     pushPreview();
   });
+
+  const dismissAttention = () => {
+    attentionDismissed = true;
+    extrapolate.classList.remove("attention");
+  };
+
+  // Game input while the clock is paused does nothing, which reads as a broken
+  // page. Say so, once, next to the two controls that DO respond.
+  //
+  // The hook is the scrubber's own window listener rather than a runtime
+  // change, and it mirrors the host page's own delivery rule: a key only counts
+  // when it would have reached the game. So it skips the bar's own chrome
+  // (arrow nudges on the handles, Enter/Space on a button), any focused text
+  // field or the webview overlay that swallows keys first, modifier chords, and
+  // shell-owned debug-camera navigation. Keys landing on the canvas remain.
+  const GAME_KEYS = new Set([
+    "ArrowUp",
+    "ArrowDown",
+    "ArrowLeft",
+    "ArrowRight",
+    "Space",
+    "KeyW",
+    "KeyA",
+    "KeyS",
+    "KeyD",
+  ]);
+  const CHROME = "input, textarea, select, button, [contenteditable], #webview";
+  const showPausedToast = () => {
+    toast.classList.add("show");
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toast.classList.remove("show"), 1600);
+  };
+  const onPausedGameKey = (event) => {
+    if (!GAME_KEYS.has(event.code)) return;
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    const target = event.target;
+    if (target instanceof Element && (el.contains(target) || target.closest(CHROME))) return;
+    if (ownsDetachedInput()) return;
+    const current = view();
+    if (!current || !current.paused) return;
+    // Staging a moment programmatically (the landing hero) pauses and then
+    // keeps working; don't flash a toast at input the visitor didn't send.
+    if (performance.now() - pausedAt < 300) return;
+    showPausedToast();
+  };
+  if (!hidden) window.addEventListener("keydown", onPausedGameKey);
   debugMode.addEventListener("change", () =>
     functor_lang_viewer_set_mode(Number(debugMode.value))
   );
@@ -939,6 +1037,24 @@ export function mountScrubber({ hidden = false } = {}) {
       if (reset) functor_lang_viewer_reset();
     },
     step: () => functor_lang_scrub_step(),
+    // Swap ⏭ for ↺ and route it back to the host. Passing null (or a
+    // non-function) restores the plain step button.
+    setReset: (handler) => {
+      resetAction = typeof handler === "function" ? handler : null;
+      step.hidden = resetAction !== null;
+      reset.hidden = resetAction === null;
+    },
+    // Point the visitor at 🔮 once. Any explicit call with a falsy
+    // `extrapolate` — like the button's own first use — retires the pulse.
+    setAttention: ({ extrapolate: wantAttention } = {}) => {
+      if (wantAttention === undefined) return;
+      if (!wantAttention) {
+        dismissAttention();
+        return;
+      }
+      if (attentionDismissed) return;
+      extrapolate.classList.add("attention");
+    },
     model: () => state,
     view,
     events: () => state.events,
@@ -986,6 +1102,14 @@ export function mountScrubber({ hidden = false } = {}) {
   window.__scrub = seam;
 
   const update = () => {
+    // One read per frame, shared with the snapshot below: it also timestamps
+    // the pause EDGE, which the paused-input toast uses to stay quiet while a
+    // host stages a moment.
+    const pausedNow = functor_lang_scrub_paused();
+    if (pausedNow !== wasPaused) {
+      wasPaused = pausedNow;
+      if (pausedNow) pausedAt = performance.now();
+    }
     const nextDetached = functor_lang_viewer_detached();
     const detachedGeneration = functor_lang_viewer_detached_generation();
     if (
@@ -1037,7 +1161,7 @@ export function mountScrubber({ hidden = false } = {}) {
         frame: functor_lang_scene_frame(),
         lo: range[0],
         hi: range[1],
-        paused: functor_lang_scrub_paused(),
+        paused: pausedNow,
         generation: functor_lang_scene_generation(),
       };
       const snapshotKey =
@@ -1048,8 +1172,7 @@ export function mountScrubber({ hidden = false } = {}) {
         dispatch({ type: "runtime-published", snapshot });
       }
     } else {
-      const paused = functor_lang_scrub_paused();
-      if (paused && state.runtime) {
+      if (pausedNow && state.runtime) {
         if (!hidden) el.style.display = "flex";
         if (state.recordingAvailable) dispatch({ type: "recording-cleared" });
       } else if (!hidden) {
@@ -1064,6 +1187,8 @@ export function mountScrubber({ hidden = false } = {}) {
   return {
     destroy() {
       cancelAnimationFrame(raf);
+      clearTimeout(toastTimer);
+      window.removeEventListener("keydown", onPausedGameKey);
       el.remove();
       document.documentElement.style.removeProperty("--functor-scrubber-h");
       if (window.__scrub === seam) delete window.__scrub;

--- a/site/index.html
+++ b/site/index.html
@@ -7,10 +7,10 @@
     <link rel="icon" href="favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
-    <title>functor — a functional toolkit for 3D games</title>
+    <title>functor — a functional toolkit for games</title>
     <meta
       name="description"
-      content="Write 3D games as pure functions in Functor Lang — a tiny, interpreted, F#-inspired game language that the Rust runtime runs live on native + WebAssembly, with state-preserving hot-reload and no compile step."
+      content="Write games as pure functions in Functor Lang — a tiny, interpreted, F#-inspired game language that the Rust runtime runs live on native + WebAssembly, with state-preserving hot-reload and no compile step."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -59,6 +59,8 @@ interface HeroScrubSeam {
     rate?: number;
     mode?: number;
   }): void;
+  setAttention(attention: { extrapolate?: boolean }): void;
+  setReset(handler: (() => void) | null): void;
 }
 
 type HeroPlayerWindow = Window & { __scrub?: HeroScrubSeam };
@@ -170,6 +172,18 @@ let region = "";
 
 const fullProgram = () => prefix + region + suffix;
 
+// The frame the demo is parked on (two before takeoff), remembered so ↺ can
+// return to it after the visitor scrubs away. Code edits are the visitor's —
+// ↺ re-seeks the timeline, it never restores the source.
+let stagedAnchor: number | null = null;
+
+const reparkStagedMoment = () => {
+  const scrub = (frame.contentWindow as HeroPlayerWindow | null)?.__scrub;
+  if (!scrub || stagedAnchor === null) return;
+  if (!scrub.paused()) scrub.togglePause();
+  scrub.seek(stagedAnchor);
+};
+
 const seedJumpHistory = async (inputs: ScriptedInput[]) => {
   const player = frame.contentWindow as HeroPlayerWindow | null;
   const scrub = player?.__scrub;
@@ -236,6 +250,14 @@ const seedJumpHistory = async (inputs: ScriptedInput[]) => {
   const seekDeadline = performance.now() + 3000;
   while (performance.now() < seekDeadline && scrub.frame() !== anchor) await delay(16);
   if (scrub.frame() !== anchor) throw new Error("the platformer timeline did not reach the jump");
+  stagedAnchor = anchor;
+
+  // The hero's bar trades ⏭ (one frame forward, which reads as fast-forward
+  // here) for ↺, which re-parks THIS staged moment. The scrubber owns the
+  // button; the staging knowledge stays in this module.
+  scrub.setReset(reparkStagedMoment);
+  // …and points at 🔮 exactly once, at the moment the demo is ready for it.
+  scrub.setAttention({ extrapolate: true });
 };
 
 const maybeStageDemo = () => {

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -49,6 +49,7 @@ interface HeroScrubEvent {
 interface HeroScrubSeam {
   paused(): boolean;
   frame(): number;
+  range(): ArrayLike<number>;
   seek(frame: number): void;
   scheduleKeyInputs(inputs: Array<{ frame: number; code: number; isDown: boolean }>): boolean;
   togglePause(): void;
@@ -176,12 +177,60 @@ const fullProgram = () => prefix + region + suffix;
 // return to it after the visitor scrubs away. Code edits are the visitor's —
 // ↺ re-seeks the timeline, it never restores the source.
 let stagedAnchor: number | null = null;
+// The takeoff the anchor sits before. ↺ re-parks only if THIS marker is still
+// recorded: resuming branches the timeline, which discards the recorded jump,
+// and the bounded ring eventually drops it — in both cases the anchor frame
+// survives as a number while the moment it named is gone.
+let stagedJumpFrame: number | null = null;
+// ↺ is asynchronous (it waits on the runtime's pause acknowledgement, and may
+// re-record), so it latches: a second click while one is in flight would
+// otherwise push a second pause toggle and leave the demo RUNNING.
+let reparking = false;
+
+const settle = async (done: () => boolean) => {
+  const deadline = performance.now() + 3000;
+  while (performance.now() < deadline && !done()) await delay(16);
+  return done();
+};
 
 const reparkStagedMoment = () => {
   const scrub = (frame.contentWindow as HeroPlayerWindow | null)?.__scrub;
-  if (!scrub || stagedAnchor === null) return;
-  if (!scrub.paused()) scrub.togglePause();
-  scrub.seek(stagedAnchor);
+  if (reparking || !scrub || stagedAnchor === null || !scriptedInputs) return;
+  reparking = true;
+  const inputs = scriptedInputs;
+  void (async () => {
+    const range = scrub.range();
+    // Re-park only onto a jump that is still THERE. `seek` clamps silently, so
+    // a stale anchor would land the demo on an arbitrary frame — and a resumed
+    // run branches the recorded future away, leaving the anchor pointing at a
+    // takeoff that no longer happens. Either way, re-record instead.
+    const jumpIntact =
+      range.length === 2 &&
+      stagedAnchor !== null &&
+      stagedAnchor >= range[0] &&
+      scrub
+        .events()
+        .some((event) => event.label === "Up down" && event.frame === stagedJumpFrame);
+    if (jumpIntact) {
+      if (!scrub.paused()) {
+        scrub.togglePause();
+        await settle(() => scrub.paused());
+      }
+      scrub.seek(stagedAnchor);
+      return;
+    }
+    if (scrub.paused()) {
+      scrub.togglePause();
+      await settle(() => !scrub.paused());
+    }
+    await seedJumpHistory(inputs);
+  })()
+    .catch((err: unknown) => {
+      setStatus("error", err instanceof Error ? err.message : String(err));
+    })
+    .finally(() => {
+      reparking = false;
+    });
 };
 
 const seedJumpHistory = async (inputs: ScriptedInput[]) => {
@@ -196,21 +245,28 @@ const seedJumpHistory = async (inputs: ScriptedInput[]) => {
   // Queue the desktop script at the runtime's fixed-step boundary. The runtime
   // applies every edge immediately before its designated simulation frame, so
   // low refresh rates and main-thread stalls cannot collapse the jump timing.
+  //
+  // Everything below matches only markers from THIS pass. ↺ can re-run the
+  // staging after the first recording has aged out of the ring, and an
+  // earlier run's markers would otherwise satisfy every wait instantly and
+  // hand back a stale (possibly already-evicted) jump frame.
+  const scheduledAt = scrub.frame();
   if (!scrub.scheduleKeyInputs(inputs)) {
     throw new Error("the platformer rejected the checked-in input script");
   }
+  const recorded = () => scrub.events().filter((event) => event.frame > scheduledAt);
 
   // The event markers publish separately from the fixed steps. Count paints
   // rather than wall time so a backgrounded tab simply resumes this wait.
   let markerPaints = 0;
   while (
     markerPaints < 600 &&
-    !inputs.every((input) => scrub.events().some((event) => event.label === input.label))
+    !inputs.every((input) => recorded().some((event) => event.label === input.label))
   ) {
     markerPaints += 1;
     await nextPaint();
   }
-  const events = scrub.events();
+  const events = recorded();
   if (!inputs.every((input) => events.some((event) => event.label === input.label))) {
     throw new Error("the platformer did not record every scripted input");
   }
@@ -251,6 +307,7 @@ const seedJumpHistory = async (inputs: ScriptedInput[]) => {
   while (performance.now() < seekDeadline && scrub.frame() !== anchor) await delay(16);
   if (scrub.frame() !== anchor) throw new Error("the platformer timeline did not reach the jump");
   stagedAnchor = anchor;
+  stagedJumpFrame = jump.frame;
 
   // The hero's bar trades ⏭ (one frame forward, which reads as fast-forward
   // here) for ↺, which re-parks THIS staged moment. The scrubber owns the

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -265,7 +265,6 @@ export function initMultiplayerPanes({
   chrono.className = "mp-chrono";
   chrono.innerHTML = `
     <button class="mp-sbtn" id="mp-pause" title="Pause / resume every client">⏸</button>
-    <button class="mp-sbtn" id="mp-camera" title="Open the focused debug camera" hidden>📷</button>
     <button class="mp-sbtn" id="mp-step" title="Step every client one frame">⏭</button>
     <span class="mp-rail" id="mp-rail" title="Drag to seek every client">
       <span class="mp-track"></span>
@@ -285,6 +284,9 @@ export function initMultiplayerPanes({
       <span class="mp-evt-tip" id="mp-evt-tip" role="status"></span>
       <span class="mp-rail-label"><b>#f</b> <span id="mp-frame">—</span></span>
     </span>
+    <!-- Right of the rail: the two ways to LOOK at the parked frame — the
+         scrubber's own grammar, so both bars read the same. -->
+    <button class="mp-sbtn" id="mp-camera" title="Open the focused debug camera" hidden>📷</button>
     <button class="mp-sbtn" id="mp-extrap" title="Extrapolate: speculatively simulate forward from the parked frame">🔮</button>
     <span class="mp-viewseg" role="group" aria-label="Pane layout">
       <button id="mp-view-tiled" aria-pressed="true" title="Tiled: every pane in one row (f cycles)">⊞ tiled</button>


### PR DESCRIPTION
Four UX refinements to the time-travel scrubber and the landing hero, all from
hands-on testing of #587's staged platformer moment — plus a small copy fix.

## What changed, and why

**1. A paused hero says what it responds to.** While the timeline is paused the
runtime genuinely drops game input (`drain_input`'s `deliver` is false), so
pressing an arrow did *nothing* — which reads as a broken page rather than a
stopped one. The bar now raises a transient notice naming the two controls that
*do* respond: **"Paused — ▶ resume · 🔮 preview"** (1.6s, `role="status"`,
`aria-live="polite"`).

The trigger is the scrubber's own `keydown` listener, not a runtime change, and
it mirrors the host page's delivery rule — a key counts only when it would have
reached the game. It stays silent for the bar's own chrome (arrow nudges on a
handle, Enter on a button), focused text fields, the webview overlay, an in-game
`Ui.textInput` (canvas-side, so it asks `functor_lang_ui_wants_keyboard()`),
the debug camera's own movement keys, modifier chords, and auto-repeat. It also
says nothing for 300ms after a pause *edge*, so a host staging a moment
programmatically never flashes it.

**2. 🔮 can be pointed at, once.** `__scrub.setAttention({ extrapolate: true })`
breathes a soft glow on the button (~2s period; a static ring under
`prefers-reduced-motion`) and **retires permanently** on first use — an
invitation, not a nag. The hero enables it at exactly one moment: when its
pre-jump frame is parked and waiting for that click.

**3. The bar reads transport, then ways to look.** ⏸ ⏭ left of the rail;
📷 🔮 right of it. All three bars over the seam now agree — the web scrubber,
the native egui one, and the sandbox's chrono bar.

**4. ⏭ becomes ↺ on the hero.** ⏭ (step one frame) read as "fast-forward" in a
context where the useful action is re-parking the staged moment.
`__scrub.setReset(handler)` swaps the button and calls the host back — the
scrubber owns the button, never the meaning of "reset". The hero's handler
re-parks *its* anchor; the sandbox and IDE pass no handler and keep ⏭.

↺ re-seeks the timeline and never touches the visitor's edits, so it works the
same over an edited or broken program. It re-parks only onto a takeoff that is
**still recorded** — a resumed run branches the recorded future away and the
bounded ring eventually drops it, while `seek` clamps silently — and otherwise
re-records the jump. The click latches while that is in flight, since a second
pause toggle would leave the demo running.

**Copy fix (separate commit).** The hero is a 2D platformer, so the general
"3D games" claim overclaims: the site `<title>`, its meta description, and
CLAUDE.md's opening line now say "games". Technical 3D mentions (`Camera3D`,
the debug camera's "FPS in 3D", README asset notes) are untouched.

## Visuals

Web bar — before / after (📷 moves right of the rail; ⏭ → ↺ on the hero; 🔮 pulses):

![web bar before](https://gist.githubusercontent.com/tommy-xr/2643d6a247958440a7818e1d83b1ed8a/raw/bar-before.png)
![web bar after](https://gist.githubusercontent.com/tommy-xr/2643d6a247958440a7818e1d83b1ed8a/raw/bar-after.png)

The paused-input notice:

![paused notice](https://gist.githubusercontent.com/tommy-xr/2643d6a247958440a7818e1d83b1ed8a/raw/toast-after.png)

Native egui bar — before / after (`--scrubber --capture-frame` on
`examples/physics`):

![native bar before](https://gist.githubusercontent.com/tommy-xr/2643d6a247958440a7818e1d83b1ed8a/raw/native-bar-before.png)
![native bar after](https://gist.githubusercontent.com/tommy-xr/2643d6a247958440a7818e1d83b1ed8a/raw/native-bar-after.png)

## Verification

- `npm run build` green (re-run after the rebase onto `b0c5108`).
- `e2e/site-sandbox.mjs`: **ALL CHECKS PASSED, 134 checks** (125 on base + 9
  new), re-run post-rebase. New checks: notice raised by a game key but not by
  scrubber chrome; auto-repeat ignored while any game key counts; the notice
  auto-dismisses; 🔮 pulses before first use and never after; 📷 immediately
  left of 🔮 on both the scrubber and the chrono bar; the hero bar shows ↺ not
  ⏭; ↺ returns to the staged anchor after a scrub-away; ↺ re-parks before a
  recorded takeoff after the demo has *run* (the re-record path).
- `npm run test:scrubber` (timeline-model): 24/24. The reducer is untouched.
- Native parity captured headlessly (above).
- Flake note: one pre-existing check (`applying a completion inserts its label`,
  a CodeMirror autocomplete race) failed in 1 of 4 post-rebase runs and passes
  otherwise; it is unrelated to this diff and also flaked on the base branch
  under machine load.

## Review (`/xreview`: Claude + Codex + a de-dup pass)

Fixed:

- **[AGREED, High]** The notice named ⏸ while the button reads ▶ when paused —
  it pointed at a glyph that is not on screen. Now ▶.
- **[AGREED, Medium]** The "would this key reach the game?" rule was a narrow
  guess (arrows/Space/WASD) while the host router delivers every letter and
  digit; and it missed `functor_lang_ui_wants_keyboard()`, so typing in an
  in-game text field raised a spurious notice. Both fixed.
- **[AGREED, Medium/Low]** Auto-repeat re-armed the dismiss timer, pinning the
  notice open while a key was held. Now skipped, matching the router.
- **[High]** ↺ re-parked onto a frame *number*, which outlives the moment it
  names; `seek` clamps silently, so after a resumed run it landed on an
  arbitrary frame with no jump ahead. Now gated on the takeoff still being
  recorded, with a re-record fallback — and the e2e covers that path.
- **[Medium]** Two fast ↺ clicks each pushed a pause toggle, leaving the demo
  running. The action latches.
- **[Medium]** Debug-camera suppression was blanket; arrows still reach the game
  while detached, so it is now scoped to that camera's own movement keys.
- **[Medium, de-dup]** The sandbox chrono bar kept the old order, making the
  documented grammar false on the bar most visitors drive. Reordered.
- Low: hoisted `dismissAttention` above its call sites; fixed a stale comment.

Dispositioned, not changed:

- *"Merge the notice with `index-functor-lang.html`'s `#capture-hint`."* Declined:
  `scrubber.js` mounts into four different host pages, only one of which has that
  element — the notice must stay self-contained.
- *"Drop the 300ms pause-edge guard; staging uses `scheduleKeyInputs`, not DOM
  keys."* Kept: it is an explicit requirement, and it also covers a key pressed
  as a programmatic pause lands. Cost is one narrow case (a key within 300ms of
  your own ⏸).
- *"`wasPaused` duplicates published state."* Kept: it is the simplest correct
  edge detector, and `state.runtime` is null before the first publish.
- *"The 3D copy change is scope creep."* Kept — an explicit maintainer request,
  isolated in its own commit.
- De-dup coverage: S1-names (10 queries / 6933 candidates), S2-clones (234 pairs,
  none touching the changed files), S3-index (3492 entries, ~12 domain greps),
  S4-read. `reparkStagedMoment` was checked against `seedJumpHistory` and is not
  a duplicate.
