### PR TITLE
feat(site): aspect-true panes — 16:9 cards, edge-attached wires, the seat moves last

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -18,7 +18,10 @@
 //   4. every pane header shows its coordinator link state;
 //   5. the GRID layout puts the clients in two columns with the server as a
 //      full-width strip below them — and switching layout reloads no pane;
-//   6. switching to a single-role example removes the server pane again.
+//   6. switching to a single-role example removes the server pane again;
+//   7. every pane CARD letterboxes to a 16:9 body inside its cell in the grid
+//      and network views, the "+" seat is last in reading order, and the
+//      network wires anchor to the cards rather than to the cells.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -33,6 +36,27 @@ const BASE = `http://127.0.0.1:${PORT}`;
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Wait for the view transition to finish. Switching layout FLIPs the cards
+ * (mp-panes.ts, 420ms), and a transform moves a card's measured box without
+ * resizing anything — so geometry read mid-flight is the card's *animated*
+ * box, not its laid-out one. The "+" seat FLIPs alongside the cards and its
+ * band geometry is asserted too, so it has to be waited on as well.
+ */
+const settle = (page) =>
+  page.waitForFunction(
+    () =>
+      [...document.querySelectorAll(".mp-pane, .mp-add-tile")].every(
+        (node) => node.getAnimations().length === 0
+      ),
+    null,
+    { timeout: 5000 }
+  );
+
+/** A letterboxed card sits centred on an axis when its two margins match. */
+const centred = (b, axis, size) =>
+  Math.abs(b[axis] - b.cell[axis] - (b.cell[axis] + b.cell[size] - (b[axis] + b[size]))) <= 2;
 
 let failures = 0;
 const check = (ok, what, detail = "") => {
@@ -123,6 +147,21 @@ const installProbe = (page) =>
           networkTitle: document.getElementById("mp-view-network").title,
         };
       },
+      /**
+       * Each wire's endpoints in PAGE coordinates, so they can be compared with
+       * the pane boxes: a wire has to leave the letterboxed CARD, not the cell
+       * the card floats in (Addendum 5b.3).
+       */
+      wireEnds: () => {
+        const origin = document.querySelector(".mp-net-layer").getBoundingClientRect();
+        return [...document.querySelectorAll(".mp-wire")].map((wire) => {
+          const at = (length) => {
+            const point = wire.getPointAtLength(length);
+            return { x: point.x + origin.x, y: point.y + origin.y };
+          };
+          return { from: at(0), to: at(wire.getTotalLength()) };
+        });
+      },
       // What a pane header still shows at its current width: the priority clip
       // keeps identity + link state and drops the frame counter first.
       headerParts: (index) => {
@@ -147,6 +186,8 @@ const installProbe = (page) =>
           hidden: !tile || tile.hidden,
           display: tile ? getComputedStyle(tile).display : "none",
           tag: tile?.tagName,
+          // Addendum 5b.1: the seat is the LAST thing in the arrangement.
+          last: !!tile && tile.parentElement.lastElementChild === tile,
           tabDisplay: getComputedStyle(document.querySelector(".mp-tab.add")).display,
         };
       },
@@ -161,18 +202,37 @@ const installProbe = (page) =>
           0
         );
       },
-      // Laid-out geometry per pane, plus the server's resolved grid placement.
+      // Laid-out geometry per pane: the CARD (the letterboxed pane itself, and
+      // what the wires anchor to), the CELL it sits in (what the layout
+      // places), and the body's aspect — 16:9 wherever the view letterboxes.
       boxes: () =>
         shells().map((s) => {
           const shell = s.frame.closest(".mp-pane");
+          const cell = shell.closest(".mp-cell");
           const box = shell.getBoundingClientRect();
+          const cellBox = cell.getBoundingClientRect();
+          const body = shell.querySelector(".mp-pane-body").getBoundingClientRect();
           return {
             role: s.role,
             x: Math.round(box.x),
             y: Math.round(box.y),
             w: Math.round(box.width),
             h: Math.round(box.height),
-            gridColumn: getComputedStyle(shell).gridColumn,
+            cell: {
+              x: Math.round(cellBox.x),
+              y: Math.round(cellBox.y),
+              w: Math.round(cellBox.width),
+              h: Math.round(cellBox.height),
+            },
+            bodyRatio: body.width / body.height,
+            /** How much of the cell the card left over, UNROUNDED: the
+             * letterbox arithmetic is exact to the pixel, and rounding would
+             * hide a card that overflows its cell by a fraction of one. */
+            slack: { w: cellBox.width - box.width, h: cellBox.height - box.height },
+            /** What the header actually needs, against the 22px the letterbox
+             * arithmetic budgets for it. */
+            headerScroll: shell.querySelector(".mp-pane-hd").scrollHeight,
+            gridColumn: getComputedStyle(cell).gridColumn,
           };
         }),
       // Document-lifetime markers for EVERY pane: a re-parented iframe reloads
@@ -264,6 +324,10 @@ try {
       "a + tile sits after the client panes, as a real button",
       JSON.stringify(tile)
     );
+    check(
+      tile.last,
+      "the seat is LAST in reading order, after every occupied cell"
+    );
     await page.evaluate(() => window.__mpProbe.clickAddTile());
     await sleep(2500);
     const afterAdd = await page.evaluate(() => ({
@@ -281,27 +345,34 @@ try {
     await page.selectOption("#client-count", "3");
     await sleep(2500);
     const atMax = await page.evaluate(() => window.__mpProbe.addTile());
-    check(atMax.hidden, "the + tile is hidden at MAX_CLIENTS", JSON.stringify(atMax));
+    // The ATTRIBUTE is not the picture: the seat sets its own `display`, which
+    // outranks the UA's `[hidden]` rule — so assert what is painted.
+    check(
+      atMax.hidden && atMax.display === "none",
+      "the + tile is hidden at MAX_CLIENTS",
+      JSON.stringify(atMax)
+    );
     await page.selectOption("#client-count", "1");
     await sleep(1500);
 
-    // Grid with a LONE client: the open seat takes the cell beside it (at the
-    // size the new client will be), with the server strip below both.
+    // Grid with a LONE client: the client takes the whole row (no peer to match)
+    // and the open seat closes the layout as a band UNDER everything — never
+    // between the client and the authority (Addendum 5b.1).
     await page.click("#mp-view-grid");
-    await sleep(700);
+    await settle(page);
     const [client, server] = await page.evaluate(() => window.__mpProbe.boxes());
     const seat = await page.evaluate(() => {
       const box = document.querySelector(".mp-add-tile").getBoundingClientRect();
-      return { x: Math.round(box.x), y: Math.round(box.y), w: Math.round(box.width) };
+      return { x: Math.round(box.x), y: Math.round(box.y), w: Math.round(box.width), h: Math.round(box.height) };
     });
     check(
-      seat.x > client.x &&
-        Math.abs(seat.w - client.w) < 2 &&
-        Math.abs(seat.y - client.y) < 2 &&
-        server.w > client.w * 1.8 &&
+      seat.y >= server.y + server.h &&
+        Math.abs(seat.w - client.cell.w) < 2 &&
+        seat.h < client.h &&
+        server.gridColumn === "1 / -1" &&
         server.y >= client.y + client.h &&
         server.h < client.h,
-      "grid puts the open seat beside the lone client, over the server strip",
+      "grid closes with the open seat as a band under the client and the strip",
       JSON.stringify([client, seat, server])
     );
     await page.close();
@@ -459,6 +530,7 @@ try {
       `${grid.view} — ${grid.pressed.join(" ")}`
     );
 
+    await settle(page);
     const boxes = await page.evaluate(() => window.__mpProbe.boxes());
     const [c1, c2, server] = boxes;
     check(
@@ -467,7 +539,9 @@ try {
       JSON.stringify([c1, c2])
     );
     check(
-      server.gridColumn === "1 / -1" && server.w > c1.w * 1.8 && server.y >= c1.y + c1.h,
+      server.gridColumn === "1 / -1" &&
+        server.cell.w > c1.cell.w * 1.8 &&
+        server.y >= c1.y + c1.h,
       "the server pane spans every column as a strip below the clients",
       JSON.stringify(server)
     );
@@ -475,6 +549,34 @@ try {
       server.h < c1.h,
       "the server strip is shorter than a client cell",
       `${server.h} vs ${c1.h}`
+    );
+    // Addendum 5b.2: every card in GRID letterboxes its body to 16:9 inside
+    // its cell — a game window reads as a game window rather
+    // than as whatever shape the track handed it. The card fitting INSIDE its
+    // cell is asserted exactly (`<=`, unrounded slack): the arithmetic budgets
+    // for the header row AND the card's own borders, and a card a fraction
+    // taller than its cell is that budget silently going wrong.
+    check(
+      boxes.every((b) => Math.abs(b.bodyRatio - 16 / 9) < 0.02) &&
+        boxes.every(
+          (b) => b.slack.w >= 0 && b.slack.h >= 0 && centred(b, "x", "w")
+        ) &&
+        boxes.some((b) => b.slack.w > 8 || b.slack.h > 8) &&
+        // The pinned header row the letterbox arithmetic subtracts: if the
+        // header ever needs more than that, the cards silently outgrow their
+        // cells — so assert the budget rather than only its symptom.
+        boxes.every((b) => b.headerScroll <= 22),
+      "every grid card letterboxes to a 16:9 body, centred across its cell",
+      JSON.stringify(boxes.map((b) => [b.role, +b.bodyRatio.toFixed(3), b.w, b.h, b.cell.w, b.cell.h]))
+    );
+    // Vertically the slack goes OUTWARD, not between the players and the
+    // authority: the client cards hug the foot of their cells, the strip the
+    // head of its band, so the two meet.
+    check(
+      Math.abs(c1.y + c1.h - (c1.cell.y + c1.cell.h)) <= 2 &&
+        Math.abs(server.y - server.cell.y) <= 2,
+      "the clients hug the foot of their cells and the strip the head of its band",
+      JSON.stringify([c1, server].map((b) => [b.role, b.y, b.h, b.cell.y, b.cell.h]))
     );
     check(
       await page.evaluate(() => window.__mpProbe.allAlive()),
@@ -485,6 +587,7 @@ try {
     await page.click("#mp-view-tiled");
     await sleep(400);
     const back = await page.evaluate(() => window.__mpProbe.layout());
+    await settle(page);
     const backBoxes = await page.evaluate(() => window.__mpProbe.boxes());
     check(
       back.view === "tiled" &&
@@ -545,14 +648,14 @@ try {
     await page.selectOption("#client-count", "3");
     await sleep(2500);
     await page.click("#mp-view-grid");
-    await sleep(400);
+    await settle(page);
     const three = await page.evaluate(() => window.__mpProbe.boxes());
     check(
       three.length === 4 &&
         Math.abs(three[2].w - three[0].w) < 2 &&
         three[2].x === three[0].x &&
         three[2].y >= three[0].y + three[0].h &&
-        three[3].w > three[2].w * 1.8,
+        three[3].cell.w > three[2].cell.w * 1.8,
       "a third client keeps its half-width cell above the full-width strip",
       JSON.stringify(three.map((b) => [b.role, b.x, b.y, b.w, b.h]))
     );
@@ -582,6 +685,7 @@ try {
       `${layout.view} — ${layout.pressed.join(" ")}`
     );
 
+    await settle(page);
     const [c1, c2, server] = await page.evaluate(() => window.__mpProbe.boxes());
     check(
       c1.x + c1.w <= server.x + 2 &&
@@ -592,11 +696,77 @@ try {
       JSON.stringify([c1, server, c2].map((b) => [b.role, b.x, b.y, b.w, b.h]))
     );
 
+    // Addendum 5b.2/5b.3: the clients are 16:9 cards flanking the hub, not
+    // full-height towers, and the hub is still the smallest card of the three.
+    const netBoxes = [c1, c2, server];
+    check(
+      netBoxes.every((b) => Math.abs(b.bodyRatio - 16 / 9) < 0.02) &&
+        netBoxes.every(
+          (b) =>
+            b.slack.h > 8 &&
+            b.slack.w >= 0 &&
+            centred(b, "x", "w") &&
+            centred(b, "y", "h") &&
+            b.headerScroll <= 22
+        ),
+      "every network card letterboxes to a 16:9 body, centred in its cell",
+      JSON.stringify(netBoxes.map((b) => [b.role, +b.bodyRatio.toFixed(3), b.w, b.h, b.cell.w, b.cell.h]))
+    );
+    check(
+      Math.abs(c1.y - c2.y) > c1.h / 2,
+      "the two clients are staggered, so no wire shares a centreline",
+      `${c1.y} vs ${c2.y} (card height ${c1.h})`
+    );
+
     const graph = await page.evaluate(() => window.__mpProbe.network());
     check(
       graph.wires === 2 && graph.drawn === 2 && graph.lengths.every((l) => l > 50),
       "one measured wire per client↔server link",
       JSON.stringify(graph.lengths)
+    );
+
+    // The wires anchor to the LETTERBOXED CARD, never to the cell it floats in:
+    // every endpoint has to sit on the edge of some card's box, and a card is
+    // strictly inside its cell here, so an endpoint on a cell edge is a miss.
+    const ends = await page.evaluate(() => window.__mpProbe.wireEnds());
+    const onEdge = (point, box) => {
+      const inX = point.x >= box.x - 2 && point.x <= box.x + box.w + 2;
+      const inY = point.y >= box.y - 2 && point.y <= box.y + box.h + 2;
+      const atX = Math.abs(point.x - box.x) <= 2 || Math.abs(point.x - (box.x + box.w)) <= 2;
+      const atY = Math.abs(point.y - box.y) <= 2 || Math.abs(point.y - (box.y + box.h)) <= 2;
+      return (inX && inY && (atX || atY));
+    };
+    // Topology as well as anchoring: each wire runs between the HUB's card and
+    // ONE client's, and every client is served exactly once — so a wire that
+    // happened to touch the right kind of edge on the wrong pane still fails.
+    const anchoredTo = (point) =>
+      onEdge(point, server) ? "server" : [c1, c2].findIndex((b) => onEdge(point, b));
+    const served = ends.map((wire) => {
+      const from = anchoredTo(wire.from);
+      const to = anchoredTo(wire.to);
+      if (from === "server" && typeof to === "number" && to >= 0) return to;
+      if (to === "server" && typeof from === "number" && from >= 0) return from;
+      return -1;
+    });
+    const anchored = served.sort().join() === "0,1";
+    // The cards take their cell's WIDTH here and letterbox on height, so a
+    // side departure is the same point either way — the endpoint that tells
+    // card-anchored from cell-anchored apart is client 2's, which leaves the
+    // TOP of a card sitting low in a tall cell. Off the cell it would be a
+    // hundred-odd pixels higher, in the dead space above the card.
+    const fromCardTop = ends.some((wire) =>
+      [wire.from, wire.to].some(
+        (point) =>
+          Math.abs(point.y - c2.y) <= 2 &&
+          point.x >= c2.x - 2 &&
+          point.x <= c2.x + c2.w + 2 &&
+          c2.y - c2.cell.y > 8
+      )
+    );
+    check(
+      ends.length === 2 && anchored && fromCardTop,
+      "each wire leaves a card's own edge, not its cell's",
+      JSON.stringify(ends.map((w) => [Math.round(w.from.x), Math.round(w.from.y), Math.round(w.to.x), Math.round(w.to.y)]))
     );
     check(
       graph.chips.length === 2 && graph.chips.every((c) => c.includes("Wi-Fi")),
@@ -662,10 +832,12 @@ try {
       `shown=${parked.stripShown} "${parked.strip}"`
     );
 
-    // Three clients: two flanking the hub, the third parked below it.
+    // Three clients: two flanking the hub, the third filling the quadrant they
+    // leave open — at a PLAYER's size, since the channel belongs to the hub.
     await page.click("#mp-view-network");
     await page.selectOption("#client-count", "3");
     await sleep(2500);
+    await settle(page);
     const three = await page.evaluate(() => window.__mpProbe.boxes());
     const graph3 = await page.evaluate(() => window.__mpProbe.network());
     const hub = three[3];
@@ -673,9 +845,14 @@ try {
       three.length === 4 &&
         three[0].x < hub.x &&
         three[1].x > hub.x &&
-        three[2].y >= hub.y + hub.h - 2 &&
-        graph3.wires === 3,
-      "a third client parks below the hub, and gets its own wire",
+        // Upper right: right of the hub, above client 2 — and clients 1 and 2
+        // have not moved to make room for it.
+        three[2].x > hub.x &&
+        three[2].y + three[2].h <= three[1].y + 2 &&
+        graph3.wires === 3 &&
+        // Every client is a player-sized window; the hub stays the smallest.
+        three.slice(0, 3).every((client) => hub.w < client.w && hub.h < client.h),
+      "a third client fills the open quadrant at a player's size, with its own wire",
       `${JSON.stringify(three.map((b) => [b.role, b.x, b.y]))} — ${graph3.wires} wires`
     );
     await page.close();
@@ -807,10 +984,12 @@ try {
     await page.selectOption("#client-count", "3");
     await sleep(2500);
     await page.click("#mp-view-grid");
-    await sleep(400);
+    await settle(page);
     const solo = await page.evaluate(() => window.__mpProbe.boxes());
     check(
-      solo.length === 3 && solo[2].w > solo[0].w * 1.8 && solo[2].y >= solo[0].y + solo[0].h,
+      solo.length === 3 &&
+        solo[2].cell.w > solo[0].cell.w * 1.8 &&
+        solo[2].y >= solo[0].y + solo[0].h,
       "in a single-role example the odd last client spans the bottom row",
       JSON.stringify(solo.map((b) => [b.role, b.x, b.y, b.w, b.h]))
     );

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -152,6 +152,10 @@ interface Pane {
   /** Aborts every listener this pane registered outside its own subtree. */
   scope: AbortController;
   iframe: HTMLIFrameElement;
+  /** The pane's CELL — its slot in the grid. The layout places this; the CARD
+   * inside letterboxes to 16:9 within it (Addendum 5b.2), so a pane's visible
+   * box is the game window, never the cell it happens to sit in. */
+  cell: HTMLElement;
   shell: HTMLElement;
   tab: HTMLButtonElement;
   state: PaneState;
@@ -334,11 +338,14 @@ export function initMultiplayerPanes({
   grid.className = "mp-grid";
   grid.dataset.view = "tiled";
 
-  // The "+" tile (Addendum 5a.7): the SPATIAL way to add a client, sitting
-  // where the client it would create is about to appear — the CLIENTS dropdown
-  // stays the numeric one, and both go through the same host call. It is a real
-  // <button>, so it is tab-reachable and answers to Enter/Space for free; it is
-  // a grid child so it takes a cell in tiled/grid, and CSS hides it in tabs
+  // The "+" tile (Addendum 5a.7): the SPATIAL way to add a client — the CLIENTS
+  // dropdown stays the numeric one, and both go through the same host call. It
+  // is always the LAST grid child (Addendum 5b.1): an open seat placed in "the
+  // cell the next client takes" can land mid-layout, where it reads as a hole
+  // rather than an invitation, so it lives at the EDGE of the arrangement,
+  // after every occupied cell. It is a real <button>, so it is
+  // tab-reachable and answers to Enter/Space for free; it is
+  // a grid child so it takes a slot in tiled/grid, and CSS hides it in tabs
   // (which has its own "+" tab) and in network. NETWORK gets no ghost spoke: a
   // wire is measured between two panes that are actually talking, and drawing
   // one to a card that is not a participant would be the one lie this view
@@ -361,9 +368,9 @@ export function initMultiplayerPanes({
 
   // The stage holds the grid plus the layers the NETWORK view adds (mounted by
   // the graph itself: the wires under the cards, the chips over them). They are
-  // siblings of the grid, never children of it — the grid's cells are the panes
-  // and the "+" tile, and another child would shift the `:nth-child` rules the
-  // grid and network views lay out with.
+  // siblings of the grid, never children of it — the grid's children are the
+  // pane cells and the "+" tile, and another child would shift the
+  // `:nth-child` rules the grid and network views lay out with.
   const stage = document.createElement("div");
   stage.className = "mp-stage";
   stage.dataset.view = "tiled";
@@ -478,12 +485,18 @@ export function initMultiplayerPanes({
       <div class="mp-pane-body"></div>
       <div class="mp-pane-err" hidden></div>`;
     shell.querySelector(".mp-pane-body")!.appendChild(iframe);
-    // A client tile is INSERTED BEFORE the "+" tile (and so before the server's
-    // card, which follows it), never appended after them: re-appending a
-    // mounted node is a remove + insert, and that reloads an iframe — the same
-    // invariant that keeps pane 1 in place would be broken for the authority,
-    // wiping the world every time the count changed.
-    grid.insertBefore(shell, client ? addTile : null);
+    // The CELL is the pane's slot; the card letterboxes inside it (see the
+    // Pane type). It is also what the aspect rules measure against, so it is a
+    // size container in the views that letterbox.
+    const cell = document.createElement("div");
+    cell.className = client ? "mp-cell" : "mp-cell server";
+    cell.appendChild(shell);
+    // A client cell is INSERTED BEFORE the server's (and both before the "+"
+    // seat, which is always last — Addendum 5b.1), never appended after them:
+    // re-appending a mounted node is a remove + insert, and that reloads an
+    // iframe — the same invariant that keeps pane 1 in place would be broken
+    // for the authority, wiping the world every time the count changed.
+    grid.insertBefore(cell, (client && serverPane?.pane.cell) || addTile);
 
     const tab = document.createElement("button");
     tab.className = client ? "mp-tab" : "mp-tab server";
@@ -500,6 +513,7 @@ export function initMultiplayerPanes({
       id,
       color,
       iframe,
+      cell,
       shell,
       tab,
       scope: new AbortController(),
@@ -620,7 +634,7 @@ export function initMultiplayerPanes({
     if (!serverPane) return;
     serverPane.bridge.reset();
     serverPane.pane.scope.abort();
-    serverPane.pane.shell.remove();
+    serverPane.pane.cell.remove();
     serverPane.pane.tab.remove();
     paneDetails.delete(serverPane.pane);
     serverPane = null;
@@ -632,7 +646,7 @@ export function initMultiplayerPanes({
     if (!removed) return;
     removed.bridge.reset();
     removed.pane.scope.abort(); // window/document/bridge listeners
-    removed.pane.shell.remove();
+    removed.pane.cell.remove();
     removed.pane.tab.remove();
     panes.pop();
   };
@@ -660,6 +674,11 @@ export function initMultiplayerPanes({
     current.forEach((pane) => {
       const on = pane === focusedPane;
       pane.shell.classList.toggle("focus", on);
+      // The CELL carries it too: TABS hides every cell but the focused one, and
+      // a class it can select directly beats asking the cell to match on its
+      // child — a selector that, unsupported, would drop the whole rule and
+      // stack every pane.
+      pane.cell.classList.toggle("focus", on);
       pane.tab.classList.toggle("focus", on);
       const you = pane.shell.querySelector(".mp-you") as HTMLElement | null;
       if (you) you.hidden = !on;
@@ -875,10 +894,8 @@ export function initMultiplayerPanes({
     const canAdd = !single && panes.length < MAX_CLIENTS;
     addTile.hidden = !canAdd;
     addTab.hidden = !canAdd;
-    // Grid's cell rules need both of these as data, not as structure: a hidden
-    // tile is still a child, so `:last-child` cannot answer "is the bottom row
-    // closed" any more.
-    grid.dataset.seat = canAdd ? "open" : "full";
+    // Grid's odd-last-client rule needs "is there an authority" as data: the
+    // strip is a cell like any other, so no structural selector answers it.
     grid.dataset.server = serverPane ? "yes" : "no";
     if (single) setView("tiled", true);
     // An example that dropped its server pane cannot stay in the hub view.

--- a/site/styles.css
+++ b/site/styles.css
@@ -3180,6 +3180,9 @@ a:hover {
 .mp-grid {
   flex: 1;
   min-height: 0;
+  /* The header row the letterboxing views pin, and subtract to size the body
+     (see the aspect block). */
+  --mp-hd-h: 22px;
   display: grid;
   gap: 10px;
   padding: 10px;
@@ -3201,6 +3204,32 @@ a:hover {
   min-width: 0;
 }
 
+/* ---- cells and cards ----
+
+   Every pane sits in a CELL (mp-panes.ts) and draws itself as a CARD inside
+   it. Tiled and tabs hand the whole cell to the card; GRID and NETWORK
+   letterbox it (Addendum 5b.2) — see the aspect block below. Splitting the
+   two is what lets the layout place a slot and the card still read as a game
+   window rather than a stretched rectangle. */
+
+.mp-cell {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+}
+
+.mp-cell > .mp-pane {
+  flex: 1;
+  min-width: 0;
+}
+
+/* An open link menu drops out of its header and must paint over the pane
+   beside it — but a size container (the aspect cells below) is a stacking
+   context, so the cell has to be raised, not just the menu. */
+.mp-cell:has(.mp-link-menu:not([hidden])) {
+  z-index: 20;
+}
+
 .mp-grid[data-view="tiled"] .mp-add-tile {
   flex: 0 0 clamp(44px, 5%, 68px);
 }
@@ -3214,8 +3243,89 @@ a:hover {
   padding-top: 0;
 }
 
-.mp-grid[data-view="tabs"] .mp-pane:not(.focus) {
+.mp-grid[data-view="tabs"] .mp-cell:not(.focus) {
   display: none;
+}
+
+/* ---- aspect-true cards: a game window reads as a game window ----
+
+   Addendum 5b.2. In GRID and NETWORK a pane's BODY letterboxes to 16:9 and
+   the card floats in its cell, instead of stretching to whatever shape the
+   track handed it (which is why network's full-height clients read as absurdly
+   tall towers). Shrink to fit: the card takes the cell's width, unless the
+   cell is too short for that width's 16:9 body, in which case the height wins
+   and the card narrows. Whatever slack is left over becomes margin around a
+   centred card.
+
+   The cell is a SIZE CONTAINER purely so that "too short" is expressible: the
+   card's width is the smaller of the cell's width and the width whose body
+   fits the cell's height, and only container units can compare the two axes.
+   The header is a fixed row so that subtraction is exact — its content already
+   clips by container query, so pinning its height costs nothing.
+
+   It is a WIDE-STAGE rule. Below the breakpoint every view collapses to a
+   one-column stack of short, full-width cells, so "shrink to fit" is always
+   height-driven there and each card would letterbox down to a third of the
+   column — a stack of stamps in a gutter of empty space. The narrow stack
+   keeps stretching, as it did before. */
+
+@media (min-width: 1281px) {
+  .mp-grid[data-view="grid"] .mp-cell,
+  .mp-grid[data-view="network"] .mp-cell {
+    container-type: size;
+  }
+
+  .mp-grid[data-view="grid"] .mp-cell > .mp-pane,
+  .mp-grid[data-view="network"] .mp-cell > .mp-pane {
+    flex: none;
+    /* Auto margins centre the card in its cell on both axes. */
+    margin: auto;
+    /* The card's own 1px borders are outside the body the ratio governs, so
+       the height budget has to give them back — otherwise the card lands a
+       fraction of a pixel taller than the cell it is fitting into. */
+    width: min(100cqw, calc((100cqh - var(--mp-hd-h) - 2px) * 16 / 9 + 2px));
+  }
+
+  /* GRID's slack goes OUTWARD. Left centred, it would pool between the client
+     row and the authority strip and read as a seam splitting the layout in
+     two; so the clients sit at the foot of their cells and the strip at the
+     head of its band, the two meet, and what is left over collects at the
+     outside of the stage where it is just margin. (Horizontally they stay
+     centred. NETWORK keeps both axes centred — there the cards are a diagram,
+     and the space around each one is what the wires cross.) */
+  .mp-grid[data-view="grid"] .mp-cell:not(.server) > .mp-pane {
+    margin-block: auto 0;
+  }
+
+  .mp-grid[data-view="grid"] .mp-cell.server > .mp-pane {
+    margin-block: 0 auto;
+  }
+
+  .mp-grid[data-view="grid"] .mp-pane-hd,
+  .mp-grid[data-view="network"] .mp-pane-hd {
+    height: var(--mp-hd-h);
+  }
+
+  .mp-grid[data-view="grid"] .mp-pane-body,
+  .mp-grid[data-view="network"] .mp-pane-body {
+    flex: none;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+  }
+
+  /* The error strip is a THIRD row the aspect arithmetic knows nothing about
+     (its height depends on how long the message is), so where the card is
+     sized to fit it overlays the foot of the body instead of growing the card
+     out of its cell. It keeps its own backdrop so the message stays readable
+     over a game. */
+  .mp-grid[data-view="grid"] .mp-pane-err,
+  .mp-grid[data-view="network"] .mp-pane-err {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: color-mix(in srgb, var(--bg-panel) 88%, rgba(242, 99, 127, 0.5));
+  }
 }
 
 /* ---- grid view: client cells over a server strip ----
@@ -3239,32 +3349,36 @@ a:hover {
    The two cases where a client would otherwise sit beside a HOLE rather than a
    notch stretch instead: a lone client (no peer to match), and an odd last
    client in a single-role example (no strip below it, so the empty cell is a
-   whole quadrant). */
+   whole quadrant).
+
+   Each card then letterboxes inside the cell it is given, centred across it
+   and anchored towards the layout's middle (see the aspect block); the cells
+   themselves are what this section places.
+
+   The open SEAT is not one of these cells: it rides the bottom edge as a band
+   (Addendum 5b.1, and see its own block below). */
 
 .mp-grid[data-view="grid"] {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.mp-grid[data-view="grid"] .mp-pane {
+.mp-grid[data-view="grid"] .mp-cell {
   grid-row: span 2;
 }
 
-/* A lone client stretches only when nothing else wants the cell beside it. An
-   OPEN SEAT (the "+" tile) is not a hole — it is the picture of what pressing
-   it does — so with the seat showing, the client sits beside it at the size its
-   new peer will be. */
-.mp-grid[data-view="grid"][data-clients="1"][data-seat="full"] .mp-pane:not(.server) {
+/* A lone client has no peer to match, so it takes the whole row. */
+.mp-grid[data-view="grid"][data-clients="1"] .mp-cell:not(.server) {
   grid-column: 1 / -1;
 }
 
 /* Three clients and no authority: nothing closes the bottom row (no server
    strip, and the seat is full at MAX_CLIENTS), so the odd last client stretches
    rather than leaving a whole empty quadrant. */
-.mp-grid[data-view="grid"][data-clients="3"][data-server="no"] .mp-pane:nth-child(3) {
+.mp-grid[data-view="grid"][data-clients="3"][data-server="no"] .mp-cell:nth-child(3) {
   grid-column: 1 / -1;
 }
 
-.mp-grid[data-view="grid"] .mp-pane.server {
+.mp-grid[data-view="grid"] .mp-cell.server {
   grid-column: 1 / -1;
   grid-row: span 1;
 }
@@ -3286,56 +3400,68 @@ a:hover {
    span rather than a computed position — the same class-change-only rule the
    other views follow, and the wires re-measure from wherever the cards land.
 
-     1 client  · the spoke on the left, the hub far right, a long wire between.
-     2 clients · left and right, full height, with the hub in the channel
-                 between them and parked ABOVE their centreline, so the two
-                 wires leave at different angles instead of forming one
-                 straight line drawn through the hub.
-     3 clients · the same two flanking cards, the third parked below the hub in
-                 the middle channel — the channel its wire runs down.
+   The clients are STAGGERED, half the stage tall each (Addendum 5b.3, and the
+   approved mockup's proportions): client 1 in the upper left, client 2 in the
+   lower right, the hub in the channel between them. Two things fall out of
+   that. The cards are 16:9 windows with the slack around them rather than
+   towers filling a full-height column — the tall-client complaint 5b.2 names.
+   And every wire leaves at its own angle, because no two cards share a
+   centreline.
 
-   Client 1 holds column 1, rows 1–8, at EVERY count: adding or dropping a
-   client never moves the pane you are playing in. */
+     1 client  · the spoke upper left, the hub across in the far column.
+     2 clients · upper left and lower right, the hub in the middle channel.
+     3 clients · the same two, the third filling the empty upper right.
+
+   The middle channel is the HUB's alone. A client parked in it would be a
+   gameplay pane at hub scale — the inversion 5a.2 exists to prevent — so the
+   third client takes the quadrant its two peers leave open instead, at their
+   size. Client 1 holds column 1, rows 1–4, and client 2 column 3, rows 5–8, at
+   EVERY count: adding or dropping a client never moves a pane you are playing
+   in. */
 
 .mp-grid[data-view="network"] {
   /* The middle track is a channel, not a pane slot: it holds the hub (which is
-     smaller than the track) and the wires that cross it. */
-  grid-template-columns: minmax(0, 1fr) minmax(0, 0.52fr) minmax(0, 1fr);
+     smaller than the track) and the wires that cross it. Its floor is the
+     hub's own minimum — a channel narrower than that would squeeze the node
+     into an unreadable thumbnail. */
+  grid-template-columns: minmax(0, 1fr) minmax(132px, 0.52fr) minmax(0, 1fr);
   grid-template-rows: repeat(8, minmax(0, 1fr));
   gap: 8px 44px;
   padding: 12px 18px;
 }
 
-.mp-grid[data-view="network"] .mp-pane:not(.server):nth-child(1) {
+.mp-grid[data-view="network"] .mp-cell:not(.server):nth-child(1) {
   grid-column: 1;
-  grid-row: 1 / span 8;
+  grid-row: 1 / span 4;
 }
 
-.mp-grid[data-view="network"] .mp-pane:not(.server):nth-child(2) {
+.mp-grid[data-view="network"] .mp-cell:not(.server):nth-child(2) {
   grid-column: 3;
-  grid-row: 1 / span 8;
-}
-
-.mp-grid[data-view="network"] .mp-pane:not(.server):nth-child(3) {
-  grid-column: 2;
   grid-row: 5 / span 4;
 }
 
-/* The hub: a compact node parked in the upper middle. `justify-self`/
-   `align-self` are what make it smaller than its cell — the clamp then keeps
-   it a node at any stage size rather than a scaled-down window. */
-.mp-grid[data-view="network"] .mp-pane.server {
+.mp-grid[data-view="network"] .mp-cell:not(.server):nth-child(3) {
+  grid-column: 3;
+  grid-row: 1 / span 4;
+}
+
+/* The hub: a compact node in the middle channel, level with the gap the two
+   staggered clients leave. It is aspect-true like every other card — it is a
+   running pane, not an icon, so it keeps a floor as well as a cap: capped it
+   stays the smallest window on the stage, floored it stays a window at all. */
+.mp-grid[data-view="network"] .mp-cell.server {
   grid-column: 2;
-  grid-row: 1 / span 3;
-  justify-self: center;
-  align-self: center;
-  width: clamp(128px, 100%, 232px);
-  height: clamp(92px, 100%, 176px);
+  grid-row: 3 / span 3;
+}
+
+.mp-grid[data-view="network"] .mp-cell.server > .mp-pane {
+  min-width: 128px;
+  max-width: 232px;
 }
 
 /* A lone client has no second flank, so the hub crosses to the far column and
    the wire gets the whole stage to run across. */
-.mp-grid[data-view="network"][data-clients="1"] .mp-pane.server {
+.mp-grid[data-view="network"][data-clients="1"] .mp-cell.server {
   grid-column: 3;
 }
 
@@ -3989,27 +4115,32 @@ a:hover {
     padding: 10px;
   }
 
-  .preview-pane.mp .mp-grid[data-view="network"] .mp-pane {
+  .preview-pane.mp .mp-grid[data-view="network"] .mp-cell {
     grid-column: 1;
     grid-row: auto;
   }
 
   /* The hub keeps its full width in a one-column stack (a centred node in a
      list reads as a broken cell) but stays the SHORT card — still the smallest
-     window, still the thing the wires run to. */
-  .preview-pane.mp .mp-grid[data-view="network"] .mp-pane.server {
-    justify-self: stretch;
-    width: auto;
+     window, still the thing the wires run to. The letterbox that carries that
+     rank on the wide stage is off here (see the aspect block), so the stack
+     states it directly. */
+  .preview-pane.mp .mp-grid[data-view="network"] .mp-cell.server > .mp-pane {
+    min-width: 0;
+    max-width: none;
     height: clamp(76px, 62%, 132px);
   }
 }
 
-/* ---- the "+" tile: add a client where the client will appear ----
+/* ---- the "+" seat: add a client at the edge of the arrangement ----
 
-   Addendum 5a.7. The CLIENTS dropdown is the numeric control; this is the
-   spatial one — an empty seat at the table, drawn as the dashed outline of the
-   pane it would become. It sits in the cell after the last client, so the
-   layout answers "what happens if I press this" before the tooltip does.
+   Addendum 5a.7, revised by 5b.1. The CLIENTS dropdown is the numeric control;
+   this is the spatial one — an empty seat at the table. It sits AFTER every
+   occupied cell, never between them: a seat placed in "the cell the next
+   client takes" lands mid-layout and reads as a hole in the arrangement, and
+   an invitation should sit at the edge you would reach for. So it is the last
+   grid child (mp-panes.ts) and takes an edge shape rather than a pane's: a
+   slim rail at the end of the tiled row, a short band under the grid.
    Hidden at MAX_CLIENTS, and in TABS (which has its own "+" tab) and NETWORK
    (a topology of real participants only — see mp-panes.ts). */
 
@@ -4046,20 +4177,15 @@ a:hover {
   opacity: 0.8;
 }
 
-/* In GRID the seat is exactly the cell the next client will take — except when
-   it would be alone on its row, where it becomes a short full-width band
-   instead of a cell beside a hole. */
+/* In GRID the seat closes the layout as a band across the bottom — under the
+   clients, under the authority strip, last in reading order at every count. It
+   opts out of the row's stretch, so an empty seat never outweighs the panes
+   that are actually running. */
 .mp-grid[data-view="grid"] .mp-add-tile {
-  grid-row: span 2;
-}
-
-.mp-grid[data-view="grid"][data-clients="2"] .mp-add-tile {
   grid-column: 1 / -1;
   grid-row: span 1;
-  /* A band, not a cell: it opts out of the row's stretch so an empty seat
-     never outweighs the panes that are actually running. */
   align-self: center;
-  height: clamp(64px, 100%, 116px);
+  height: clamp(56px, 100%, 96px);
 }
 
 .mp-grid[data-view="tabs"] .mp-add-tile,


### PR DESCRIPTION
![aspect-true network view](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-network-2clients.png)

<sub>Aspect-true cards: every pane is a 16:9 game window; the SERVER hub is now the smallest window on the stage.</sub>

### Before → after

![before/after — network view](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-beforeafter.png)

<sub>Same stage, same viewport (1600×1000, `example=mp`, 2 clients, network view). Before, the client panes stretched to fill their column and dwarfed the hub; after, each pane keeps a true 16:9 game window and the hub is the smallest card.</sub>

<details>
<summary>More arrangements — grid, three clients, both seat placements, the narrow collapse</summary>

**Grid view, two clients** — the seat is the last child, a band under the grid.

![grid, two clients](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-grid-2clients.png)

**Network view, three clients (1440px)** — wires attach at the card edges.

![network, three clients](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-network-3clients-1440.png)

**The "+" seat is always last** — under the grid, and as a slim rail at the end of the tiled row.

![seat, grid, one client](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-seat-grid-1client.png)

![seat, tiled, one client](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-seat-tiled-1client.png)

**≤1280px — the network view collapses to a stack.**

![collapsed at 1200px](https://gist.githubusercontent.com/tommy-xr/1b0ffceb050a07a0c0f44b2f63b03859/raw/mpnet3-network-collapsed-1200.png)

</details>

---

Bryan's second iteration round on the multiplayer pane grid (design addendum
5b), three items.

**The "+" seat never sits between things.** An open seat placed in "the cell
the next client takes" can land mid-layout, where it reads as a hole rather
than an invitation. It is now always the LAST grid child — a slim rail at the
end of the tiled row, a short band under the grid — and clients insert before
the server's cell rather than before the seat.

**Grid and network panes respect aspect ratio.** Each pane now sits in a
`.mp-cell` and draws itself as a CARD inside it: on a wide stage those two
views letterbox the card to a 16:9 body and float it in its cell instead of
stretching it to whatever shape the track handed it — which is why network's
clients read as absurdly tall towers, filling eight rows. The cell is a size
container so that "this cell is too short for that width" is expressible at
all; the header is a pinned 22px row and the card's own borders are given
back, so the arithmetic is exact to the pixel. The error strip overlays the
body rather than growing the card out of its cell. Below the collapse
breakpoint the stack keeps stretching: there every cell is short and
full-width, so fitting would shrink each card to a stamp in a wide gutter.

**The network layout is rebuilt around those cards.** Clients are staggered
half-height 16:9 windows flanking the hub — client 1 upper left, client 2 lower
right, a third filling the open upper-right quadrant at the same size — so no
two cards share a centreline and every wire leaves at its own angle. The middle
channel belongs to the hub alone: floored so it stays a window, capped so it
stays the smallest one. The wires already measured the pane card, so they now
attach to the letterboxed edges for free.

Verified: `npx tsc -p site --noEmit`, `node site/build.mjs`, `npm run
test:site` (116), `node e2e/sandbox-mp.mjs` (56) and `node
e2e/net-coordinator.mjs` (15). The e2e gains aspect, centring, header-budget,
seat-placement and wire-anchoring assertions, plus a `settle()` that waits out
the FLIP before reading geometry.

Co-Authored-By: Claude <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
