### PR TITLE
test(e2e): de-flake the completion-accept check in wasm-smoke

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1817,8 +1817,22 @@ let draw = (model, tts: float) =>
       typoCursor,
       (labels) => labels[0] === "sphere"
     );
-    // Accept via the editor's own apply path (deterministic — no key focus).
-    const accepted = await page.evaluate(() => window.__sandbox.acceptCompletion());
+    // Accept via the editor's own apply path (no key focus) — but CM renders
+    // the popup's labels a beat before its selection state goes active, and
+    // an accept in that window is a silent no-op. Wait for a selected option,
+    // then retry the accept until it reports true (bounded).
+    await page
+      .waitForFunction(
+        () => !!document.querySelector(".cm-tooltip-autocomplete li[aria-selected]"),
+        null,
+        { timeout: 4000 }
+      )
+      .catch(() => {}); // the retry below is the real gate; the check reports honestly
+    let accepted = false;
+    for (let i = 0; i < 20 && !accepted; i++) {
+      accepted = await page.evaluate(() => window.__sandbox.acceptCompletion());
+      if (!accepted) await sleep(100);
+    }
     await sleep(150);
     const afterAccept = await page.evaluate(() => window.__sandbox.getSource());
     check(


### PR DESCRIPTION
## What

The \`wasm-smoke\` job's "applying a completion inserts its label" check has failed on three unrelated PRs today (#598, #621, and a docs-only branch run) with the same signature: \`accepted=false\` while the popup correctly shows \`["sphere"]\`.

Root cause: CodeMirror renders the autocomplete popup's **labels** a beat before its **selection state** goes active. The test's readiness poll watches the labels, so \`window.__sandbox.acceptCompletion()\` can fire inside that window — where it is a silent no-op returning \`false\`.

Fix, test-side only: after the labels appear, wait for an \`aria-selected\` option (bounded, non-fatal), then retry the accept until it reports \`true\` (bounded). The assertion itself is unchanged and still reports \`accepted\` honestly if the retries exhaust.

## Verification

- \`node --check\` clean; full \`node e2e/site-sandbox.mjs\` run against the built site: result to be posted below before marking ready.

## Not addressed

Two other timing-sensitive checks flaked once each today (a time-travel history check, a net-coordinator ordering check) — single occurrences, left alone until they repeat.