### PR TITLE
fix(site): give the gh hover tooltip the pointer hover's chrome

### DIFF
--- a/site/src/lang-intel.ts
+++ b/site/src/lang-intel.ts
@@ -1303,8 +1303,12 @@ const mono = "'JetBrains Mono', 'Fira Code', ui-monospace, monospace";
 
 const intelTheme = EditorView.theme({
   ".cm-lintRange-error": { backgroundImage: wavyUnderline("#f2637f") },
-  // Hover: a small dark panel consistent with the editor chrome.
-  ".cm-tooltip.cm-tooltip-hover": {
+  // Hover: a small dark panel consistent with the editor chrome. Two shapes:
+  // the pointer hover renders our div inside CodeMirror's hover HOST
+  // (.cm-tooltip-hover), while the caret-summoned tooltip (Vim `gh`) goes
+  // through showTooltip, which stamps the cm-tooltip classes directly onto
+  // our .cm-hover-type div — no wrapper.
+  ".cm-tooltip.cm-tooltip-hover, .cm-tooltip.cm-hover-type": {
     backgroundColor: "#1e1833",
     border: "1px solid #2b2542",
     borderRadius: "5px",


### PR DESCRIPTION
## Summary

Follow-up to #589. The Vim `gh` hover tooltip renders through CodeMirror's `showTooltip`, which stamps the `cm-tooltip` classes directly onto the tooltip view's dom — there is no wrapper element — so it missed the `.cm-tooltip-hover` panel styling and appeared in CodeMirror's default grey container. The theme now styles `.cm-tooltip.cm-hover-type` alongside the hover host, giving the caret-summoned tooltip the same calm chrome as the pointer hover.

## Verification

- `npm run check:site`
- `npm run test:editor-keybindings` (30 checks, including the `gh` pair)
- computed-style check on the summoned tooltip: `rgb(30, 24, 51)` background, 1px `#2b2542` border, 5px radius — matching the pointer hover

## Before → after

![gh tooltip before and after](https://gist.githubusercontent.com/tommy-xr/09461e695bafc4c81e43966df10cc39e/raw/gh-tooltip-before-after.png)

<sub>Vim normal mode, `gh` on `init`. Before: the default grey tooltip container. After: the shared hover panel chrome.</sub>
