### PR TITLE
feat(examples): orbs speaks the real transport

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -235,8 +235,9 @@ a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
 — resolving every canonical entry binding through the prefix as camelCase
 (`serverInit`/`serverTick`/…). A role declares at most one of the two.
 `examples/orbs` is the same-file reference: its `client` role is the file's
-plain top-level contract and its `server` role is a `module Server { … }`
-block. Module roles are **native-only** for now (`run wasm`/`build wasm`/
+plain top-level contract and its `server` role is the `server` PREFIX — the
+form that also runs in the browser, which its sandbox server pane needs.
+Module roles are **native-only** for now (`run wasm`/`build wasm`/
 `run vr` refuse them, like vr already refuses prefixes), so a role that must
 also run in the browser stays on the prefix form until the web runtime learns
 the module one; prefixed roles run on native and wasm (`run wasm`/`build wasm` bake the prefix into the page's
@@ -439,8 +440,8 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   top-level lookups, so `module Main { let tick = … }` does NOT satisfy a
   plain entry. A functor.json ROLE may opt into a block instead —
   `"server": { "file": "game.fun", "module": "Server" }` resolves
-  `Server.init`/`Server.tick`/… (see `entries` above); `examples/orbs` is the
-  reference, and the role is native-only for now.
+  `Server.init`/`Server.tick`/… (see `entries` above); the role is
+  native-only for now.
 - **Hot reload**: canonical names are the rebind identity, so an inline
   module's closures rebind normally — but MOVING a def into (or out of) a
   module renames it (`step` → `Server.step`), which the rebinder treats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,8 @@ them, so a role that must also run in the browser stays on the prefix form);
 prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
 page's boot config; the site player takes `?prefix=<ident>`) — vr loads the unprefixed
 contract only. `examples/orbs` is the same-file reference: its `client` role is the
-file's plain top-level contract and its `server` role is a `module Server { … }` block.
+file's plain top-level contract and its `server` role is the `server` PREFIX — the form
+that also runs in the browser, which the sandbox's server pane needs.
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -686,10 +686,11 @@ snapshots — no GPU, fully agent-verifiable.
       old program instead of reporting every binding missing. Module roles
       are native-only for now (`run wasm`/`build wasm`/`run vr` refuse them,
       as vr already refuses prefixes) because those shells boot the
-      unprefixed contract. `examples/orbs` is the reference: its `client`
-      role is now the file's plain top-level contract (so the sandbox and
-      the docs teach the same `init`/`tick`/`draw`) and its `server` role is
-      a `module Server { … }` block. *Verify:* config-shape tests
+      unprefixed contract. `examples/orbs` is the same-file reference: its
+      `client` role is the file's plain top-level contract (so the sandbox
+      and the docs teach the same `init`/`tick`/`draw`) and its `server`
+      role stays on the PREFIX form, because the sandbox runs that role in
+      a browser pane. *Verify:* config-shape tests
       (module form, module+prefix refusal, non-string/non-Capitalized names,
       unknown keys), contract tests naming `Server.tick`, an unknown-block
       error test, a desktop load + hot-reload test for a module role, the

--- a/examples/orbs/functor.json
+++ b/examples/orbs/functor.json
@@ -2,6 +2,6 @@
   "language": "functor-lang",
   "entries": {
     "client": "game.fun",
-    "server": { "file": "game.fun", "module": "Server" }
+    "server": { "file": "game.fun", "prefix": "server" }
   }
 }

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -1,14 +1,19 @@
-// game.fun — Orbs: the smallest multiplayer sample.
-//   functor -d examples/orbs run native
+// game.fun — Orbs: the smallest multiplayer sample, over a REAL wire.
+//   functor -d examples/orbs run native --entry server   # the authority
+//   functor -d examples/orbs run native                  # a pilot dials it
+//   functor -d examples/orbs run native                  # …and a second: the rival
 // Left/Right (A/D) turn, Up (W) thrusts, HOLD SPACE over a glowing orb to
 // claim it: it takes your color, and your score is the orbs you own. A full
-// board deals a fresh round. The client HOSTS the authoritative world
-// in-process — when the multiplayer transport lands, the SERVER section moves
-// behind the wire (a functor.json `entries` role, see examples/mp) unchanged.
+// board deals a fresh round. The server owns the world; a client sends what
+// it is doing and draws the snapshots it gets back.
 
 // ==========================  PROTOCOL  ================================
-// What both roles agree on — with a real transport, exactly what
-// `Effect.sendMsg` carries (no string codec; a typo is a check-time error).
+// What both roles agree on — exactly what `Effect.sendMsg` carries (no string
+// codec; a typo is a check-time error). One file, so ONE declaration: the two
+// ends cannot drift apart.
+
+let bind = "127.0.0.1:9101"                  // the server's listen address…
+let serverUrl = "ws://127.0.0.1:9101/orbs"   // …and the string a client dials
 
 let halfW = 13.0          // arena half-extents (world units)
 let halfH = 8.0
@@ -21,8 +26,8 @@ type Intent = { turn: float, thrust: bool, claim: bool }     // held controls, p
 //   Join           client -> server, once: opens the handshake
 //   Welcome(pid)   server -> client: your identity (the handshake's reply)
 //   Steer(intent)  client -> server, per tick: held controls. Carries NO pid —
-//                  the server keys it by the connection it arrived on (recv's
-//                  senderPid), so you can only ever steer yourself.
+//                  the server keys it by the connection it arrived on, so you
+//                  can only ever steer yourself.
 //   Claim(orbId)   client -> server: "I am over orb N with claim held" — a
 //                  REQUEST, not a fact; the server re-checks and resolves it.
 //   Snapshot(...)  server -> client, per tick: the authoritative state.
@@ -33,10 +38,21 @@ type Wire =
   | Claim(orbId: float)
   | Snapshot(ships: List<Ship>, orbs: List<Orb>)
 
-let welcomePid = (wire: Wire): float =>   // the one message a joiner decodes
-  match wire with
-  | Welcome(pid) => pid
-  | _ => 0.0 - 1.0
+// Both ends see the same socket events; only what they DO with them differs.
+type Msg =
+  | Opened(id: float)               // the socket is up
+  | Packet(id: float, wire: Wire)   // a Wire value arrived, already decoded
+  | Closed(id: float)               // …and gone for good
+  | Noise(why: string)              // a bad frame or a hiccup — NOT a disconnect
+
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => Opened(id)
+  | Net.Data(id, wire) => Packet(id, wire)
+  | Net.Disconnected(id) => Closed(id)
+  | Net.Error(_, why) => Noise(why)
+  | Net.Message(_, _) => Noise("unexpected text frame")   // this wire is typed
+
 let dist2 = (ax: float, ay: float, bx: float, by: float): float =>
   (ax - bx) * (ax - bx) + (ay - by) * (ay - by)
 
@@ -46,8 +62,9 @@ let overOrb = (ship: Ship, o: Orb): bool =>
   dist2(ship.x, ship.y, o.x, o.y) < claimRange * claimRange
 
 // ===========================  SERVER  =================================
-// PURE functions over the protocol types: `join` admits a connection,
-// `recv` folds one message in, `step` advances a tick and settles claims.
+// PURE functions over the protocol types: `join` seats a pilot, `recv` folds
+// one arriving message in, `step` advances a tick and settles claims. The
+// role that puts them behind a socket is at the bottom of the file.
 
 let turnSpeed = 3.2       // radians/second
 let moveSpeed = 9.0       // units/second while thrusting
@@ -66,12 +83,16 @@ let initialOrbs: List<Orb> = [
   { id: 4.0, x: 6.0, y: -5.0, owner: -1.0 }]
 
 let newWorld = (): World => { pilots: [], orbs: initialOrbs, claims: [], nextPid: 0.0 }
-let newShip = (pid: float): Ship =>   // one spawn slot per pid (this sample seats two)
-  { pid: pid, x: -11.0 + pid * 22.0, y: 0.0, rot: 0.0 }
-let join = (w: World): (World, Wire) =>   // allocate a pid, spawn, answer Welcome
+let newShip = (pid: float): Ship =>   // spawn slots along the arena, wrapping every four
+  { pid: pid, x: 0.0 - 11.0 + Math.mod(pid, 4.0) * 7.3, y: 0.0, rot: 0.0 }
+let join = (w: World): (World, float) =>   // allocate a pid and spawn its ship
   let pid = w.nextPid in
   let p = { ship: newShip(pid), intent: coast } in
-  ({ w with pilots: [p, ..w.pilots], nextPid: pid + 1.0 }, Welcome(pid))
+  ({ w with pilots: [p, ..w.pilots], nextPid: pid + 1.0 }, pid)
+let leave = (pid: float, w: World): World =>   // a departure releases its orbs
+  { w with pilots: w.pilots |> List.filter((p) => not p.ship.pid == pid),
+      orbs: w.orbs |> List.map((o) =>
+        if o.owner == pid then { o with owner: 0.0 - 1.0 } else o) }
 let shipOf = (pid: float, w: World): Option.t<Ship> =>
   w.pilots |> List.find((p) => p.ship.pid == pid) |> Option.map((p) => p.ship)
 
@@ -84,7 +105,7 @@ let recv = (senderPid: float, wire: Wire, w: World): World =>
           if p.ship.pid == senderPid then { p with intent: intent } else p) }
   | Claim(orbId) =>       // queue it; `step` resolves the tick's claims at once
       { w with claims: [{ pid: senderPid, orbId: orbId }, ..w.claims] }
-  | Join => w             // handled by `join` (it returns the Welcome)
+  | Join => w             // the handshake, answered where seats are handed out
   | Welcome(_) => w       // server -> client only; nothing to fold
   | Snapshot(_, _) => w   // server -> client only; nothing to fold
 
@@ -135,55 +156,45 @@ let step = (dt: float, w: World): World =>
 let scoreOf = (pid: float, orbs: List<Orb>): float =>
   orbs |> List.filter((o) => o.owner == pid) |> List.length
 
-// =============================  BOT  ==================================
-// A remote peer owning NO world state: the client asks it for an Intent each
-// tick and folds it through the SAME Steer/Claim path real packets will take.
-
-let botIntent = (ship: Ship, orbs: List<Orb>): Intent =>
-  let target =
-    orbs
-      |> List.filter((o) => o.owner < 0.0)
-      |> List.sortBy((o) => dist2(ship.x, ship.y, o.x, o.y))
-      |> List.head in
-  match target with
-  | Option.None => coast    // nothing unclaimed right now
-  | Option.Some(o) =>
-    // Nose at rot a points (-sin a, cos a), so the aim angle is atan2(-dx, dy).
-    let want = Math.atan2(ship.x - o.x, o.y - ship.y) in
-    let diff = Math.mod(want - ship.rot + Math.pi, Math.pi * 2.0) - Math.pi in
-    let arrived = overOrb(ship, o) in
-    { turn: if arrived then 0.0 else Math.sign(diff),
-      thrust: not arrived, claim: arrived }
-
 // ===========================  CLIENT  =================================
 // The `client` role is this file's ordinary top-level contract
-// (init/sampledInput/tick/draw — functor.json maps it to "game.fun").
-// YOU (cyan) and the bot (pink) join through the real protocol path; both
-// Intents fold in as Steers + Claims, then `step` runs. With a real
-// transport the client keeps only its OWN sends; nothing changes shape.
+// (init/subscriptions/update/sampledInput/tick/draw). It holds NO authority:
+// it dials the server, says what it is doing, and draws the last Snapshot it
+// was sent. Your pid arrives in the Welcome — identity comes from the server.
 
 // Palette: zero-arg functions, not top-level values — the sandbox's lang-intel
 // evaluates this module under the plain prelude, where Color.* doesn't exist.
-let cyan = () => Color.rgb(0.255, 0.847, 0.902)   // me — the site's #41d8e6
-let pink = () => Color.rgb(0.91, 0.345, 0.72)     // bot — the site's #e858b8
+let cyan = () => Color.rgb(0.255, 0.847, 0.902)   // the site's #41d8e6
+let pink = () => Color.rgb(0.91, 0.345, 0.72)     // the site's #e858b8
 let orbFree = () => Color.rgb(0.85, 0.88, 0.95)   // unclaimed: dim white glow
 let wallColor = () => Color.rgb(0.3, 0.35, 0.55)
 let bg = () => Color.rgb(0.02, 0.025, 0.06)
 
-// The starting model both roles begin from: two seats joined through the
-// handshake. `init` aliases it rather than owning it (like `draw`/`board`
-// below), so the `Server` block can start from the same model without
-// shadowing itself.
-let initialGame =
-  let (w1, meWelcome) = join(newWorld()) in
-  let (w2, botWelcome) = join(w1) in
-  { myPid: welcomePid(meWelcome), botPid: welcomePid(botWelcome),
-    world: w2, intent: coast }
+// Color carries IDENTITY, not "me": a pid looks the same in every pane.
+let inkFor = (pid: float) => if Math.mod(pid, 2.0) == 0.0 then cyan() else pink()
 
-let init = initialGame
+type Client = { conn: Option.t<float>, myPid: float,
+                ships: List<Ship>, orbs: List<Orb>, intent: Intent }
 
-// Held LEVELS, read once per tick — exactly what a transport forwards as a Steer.
-let sampledInput = (m, snap: Input.snapshot) =>
+let init: Client = { conn: Option.None, myPid: 0.0 - 1.0,
+                     ships: [], orbs: [], intent: coast }
+
+// Declaring the connection in `subscriptions` keeps the socket open.
+let subscriptions = (m: Client) => Sub.connect(serverUrl, toMsg)
+
+let update = (m: Client, msg: Msg) =>
+  match msg with
+  | Opened(id) => ({ m with conn: Option.Some(id) }, Effect.sendMsg(id, Join))
+  | Packet(_, wire) =>
+      (match wire with
+       | Welcome(pid) => { m with myPid: pid }
+       | Snapshot(ships, orbs) => { m with ships: ships, orbs: orbs }
+       | _ => m)          // Join/Steer/Claim are client -> server only
+  | Closed(_) => { m with conn: Option.None, ships: [], orbs: [] }
+  | Noise(_) => m       // a hiccup is not a disconnect: keep playing
+
+// Held LEVELS, read once per tick — exactly what the Steer forwards.
+let sampledInput = (m: Client, snap: Input.snapshot) =>
   let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
   { m with intent: {
       turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
@@ -191,91 +202,126 @@ let sampledInput = (m, snap: Input.snapshot) =>
       thrust: held(Key.Up) || held(Key.W),
       claim: held(Key.Space) } }
 
-// Over an unclaimed orb with claim held -> a Claim on the wire; the server decides.
-let sendClaim = (pid: float, intent: Intent, w: World): World =>
-  if not intent.claim then w
-  else
-    match shipOf(pid, w) with
-    | Option.None => w
-    | Option.Some(s) =>
-      (match w.orbs |> List.find((o) => o.owner < 0.0 && overOrb(s, o)) with
-       | Option.Some(o) => w |> recv(pid, Claim(o.id))
-       | Option.None => w)
-
-let tick = (m, dt: float, tts: float) =>
-  let bot =
-    (match shipOf(m.botPid, m.world) with
-     | Option.None => coast
-     | Option.Some(s) => botIntent(s, m.world.orbs)) in
-  { m with world:
-      m.world
-        |> recv(m.myPid, Steer(m.intent))
-        |> recv(m.botPid, Steer(bot))
-        |> sendClaim(m.myPid, m.intent)
-        |> sendClaim(m.botPid, bot)
-        |> step(dt) }
+// One burst per tick — and nothing at all before the server has seated us.
+// `Steer` reports the input we are holding right now; a `Claim` rides along
+// only when the last Snapshot we were sent puts us over a free orb. Both are
+// PROPOSALS — neither is a fact until the server re-checks it.
+let tick = (m: Client, dt: float, tts: float) =>
+  match m.conn with
+  | Option.None => m
+  | Option.Some(id) =>
+    (match m.ships |> List.find((s) => s.pid == m.myPid) with
+     | Option.None => m
+     | Option.Some(s) =>
+       let claim =
+         if not m.intent.claim then []
+         else (match m.orbs |> List.find((o) => o.owner < 0.0 && overOrb(s, o)) with
+               | Option.Some(o) => [Claim(o.id)]
+               | Option.None => []) in
+       (m, Effect.batch([Steer(m.intent), ..claim]
+                          |> List.map((w) => Effect.sendMsg(id, w)))))
 
 // ---------- rendering ----------
-let colorFor = (m, pid: float) => if pid == m.myPid then cyan() else pink()
-
 // Unclaimed orbs glow dim white; a claimed orb burns its owner's color.
-let orbSprite = (m, o: Orb) =>
+let orbSprite = (o: Orb) =>
   let claimed = o.owner >= 0.0 in
-  let c = if claimed then colorFor(m, o.owner) else orbFree() in
+  let c = if claimed then inkFor(o.owner) else orbFree() in
   Sprite.group([
     Sprite.circle(c, 1.5) |> Sprite.fade(if claimed then 0.3 else 0.16),
     Sprite.circle(c, 0.6) |> Sprite.fade(if claimed then 1.0 else 0.7),
   ]) |> Sprite.move(o.x, o.y)
 
-let shipSprite = (m, p: Pilot) =>
-  Sprite.polygon(colorFor(m, p.ship.pid),
+let shipSprite = (me: float, s: Ship) =>
+  Sprite.polygon(inkFor(s.pid),
                  [{ x: 0.0, y: 1.2 }, { x: -0.8, y: -0.9 }, { x: 0.8, y: -0.9 }])
-    |> Sprite.rotate(Angle.radians(p.ship.rot))
-    |> Sprite.move(p.ship.x, p.ship.y)
+    |> Sprite.fade(if s.pid == me then 1.0 else 0.6)   // yours is the bright one
+    |> Sprite.rotate(Angle.radians(s.rot))
+    |> Sprite.move(s.x, s.y)
 
-let hud = (m) =>
-  Sprite.group([
-    Text.concat("YOU ", Text.fixed(scoreOf(m.myPid, m.world.orbs), 0.0))
-      |> Sprite.text(cyan(), 1.2) |> Sprite.move(0.0 - halfW * 0.5, halfH + 2.2),
-    Text.concat("BOT ", Text.fixed(scoreOf(m.botPid, m.world.orbs), 0.0))
-      |> Sprite.text(pink(), 1.2) |> Sprite.move(halfW * 0.5, halfH + 2.2)])
+// One score per seated pilot, over a status line that stays honest about who is
+// actually in the arena. An EMPTY board means something different to each role,
+// so each supplies its own `alone` line; one lonely ship reads the same either
+// way — you can still fly and claim uncontested, but it takes two to race.
+let hud = (alone: string, ships: List<Ship>, orbs: List<Orb>) =>
+  let scores = ships |> List.map((s) =>
+    $"P{s.pid} {scoreOf(s.pid, orbs)}"
+      |> Sprite.text(inkFor(s.pid), 1.0)
+      |> Sprite.move(0.0 - 10.5 + Math.mod(s.pid, 4.0) * 7.0, halfH + 2.2)) in
+  let waiting =
+    if List.length(ships) >= 2.0 then []
+    else [(if List.length(ships) == 0.0 then alone else "waiting for a rival...")
+            |> Sprite.text(orbFree(), 1.0)
+            |> Sprite.move(0.0, 0.0 - halfH - 2.2)] in
+  Sprite.group(scores |> List.append(waiting))
 
-// The board both roles render. `draw` aliases it rather than owning the body,
-// so the `Server` block can render the same view without shadowing itself.
-let board = (m, tts: float) =>
+// The board both roles render — from ships and orbs, which is all a Snapshot
+// carries and all the authority needs to show.
+let board = (me: float, alone: string, ships: List<Ship>, orbs: List<Orb>) =>
   Frame.create2D(
     Camera2D.create((halfW + 2.0) * 2.0, (halfH + 3.0) * 2.0),
     Sprite.group(
       [Sprite.rectangle(wallColor(), halfW * 2.0 + 2.6, halfH * 2.0 + 2.6),
        Sprite.rectangle(bg(), halfW * 2.0 + 2.0, halfH * 2.0 + 2.0)]
-        |> List.append(m.world.orbs |> List.map((o) => orbSprite(m, o)))
-        |> List.append(m.world.pilots |> List.map((p) => shipSprite(m, p)))
-        |> List.append([hud(m)])))
+        |> List.append(orbs |> List.map(orbSprite))
+        |> List.append(ships |> List.map((s) => shipSprite(me, s)))
+        |> List.append([hud(alone, ships, orbs)])))
     |> Frame.withClearColor(bg())
 
-let draw = board
+let draw = (m: Client, tts: float) =>
+  board(m.myPid, "waiting for the server...", m.ships, m.orbs)
 
 // ========================  SERVER ROLE  ===============================
 // The same file is ALSO the `server` entry: functor.json maps the role to
-// { "file": "game.fun", "module": "Server" }, so the runner resolves this
-// block's members as the contract — Server.init/Server.tick/Server.draw
+// { "file": "game.fun", "prefix": "server" }, so the runner resolves this
+// section's bindings as the contract — serverInit/serverTick/serverDraw/…
 // (functor -d examples/orbs run native --entry server). One buffer, both
-// roles, one hot reload. The role is the authoritative SERVER section
-// stepped directly, with the bot steering both seats so the view moves on
-// its own. Everything at the file's top level (the protocol, the world
-// step, the renderer) is visible in here bare.
+// roles, one hot reload.
 
-module Server {
-  let init = initialGame
+type Seat = { cid: float, pid: float }   // connection -> the pilot it steers
 
-  let tick = (m, dt: float, tts: float) =>
-    let steer = (pid: float, w: World): World =>
-      (match shipOf(pid, w) with
-       | Option.None => w
-       | Option.Some(s) =>
-         let i = botIntent(s, w.orbs) in
-         w |> recv(pid, Steer(i)) |> sendClaim(pid, i)) in
-    { m with world: m.world |> steer(m.myPid) |> steer(m.botPid) |> step(dt) }
+// An empty arena: every pilot arrives over a wire, so the board starts with
+// five unclaimed orbs and nobody in it.
+let serverInit = { world: newWorld(), seats: [] }
 
-  let draw = board   // the same board, seen from the authority
-}
+// Declaring the listener in `subscriptions` keeps the server bound.
+let serverSubscriptions = (m) => Sub.listen(bind, toMsg)
+
+let seatPid = (cid: float, m): Option.t<float> =>
+  m.seats |> List.find((s) => s.cid == cid) |> Option.map((s) => s.pid)
+
+let serverUpdate = (m, msg: Msg) =>
+  match msg with
+  | Opened(_) => m        // a socket, not yet a pilot: the Join seats it
+  | Packet(cid, wire) =>
+      (match wire with
+       // The handshake: seat a pilot for this connection, answer its identity.
+       // A re-Join is answered from the seat it already has — one connection
+       // is one pilot, however many times it asks.
+       | Join =>
+         (match seatPid(cid, m) with
+          | Option.Some(pid) => (m, Effect.sendMsg(cid, Welcome(pid)))
+          | Option.None =>
+            let (w, pid) = join(m.world) in
+            ({ m with world: w, seats: [{ cid: cid, pid: pid }, ..m.seats] },
+             Effect.sendMsg(cid, Welcome(pid))))
+       // Everything else is keyed by the connection, never by the wire value.
+       | _ =>
+         (match seatPid(cid, m) with
+          | Option.Some(pid) => { m with world: m.world |> recv(pid, wire) }
+          | Option.None => m))
+  | Noise(_) => m
+  | Closed(cid) =>
+      (match seatPid(cid, m) with
+       | Option.Some(pid) => { m with world: m.world |> leave(pid),
+                               seats: m.seats |> List.filter((s) => not s.cid == cid) }
+       | Option.None => m)
+
+let serverTick = (m, dt: float, tts: float) =>
+  let stepped = m.world |> step(dt) in
+  let snap = Snapshot(stepped.pilots |> List.map((p) => p.ship), stepped.orbs) in
+  ({ m with world: stepped },
+   Effect.batch(m.seats |> List.map((s) => Effect.sendMsg(s.cid, snap))))
+
+let serverDraw = (m, tts: float) =>   // the authority holds no seat of its own
+  board(0.0 - 1.0, "waiting for a pilot...",
+        m.world.pilots |> List.map((p) => p.ship), m.world.orbs)

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -58,11 +58,15 @@ export interface Example {
    * net coordinator routes the client panes' traffic to it. The editable
    * `source` stays the CLIENT entry.
    *
-   * The file must ALSO appear in `siblings`: that is what copies it into the
-   * built site and puts it in the fetched project file list. Naming a file
-   * here that nothing copies would 404 the server pane.
+   * The file must ALSO appear in `siblings` — that is what copies it into the
+   * built site and puts it in the fetched project file list; naming a file
+   * here that nothing copies would 404 the server pane — UNLESS it is the
+   * example's own entry, which is copied and listed already. A same-file
+   * sample says so by naming that entry and the `prefix` its server role
+   * resolves through (orbs: `serverInit`/`serverTick`/…), which the server
+   * pane's `?prefix=` carries.
    */
-  server?: { file: string };
+  server?: { file: string; prefix?: string };
 }
 
 /**
@@ -138,16 +142,17 @@ export const EXAMPLES: Example[] = [
   // module literally named `Physics` collides with the builtin/prelude namespace.
   { id: "bounce", label: "Physics", source: "examples/physics/game.fun" },
   // The minimal multiplayer-mechanics sample in ONE module (banner sections:
-  // PROTOCOL / SERVER / BOT / CLIENT), so the wire ADT and the authoritative
-  // claim resolution are right there in the editable buffer.
+  // PROTOCOL / SERVER / CLIENT / SERVER ROLE), so the wire ADT and the
+  // authoritative claim resolution are right there in the editable buffer.
   {
     id: "orbs",
     label: "Orbs (multiplayer)",
     source: "examples/orbs/game.fun",
     multiplayer: true,
-    // The sandbox plays the `client` role, which is the file's ordinary
-    // top-level contract (the `server` role lives in its `module Server`
-    // block, a native-only entries form) — so no `prefix` is needed.
+    // Both roles are in the ONE editable buffer: the sandbox plays the
+    // `client` role (the file's ordinary top-level contract, so no `prefix`),
+    // and the server pane re-enters the same file through the `server` prefix.
+    server: { file: exampleEntryPath("orbs"), prefix: "server" },
   },
   // The client/server sample: two ROLES over a shared typed protocol, run
   // end-to-end in the pane grid — the client panes and a server pane, wired to

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -439,9 +439,15 @@ const loadExample = async (id: string) => {
   if (serverFile) {
     // Derived from the client's params, so every project setting the sample
     // declares (prefix, cursor, mouseCapture) reaches the server pane too —
-    // only the entry and the file ORDER differ.
+    // only the entry, the file ORDER, and the role prefix differ.
     const serverParams = new URLSearchParams(params);
     serverParams.set("game", serverFile);
+    // …except the role PREFIX, which is the one param the server owns: a
+    // same-file sample (orbs) has both roles in one entry, so the server pane
+    // differs from the client pane only by the prefix it resolves through, and
+    // inheriting the client's would boot the wrong contract.
+    serverParams.delete("prefix");
+    if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     serverParams.delete("file");
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);


### PR DESCRIPTION
![orbs over the real transport](https://gist.githubusercontent.com/tommy-xr/6ee050f3e2d94ebfbf8aed30ead1ca08/raw/orbs3-hero.gif)

<sub>`orbs` — the minimal multiplayer sample — running its own Join/Steer/Claim/Snapshot protocol over the coordinator. No bot: every pilot arrives over a wire; the arena waits honestly until they do.</sub>

![network view — two clients, one server, packets both ways](https://gist.githubusercontent.com/tommy-xr/6ee050f3e2d94ebfbf8aed30ead1ca08/raw/orbs3-network.png)

<sub>Network view: two client panes and the authoritative server pane, intent flowing up and snapshots flowing down.</sub>

<details>
<summary>More: tiled view, the native server, and the honest empty states</summary>

![tiled view](https://gist.githubusercontent.com/tommy-xr/6ee050f3e2d94ebfbf8aed30ead1ca08/raw/orbs3-tiled.png)

<sub>Tiled view — the same two ships in all three panes: each client's world and the server's authoritative one.</sub>

![native server with two pilots](https://gist.githubusercontent.com/tommy-xr/6ee050f3e2d94ebfbf8aed30ead1ca08/raw/orbs3-server.png)

<sub>The native server process over real sockets, with two pilots seated (P0 / P1).</sub>

![server alone](https://gist.githubusercontent.com/tommy-xr/6ee050f3e2d94ebfbf8aed30ead1ca08/raw/orbs3-server-solo.png)

<sub>A server with nobody connected: the unclaimed board and "waiting for a pilot...".</sub>

![client with no server](https://gist.githubusercontent.com/tommy-xr/6ee050f3e2d94ebfbf8aed30ead1ca08/raw/orbs3-client-noserver.png)

<sub>A client that can't reach the server: an empty arena and "waiting for the server...".</sub>

</details>

---

The flagship multiplayer sample's `Join → Welcome → Steer/Claim → Snapshot` handshake now runs over **real wires** — the coordinator in the sandbox (server pane + client panes, packets visible in the network view), real sockets natively. Same one file, same pedagogy: **Steer carries no pid** (identity is the connection) and **Claim is a request the server re-checks** (closest wins, ties to lower pid).

**The bot is gone** (Bryan: with real clients, a second player IS the rival). The arena starts empty; every pilot arrives over a wire. The HUD is honest per role about an empty board — the server says "waiting for a pilot...", a client that can't reach the server says "waiting for the server...", one ship says "waiting for a rival..." — and the "+" seat is the invitation. A lone player steers and claims uncontested; contention (the pedagogy) begins the moment a second client joins.

**Line-count honesty** (the standing constraint: transport must move lines, not add them): 281 → 327. The +46 is the real handshake surface a simulated loop never needed — one `Msg` ADT + one `toMsg` tagger shared by BOTH roles (mp needs one per role), `Sub.connect`/`Sub.listen`, the seat map — minus the deleted in-model loopback AND the whole BOT section. Review audited every added line against the constraint; none is padding.

**Cross-track note (needs Bryan's ack):** the base had orbs' server as `module Server { … }` (from #601) and the docs named it the module-role reference — but module roles are native-only today (the web shell only knows `?prefix=`), so a sandbox server pane was impossible in that form. Converted back to `prefix:` per the standing both-roles-prefixed constraint, with the three doc sites updated to say why. Module roles keep their Rust tests but lose their bundled example until the web shell learns `?module=` (the #554-shaped follow-up), at which point orbs converts forward again.

**Site enablement (minimal):** `Example.server` gains `prefix?`; orbs declares its server role; the server pane URL swaps the prefix (and *deletes* the inherited client prefix — review caught that an inherited prefix could boot the wrong contract).

**Cross-engine review (Claude + Codex), all findings dispositioned:**
- Fixed [AGREED]: `Net.Error`/`Net.Message` mapped to `Closed` — one bad frame evicted a live pilot server-side and permanently killed the client session → new `Noise(why)` variant; only `Disconnected` closes. `leave` never released a departed pilot's orbs (permanently dead orbs) → reset to unclaimed. A repeated `Join` double-seated a connection → the handshake re-answers from the existing seat.
- Fixed (single-engine): client `Closed` clears `orbs`; ASCII `...` (the sprite font has no `…` — caught in a capture); own ship bright / others dimmed (restores "which one is me"); `Snapshot` built once, not per recipient.
- Dispositioned, unchanged: no reconnect after drop (known runtime gap, not this PR); the client gating claims on its stale snapshot (that IS the pedagogy — propose what you see, the server re-checks); O(N²) snapshot fan-out (deliberately naive, same as mp).

**Verification (re-run in full after the bot removal):** `functor -d examples/orbs build` green (both role contracts); native captures for both roles (a solo server shows the unclaimed board + "waiting for a pilot..."; a client with no server shows "waiting for the server..."); **three native processes over real sockets** — server + two clients, P0/P1 scores, each client seeing both ships with its own bright; sandbox proof — server pane + 2 clients, pill `2+1 running`, distinct pids from `Welcome`, exactly two ships in every world, zero errors; `npm run test:site` ALL CHECKS PASSED (125); `sandbox-mp` e2e ALL CHECKS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

