### PR TITLE
feat(web): module entry roles on the embedded producer

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -241,12 +241,12 @@ a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
 (`serverInit`/`serverTick`/…). A role declares at most one of the two.
 `examples/orbs` is the same-file reference: its `client` role is the file's
 plain top-level contract and its `server` role is the `server` PREFIX — the
-form that also runs in the browser, which its sandbox server pane needs.
-Module roles are **native-only** for now (`run wasm`/`build wasm`/
-`run vr` refuse them, like vr already refuses prefixes), so a role that must
-also run in the browser stays on the prefix form until the web runtime learns
-the module one; prefixed roles run on native and wasm (`run wasm`/`build wasm` bake the prefix into the page's
-boot config; the site player takes `?prefix=<ident>`). `entry` and `entries`
+form its sandbox server pane shipped with. **Both forms run on native and
+wasm**: `run wasm`/`build wasm` bake the
+role into the served/exported page's boot config (`window.__functorLangEntryModule`
+/ `…EntryPrefix`; the site player takes `?module=<Ident>` or `?prefix=<ident>`,
+one of the two). Only **vr** still refuses a role — its device push path boots
+the APK's embedded producer with the unprefixed contract. `entry` and `entries`
 together are refused.
 
 ```functor
@@ -445,8 +445,8 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   top-level lookups, so `module Main { let tick = … }` does NOT satisfy a
   plain entry. A functor.json ROLE may opt into a block instead —
   `"server": { "file": "game.fun", "module": "Server" }` resolves
-  `Server.init`/`Server.tick`/… (see `entries` above); the role is
-  native-only for now.
+  `Server.init`/`Server.tick`/… (see `entries` above). Such a role runs on
+  native and wasm; only vr still refuses it.
 - **Hot reload**: canonical names are the rebind identity, so an inline
   module's closures rebind normally — but MOVING a def into (or out of) a
   module renames it (`step` → `Server.step`), which the rebinder treats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,7 @@ error listing the file's blocks). The transitional form names a binding **prefix
 `"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical entry
 binding through the prefix as camelCase (`serverInit`/`serverTick`/…); a role declares at
 most one of the two. `build` validates every declared role's contract with its resolved
+<<<<<<< HEAD
 names. Module roles are native-only for now (`run wasm`/`build wasm`/`run vr` refuse
 them, so a role that must also run in the browser stays on the prefix form);
 prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
@@ -255,6 +256,14 @@ page's boot config; the site player takes `?prefix=<ident>`) — vr loads the un
 contract only. `examples/orbs` is the same-file reference: its `client` role is the
 file's plain top-level contract and its `server` role is the `server` PREFIX — the form
 that also runs in the browser, which the sandbox's server pane needs.
+=======
+names. Both forms run on native and wasm — `run wasm`/`build wasm` bake the role into the
+served/exported page's boot config, and the site player takes `?module=<Ident>` or
+`?prefix=<ident>`. Only `run vr` refuses a role (the device push path boots the APK's
+embedded producer with the unprefixed contract). `examples/orbs` is the same-file
+reference: its `client` role is the file's plain top-level contract and its `server` role
+is a `module Server { … }` block.
+>>>>>>> 8333093 (feat(web): module entry roles on the embedded producer)
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -627,6 +627,32 @@ impl FunctorLangProject {
         Ok(())
     }
 
+    /// Can this shell boot this role? Native takes either same-file form
+    /// (`--entry-prefix` / `--entry-module`) and wasm bakes either into the
+    /// served page's boot config, but the vr device push path still boots the
+    /// APK's embedded producer with the unprefixed contract — so running a
+    /// role there would silently play the WRONG role. The test names the
+    /// shells that DO support the forms, so a future environment is refused
+    /// until it is taught them. The config refuses a role declaring both
+    /// forms, so at most one is ever named here.
+    fn check_role_supported(&self, environment: &Environment) -> Result<(), Error> {
+        let shell = match environment {
+            Environment::Native | Environment::Wasm => return Ok(()),
+            Environment::Vr => "vr",
+        };
+        let (form, name) = if !self.module.is_empty() {
+            ("module", self.module.as_str())
+        } else if !self.prefix.is_empty() {
+            ("prefix", self.prefix.as_str())
+        } else {
+            return Ok(());
+        };
+        Err(Error::other(format!(
+            "entry {form} `{name}` is not supported on {shell} yet — run this role with \
+`run native` or `run wasm` (the vr shell loads the unprefixed contract)"
+        )))
+    }
+
     /// Spawn the runner on the entry (`run` and `develop` — hot reload is
     /// built into the producer, so there is no separate watch loop).
     pub async fn run(
@@ -637,35 +663,7 @@ impl FunctorLangProject {
         develop: bool,
     ) -> Result<(), Error> {
         refresh_manifest(working_directory);
-        // A prefixed role can't run on VR yet: the device push path boots the
-        // APK's embedded producer with the unprefixed contract, so running it
-        // would silently play the wrong role. (Native passes --entry-prefix;
-        // wasm bakes the prefix into the served page's boot config.)
-        if !self.prefix.is_empty() && matches!(environment, Environment::Vr) {
-            return Err(Error::other(format!(
-                "entry prefix `{}` is not supported on vr yet — run this role with \
-`run native` or `run wasm` (the vr shell loads the unprefixed contract)",
-                self.prefix
-            )));
-        }
-        // An inline-module role is native-only for now: the wasm host page and
-        // the device push path both boot their embedded producer with the
-        // unprefixed contract, so running it there would silently play the
-        // wrong role. (Native passes --entry-module.) The test is "not
-        // native", so a future environment is refused until it is taught the
-        // form, rather than silently booting the wrong role.
-        if !self.module.is_empty() && !matches!(environment, Environment::Native) {
-            return Err(Error::other(format!(
-                "entry module `{}` is not supported on {} yet — run this role with \
-`run native` (the other shells load the unprefixed contract)",
-                self.module,
-                match environment {
-                    Environment::Vr => "vr",
-                    Environment::Wasm => "wasm",
-                    Environment::Native => unreachable!("guarded above"),
-                }
-            )));
-        }
+        self.check_role_supported(environment)?;
         if matches!(environment, Environment::Vr) {
             if !runner_args.is_empty() {
                 emit(Event::Warning {
@@ -1000,16 +998,6 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         #[cfg(feature = "web")]
         {
             self.entry_path(working_directory)?;
-            // Same restriction as `run wasm`: the exported page boots the web
-            // runtime's unprefixed contract, so a module role would ship as
-            // the wrong role.
-            if !self.module.is_empty() {
-                return Err(Error::other(format!(
-                    "entry module `{}` is not supported on wasm yet — `build native` this role \
-(the wasm bundle loads the unprefixed contract)",
-                    self.module
-                )));
-            }
             // Same constraint as `run wasm`: the bundle carries the project
             // directory, so the entry must live inside it.
             if entry_escapes_project(&self.entry) {
@@ -1025,6 +1013,7 @@ relative path inside it (got {})",
                 self.mouse_capture,
                 self.cursor.as_str(),
                 &self.prefix,
+                &self.module,
             )?;
             for name in &export.shadowed {
                 emit(Event::Warning {
@@ -1123,6 +1112,7 @@ relative path inside it (got {})",
                 self.mouse_capture,
                 self.cursor.as_str(),
                 &self.prefix,
+                &self.module,
             );
             if no_open {
                 emit(Event::Info {
@@ -1638,6 +1628,7 @@ mod tests {
         manifest_mouse_capture, nth_line, project_asset_files, resolve_debug_args, CursorPolicy,
         FunctorLangConfig, FunctorLangEntries, FunctorLangProject,
     };
+    use crate::Environment;
 
     fn resolve(develop: bool, args: &[&str]) -> (Vec<String>, Option<String>) {
         let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();
@@ -1966,6 +1957,42 @@ mod tests {
         )]);
         let err = config.select(Some("server")).unwrap_err();
         assert!(err.to_string().contains("valid identifier"), "{err}");
+    }
+
+    /// The shells that can boot a same-file ROLE. Both forms run on native
+    /// and wasm (the page's boot config carries the module now); vr still
+    /// boots the unprefixed contract, so a role is refused there with a
+    /// teaching error naming the form.
+    #[test]
+    fn a_role_runs_on_native_and_wasm_but_not_vr() {
+        let config = named_json(&[
+            (
+                "client",
+                serde_json::json!({ "file": "game.fun", "module": "Client" }),
+            ),
+            (
+                "legacy",
+                serde_json::json!({ "file": "game.fun", "prefix": "legacy" }),
+            ),
+            ("plain", serde_json::json!("game.fun")),
+        ]);
+        for role in ["client", "legacy"] {
+            let project = config.select(Some(role)).unwrap();
+            for env in [Environment::Native, Environment::Wasm] {
+                assert!(
+                    project.check_role_supported(&env).is_ok(),
+                    "`{role}` must boot on {env:?}"
+                );
+            }
+            let err = project
+                .check_role_supported(&Environment::Vr)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("not supported on vr yet"), "{err}");
+        }
+        // A role with neither form is the plain contract — every shell boots it.
+        let plain = config.select(Some("plain")).unwrap();
+        assert!(plain.check_role_supported(&Environment::Vr).is_ok());
     }
 
     #[test]

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -523,12 +523,10 @@ impl FunctorLangProject {
     /// binding prefix. The config refuses both at once, so the choice is
     /// unambiguous here.
     fn entry_role(&self) -> functor_runtime_common::functor_lang_producer::EntryRole {
-        use functor_runtime_common::functor_lang_producer::EntryRole;
-        if self.module.is_empty() {
-            EntryRole::Prefix(self.prefix.clone())
-        } else {
-            EntryRole::Module(self.module.clone())
-        }
+        functor_runtime_common::functor_lang_producer::EntryRole::from_parts(
+            &self.module,
+            &self.prefix,
+        )
     }
 
     /// `build`'s per-role contract gate (same-file entries): load a Session
@@ -636,16 +634,16 @@ impl FunctorLangProject {
     /// until it is taught them. The config refuses a role declaring both
     /// forms, so at most one is ever named here.
     fn check_role_supported(&self, environment: &Environment) -> Result<(), Error> {
-        let shell = match environment {
+        use functor_runtime_common::functor_lang_producer::EntryRole;
+        match environment {
             Environment::Native | Environment::Wasm => return Ok(()),
-            Environment::Vr => "vr",
-        };
-        let (form, name) = if !self.module.is_empty() {
-            ("module", self.module.as_str())
-        } else if !self.prefix.is_empty() {
-            ("prefix", self.prefix.as_str())
-        } else {
-            return Ok(());
+            Environment::Vr => {}
+        }
+        let shell = environment.as_str();
+        let (form, name) = match self.entry_role() {
+            EntryRole::Prefix(prefix) if prefix.is_empty() => return Ok(()),
+            EntryRole::Prefix(prefix) => ("prefix", prefix),
+            EntryRole::Module(module) => ("module", module),
         };
         Err(Error::other(format!(
             "entry {form} `{name}` is not supported on {shell} yet — run this role with \

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -40,6 +40,10 @@ fn script_safe(json: String) -> String {
 /// - `"__FUNCTOR_LANG_ENTRY_PREFIX__"` becomes a JSON string literal →
 ///   `window.__functorLangEntryPrefix`, the role's binding prefix (same-file
 ///   entries; empty = the classic unprefixed contract).
+/// - `"__FUNCTOR_LANG_ENTRY_MODULE__"` becomes a JSON string literal →
+///   `window.__functorLangEntryModule`, the role's inline entry module
+///   (same-file entries; empty = no module role). The config refuses a role
+///   declaring both, so at most one of the two is ever non-empty.
 ///
 /// All substitutions are valid JS for any path (quotes/backslashes included).
 pub(crate) fn render_functor_lang_index(
@@ -48,6 +52,7 @@ pub(crate) fn render_functor_lang_index(
     mouse_capture: bool,
     cursor: &str,
     prefix: &str,
+    module: &str,
 ) -> String {
     let entry_literal =
         script_safe(serde_json::to_string(entry).expect("a string always serializes"));
@@ -59,12 +64,15 @@ pub(crate) fn render_functor_lang_index(
         script_safe(serde_json::to_string(cursor).expect("a string always serializes"));
     let prefix_literal =
         script_safe(serde_json::to_string(prefix).expect("a string always serializes"));
+    let module_literal =
+        script_safe(serde_json::to_string(module).expect("a string always serializes"));
     INDEX_FUNCTOR_LANG_HTML
         .replace("\"__FUNCTOR_LANG_ENTRY__\"", &entry_literal)
         .replace("\"__FUNCTOR_LANG_PROJECT_FILES__\"", &files_literal)
         .replace("\"__FUNCTOR_MOUSE_CAPTURE__\"", &mouse_capture_literal)
         .replace("\"__FUNCTOR_CURSOR_POLICY__\"", &cursor_literal)
         .replace("\"__FUNCTOR_LANG_ENTRY_PREFIX__\"", &prefix_literal)
+        .replace("\"__FUNCTOR_LANG_ENTRY_MODULE__\"", &module_literal)
 }
 
 /// The project's file list as URLs relative to the served directory (entry
@@ -101,11 +109,13 @@ impl WasmDevServer {
         mouse_capture: bool,
         cursor: &str,
         prefix: &str,
+        module: &str,
     ) -> Result<(), io::Error> {
         let files = project_file_urls(working_directory, entry);
         Self::serve(
             working_directory,
-            render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix).into_bytes(),
+            render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix, module)
+                .into_bytes(),
         )
         .await
     }
@@ -195,6 +205,7 @@ mod tests {
             true,
             "captured",
             "",
+            "",
         );
         assert!(html.contains("window.__functorLangGamePath = \"game.fun\""));
         assert!(html.contains("const gameMouseCapture = true"));
@@ -214,6 +225,7 @@ mod tests {
             false,
             "visible",
             "",
+            "",
         );
         assert!(html.contains("(["));
         assert!(html.contains("\"game.fun\",\"pieces.fun\""));
@@ -228,6 +240,7 @@ mod tests {
             &["game.fun".to_string()],
             false,
             "visible",
+            "",
             "",
         );
         for expected in [
@@ -274,6 +287,7 @@ mod tests {
             true,
             "captured",
             "",
+            "",
         );
         assert!(html.contains("we\\\"ird\\\\name.fun"));
     }
@@ -285,6 +299,7 @@ mod tests {
             &["bad</script>.fun".to_string()],
             true,
             "captured",
+            "",
             "",
         );
         assert!(html.contains("bad<\\/script>.fun"));
@@ -300,15 +315,35 @@ mod tests {
             true,
             "captured",
             "server",
+            "",
         );
         assert!(html.contains("window.__functorLangEntryPrefix = \"server\""));
         assert!(!html.contains("__FUNCTOR_LANG_ENTRY_PREFIX__"));
     }
 
+    /// The role's inline entry MODULE reaches the page: the web producer reads
+    /// `window.__functorLangEntryModule` to resolve `Server.init`/`Server.tick`/….
+    #[test]
+    fn substitutes_the_entry_module() {
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            true,
+            "captured",
+            "",
+            "Server",
+        );
+        assert!(html.contains("window.__functorLangEntryModule = \"Server\""));
+        assert!(!html.contains("__FUNCTOR_LANG_ENTRY_MODULE__"));
+        // The two forms are mutually exclusive: a module role's page carries
+        // no prefix.
+        assert!(html.contains("window.__functorLangEntryPrefix = \"\""));
+    }
+
     #[test]
     fn substitutes_the_mouse_capture_boolean() {
         let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "captured", "");
+            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "captured", "", "");
         assert!(html.contains("const gameMouseCapture = false"));
         assert!(!html.contains("__FUNCTOR_MOUSE_CAPTURE__"));
     }

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -69,6 +69,7 @@ pub fn export_functor_lang_wasm(
     mouse_capture: bool,
     cursor: &str,
     prefix: &str,
+    module: &str,
 ) -> Result<WasmExport, Error> {
     let root = Path::new(working_directory);
 
@@ -120,7 +121,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(
         out.join("index.html"),
-        render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix),
+        render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix, module),
     )?;
     std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
     std::fs::write(out.join("timeline-model.js"), TIMELINE_MODEL_JS)?;
@@ -306,7 +307,7 @@ mod tests {
         dir.write("dist/web/stale.txt", "from a previous export");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "", "").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -360,10 +361,25 @@ mod tests {
         dir.write("game.fun", "let init = 0");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "server").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "server", "").unwrap();
 
         let index = fs::read_to_string(export.out_dir.join("index.html")).unwrap();
         assert!(index.contains("window.__functorLangEntryPrefix = \"server\""));
+    }
+
+    /// …and so does a role's inline entry MODULE — `build wasm` bakes it into
+    /// the exported page's boot config, so the bundle plays the right role.
+    #[test]
+    fn exports_the_entry_module() {
+        let dir = TestDir::new("module");
+        dir.write("game.fun", "let init = 0");
+
+        let wd = dir.path().to_string_lossy().to_string();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "", "Server").unwrap();
+
+        let index = fs::read_to_string(export.out_dir.join("index.html")).unwrap();
+        assert!(index.contains("window.__functorLangEntryModule = \"Server\""));
+        assert!(index.contains("window.__functorLangEntryPrefix = \"\""));
     }
 
     #[test]
@@ -374,7 +390,7 @@ mod tests {
         dir.write("pkg/junk.js", "not the runtime");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -432,7 +448,7 @@ let g = "pkg/tex.png"
         dir.write(".hidden.fun", "let ghost = 1");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap();
         assert_eq!(export.file_count, 1, "only game.fun ships");
         assert!(
             !export.out_dir.join(".hidden.fun").exists(),
@@ -449,7 +465,7 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path().join("elsewhere"), dir.path().join("dist")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let err = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap_err();
+        let err = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap_err();
         assert!(err.to_string().contains("symlink"), "{err}");
         assert!(
             dir.path().join("elsewhere/precious.txt").is_file(),
@@ -472,7 +488,7 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path(), dir.path().join("loop")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap();
         assert_eq!(
             fs::read(export.out_dir.join("linked.glb")).unwrap(),
             b"glb-bytes",

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -707,18 +707,35 @@ snapshots — no GPU, fully agent-verifiable.
       naming the role, the file, and the blocks it does declare — re-resolved
       on every hot reload, so deleting the block fails loudly and keeps the
       old program instead of reporting every binding missing. Module roles
-      are native-only for now (`run wasm`/`build wasm`/`run vr` refuse them,
-      as vr already refuses prefixes) because those shells boot the
-      unprefixed contract. `examples/orbs` is the same-file reference: its
-      `client` role is the file's plain top-level contract (so the sandbox
-      and the docs teach the same `init`/`tick`/`draw`) and its `server`
-      role stays on the PREFIX form, because the sandbox runs that role in
-      a browser pane. *Verify:* config-shape tests
+      landed native-only here; Part 9 lifted that to wasm. `examples/orbs`
+      is the same-file reference: its `client` role is the file's plain
+      top-level contract (so the sandbox and the docs teach the same
+      `init`/`tick`/`draw`) and its `server` role stays on the PREFIX form,
+      the one its sandbox server pane shipped with. *Verify:* config-shape tests
       (module form, module+prefix refusal, non-string/non-Capitalized names,
       unknown keys), contract tests naming `Server.tick`, an unknown-block
       error test, a desktop load + hot-reload test for a module role, the
       example sweep over both orbs roles, and headless captures of both
       roles.
+      **Part 9 — module roles on the embedded/wasm producer — done:** the
+      embedded producer (`functor_lang_game_embedded.rs`, the web and device
+      shells) takes the same `EntryRole` the desktop one does and re-resolves
+      it on every (re)load, so a module role hot-reloads through the push
+      seam exactly as it does natively. The web runtime reads the role from
+      the page's boot config — `window.__functorLangEntryModule` beside the
+      existing `…EntryPrefix`, mutually exclusive — which `run wasm` and
+      `build wasm` bake into the served/exported index page, and the site
+      player takes as `?module=<Ident>` (capitalized identifier; anything
+      else warns and boots the unprefixed contract). `run wasm` and
+      `build wasm` no longer refuse a module role; **vr still does**, because
+      its device push path boots the APK's embedded producer with the
+      unprefixed contract and teaching it the form needs a protocol +
+      on-device change. *Verify:* embedded-producer tests (a module role's
+      contract is the block's, a push re-resolves it with the model
+      preserved, a push deleting the block keeps the old program, an unknown
+      block lists the file's blocks), CLI tests for the lifted guards and the
+      page's baked boot config, and a headless `run wasm` browser smoke of a
+      `module Server` role.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/e2e/fixtures/module-role/functor.json
+++ b/e2e/fixtures/module-role/functor.json
@@ -1,0 +1,6 @@
+{
+  "language": "functor-lang",
+  "entries": {
+    "server": { "file": "game.fun", "module": "Server" }
+  }
+}

--- a/e2e/fixtures/module-role/game.fun
+++ b/e2e/fixtures/module-role/game.fun
@@ -1,0 +1,15 @@
+// The file's TOP LEVEL deliberately declares no init/tick/draw: if the page
+// booted the plain contract it would fail to load, so a successful load proves
+// the `module Server` role resolved on wasm.
+let spinRate = 1.5
+
+module Server {
+  let init = { spin: 0.0 }
+
+  let tick = (model, dt, tts) => { spin: model.spin + dt * spinRate }
+
+  let draw = (model, tts) =>
+    Frame.create(
+      Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
+      Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)))
+}

--- a/e2e/module-role-wasm.mjs
+++ b/e2e/module-role-wasm.mjs
@@ -1,0 +1,100 @@
+// A same-file MODULE entry role must boot in the browser, not just natively.
+//
+// `e2e/fixtures/module-role` declares one role — `{ "file": "game.fun",
+// "module": "Server" }` — and its file deliberately has NO top-level
+// `init`/`tick`/`draw`: if the page booted the plain contract it would fail to
+// load, so reaching "[functor-lang] loaded" IS the proof the role resolved.
+//
+// The bundle is exported with `build wasm` and served from an ephemeral port
+// rather than driven through `run wasm` (which hardcodes :8080): both render
+// the SAME page from the same template — that `run wasm`'s served index
+// carries the module is pinned by `substitutes_the_entry_module` in
+// cli/src/util/wasm_dev_server.rs — and exporting keeps this check hermetic
+// next to a dev server someone else is running.
+//
+//   npm run build:cli:debug   # once, so target/debug/functor embeds the runtime
+//   node e2e/module-role-wasm.mjs
+import { execFileSync } from "node:child_process";
+import { createReadStream, statSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DIR = path.join(ROOT, "e2e", "fixtures", "module-role");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+console.log(
+  execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", DIR, "build", "wasm"], {
+    encoding: "utf8",
+  })
+);
+
+const TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".wasm": "application/wasm",
+  ".fun": "text/plain",
+};
+const root = path.join(DIR, "dist", "web");
+const server = http.createServer((req, res) => {
+  let rel = decodeURIComponent(req.url.split("?")[0]);
+  if (rel === "/") rel = "/index.html";
+  const file = path.join(root, rel);
+  try {
+    statSync(file);
+  } catch {
+    res.writeHead(404).end("not found");
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
+  });
+  createReadStream(file).pipe(res);
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const { port } = server.address();
+
+// Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
+// runner — no real GPU needed; this check compares no pixels.
+const browser = await chromium.launch({
+  args: [
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+  ],
+});
+let ok = false;
+let reason = "";
+try {
+  const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+  const log = [];
+  page.on("console", (m) => log.push(`${m.type()}: ${m.text()}`));
+  page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+  await page.goto(`http://127.0.0.1:${port}/`);
+  for (let i = 0; !log.some((m) => m.includes("[functor-lang] loaded")); i++) {
+    if (i > 60) throw new Error(`never loaded:\n${log.join("\n")}`);
+    await sleep(250);
+  }
+  const [bootModule, bootPrefix] = await page.evaluate(() => [
+    window.__functorLangEntryModule,
+    window.__functorLangEntryPrefix,
+  ]);
+  await sleep(1500); // run frames: a broken role would error per frame
+  const errors = log.filter((l) => /\[functor-lang\].*error/.test(l));
+  console.log(
+    `boot config: module=${JSON.stringify(bootModule)} prefix=${JSON.stringify(bootPrefix)}`
+  );
+  console.log(log.filter((l) => l.includes("[functor-lang]")).join("\n"));
+  ok = bootModule === "Server" && bootPrefix === "" && errors.length === 0;
+  reason = ok ? "" : `module=${bootModule} prefix=${bootPrefix} errors=${errors.join(" | ")}`;
+} catch (e) {
+  reason = String(e);
+} finally {
+  await browser.close();
+  server.close();
+}
+console.log(ok ? "PASS: the module role booted on wasm" : `FAIL: ${reason}`);
+process.exit(ok ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",
     "site:serve": "node site/serve.mjs",
+    "test:module-role": "node e2e/module-role-wasm.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
     "test:net-coordinator": "node e2e/net-coordinator.mjs",
     "test:sandbox-mp": "node e2e/sandbox-mp.mjs",

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -31,8 +31,8 @@ use crate::functor_lang_prelude::{
     EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
-    journal_arm, journal_swap, validate_contract, EntryNames, FrameCtx, JournalEntry, Reporter,
-    SpanSource,
+    journal_arm, journal_swap, validate_contract, EntryNames, EntryRole, FrameCtx, JournalEntry,
+    Reporter, SpanSource,
 };
 use crate::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use crate::physics;
@@ -85,8 +85,11 @@ impl ProducerPlatform for NativePlatform {
 
 pub struct FunctorLangEmbeddedGame {
     path: String,
-    /// The role's resolved entry-point names (same-file entries): built once
-    /// from the role's prefix at create time and reused by every reload —
+    /// How the role names its entry bindings (same-file entries): a binding
+    /// prefix or an inline `module` block. Kept because an inline-module role
+    /// re-resolves against every (re)loaded project.
+    role: EntryRole,
+    /// The role's resolved entry-point names, from the CURRENT program —
     /// every canonical lookup and contract error goes through it.
     names: EntryNames,
     /// The project's source files (entry FIRST, then siblings) as
@@ -208,6 +211,9 @@ pub struct FunctorLangEmbeddedGame {
 /// A successfully loaded, contract-validated game module (the desktop
 /// producer's `Loaded`, verbatim minus the file-shaped fields).
 struct Loaded {
+    /// The role's binding names, resolved against THIS load (an inline-module
+    /// role's canonical path comes from the linked project).
+    names: EntryNames,
     sources: SourceMap,
     module: functor_lang::ir::Module,
     session: Session,
@@ -230,7 +236,7 @@ struct Loaded {
 /// is every project file as `(path, source)`, the ENTRY first, then siblings
 /// (`file = module`, so `pieces.fun` is module `Pieces`). Errors come back as
 /// fully rendered strings (`path:line:col: message`).
-fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loaded, String> {
+fn load_source(sources: &[(String, String)], role: &EntryRole) -> Result<Loaded, String> {
     let path = sources
         .first()
         .map(|(p, _)| p.clone())
@@ -246,6 +252,10 @@ fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loade
         &functor_prelude::bundled_modules(),
     )
     .map_err(|e| format!("cannot load {}", e.render()))?;
+    // An inline-module role resolves against the linked project, so a reload
+    // that renamed or deleted the block fails here — naming the block — rather
+    // than reporting its every entry binding as missing.
+    let names = role.resolve(&path, &project)?;
     let module = project.module;
     let source_map = project.sources;
     // Type diagnostics are advisory in the dev loop: warn, keep going
@@ -266,8 +276,9 @@ fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loade
     // arity, optional hooks well-shaped) is shared with the desktop producer
     // and the CLI's build gate — errors name the ROLE'S resolved bindings
     // (`serverTick`, not `tick`) via `names`.
-    let contract = validate_contract(&path, &session, names)?;
+    let contract = validate_contract(&path, &session, &names)?;
     Ok(Loaded {
+        names,
         sources: source_map,
         module,
         session,
@@ -293,27 +304,27 @@ impl FunctorLangEmbeddedGame {
         sources: Vec<(String, String)>,
         platform: Box<dyn ProducerPlatform>,
     ) -> Result<FunctorLangEmbeddedGame, String> {
-        Self::create_with_prefix(sources, "", platform)
+        Self::create_for_role(sources, EntryRole::Prefix(String::new()), platform)
     }
 
-    /// [`Self::create`] for a PREFIXED role (same-file entries): every
-    /// canonical entry binding resolves through `prefix` as camelCase
-    /// (`"server"` → `serverInit`/`serverTick`/…). An empty prefix is the
-    /// classic unprefixed contract.
-    pub fn create_with_prefix(
+    /// [`Self::create`] for one same-file ROLE: either a binding prefix
+    /// (`"server"` → `serverInit`/`serverTick`/…, empty = the classic
+    /// unprefixed contract) or an inline `module Server { … }` block, whose
+    /// members ARE the role's contract (`Server.init`/`Server.tick`/…). The
+    /// role is kept, so every (re)load re-resolves it against that program.
+    pub fn create_for_role(
         sources: Vec<(String, String)>,
-        prefix: &str,
+        role: EntryRole,
         platform: Box<dyn ProducerPlatform>,
     ) -> Result<FunctorLangEmbeddedGame, String> {
         // Install the shell's diagnostics sinks BEFORE the first load so load
         // errors surface (native: the `log` sink; web: console/event bridge).
         platform.install_sinks();
-        let names = EntryNames::with_prefix(prefix);
         let path = sources
             .first()
             .map(|(p, _)| p.clone())
             .unwrap_or_else(|| "game.fun".to_string());
-        let loaded = load_source(&sources, &names)?;
+        let loaded = load_source(&sources, &role)?;
         log::info!("[functor-lang] loaded {path}");
         // Arm the paused-inspector journal on this thread: from now on every
         // live model-updating call is journaled (a cheap Rc-clone push).
@@ -329,7 +340,8 @@ impl FunctorLangEmbeddedGame {
             source_hashes,
             sources,
             path,
-            names,
+            role,
+            names: loaded.names,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -408,6 +420,7 @@ impl FunctorLangEmbeddedGame {
         journal_swap(); // discard any partial current-frame journal
         self.reporter
             .set_source(SpanSource::Project(loaded.sources));
+        self.names = loaded.names;
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -507,6 +520,7 @@ impl FunctorLangEmbeddedGame {
         journal_swap();
         self.reporter
             .set_source(SpanSource::Project(loaded.sources));
+        self.names = loaded.names;
         self.module = loaded.module;
         self.session = loaded.session;
         self.model = loaded.init;
@@ -610,7 +624,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
         } else {
             sources.push((self.path.clone(), source.to_string()));
         }
-        let loaded = load_source(&sources, &self.names)?;
+        let loaded = load_source(&sources, &self.role)?;
         self.sources = sources;
         let (rebound, history_replay) = self.swap_in(loaded);
         let stored = if rebound > 0 {
@@ -637,7 +651,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = now_ms();
-        let loaded = load_source(files, &self.names)?;
+        let loaded = load_source(files, &self.role)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
         let (rebound, history_replay) = self.swap_in(loaded);
@@ -663,7 +677,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = now_ms();
-        let loaded = load_source(files, &self.names)?;
+        let loaded = load_source(files, &self.role)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
         self.reset_in(loaded);
@@ -1257,9 +1271,9 @@ let draw = (model, tts) =>
             .replace("let init", "let serverInit")
             .replace("let tick", "let serverTick")
             .replace("let draw", "let serverDraw");
-        let mut game = FunctorLangEmbeddedGame::create_with_prefix(
+        let mut game = FunctorLangEmbeddedGame::create_for_role(
             vec![("game.fun".to_string(), server_boot)],
-            "server",
+            EntryRole::Prefix("server".to_string()),
             Box::new(NativePlatform),
         )
         .expect("prefixed role loads");
@@ -1284,15 +1298,101 @@ let draw = (model, tts) =>
 
         // An UNPREFIXED program under the server role misses the contract —
         // and the error teaches the resolved name it looked for.
-        let err = match FunctorLangEmbeddedGame::create_with_prefix(
+        let err = match FunctorLangEmbeddedGame::create_for_role(
             vec![("game.fun".to_string(), BOOT.to_string())],
-            "server",
+            EntryRole::Prefix("server".to_string()),
             Box::new(NativePlatform),
         ) {
             Err(err) => err,
             Ok(_) => panic!("unprefixed bindings don't satisfy a prefixed role"),
         };
         assert!(err.contains("serverInit"), "{err}");
+    }
+
+    /// A `{ "file": …, "module": "Server" }` role runs the BLOCK's members as
+    /// its contract on the EMBEDDED producer too (the web/device shells), and
+    /// keeps re-resolving them on every pushed reload: an edit inside the
+    /// block lands with the model preserved, while a push that removes the
+    /// block fails loudly — naming it — and keeps the old program.
+    #[test]
+    fn a_module_role_resolves_and_hot_reloads_on_a_push() {
+        let role_src = |probe: f64| {
+            format!(
+                "{BOOT}module Server {{\n\
+                 let init = {{ n: 7.0 }}\n\
+                 let tick = (m, dt, tts) => m\n\
+                 let draw = (m, tts) => Frame.create(Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), \
+Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
+                 let probe = {probe}.0\n\
+                 }}\n"
+            )
+        };
+        let mut game = FunctorLangEmbeddedGame::create_for_role(
+            vec![("game.fun".to_string(), role_src(1.0))],
+            EntryRole::Module("Server".to_string()),
+            Box::new(NativePlatform),
+        )
+        .expect("module role loads");
+        // The role's contract is the block's, not the file's top level: the
+        // file's own `init` is `{ spin: 0.0 }`.
+        assert_eq!(game.names.tick, "Server.tick");
+        assert!(
+            game.state_debug().contains("n: 7"),
+            "the block's init is the role's model: {}",
+            game.state_debug()
+        );
+        let ft = frame_time(0.016, 0.016);
+        game.tick(ft.clone());
+        let _ = game.render(ft);
+
+        // A push re-resolves the block: the edit lands, the model survives.
+        game.reload_source(&role_src(2.0)).expect("push reloads");
+        assert_eq!(game.names.tick, "Server.tick");
+        assert_eq!(
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
+            "2",
+            "the edit must have landed"
+        );
+        assert!(game.state_debug().contains("n: 7"), "model preserved");
+
+        // Deleting the block fails the reload naming it, keeping the program.
+        let err = game
+            .reload_source(BOOT)
+            .expect_err("a role whose module vanished cannot load");
+        assert!(
+            err.contains("module Server"),
+            "the error names the block: {err}"
+        );
+        assert_eq!(
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
+            "2",
+            "the old program keeps running"
+        );
+    }
+
+    /// An unknown role module is a load error naming the role's file and the
+    /// blocks it DOES declare — the resolver's teaching error, reaching the
+    /// embedded shells' boot path.
+    #[test]
+    fn an_unknown_role_module_lists_the_files_blocks() {
+        let source = format!("{BOOT}module Server {{ let probe = 1.0 }}\n");
+        let err = FunctorLangEmbeddedGame::create_for_role(
+            vec![("game.fun".to_string(), source)],
+            EntryRole::Module("Sever".to_string()),
+            Box::new(NativePlatform),
+        )
+        .err()
+        .expect("an unknown block cannot boot");
+        assert!(
+            err.contains("no inline `module Sever") && err.contains("it declares: Server"),
+            "{err}"
+        );
     }
 
     /// A prefixed role's EFFECTS must fold through the role's own update
@@ -1310,9 +1410,9 @@ let serverTick = (m, dt, tts) =>\n\
   ({ m with ticks: m.ticks + dt }, Effect.now((t) => GotTime(t)))\n\
 let serverDraw = (m, tts) =>\n\
   Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
-        let mut game = FunctorLangEmbeddedGame::create_with_prefix(
+        let mut game = FunctorLangEmbeddedGame::create_for_role(
             vec![("game.fun".to_string(), source.to_string())],
-            "server",
+            EntryRole::Prefix("server".to_string()),
             Box::new(NativePlatform),
         )
         .expect("prefixed role loads");

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -181,6 +181,21 @@ pub enum EntryRole {
 }
 
 impl EntryRole {
+    /// The role a config/flag/boot-config PAIR declares. Every carrier of a
+    /// same-file role transports it as two strings — functor.json's
+    /// `module`/`prefix` keys, the runtime's `--entry-module`/`--entry-prefix`
+    /// flags, the web page's `__functorLangEntryModule`/`…Prefix` globals — so
+    /// the "a non-empty module wins, else the prefix (empty = the plain
+    /// contract)" rule lives here once rather than at each seam. The declaring
+    /// layers refuse both at once; this resolves the pair regardless.
+    pub fn from_parts(module: &str, prefix: &str) -> EntryRole {
+        if module.is_empty() {
+            EntryRole::Prefix(prefix.to_string())
+        } else {
+            EntryRole::Module(module.to_string())
+        }
+    }
+
     /// Resolve this role's binding names against the linked `project` whose
     /// entry is the role's file. An inline-module role names a block of THAT
     /// file; an unknown name is an error listing the blocks it does declare.

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1296,15 +1296,10 @@ pub fn run(args: Args) {
     let mut game: Box<dyn Game> = if args.replay {
         Box::new(replay_game::ReplayGame::create(game_path.as_str()))
     } else if args.functor_lang {
-        let role = if args.entry_module.is_empty() {
-            functor_runtime_common::functor_lang_producer::EntryRole::Prefix(
-                args.entry_prefix.clone(),
-            )
-        } else {
-            functor_runtime_common::functor_lang_producer::EntryRole::Module(
-                args.entry_module.clone(),
-            )
-        };
+        let role = functor_runtime_common::functor_lang_producer::EntryRole::from_parts(
+            &args.entry_module,
+            &args.entry_prefix,
+        );
         Box::new(functor_lang_game::FunctorLangGame::create_for_role(
             game_path.as_str(),
             role,

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -117,6 +117,12 @@
       // unprefixed contract. Substituted by the CLI like the entry above.
       window.__functorLangEntryPrefix = "__FUNCTOR_LANG_ENTRY_PREFIX__";
 
+      // The role's inline entry MODULE (same-file entries): the runtime
+      // resolves `Server.init`/`Server.tick`/… as that block's members. Empty
+      // = no module role. Mutually exclusive with the prefix above (the CLI's
+      // config refuses a role declaring both).
+      window.__functorLangEntryModule = "__FUNCTOR_LANG_ENTRY_MODULE__";
+
       // Captured game mouse input defaults on. A project can opt out with
       // mouseCapture: false; programs without captured mouse hooks never show
       // capture chrome. The debug camera owns its input independently.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -184,12 +184,7 @@ fn functor_lang_entry_module() -> String {
 /// the prefix when a module is given), otherwise the binding prefix (empty =
 /// the classic unprefixed contract).
 fn functor_lang_entry_role() -> EntryRole {
-    let module = functor_lang_entry_module();
-    if module.is_empty() {
-        EntryRole::Prefix(functor_lang_entry_prefix())
-    } else {
-        EntryRole::Module(module)
-    }
+    EntryRole::from_parts(&functor_lang_entry_module(), &functor_lang_entry_prefix())
 }
 
 /// Where the runtime's networking goes. Two routings exist: real browser

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use functor_runtime_common::asset::pipelines::TexturePipeline;
 use functor_runtime_common::asset::{AssetCache, AssetLoader};
 use functor_runtime_common::functor_lang_game_embedded::FunctorLangEmbeddedGame;
+use functor_runtime_common::functor_lang_producer::EntryRole;
 use functor_runtime_common::geometry::Geometry;
 use functor_runtime_common::io::load_bytes_async;
 use functor_runtime_common::net::{
@@ -163,6 +164,34 @@ fn functor_lang_entry_prefix() -> String {
         .unwrap_or_default()
 }
 
+/// The role's inline entry MODULE (same-file entries, mirroring the desktop
+/// `--entry-module` flag): the page sets `window.__functorLangEntryModule`
+/// before initializing this module (the CLI's Functor Lang index page
+/// substitutes the role's declared module; the site's player.html reads
+/// `?module=<Ident>`), and the producer resolves every canonical entry
+/// binding as a member of that `module` block (`"Server"` →
+/// `Server.init`/`Server.tick`/…). Absent or empty = no module role.
+fn functor_lang_entry_module() -> String {
+    js_sys::Reflect::get(&window(), &JsValue::from_str("__functorLangEntryModule"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default()
+}
+
+/// This page's role, as the producers' shared resolver takes it: an inline
+/// `module` block wins when the page declares one (the two boot keys are
+/// mutually exclusive — the CLI's config refuses both, and player.html drops
+/// the prefix when a module is given), otherwise the binding prefix (empty =
+/// the classic unprefixed contract).
+fn functor_lang_entry_role() -> EntryRole {
+    let module = functor_lang_entry_module();
+    if module.is_empty() {
+        EntryRole::Prefix(functor_lang_entry_prefix())
+    } else {
+        EntryRole::Module(module)
+    }
+}
+
 /// Where the runtime's networking goes. Two routings exist: real browser
 /// WebSockets, and the *embedder* — the page hosting this runtime.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -261,9 +290,9 @@ fn parse_project_files(value: &JsValue) -> Option<Vec<(String, String)>> {
 /// `run_async` to fail loud with.
 async fn create_functor_lang_game(entry: &str) -> Result<FunctorLangEmbeddedGame, String> {
     let sources = load_project_sources(entry).await?;
-    FunctorLangEmbeddedGame::create_with_prefix(
+    FunctorLangEmbeddedGame::create_for_role(
         sources,
-        &functor_lang_entry_prefix(),
+        functor_lang_entry_role(),
         Box::new(WebPlatform::new()),
     )
 }

--- a/site/player.html
+++ b/site/player.html
@@ -210,12 +210,26 @@
         requested && !requested.startsWith("/") && !requested.includes(":")
           ? requested
           : "examples/hero.fun";
-      // ?prefix=<ident>: the role's entry-point binding prefix (same-file
-      // entries) — the runtime resolves clientInit/clientTick/… through it.
-      // Identifier or absent; anything else warns and boots unprefixed (the
-      // scrubber param's fail-visible style).
+      // The role this page plays (same-file entries), in one of two forms —
+      // ?module=<Ident>, the role's inline entry MODULE (the runtime resolves
+      // Server.init/Server.tick/… as that block's members; capitalized
+      // identifier), or ?prefix=<ident>, the role's entry-point binding prefix
+      // (clientInit/clientTick/… through it). Absent or malformed boots the
+      // unprefixed contract with a warning (the scrubber param's fail-visible
+      // style). The two are mutually exclusive — a role declares one form, so
+      // both together is a caller bug: warn, and the module wins.
+      const entryModule = params.get("module");
       const prefix = params.get("prefix");
-      if (prefix !== null) {
+      if (entryModule !== null) {
+        if (/^[A-Z][A-Za-z0-9_]*$/.test(entryModule)) {
+          window.__functorLangEntryModule = entryModule;
+        } else {
+          console.warn(`[player] invalid ?module=${entryModule} (not a capitalized identifier); booting the unprefixed contract`);
+        }
+        if (prefix !== null) {
+          console.warn(`[player] ?module= and ?prefix= are mutually exclusive; ignoring ?prefix=${prefix}`);
+        }
+      } else if (prefix !== null) {
         if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(prefix)) {
           window.__functorLangEntryPrefix = prefix;
         } else {

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -47,10 +47,16 @@ export interface Example {
    * The entry-point binding prefix of the role the sandbox plays, for a
    * same-file-entries sample whose role is declared as
    * `{ "file": …, "prefix": "client" }` (resolving clientInit/clientTick/…).
-   * Passed to the player as `?prefix=`. The `{ "file": …, "module": … }`
-   * form is native-only, so a module role cannot be played here.
+   * Passed to the player as `?prefix=`. Mutually exclusive with `module`.
    */
   prefix?: string;
+  /**
+   * The inline entry MODULE of the role the sandbox plays, for a
+   * same-file-entries sample whose role is declared as
+   * `{ "file": …, "module": "Client" }` (resolving Client.init/Client.tick/…).
+   * Passed to the player as `?module=`. Mutually exclusive with `prefix`.
+   */
+  module?: string;
   /**
    * The sample's SERVER role, as a dist path in its own file list. The pane
    * grid mounts a server pane for every example that declares one — booted
@@ -61,12 +67,16 @@ export interface Example {
    * The file must ALSO appear in `siblings` — that is what copies it into the
    * built site and puts it in the fetched project file list; naming a file
    * here that nothing copies would 404 the server pane — UNLESS it is the
-   * example's own entry, which is copied and listed already. A same-file
-   * sample says so by naming that entry and the `prefix` its server role
-   * resolves through (orbs: `serverInit`/`serverTick`/…), which the server
-   * pane's `?prefix=` carries.
+   * example's own entry, which is copied and listed already.
+   *
+   * The server pane derives its params from the client's, so the server
+   * ROLE must be stated here rather than inherited: `prefix` when the role
+   * resolves prefixed bindings in a shared file (orbs: `serverInit`/…,
+   * carried as `?prefix=`), or `module` when it is an inline entry module
+   * (`{ "file": …, "module": "Server" }`, carried as `?module=`). At most
+   * one of the two.
    */
-  server?: { file: string; prefix?: string };
+  server?: { file: string; module?: string; prefix?: string };
 }
 
 /**

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -461,10 +461,11 @@ const loadExample = async (id: string) => {
     serverParams.delete("prefix");
     if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     serverParams.delete("file");
-    // The client's ROLE must not leak into the server pane: a same-file
-    // sample states the server's own inline module (absent = the file's plain
-    // top-level contract).
+    // The client's ROLE must not leak into the server pane — neither form.
+    // A same-file sample states the server's own inline module; absent, the
+    // server file's plain top-level contract is the role.
     serverParams.delete("module");
+    serverParams.delete("prefix");
     if (example?.server?.module) serverParams.set("module", example.server.module);
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -438,6 +438,9 @@ const loadExample = async (id: string) => {
   // A same-file-entries sample plays its declared role: the player boots the
   // prefixed contract (e.g. orbs' clientInit/clientTick/…).
   if (example?.prefix) params.set("prefix", example.prefix);
+  // …or, in the preferred same-file form, the role's inline module (the
+  // player takes one of the two).
+  if (example?.module) params.set("module", example.module);
   frame.src = `player.html?${params}`;
   // A sample with a SERVER role (examples.ts `server`) also boots a server
   // pane: the SAME file list re-entered at the server file. `?file=` is the
@@ -458,6 +461,11 @@ const loadExample = async (id: string) => {
     serverParams.delete("prefix");
     if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     serverParams.delete("file");
+    // The client's ROLE must not leak into the server pane: a same-file
+    // sample states the server's own inline module (absent = the file's plain
+    // top-level contract).
+    serverParams.delete("module");
+    if (example?.server?.module) serverParams.set("module", example.server.module);
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);
     }


### PR DESCRIPTION
Follow-up to **#601**, which made a functor.json role resolvable from an inline
`module` block (`{"file": "game.fun", "module": "Server"}` → `Server.init`/`Server.tick`/…)
but **only on the native producer**. #601's own review recorded the fix at the right
seam: *"making the embedded producer itself take an `EntryRole` is the right seam-level
fix … it is the same work that unblocks module roles in the browser."* This is that work.

**Module roles now run on wasm.** `run wasm` and `build wasm` no longer refuse them; the
role rides the page's boot config and the embedded producer resolves it exactly as the
desktop one does. **vr still refuses** — see the decision below.

## What changed

1. **Embedded producer** (`functor_lang_game_embedded.rs`) — takes an `EntryRole`
   (`create_for_role`; `create_with_prefix` migrated away, 5 call sites) and stores it, so
   `EntryNames` are **re-resolved on every load and every push**, not once at create. That
   is what makes a pushed edit deleting the block fail loudly *naming the block* and keep
   the old program running, instead of reporting all fourteen bindings missing. `Loaded`
   carries `names`; `swap_in`/`reset_in` assign them before any consumer. The desktop
   producer's shape from #601, mirrored — the two stay the documented twins.
2. **Web boot config** — `window.__functorLangEntryModule` beside the existing
   `…EntryPrefix`, read through the shared `EntryRole::from_parts` (a non-empty module
   wins; the declaring layers refuse both at once). The CLI's index template gained
   `"__FUNCTOR_LANG_ENTRY_MODULE__"`, substituted by `run wasm` and `build wasm` alike.
3. **CLI** — the wasm/`export_wasm` refusals are gone; `build wasm` bakes the module into
   the exported page's boot config exactly as it bakes the prefix. The two per-environment
   role guards (#554's prefix-on-vr and #601's module-on-non-native, by then
   message-identical) merged into one `check_role_supported`, matched **exhaustively** over
   `Environment` — so a new shell is a compile error rather than a silent allow, stronger
   than the `!matches!(_, Native)` #601 settled for.
4. **Site player** — `?module=<Ident>` (capitalized identifier; anything else warns and
   boots the unprefixed contract, the scrubber param's fail-visible style), mutually
   exclusive with `?prefix=`. `examples.ts` gains `module?`, and the server pane no longer
   inherits the client's role (review finding 1).

No example migrates here — `examples/orbs` and `examples/mp` move in the stacked follow-up.
This PR is pure capability + tests.

## The vr decision: still refused, deliberately

Extending vr is **not** the same seam. The oculus shell builds its producer with
`FunctorLangEmbeddedGame::create(...)` from a project pushed over the device HTTP endpoint —
no channel carries a role, so teaching it the form means a push-protocol change plus an APK
rebuild, and neither is verifiable without a headset (none attached for this work). `run vr`
therefore keeps refusing a role, now through the shared guard:

```
$ functor -d e2e/fixtures/module-role run vr
error: entry module `Server` is not supported on vr yet — run this role with `run native`
       or `run wasm` (the vr shell loads the unprefixed contract)
```

## Verification

- `cargo test --no-fail-fast -p functor-lang -p functor_runtime_common -p functor-runtime-desktop -p functor-cli`
  — all green **except one pre-existing failure**: `scrubber_only_captures_primary_pointer_drags`
  fails identically on the base ref (43dcde9), unrelated to this change.
  New: `a_module_role_resolves_and_hot_reloads_on_a_push` and
  `an_unknown_role_module_lists_the_files_blocks` (embedded producer — the siblings of #601's
  desktop tests), `a_role_runs_on_native_and_wasm_but_not_vr` (the lifted guard, both forms),
  `substitutes_the_entry_module` + `exports_the_entry_module` (the served and exported pages'
  boot config, including that a module role's page carries **no** prefix).
- **`npm run test:module-role` — PASS** (new, committed): `e2e/fixtures/module-role` declares
  one role, `{"file": "game.fun", "module": "Server"}`, in a file with **no top-level
  `init`/`tick`/`draw`, on purpose — booting the plain contract would fail to load, so
  reaching `[functor-lang] loaded` in chromium IS the proof the role resolved. It asserts
  `window.__functorLangEntryModule === "Server"`, an empty prefix, and no `[functor-lang]`
  error over ~1.5s of frames.
- `npm run check:site` clean. **`npm run test:site` — ALL CHECKS PASSED** (its first run
  timed out inside #615's marker section; the base ref fails the same way in the same
  section, so that check is flaky there, not broken here).
- `functor -d e2e/fixtures/module-role run native --capture-frame …` renders the module
  role's scene natively; `run vr` refuses as quoted above.
- **`run wasm` live in a browser could not be driven on this machine** — it hardcodes
  :8080, which another long-running `functor run wasm` owned throughout. It renders the
  page from the *same* template as `build wasm` (`render_functor_lang_index`), and that its
  served index carries the module is pinned by `substitutes_the_entry_module`; the exported
  bundle is what the committed e2e boots for real.

## frame_bench (release, back-to-back, same machine)

The role resolves at LOAD, so parity was expected — `allocs/frame` and `bytes/frame` are
**byte-identical** (the deterministic signal), and equal to #601's table.

| cells | base us/frame (min, 2 runs) | change us/frame (min, 2 runs) | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 400 | 609.0 / 602.5 | 605.5 / 603.5 | 13877 → 13877 | 843393 → 843393 |
| 1600 | 2593.2 / 2596.4 | 2783.7 / 2554.3 | 54717 → 54717 | 3307233 → 3307233 |
| 3136 | 5037.3 / 4950.4 | 5009.0 / 5348.8 | 106973 → 106973 | 6460257 → 6460257 |

Wall-clock deltas are inside run-to-run spread (the 1600/3136 columns straddle in both
directions).

## xreview dispositions

Three reviewers over `43dcde9...HEAD`: a Claude subagent, the Codex CLI, and the dedicated
de-duplication pass. **Neither engine raised a Critical or High finding.** Everything
actionable is fixed in `dbcf040`.

| # | Finding | Engine | Disposition |
| --- | --- | --- | --- |
| 1 | **Medium [AGREED]** — the server pane clones the client's params and deleted only `module`, so a prefixed client would boot the SERVER file as `clientInit`/`clientTick`; the new comment claimed otherwise | Claude + Codex | **Fixed.** `serverParams.delete("prefix")` beside the module delete — neither role form leaks; the server pane states its own or boots the plain contract. |
| 2 | **Medium** — the site `module` plumbing is unreachable: no example declares `module`/`server.module` | Claude | **Won't fix (scoped).** Migrating orbs/mp is explicitly the stacked follow-up; this PR is the capability its `examples.ts` seat plugs into. Both reviewers' recommended fix for #1 ("delete both role params, then apply the server's own") *is* this shape, so the `server: { file, module? }` seat is what makes #1's fix complete rather than speculative. |
| 3 | **Medium** — no committed coverage for the wasm boot path (only an untracked scratch script) | Claude | **Fixed.** Landed as `e2e/module-role-wasm.mjs` + `e2e/fixtures/module-role` + `npm run test:module-role` — hermetic (ephemeral port, no :8080), and the fixture's missing top-level contract makes "loaded" a real assertion. |
| 4 | **Low (dup, `extract` [S1-names, S4-read])** — "non-empty module wins, else prefix" was written a third time in `functor_lang_entry_role()` | de-dup | **Fixed.** `EntryRole::from_parts` on the shared enum; the web runtime, the CLI's `entry_role()`, and the desktop `run.rs` all call it. |
| 5 | **Low** — `check_role_supported` re-derived which form is declared | Claude | **Fixed.** It matches on `self.entry_role()` now, so the form is named in one place. |
| 6 | **Low (dup, `reuse`)** — the guard hand-mapped `Environment::Vr => "vr"`, the third such map in the CLI | de-dup | **Fixed.** Uses `Environment::as_str()`. |
| 7 | **Low** — `examples.ts`'s orbs comment still called `module Server` "a native-only entries form" | Claude + Codex | **Fixed.** This PR is what makes it false. |
| 8 | **Low (simplicity)** — the role now travels through `render_functor_lang_index` as two adjacent same-typed `&str`s; thread `&EntryRole` instead | Claude | **Won't fix.** That renderer emits boot-config *literals*, and its four other args (`entry`, files, `cursor`, `mouse_capture`) are the same plain shape; typing only this pair would be inconsistent and touches every call site for no behavior change. The wrong-role hazard it names is covered by `substitutes_the_entry_module`, which asserts the module lands in its own global AND that the prefix stays empty. |

Both engines independently confirmed the substance clean: `self.names` is assigned before
every consumer in `swap_in`/`reset_in` (the only pre-assignment reads are the deliberate OLD
`self.module` for rebinding, and `close_all_connections`), every reload path threads
`&self.role`, the boot keys cannot conflict (the web resolver short-circuits on module,
player.html is `if/else if`, and `"__FUNCTOR_LANG_ENTRY__"` is not a substring of
`"__FUNCTOR_LANG_ENTRY_MODULE__"`, so the substitution order is safe), and `?module=`'s
validated value is only ever assigned to a window property. The de-dup pass found no new
clone pairs:

> Coverage: all four strategies ran. S1 = `names --base` (20 queries over 7000 candidates,
> min-score 0.3); S2 = `clones` (242 pairs repo-wide, 37 touching changed files, **0
> introduced by this change**); S3 = `index` (3526 entries, grepped for entry role / boot
> config / binding prefix / inline module / index-render); S4 = the full diff.

Re-validated after the fixes: the full Rust suite re-run (same one pre-existing failure),
`npm run test:module-role` PASS, `npm run test:site` ALL CHECKS PASSED, `check:site` clean,
`run vr` still refuses, and frame_bench re-run on the final tree.

## Docs

The skill's `entries` paragraph and its inline-module subsection, CLAUDE.md's `entries`
paragraph, and `docs/functor-lang.md` (new **Part 9**; Part 8's "native-only" line now
points at it) all say the same thing: both same-file forms run on native and wasm, the page
takes `?module=<Ident>` / `?prefix=<ident>`, and only vr still boots the unprefixed contract.

## What the sample-migration PR needs

- The client role's param is `?module=<Ident>` on player.html — declared in `examples.ts`
  as `module: "Client"` (mutually exclusive with `prefix`).
- The **server pane** no longer inherits the client's role: declare it as
  `server: { file: …, module: "Server" }`. Omitting `module` means the server file's plain
  top-level contract.
- `build wasm` / `run wasm` need nothing new — the role comes from functor.json.
