### PR TITLE
refactor(examples): orbs adopts module Client for one-file role symmetry

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -236,11 +236,11 @@ a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
 (`serverInit`/`serverTick`/…). A role declares at most one of the two.
 `examples/orbs` is the same-file reference: its `client` role is the file's
 plain top-level contract and its `server` role is a `module Server { … }`
-block. Module roles are **native-only** for now (`run wasm`/`build wasm`/
-`run vr` refuse them, like vr already refuses prefixes), so a role that must
-also run in the browser stays on the prefix form until the web runtime learns
-the module one; prefixed roles run on native and wasm (`run wasm`/`build wasm` bake the prefix into the page's
-boot config; the site player takes `?prefix=<ident>`). `entry` and `entries`
+block. **Both forms run on native and wasm**: `run wasm`/`build wasm` bake the
+role into the served/exported page's boot config (`window.__functorLangEntryModule`
+/ `…EntryPrefix`; the site player takes `?module=<Ident>` or `?prefix=<ident>`,
+one of the two). Only **vr** still refuses a role — its device push path boots
+the APK's embedded producer with the unprefixed contract. `entry` and `entries`
 together are refused.
 
 ```functor
@@ -440,7 +440,7 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   plain entry. A functor.json ROLE may opt into a block instead —
   `"server": { "file": "game.fun", "module": "Server" }` resolves
   `Server.init`/`Server.tick`/… (see `entries` above); `examples/orbs` is the
-  reference, and the role is native-only for now.
+  reference. Such a role runs on native and wasm; only vr still refuses it.
 - **Hot reload**: canonical names are the rebind identity, so an inline
   module's closures rebind normally — but MOVING a def into (or out of) a
   module renames it (`step` → `Server.step`), which the rebinder treats

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -234,9 +234,16 @@ error listing the blocks the file does declare). The transitional form names
 a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
 — resolving every canonical entry binding through the prefix as camelCase
 (`serverInit`/`serverTick`/…). A role declares at most one of the two.
-`examples/orbs` is the same-file reference: its `client` role is the file's
-plain top-level contract and its `server` role is a `module Server { … }`
-block. **Both forms run on native and wasm**: `run wasm`/`build wasm` bake the
+The two shipped multiplayer samples are the two canonical shapes.
+**`examples/orbs`** is the ONE-FILE reference: a whole game in a single
+buffer, both roles inline modules of it (`"client": { "file": "game.fun",
+"module": "Client" }` + the same for `Server`), with the protocol, the world
+step and the renderer shared bare at the file's top level — one edit
+hot-reloads both roles atomically. **`examples/mp`** is the SEPARATE-FILES
+reference (deliberately not migrated): `client.fun` and `server.fun` as plain
+top-level contracts over a shared `protocol.fun`, the shape to reach for once
+the roles grow past one screen or want independent deploy units.
+**Both forms run on native and wasm**: `run wasm`/`build wasm` bake the
 role into the served/exported page's boot config (`window.__functorLangEntryModule`
 / `…EntryPrefix`; the site player takes `?module=<Ident>` or `?prefix=<ident>`,
 one of the two). Only **vr** still refuses a role — its device push path boots
@@ -440,7 +447,13 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   plain entry. A functor.json ROLE may opt into a block instead —
   `"server": { "file": "game.fun", "module": "Server" }` resolves
   `Server.init`/`Server.tick`/… (see `entries` above); `examples/orbs` is the
-  reference. Such a role runs on native and wasm; only vr still refuses it.
+  reference — EVERY role of it is a block (`Client` and `Server`), nothing at
+  its top level answers a plain entry. Such a role runs on native and wasm;
+  only vr still refuses it.
+  Note the shadowing trap when two roles share a value: a block's own `init`
+  shadows the file's, so `let init = init` inside it is self-referential —
+  name the shared value distinctly (orbs' `initialGame` / `board`) and have
+  each block alias that.
 - **Hot reload**: canonical names are the rebind identity, so an inline
   module's closures rebind normally — but MOVING a def into (or out of) a
   module renames it (`step` → `Server.step`), which the rebinder treats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,9 +251,13 @@ most one of the two. `build` validates every declared role's contract with its r
 names. Both forms run on native and wasm — `run wasm`/`build wasm` bake the role into the
 served/exported page's boot config, and the site player takes `?module=<Ident>` or
 `?prefix=<ident>`. Only `run vr` refuses a role (the device push path boots the APK's
-embedded producer with the unprefixed contract). `examples/orbs` is the same-file
-reference: its `client` role is the file's plain top-level contract and its `server` role
-is a `module Server { … }` block.
+embedded producer with the unprefixed contract). The two multiplayer samples are the two
+canonical shapes: **`examples/orbs`** is the whole game in ONE file, both roles inline
+modules of it (`{"client": {"file": "game.fun", "module": "Client"}, "server": {…,
+"module": "Server"}}`), sharing the protocol/world-step/renderer bare at the file's top
+level so one edit hot-reloads both; **`examples/mp`** is the roles-as-separate-FILES
+reference (`client.fun` + `server.fun` over a shared `protocol.fun`), for when the roles
+outgrow one buffer.
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,12 +248,12 @@ error listing the file's blocks). The transitional form names a binding **prefix
 `"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical entry
 binding through the prefix as camelCase (`serverInit`/`serverTick`/…); a role declares at
 most one of the two. `build` validates every declared role's contract with its resolved
-names. Module roles are native-only for now (`run wasm`/`build wasm`/`run vr` refuse
-them, so a role that must also run in the browser stays on the prefix form);
-prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
-page's boot config; the site player takes `?prefix=<ident>`) — vr loads the unprefixed
-contract only. `examples/orbs` is the same-file reference: its `client` role is the
-file's plain top-level contract and its `server` role is a `module Server { … }` block.
+names. Both forms run on native and wasm — `run wasm`/`build wasm` bake the role into the
+served/exported page's boot config, and the site player takes `?module=<Ident>` or
+`?prefix=<ident>`. Only `run vr` refuses a role (the device push path boots the APK's
+embedded producer with the unprefixed contract). `examples/orbs` is the same-file
+reference: its `client` role is the file's plain top-level contract and its `server` role
+is a `module Server { … }` block.
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -627,6 +627,32 @@ impl FunctorLangProject {
         Ok(())
     }
 
+    /// Can this shell boot this role? Native takes either same-file form
+    /// (`--entry-prefix` / `--entry-module`) and wasm bakes either into the
+    /// served page's boot config, but the vr device push path still boots the
+    /// APK's embedded producer with the unprefixed contract — so running a
+    /// role there would silently play the WRONG role. The test names the
+    /// shells that DO support the forms, so a future environment is refused
+    /// until it is taught them. The config refuses a role declaring both
+    /// forms, so at most one is ever named here.
+    fn check_role_supported(&self, environment: &Environment) -> Result<(), Error> {
+        let shell = match environment {
+            Environment::Native | Environment::Wasm => return Ok(()),
+            Environment::Vr => "vr",
+        };
+        let (form, name) = if !self.module.is_empty() {
+            ("module", self.module.as_str())
+        } else if !self.prefix.is_empty() {
+            ("prefix", self.prefix.as_str())
+        } else {
+            return Ok(());
+        };
+        Err(Error::other(format!(
+            "entry {form} `{name}` is not supported on {shell} yet — run this role with \
+`run native` or `run wasm` (the vr shell loads the unprefixed contract)"
+        )))
+    }
+
     /// Spawn the runner on the entry (`run` and `develop` — hot reload is
     /// built into the producer, so there is no separate watch loop).
     pub async fn run(
@@ -637,35 +663,7 @@ impl FunctorLangProject {
         develop: bool,
     ) -> Result<(), Error> {
         refresh_manifest(working_directory);
-        // A prefixed role can't run on VR yet: the device push path boots the
-        // APK's embedded producer with the unprefixed contract, so running it
-        // would silently play the wrong role. (Native passes --entry-prefix;
-        // wasm bakes the prefix into the served page's boot config.)
-        if !self.prefix.is_empty() && matches!(environment, Environment::Vr) {
-            return Err(Error::other(format!(
-                "entry prefix `{}` is not supported on vr yet — run this role with \
-`run native` or `run wasm` (the vr shell loads the unprefixed contract)",
-                self.prefix
-            )));
-        }
-        // An inline-module role is native-only for now: the wasm host page and
-        // the device push path both boot their embedded producer with the
-        // unprefixed contract, so running it there would silently play the
-        // wrong role. (Native passes --entry-module.) The test is "not
-        // native", so a future environment is refused until it is taught the
-        // form, rather than silently booting the wrong role.
-        if !self.module.is_empty() && !matches!(environment, Environment::Native) {
-            return Err(Error::other(format!(
-                "entry module `{}` is not supported on {} yet — run this role with \
-`run native` (the other shells load the unprefixed contract)",
-                self.module,
-                match environment {
-                    Environment::Vr => "vr",
-                    Environment::Wasm => "wasm",
-                    Environment::Native => unreachable!("guarded above"),
-                }
-            )));
-        }
+        self.check_role_supported(environment)?;
         if matches!(environment, Environment::Vr) {
             if !runner_args.is_empty() {
                 emit(Event::Warning {
@@ -1000,16 +998,6 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         #[cfg(feature = "web")]
         {
             self.entry_path(working_directory)?;
-            // Same restriction as `run wasm`: the exported page boots the web
-            // runtime's unprefixed contract, so a module role would ship as
-            // the wrong role.
-            if !self.module.is_empty() {
-                return Err(Error::other(format!(
-                    "entry module `{}` is not supported on wasm yet — `build native` this role \
-(the wasm bundle loads the unprefixed contract)",
-                    self.module
-                )));
-            }
             // Same constraint as `run wasm`: the bundle carries the project
             // directory, so the entry must live inside it.
             if entry_escapes_project(&self.entry) {
@@ -1025,6 +1013,7 @@ relative path inside it (got {})",
                 self.mouse_capture,
                 self.cursor.as_str(),
                 &self.prefix,
+                &self.module,
             )?;
             for name in &export.shadowed {
                 emit(Event::Warning {
@@ -1123,6 +1112,7 @@ relative path inside it (got {})",
                 self.mouse_capture,
                 self.cursor.as_str(),
                 &self.prefix,
+                &self.module,
             );
             if no_open {
                 emit(Event::Info {
@@ -1638,6 +1628,7 @@ mod tests {
         manifest_mouse_capture, nth_line, project_asset_files, resolve_debug_args, CursorPolicy,
         FunctorLangConfig, FunctorLangEntries, FunctorLangProject,
     };
+    use crate::Environment;
 
     fn resolve(develop: bool, args: &[&str]) -> (Vec<String>, Option<String>) {
         let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();
@@ -1966,6 +1957,42 @@ mod tests {
         )]);
         let err = config.select(Some("server")).unwrap_err();
         assert!(err.to_string().contains("valid identifier"), "{err}");
+    }
+
+    /// The shells that can boot a same-file ROLE. Both forms run on native
+    /// and wasm (the page's boot config carries the module now); vr still
+    /// boots the unprefixed contract, so a role is refused there with a
+    /// teaching error naming the form.
+    #[test]
+    fn a_role_runs_on_native_and_wasm_but_not_vr() {
+        let config = named_json(&[
+            (
+                "client",
+                serde_json::json!({ "file": "game.fun", "module": "Client" }),
+            ),
+            (
+                "legacy",
+                serde_json::json!({ "file": "game.fun", "prefix": "legacy" }),
+            ),
+            ("plain", serde_json::json!("game.fun")),
+        ]);
+        for role in ["client", "legacy"] {
+            let project = config.select(Some(role)).unwrap();
+            for env in [Environment::Native, Environment::Wasm] {
+                assert!(
+                    project.check_role_supported(&env).is_ok(),
+                    "`{role}` must boot on {env:?}"
+                );
+            }
+            let err = project
+                .check_role_supported(&Environment::Vr)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("not supported on vr yet"), "{err}");
+        }
+        // A role with neither form is the plain contract — every shell boots it.
+        let plain = config.select(Some("plain")).unwrap();
+        assert!(plain.check_role_supported(&Environment::Vr).is_ok());
     }
 
     #[test]

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -523,12 +523,10 @@ impl FunctorLangProject {
     /// binding prefix. The config refuses both at once, so the choice is
     /// unambiguous here.
     fn entry_role(&self) -> functor_runtime_common::functor_lang_producer::EntryRole {
-        use functor_runtime_common::functor_lang_producer::EntryRole;
-        if self.module.is_empty() {
-            EntryRole::Prefix(self.prefix.clone())
-        } else {
-            EntryRole::Module(self.module.clone())
-        }
+        functor_runtime_common::functor_lang_producer::EntryRole::from_parts(
+            &self.module,
+            &self.prefix,
+        )
     }
 
     /// `build`'s per-role contract gate (same-file entries): load a Session
@@ -636,16 +634,16 @@ impl FunctorLangProject {
     /// until it is taught them. The config refuses a role declaring both
     /// forms, so at most one is ever named here.
     fn check_role_supported(&self, environment: &Environment) -> Result<(), Error> {
-        let shell = match environment {
+        use functor_runtime_common::functor_lang_producer::EntryRole;
+        match environment {
             Environment::Native | Environment::Wasm => return Ok(()),
-            Environment::Vr => "vr",
-        };
-        let (form, name) = if !self.module.is_empty() {
-            ("module", self.module.as_str())
-        } else if !self.prefix.is_empty() {
-            ("prefix", self.prefix.as_str())
-        } else {
-            return Ok(());
+            Environment::Vr => {}
+        }
+        let shell = environment.as_str();
+        let (form, name) = match self.entry_role() {
+            EntryRole::Prefix(prefix) if prefix.is_empty() => return Ok(()),
+            EntryRole::Prefix(prefix) => ("prefix", prefix),
+            EntryRole::Module(module) => ("module", module),
         };
         Err(Error::other(format!(
             "entry {form} `{name}` is not supported on {shell} yet — run this role with \

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -2268,13 +2268,25 @@ examples move?",
                     &functor_prelude::bundled_modules(),
                 ) {
                     Ok(loaded) => {
-                        for diag in loaded.check() {
+                        let diags = loaded.check();
+                        let clean = diags.is_empty();
+                        for diag in diags {
                             let (file, line, col) = loaded.sources.resolve(diag.span.start);
                             failures.push(format!(
                                 "{label}: {}:{line}:{col}: {}",
                                 file.path.display(),
                                 diag.message
                             ));
+                        }
+                        // A multi-entry project's ROLE also has to answer its
+                        // contract at the names it declares — a typecheck
+                        // alone cannot see that `module Client` lost its
+                        // `init`, since nothing in the file references it.
+                        // This is `build`'s exact per-role gate.
+                        if clean && config.is_named() {
+                            if let Err(e) = project.check_contract(&loaded) {
+                                failures.push(format!("{label}: {e}"));
+                            }
                         }
                     }
                     Err(e) => failures.push(format!(

--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -40,6 +40,10 @@ fn script_safe(json: String) -> String {
 /// - `"__FUNCTOR_LANG_ENTRY_PREFIX__"` becomes a JSON string literal →
 ///   `window.__functorLangEntryPrefix`, the role's binding prefix (same-file
 ///   entries; empty = the classic unprefixed contract).
+/// - `"__FUNCTOR_LANG_ENTRY_MODULE__"` becomes a JSON string literal →
+///   `window.__functorLangEntryModule`, the role's inline entry module
+///   (same-file entries; empty = no module role). The config refuses a role
+///   declaring both, so at most one of the two is ever non-empty.
 ///
 /// All substitutions are valid JS for any path (quotes/backslashes included).
 pub(crate) fn render_functor_lang_index(
@@ -48,6 +52,7 @@ pub(crate) fn render_functor_lang_index(
     mouse_capture: bool,
     cursor: &str,
     prefix: &str,
+    module: &str,
 ) -> String {
     let entry_literal =
         script_safe(serde_json::to_string(entry).expect("a string always serializes"));
@@ -59,12 +64,15 @@ pub(crate) fn render_functor_lang_index(
         script_safe(serde_json::to_string(cursor).expect("a string always serializes"));
     let prefix_literal =
         script_safe(serde_json::to_string(prefix).expect("a string always serializes"));
+    let module_literal =
+        script_safe(serde_json::to_string(module).expect("a string always serializes"));
     INDEX_FUNCTOR_LANG_HTML
         .replace("\"__FUNCTOR_LANG_ENTRY__\"", &entry_literal)
         .replace("\"__FUNCTOR_LANG_PROJECT_FILES__\"", &files_literal)
         .replace("\"__FUNCTOR_MOUSE_CAPTURE__\"", &mouse_capture_literal)
         .replace("\"__FUNCTOR_CURSOR_POLICY__\"", &cursor_literal)
         .replace("\"__FUNCTOR_LANG_ENTRY_PREFIX__\"", &prefix_literal)
+        .replace("\"__FUNCTOR_LANG_ENTRY_MODULE__\"", &module_literal)
 }
 
 /// The project's file list as URLs relative to the served directory (entry
@@ -101,11 +109,13 @@ impl WasmDevServer {
         mouse_capture: bool,
         cursor: &str,
         prefix: &str,
+        module: &str,
     ) -> Result<(), io::Error> {
         let files = project_file_urls(working_directory, entry);
         Self::serve(
             working_directory,
-            render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix).into_bytes(),
+            render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix, module)
+                .into_bytes(),
         )
         .await
     }
@@ -195,6 +205,7 @@ mod tests {
             true,
             "captured",
             "",
+            "",
         );
         assert!(html.contains("window.__functorLangGamePath = \"game.fun\""));
         assert!(html.contains("const gameMouseCapture = true"));
@@ -214,6 +225,7 @@ mod tests {
             false,
             "visible",
             "",
+            "",
         );
         assert!(html.contains("(["));
         assert!(html.contains("\"game.fun\",\"pieces.fun\""));
@@ -228,6 +240,7 @@ mod tests {
             &["game.fun".to_string()],
             false,
             "visible",
+            "",
             "",
         );
         for expected in [
@@ -274,6 +287,7 @@ mod tests {
             true,
             "captured",
             "",
+            "",
         );
         assert!(html.contains("we\\\"ird\\\\name.fun"));
     }
@@ -285,6 +299,7 @@ mod tests {
             &["bad</script>.fun".to_string()],
             true,
             "captured",
+            "",
             "",
         );
         assert!(html.contains("bad<\\/script>.fun"));
@@ -300,15 +315,35 @@ mod tests {
             true,
             "captured",
             "server",
+            "",
         );
         assert!(html.contains("window.__functorLangEntryPrefix = \"server\""));
         assert!(!html.contains("__FUNCTOR_LANG_ENTRY_PREFIX__"));
     }
 
+    /// The role's inline entry MODULE reaches the page: the web producer reads
+    /// `window.__functorLangEntryModule` to resolve `Server.init`/`Server.tick`/….
+    #[test]
+    fn substitutes_the_entry_module() {
+        let html = render_functor_lang_index(
+            "game.fun",
+            &["game.fun".to_string()],
+            true,
+            "captured",
+            "",
+            "Server",
+        );
+        assert!(html.contains("window.__functorLangEntryModule = \"Server\""));
+        assert!(!html.contains("__FUNCTOR_LANG_ENTRY_MODULE__"));
+        // The two forms are mutually exclusive: a module role's page carries
+        // no prefix.
+        assert!(html.contains("window.__functorLangEntryPrefix = \"\""));
+    }
+
     #[test]
     fn substitutes_the_mouse_capture_boolean() {
         let html =
-            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "captured", "");
+            render_functor_lang_index("game.fun", &["game.fun".to_string()], false, "captured", "", "");
         assert!(html.contains("const gameMouseCapture = false"));
         assert!(!html.contains("__FUNCTOR_MOUSE_CAPTURE__"));
     }

--- a/cli/src/util/wasm_export.rs
+++ b/cli/src/util/wasm_export.rs
@@ -69,6 +69,7 @@ pub fn export_functor_lang_wasm(
     mouse_capture: bool,
     cursor: &str,
     prefix: &str,
+    module: &str,
 ) -> Result<WasmExport, Error> {
     let root = Path::new(working_directory);
 
@@ -120,7 +121,7 @@ name {RESERVED_ROOT:?} at the project root): {} — rename or move them",
     // The runtime files go in last so nothing in the project can shadow them.
     std::fs::write(
         out.join("index.html"),
-        render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix),
+        render_functor_lang_index(entry, &files, mouse_capture, cursor, prefix, module),
     )?;
     std::fs::write(out.join("scrubber.js"), SCRUBBER_JS)?;
     std::fs::write(out.join("timeline-model.js"), TIMELINE_MODEL_JS)?;
@@ -306,7 +307,7 @@ mod tests {
         dir.write("dist/web/stale.txt", "from a previous export");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "", "").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -360,10 +361,25 @@ mod tests {
         dir.write("game.fun", "let init = 0");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "server").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "server", "").unwrap();
 
         let index = fs::read_to_string(export.out_dir.join("index.html")).unwrap();
         assert!(index.contains("window.__functorLangEntryPrefix = \"server\""));
+    }
+
+    /// …and so does a role's inline entry MODULE — `build wasm` bakes it into
+    /// the exported page's boot config, so the bundle plays the right role.
+    #[test]
+    fn exports_the_entry_module() {
+        let dir = TestDir::new("module");
+        dir.write("game.fun", "let init = 0");
+
+        let wd = dir.path().to_string_lossy().to_string();
+        let export = export_functor_lang_wasm(&wd, "game.fun", false, "visible", "", "Server").unwrap();
+
+        let index = fs::read_to_string(export.out_dir.join("index.html")).unwrap();
+        assert!(index.contains("window.__functorLangEntryModule = \"Server\""));
+        assert!(index.contains("window.__functorLangEntryPrefix = \"\""));
     }
 
     #[test]
@@ -374,7 +390,7 @@ mod tests {
         dir.write("pkg/junk.js", "not the runtime");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap();
 
         let out = &export.out_dir;
         let index = fs::read_to_string(out.join("index.html")).unwrap();
@@ -432,7 +448,7 @@ let g = "pkg/tex.png"
         dir.write(".hidden.fun", "let ghost = 1");
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap();
         assert_eq!(export.file_count, 1, "only game.fun ships");
         assert!(
             !export.out_dir.join(".hidden.fun").exists(),
@@ -449,7 +465,7 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path().join("elsewhere"), dir.path().join("dist")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let err = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap_err();
+        let err = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap_err();
         assert!(err.to_string().contains("symlink"), "{err}");
         assert!(
             dir.path().join("elsewhere/precious.txt").is_file(),
@@ -472,7 +488,7 @@ let g = "pkg/tex.png"
         std::os::unix::fs::symlink(dir.path(), dir.path().join("loop")).unwrap();
 
         let wd = dir.path().to_string_lossy().to_string();
-        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "").unwrap();
+        let export = export_functor_lang_wasm(&wd, "game.fun", true, "captured", "", "").unwrap();
         assert_eq!(
             fs::read(export.out_dir.join("linked.glb")).unwrap(),
             b"glb-bytes",

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -685,10 +685,10 @@ snapshots — no GPU, fully agent-verifiable.
       on every hot reload, so deleting the block fails loudly and keeps the
       old program instead of reporting every binding missing. Module roles
       landed native-only here; Part 9 lifted that to wasm. `examples/orbs`
-      is the reference: its `client`
-      role is now the file's plain top-level contract (so the sandbox and
-      the docs teach the same `init`/`tick`/`draw`) and its `server` role is
-      a `module Server { … }` block. *Verify:* config-shape tests
+      moved off prefixes here: its `client` role became the file's plain
+      top-level contract (the only form the sandbox could boot on wasm at the
+      time) and its `server` role a `module Server { … }` block — Part 10
+      completed the symmetry. *Verify:* config-shape tests
       (module form, module+prefix refusal, non-string/non-Capitalized names,
       unknown keys), contract tests naming `Server.tick`, an unknown-block
       error test, a desktop load + hot-reload test for a module role, the
@@ -713,6 +713,22 @@ snapshots — no GPU, fully agent-verifiable.
       block lists the file's blocks), CLI tests for the lifted guards and the
       page's baked boot config, and a headless `run wasm` browser smoke of a
       `module Server` role.
+      **Part 10 — the samples adopt the two canonical shapes — done:** with
+      wasm unblocked, `examples/orbs` moved its `client` role into a
+      `module Client { … }` block as well, so **both** of its roles are inline
+      modules of one file and nothing at its top level answers a plain entry;
+      the protocol, the world step and the renderer stay shared bare at the
+      file's top level, and one edit hot-reloads both roles. The sandbox plays
+      it as `?module=Client` and mounts a SERVER pane on the very same buffer
+      at `?module=Server`. `examples/mp` deliberately stays the
+      roles-as-separate-FILES reference (`client.fun` + `server.fun` over a
+      shared `protocol.fun`), so the two shipped multiplayer samples document
+      the two shapes side by side. *Verify:* the example sweep now validates
+      every declared role's CONTRACT (not just its typecheck), so a role whose
+      block loses a binding fails `cargo test`; plus `build`/`test`/`build
+      wasm` on orbs, headless native captures of both roles compared against
+      the pre-migration renders, and the site sandbox e2e over the client and
+      server panes.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -684,9 +684,8 @@ snapshots — no GPU, fully agent-verifiable.
       naming the role, the file, and the blocks it does declare — re-resolved
       on every hot reload, so deleting the block fails loudly and keeps the
       old program instead of reporting every binding missing. Module roles
-      are native-only for now (`run wasm`/`build wasm`/`run vr` refuse them,
-      as vr already refuses prefixes) because those shells boot the
-      unprefixed contract. `examples/orbs` is the reference: its `client`
+      landed native-only here; Part 9 lifted that to wasm. `examples/orbs`
+      is the reference: its `client`
       role is now the file's plain top-level contract (so the sandbox and
       the docs teach the same `init`/`tick`/`draw`) and its `server` role is
       a `module Server { … }` block. *Verify:* config-shape tests
@@ -695,6 +694,25 @@ snapshots — no GPU, fully agent-verifiable.
       error test, a desktop load + hot-reload test for a module role, the
       example sweep over both orbs roles, and headless captures of both
       roles.
+      **Part 9 — module roles on the embedded/wasm producer — done:** the
+      embedded producer (`functor_lang_game_embedded.rs`, the web and device
+      shells) takes the same `EntryRole` the desktop one does and re-resolves
+      it on every (re)load, so a module role hot-reloads through the push
+      seam exactly as it does natively. The web runtime reads the role from
+      the page's boot config — `window.__functorLangEntryModule` beside the
+      existing `…EntryPrefix`, mutually exclusive — which `run wasm` and
+      `build wasm` bake into the served/exported index page, and the site
+      player takes as `?module=<Ident>` (capitalized identifier; anything
+      else warns and boots the unprefixed contract). `run wasm` and
+      `build wasm` no longer refuse a module role; **vr still does**, because
+      its device push path boots the APK's embedded producer with the
+      unprefixed contract and teaching it the form needs a protocol +
+      on-device change. *Verify:* embedded-producer tests (a module role's
+      contract is the block's, a push re-resolves it with the model
+      preserved, a push deleting the block keeps the old program, an unknown
+      block lists the file's blocks), CLI tests for the lifted guards and the
+      page's baked boot config, and a headless `run wasm` browser smoke of a
+      `module Server` role.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -719,16 +719,19 @@ snapshots — no GPU, fully agent-verifiable.
       modules of one file and nothing at its top level answers a plain entry;
       the protocol, the world step and the renderer stay shared bare at the
       file's top level, and one edit hot-reloads both roles. The sandbox plays
-      it as `?module=Client` and mounts a SERVER pane on the very same buffer
-      at `?module=Server`. `examples/mp` deliberately stays the
+      it as `?module=Client`. (It does NOT get a server pane: the pane grid
+      pushes editor edits only to the client mirrors and labels the pane
+      `authority` over coordinator wires, neither of which a transport-less
+      one-buffer sample can honor — a follow-up for when orbs adopts the
+      transport.) `examples/mp` deliberately stays the
       roles-as-separate-FILES reference (`client.fun` + `server.fun` over a
       shared `protocol.fun`), so the two shipped multiplayer samples document
       the two shapes side by side. *Verify:* the example sweep now validates
       every declared role's CONTRACT (not just its typecheck), so a role whose
       block loses a binding fails `cargo test`; plus `build`/`test`/`build
       wasm` on orbs, headless native captures of both roles compared against
-      the pre-migration renders, and the site sandbox e2e over the client and
-      server panes.
+      the pre-migration renders, and a sandbox e2e asserting every orbs pane
+      boots `?module=Client` and reaches live.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/e2e/fixtures/module-role/functor.json
+++ b/e2e/fixtures/module-role/functor.json
@@ -1,0 +1,6 @@
+{
+  "language": "functor-lang",
+  "entries": {
+    "server": { "file": "game.fun", "module": "Server" }
+  }
+}

--- a/e2e/fixtures/module-role/game.fun
+++ b/e2e/fixtures/module-role/game.fun
@@ -1,0 +1,15 @@
+// The file's TOP LEVEL deliberately declares no init/tick/draw: if the page
+// booted the plain contract it would fail to load, so a successful load proves
+// the `module Server` role resolved on wasm.
+let spinRate = 1.5
+
+module Server {
+  let init = { spin: 0.0 }
+
+  let tick = (model, dt, tts) => { spin: model.spin + dt * spinRate }
+
+  let draw = (model, tts) =>
+    Frame.create(
+      Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.0, 0.0)),
+      Scene.cube() |> Scene.rotateY(Angle.radians(model.spin)))
+}

--- a/e2e/module-role-wasm.mjs
+++ b/e2e/module-role-wasm.mjs
@@ -1,0 +1,100 @@
+// A same-file MODULE entry role must boot in the browser, not just natively.
+//
+// `e2e/fixtures/module-role` declares one role — `{ "file": "game.fun",
+// "module": "Server" }` — and its file deliberately has NO top-level
+// `init`/`tick`/`draw`: if the page booted the plain contract it would fail to
+// load, so reaching "[functor-lang] loaded" IS the proof the role resolved.
+//
+// The bundle is exported with `build wasm` and served from an ephemeral port
+// rather than driven through `run wasm` (which hardcodes :8080): both render
+// the SAME page from the same template — that `run wasm`'s served index
+// carries the module is pinned by `substitutes_the_entry_module` in
+// cli/src/util/wasm_dev_server.rs — and exporting keeps this check hermetic
+// next to a dev server someone else is running.
+//
+//   npm run build:cli:debug   # once, so target/debug/functor embeds the runtime
+//   node e2e/module-role-wasm.mjs
+import { execFileSync } from "node:child_process";
+import { createReadStream, statSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DIR = path.join(ROOT, "e2e", "fixtures", "module-role");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+console.log(
+  execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", DIR, "build", "wasm"], {
+    encoding: "utf8",
+  })
+);
+
+const TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".wasm": "application/wasm",
+  ".fun": "text/plain",
+};
+const root = path.join(DIR, "dist", "web");
+const server = http.createServer((req, res) => {
+  let rel = decodeURIComponent(req.url.split("?")[0]);
+  if (rel === "/") rel = "/index.html";
+  const file = path.join(root, rel);
+  try {
+    statSync(file);
+  } catch {
+    res.writeHead(404).end("not found");
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
+  });
+  createReadStream(file).pipe(res);
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const { port } = server.address();
+
+// Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
+// runner — no real GPU needed; this check compares no pixels.
+const browser = await chromium.launch({
+  args: [
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+  ],
+});
+let ok = false;
+let reason = "";
+try {
+  const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+  const log = [];
+  page.on("console", (m) => log.push(`${m.type()}: ${m.text()}`));
+  page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+  await page.goto(`http://127.0.0.1:${port}/`);
+  for (let i = 0; !log.some((m) => m.includes("[functor-lang] loaded")); i++) {
+    if (i > 60) throw new Error(`never loaded:\n${log.join("\n")}`);
+    await sleep(250);
+  }
+  const [bootModule, bootPrefix] = await page.evaluate(() => [
+    window.__functorLangEntryModule,
+    window.__functorLangEntryPrefix,
+  ]);
+  await sleep(1500); // run frames: a broken role would error per frame
+  const errors = log.filter((l) => /\[functor-lang\].*error/.test(l));
+  console.log(
+    `boot config: module=${JSON.stringify(bootModule)} prefix=${JSON.stringify(bootPrefix)}`
+  );
+  console.log(log.filter((l) => l.includes("[functor-lang]")).join("\n"));
+  ok = bootModule === "Server" && bootPrefix === "" && errors.length === 0;
+  reason = ok ? "" : `module=${bootModule} prefix=${bootPrefix} errors=${errors.join(" | ")}`;
+} catch (e) {
+  reason = String(e);
+} finally {
+  await browser.close();
+  server.close();
+}
+console.log(ok ? "PASS: the module role booted on wasm" : `FAIL: ${reason}`);
+process.exit(ok ? 0 : 1);

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -18,7 +18,9 @@
 //   4. every pane header shows its coordinator link state;
 //   5. the GRID layout puts the clients in two columns with the server as a
 //      full-width strip below them — and switching layout reloads no pane;
-//   6. switching to a single-role example removes the server pane again.
+//   6. switching to a single-role example removes the server pane again;
+//   7. the ONE-FILE shape (examples/orbs) mounts the same grid, with the two
+//      panes differing only in which inline module they boot.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -85,6 +87,9 @@ const installProbe = (page) =>
     window.__mpProbe = {
       roles: () => shells().map((s) => s.role),
       headers: () => shells().map((s) => s.header),
+      // Each pane's player URL — what says which FILE it booted and, for a
+      // same-file sample, which inline module it booted it as.
+      srcs: () => shells().map((s) => s.frame.getAttribute("src")),
       // The link indicator, read as STATE rather than as prose: the dot is what
       // survives when a thumbnail header clips the word off (see headerParts).
       links: () =>
@@ -814,6 +819,49 @@ try {
       "in a single-role example the odd last client spans the bottom row",
       JSON.stringify(solo.map((b) => [b.role, b.x, b.y, b.w, b.h]))
     );
+    await page.close();
+  }
+
+  // --- 6. ORBS: both roles out of ONE file, as inline modules. ----------------
+  // examples/mp proves the pane grid over roles-as-FILES. Orbs is the other
+  // canonical shape — one buffer, `module Client` and `module Server` — so the
+  // server pane re-enters the SAME dist file at a different module. That the
+  // panes differ ONLY in `module=` is the whole claim; if the client's role
+  // leaked, or the server's were inherited, both would boot the same half.
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    await page.goto(`${BASE}/sandbox.html?example=orbs`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    const mounted = await page
+      .waitForFunction(() => window.__mpProbe.roles().length === 2, null, { timeout: 15000 })
+      .then(() => true)
+      .catch(() => false);
+    check(
+      mounted,
+      "a one-file sample mounts a server pane too",
+      (await page.evaluate(() => window.__mpProbe.roles())).join(", ")
+    );
+    const srcs = (await page.evaluate(() => window.__mpProbe.srcs())).map(
+      (src) => new URLSearchParams(src.split("?")[1])
+    );
+    check(
+      srcs.length === 2 && srcs[0].get("game") === srcs[1].get("game"),
+      "both roles boot the very same file",
+      srcs.map((p) => p.get("game")).join(" vs ")
+    );
+    check(
+      srcs[0]?.get("module") === "Client" && srcs[1]?.get("module") === "Server",
+      "the panes differ only in which inline module they boot",
+      srcs.map((p) => p.get("module")).join(" / ")
+    );
+    // A `?module=` the runtime cannot resolve boots the plain contract and
+    // never reaches `live`, so a live pill over both panes IS the proof both
+    // blocks answered their contract in the browser.
+    const pill = await page.evaluate(() => window.__mpProbe.pill());
+    check(pill.includes("1+1"), "the pill counts the client and its authority", pill);
     await page.close();
   }
 } finally {

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -19,8 +19,8 @@
 //   5. the GRID layout puts the clients in two columns with the server as a
 //      full-width strip below them — and switching layout reloads no pane;
 //   6. switching to a single-role example removes the server pane again;
-//   7. the ONE-FILE shape (examples/orbs) mounts the same grid, with the two
-//      panes differing only in which inline module they boot.
+//   7. the ONE-FILE shape (examples/orbs) plays its role by name — every
+//      client pane boots `?module=Client` and reaches live.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -822,46 +822,46 @@ try {
     await page.close();
   }
 
-  // --- 6. ORBS: both roles out of ONE file, as inline modules. ----------------
-  // examples/mp proves the pane grid over roles-as-FILES. Orbs is the other
-  // canonical shape — one buffer, `module Client` and `module Server` — so the
-  // server pane re-enters the SAME dist file at a different module. That the
-  // panes differ ONLY in `module=` is the whole claim; if the client's role
-  // leaked, or the server's were inherited, both would boot the same half.
+  // --- 6. ORBS: a ROLE the sandbox plays by name. -----------------------------
+  // examples/mp is the roles-as-FILES shape; orbs is the one-file one, both of
+  // its roles inline modules of the editable buffer. Nothing at that file's top
+  // level answers a plain entry, so booting it at all takes `?module=Client` —
+  // which makes "reaches live and keeps ticking" the real assertion here: a
+  // dropped or misspelled role would boot the unprefixed contract and fail to
+  // load. Orbs declares no `server` (see examples.ts), so the grid stays
+  // client-only.
   {
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
-    await page.goto(`${BASE}/sandbox.html?example=orbs`);
+    await page.goto(`${BASE}/sandbox.html?example=orbs#clients=2`);
     await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
       timeout: 40000,
     });
     await installProbe(page);
-    const mounted = await page
-      .waitForFunction(() => window.__mpProbe.roles().length === 2, null, { timeout: 15000 })
+    const grew = await page
+      .waitForFunction(() => window.__mpProbe.roles().length === 2, null, { timeout: 20000 })
       .then(() => true)
       .catch(() => false);
-    check(
-      mounted,
-      "a one-file sample mounts a server pane too",
-      (await page.evaluate(() => window.__mpProbe.roles())).join(", ")
-    );
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    check(grew && !roles.includes("server"), "a one-file sample stays client-only", roles.join(", "));
     const srcs = (await page.evaluate(() => window.__mpProbe.srcs())).map(
       (src) => new URLSearchParams(src.split("?")[1])
     );
     check(
-      srcs.length === 2 && srcs[0].get("game") === srcs[1].get("game"),
-      "both roles boot the very same file",
-      srcs.map((p) => p.get("game")).join(" vs ")
+      srcs.length === 2 && srcs.every((p) => p.get("module") === "Client"),
+      "every client pane boots the sample's inline CLIENT module",
+      srcs.map((p) => `${p.get("game")}?module=${p.get("module")}`).join(" | ")
     );
+    const ran = await page
+      .waitForFunction(() => window.__mpProbe.pill().includes("2 running"), null, {
+        timeout: 20000,
+      })
+      .then(() => true)
+      .catch(() => false);
     check(
-      srcs[0]?.get("module") === "Client" && srcs[1]?.get("module") === "Server",
-      "the panes differ only in which inline module they boot",
-      srcs.map((p) => p.get("module")).join(" / ")
+      ran,
+      "both panes reach live on the module role",
+      await page.evaluate(() => window.__mpProbe.pill())
     );
-    // A `?module=` the runtime cannot resolve boots the plain contract and
-    // never reaches `live`, so a live pill over both panes IS the proof both
-    // blocks answered their contract in the browser.
-    const pill = await page.evaluate(() => window.__mpProbe.pill());
-    check(pill.includes("1+1"), "the pill counts the client and its authority", pill);
     await page.close();
   }
 } finally {

--- a/examples/orbs/functor.json
+++ b/examples/orbs/functor.json
@@ -1,7 +1,7 @@
 {
   "language": "functor-lang",
   "entries": {
-    "client": "game.fun",
+    "client": { "file": "game.fun", "module": "Client" },
     "server": { "file": "game.fun", "module": "Server" }
   }
 }

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -155,12 +155,12 @@ let botIntent = (ship: Ship, orbs: List<Orb>): Intent =>
     { turn: if arrived then 0.0 else Math.sign(diff),
       thrust: not arrived, claim: arrived }
 
-// ===========================  CLIENT  =================================
-// The `client` role is this file's ordinary top-level contract
-// (init/sampledInput/tick/draw — functor.json maps it to "game.fun").
-// YOU (cyan) and the bot (pink) join through the real protocol path; both
-// Intents fold in as Steers + Claims, then `step` runs. With a real
-// transport the client keeps only its OWN sends; nothing changes shape.
+// ===========================  SHARED  =================================
+// The palette, the starting model, the claim send and the renderer: named at
+// the FILE's top level so BOTH role blocks below can reach them bare. A role
+// block's own `init`/`draw` would shadow a same-named top-level binding, so
+// the shared values carry distinct names (`initialGame`, `board`) and each
+// role aliases them — `let init = init` inside a block is self-referential.
 
 // Palette: zero-arg functions, not top-level values — the sandbox's lang-intel
 // evaluates this module under the plain prelude, where Color.* doesn't exist.
@@ -171,25 +171,12 @@ let wallColor = () => Color.rgb(0.3, 0.35, 0.55)
 let bg = () => Color.rgb(0.02, 0.025, 0.06)
 
 // The starting model both roles begin from: two seats joined through the
-// handshake. `init` aliases it rather than owning it (like `draw`/`board`
-// below), so the `Server` block can start from the same model without
-// shadowing itself.
+// handshake.
 let initialGame =
   let (w1, meWelcome) = join(newWorld()) in
   let (w2, botWelcome) = join(w1) in
   { myPid: welcomePid(meWelcome), botPid: welcomePid(botWelcome),
     world: w2, intent: coast }
-
-let init = initialGame
-
-// Held LEVELS, read once per tick — exactly what a transport forwards as a Steer.
-let sampledInput = (m, snap: Input.snapshot) =>
-  let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
-  { m with intent: {
-      turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
-          - (if held(Key.Right) || held(Key.D) then 1.0 else 0.0),
-      thrust: held(Key.Up) || held(Key.W),
-      claim: held(Key.Space) } }
 
 // Over an unclaimed orb with claim held -> a Claim on the wire; the server decides.
 let sendClaim = (pid: float, intent: Intent, w: World): World =>
@@ -201,19 +188,6 @@ let sendClaim = (pid: float, intent: Intent, w: World): World =>
       (match w.orbs |> List.find((o) => o.owner < 0.0 && overOrb(s, o)) with
        | Option.Some(o) => w |> recv(pid, Claim(o.id))
        | Option.None => w)
-
-let tick = (m, dt: float, tts: float) =>
-  let bot =
-    (match shipOf(m.botPid, m.world) with
-     | Option.None => coast
-     | Option.Some(s) => botIntent(s, m.world.orbs)) in
-  { m with world:
-      m.world
-        |> recv(m.myPid, Steer(m.intent))
-        |> recv(m.botPid, Steer(bot))
-        |> sendClaim(m.myPid, m.intent)
-        |> sendClaim(m.botPid, bot)
-        |> step(dt) }
 
 // ---------- rendering ----------
 let colorFor = (m, pid: float) => if pid == m.myPid then cyan() else pink()
@@ -240,8 +214,7 @@ let hud = (m) =>
     Text.concat("BOT ", Text.fixed(scoreOf(m.botPid, m.world.orbs), 0.0))
       |> Sprite.text(pink(), 1.2) |> Sprite.move(halfW * 0.5, halfH + 2.2)])
 
-// The board both roles render. `draw` aliases it rather than owning the body,
-// so the `Server` block can render the same view without shadowing itself.
+// The board both roles render — each role's `draw` aliases it.
 let board = (m, tts: float) =>
   Frame.create2D(
     Camera2D.create((halfW + 2.0) * 2.0, (halfH + 3.0) * 2.0),
@@ -253,17 +226,58 @@ let board = (m, tts: float) =>
         |> List.append([hud(m)])))
     |> Frame.withClearColor(bg())
 
-let draw = board
+// ==========================  THE ROLES  ===============================
+// Both entry roles are inline modules in THIS file, so functor.json names a
+// block per role and the runner resolves that block's members as the
+// contract — Client.init/Client.tick/Client.draw and Server.init/… :
+//
+//   "entries": { "client": { "file": "game.fun", "module": "Client" },
+//                "server": { "file": "game.fun", "module": "Server" } }
+//
+//   functor -d examples/orbs run native --entry client   (you steer)
+//   functor -d examples/orbs run native --entry server   (the authority)
+//
+// One buffer, both roles, one hot reload. Everything at the file's top level
+// (the protocol, the world step, the renderer) is visible in here bare.
+// `examples/mp` is the other canonical shape: roles as separate FILES over a
+// shared protocol.fun.
+
+// ========================  CLIENT ROLE  ===============================
+// YOU (cyan) and the bot (pink) join through the real protocol path; both
+// Intents fold in as Steers + Claims, then `step` runs. With a real
+// transport the client keeps only its OWN sends; nothing changes shape.
+
+module Client {
+  let init = initialGame
+
+  // Held LEVELS, read once per tick — what a transport forwards as a Steer.
+  let sampledInput = (m, snap: Input.snapshot) =>
+    let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
+    { m with intent: {
+        turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
+            - (if held(Key.Right) || held(Key.D) then 1.0 else 0.0),
+        thrust: held(Key.Up) || held(Key.W),
+        claim: held(Key.Space) } }
+
+  let tick = (m, dt: float, tts: float) =>
+    let bot =
+      (match shipOf(m.botPid, m.world) with
+       | Option.None => coast
+       | Option.Some(s) => botIntent(s, m.world.orbs)) in
+    { m with world:
+        m.world
+          |> recv(m.myPid, Steer(m.intent))
+          |> recv(m.botPid, Steer(bot))
+          |> sendClaim(m.myPid, m.intent)
+          |> sendClaim(m.botPid, bot)
+          |> step(dt) }
+
+  let draw = board
+}
 
 // ========================  SERVER ROLE  ===============================
-// The same file is ALSO the `server` entry: functor.json maps the role to
-// { "file": "game.fun", "module": "Server" }, so the runner resolves this
-// block's members as the contract — Server.init/Server.tick/Server.draw
-// (functor -d examples/orbs run native --entry server). One buffer, both
-// roles, one hot reload. The role is the authoritative SERVER section
-// stepped directly, with the bot steering both seats so the view moves on
-// its own. Everything at the file's top level (the protocol, the world
-// step, the renderer) is visible in here bare.
+// The authoritative SERVER section stepped directly, with the bot steering
+// both seats so the view moves on its own.
 
 module Server {
   let init = initialGame

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -4,7 +4,8 @@
 // claim it: it takes your color, and your score is the orbs you own. A full
 // board deals a fresh round. The client HOSTS the authoritative world
 // in-process — when the multiplayer transport lands, the SERVER section moves
-// behind the wire (a functor.json `entries` role, see examples/mp) unchanged.
+// behind the wire (see examples/mp) unchanged. Both roles are already
+// `entries` roles, as inline modules of this one file (see THE ROLES below).
 
 // ==========================  PROTOCOL  ================================
 // What both roles agree on — with a real transport, exactly what

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",
     "site:serve": "node site/serve.mjs",
+    "test:module-role": "node e2e/module-role-wasm.mjs",
     "test:site": "node e2e/site-sandbox.mjs",
     "test:net-coordinator": "node e2e/net-coordinator.mjs",
     "test:sandbox-mp": "node e2e/sandbox-mp.mjs",

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -31,8 +31,8 @@ use crate::functor_lang_prelude::{
     EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
-    journal_arm, journal_swap, validate_contract, EntryNames, FrameCtx, JournalEntry, Reporter,
-    SpanSource,
+    journal_arm, journal_swap, validate_contract, EntryNames, EntryRole, FrameCtx, JournalEntry,
+    Reporter, SpanSource,
 };
 use crate::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use crate::physics;
@@ -85,8 +85,11 @@ impl ProducerPlatform for NativePlatform {
 
 pub struct FunctorLangEmbeddedGame {
     path: String,
-    /// The role's resolved entry-point names (same-file entries): built once
-    /// from the role's prefix at create time and reused by every reload —
+    /// How the role names its entry bindings (same-file entries): a binding
+    /// prefix or an inline `module` block. Kept because an inline-module role
+    /// re-resolves against every (re)loaded project.
+    role: EntryRole,
+    /// The role's resolved entry-point names, from the CURRENT program —
     /// every canonical lookup and contract error goes through it.
     names: EntryNames,
     /// The project's source files (entry FIRST, then siblings) as
@@ -208,6 +211,9 @@ pub struct FunctorLangEmbeddedGame {
 /// A successfully loaded, contract-validated game module (the desktop
 /// producer's `Loaded`, verbatim minus the file-shaped fields).
 struct Loaded {
+    /// The role's binding names, resolved against THIS load (an inline-module
+    /// role's canonical path comes from the linked project).
+    names: EntryNames,
     sources: SourceMap,
     module: functor_lang::ir::Module,
     session: Session,
@@ -230,7 +236,7 @@ struct Loaded {
 /// is every project file as `(path, source)`, the ENTRY first, then siblings
 /// (`file = module`, so `pieces.fun` is module `Pieces`). Errors come back as
 /// fully rendered strings (`path:line:col: message`).
-fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loaded, String> {
+fn load_source(sources: &[(String, String)], role: &EntryRole) -> Result<Loaded, String> {
     let path = sources
         .first()
         .map(|(p, _)| p.clone())
@@ -246,6 +252,10 @@ fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loade
         &functor_prelude::bundled_modules(),
     )
     .map_err(|e| format!("cannot load {}", e.render()))?;
+    // An inline-module role resolves against the linked project, so a reload
+    // that renamed or deleted the block fails here — naming the block — rather
+    // than reporting its every entry binding as missing.
+    let names = role.resolve(&path, &project)?;
     let module = project.module;
     let source_map = project.sources;
     // Type diagnostics are advisory in the dev loop: warn, keep going
@@ -266,8 +276,9 @@ fn load_source(sources: &[(String, String)], names: &EntryNames) -> Result<Loade
     // arity, optional hooks well-shaped) is shared with the desktop producer
     // and the CLI's build gate — errors name the ROLE'S resolved bindings
     // (`serverTick`, not `tick`) via `names`.
-    let contract = validate_contract(&path, &session, names)?;
+    let contract = validate_contract(&path, &session, &names)?;
     Ok(Loaded {
+        names,
         sources: source_map,
         module,
         session,
@@ -293,27 +304,27 @@ impl FunctorLangEmbeddedGame {
         sources: Vec<(String, String)>,
         platform: Box<dyn ProducerPlatform>,
     ) -> Result<FunctorLangEmbeddedGame, String> {
-        Self::create_with_prefix(sources, "", platform)
+        Self::create_for_role(sources, EntryRole::Prefix(String::new()), platform)
     }
 
-    /// [`Self::create`] for a PREFIXED role (same-file entries): every
-    /// canonical entry binding resolves through `prefix` as camelCase
-    /// (`"server"` → `serverInit`/`serverTick`/…). An empty prefix is the
-    /// classic unprefixed contract.
-    pub fn create_with_prefix(
+    /// [`Self::create`] for one same-file ROLE: either a binding prefix
+    /// (`"server"` → `serverInit`/`serverTick`/…, empty = the classic
+    /// unprefixed contract) or an inline `module Server { … }` block, whose
+    /// members ARE the role's contract (`Server.init`/`Server.tick`/…). The
+    /// role is kept, so every (re)load re-resolves it against that program.
+    pub fn create_for_role(
         sources: Vec<(String, String)>,
-        prefix: &str,
+        role: EntryRole,
         platform: Box<dyn ProducerPlatform>,
     ) -> Result<FunctorLangEmbeddedGame, String> {
         // Install the shell's diagnostics sinks BEFORE the first load so load
         // errors surface (native: the `log` sink; web: console/event bridge).
         platform.install_sinks();
-        let names = EntryNames::with_prefix(prefix);
         let path = sources
             .first()
             .map(|(p, _)| p.clone())
             .unwrap_or_else(|| "game.fun".to_string());
-        let loaded = load_source(&sources, &names)?;
+        let loaded = load_source(&sources, &role)?;
         log::info!("[functor-lang] loaded {path}");
         // Arm the paused-inspector journal on this thread: from now on every
         // live model-updating call is journaled (a cheap Rc-clone push).
@@ -329,7 +340,8 @@ impl FunctorLangEmbeddedGame {
             source_hashes,
             sources,
             path,
-            names,
+            role,
+            names: loaded.names,
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
@@ -400,6 +412,7 @@ impl FunctorLangEmbeddedGame {
         journal_swap(); // discard any partial current-frame journal
         self.reporter
             .set_source(SpanSource::Project(loaded.sources));
+        self.names = loaded.names;
         self.module = loaded.module;
         self.session = loaded.session;
         self.has_input = loaded.has_input;
@@ -491,6 +504,7 @@ impl FunctorLangEmbeddedGame {
         journal_swap();
         self.reporter
             .set_source(SpanSource::Project(loaded.sources));
+        self.names = loaded.names;
         self.module = loaded.module;
         self.session = loaded.session;
         self.model = loaded.init;
@@ -590,7 +604,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
         } else {
             sources.push((self.path.clone(), source.to_string()));
         }
-        let loaded = load_source(&sources, &self.names)?;
+        let loaded = load_source(&sources, &self.role)?;
         self.sources = sources;
         let (rebound, history_replay) = self.swap_in(loaded);
         let stored = if rebound > 0 {
@@ -617,7 +631,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = now_ms();
-        let loaded = load_source(files, &self.names)?;
+        let loaded = load_source(files, &self.role)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
         let (rebound, history_replay) = self.swap_in(loaded);
@@ -643,7 +657,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
             return Err("a pushed project needs at least the entry file".to_string());
         }
         let started = now_ms();
-        let loaded = load_source(files, &self.names)?;
+        let loaded = load_source(files, &self.role)?;
         self.sources = files.to_vec();
         self.path = files[0].0.clone();
         self.reset_in(loaded);
@@ -1237,9 +1251,9 @@ let draw = (model, tts) =>
             .replace("let init", "let serverInit")
             .replace("let tick", "let serverTick")
             .replace("let draw", "let serverDraw");
-        let mut game = FunctorLangEmbeddedGame::create_with_prefix(
+        let mut game = FunctorLangEmbeddedGame::create_for_role(
             vec![("game.fun".to_string(), server_boot)],
-            "server",
+            EntryRole::Prefix("server".to_string()),
             Box::new(NativePlatform),
         )
         .expect("prefixed role loads");
@@ -1264,15 +1278,101 @@ let draw = (model, tts) =>
 
         // An UNPREFIXED program under the server role misses the contract —
         // and the error teaches the resolved name it looked for.
-        let err = match FunctorLangEmbeddedGame::create_with_prefix(
+        let err = match FunctorLangEmbeddedGame::create_for_role(
             vec![("game.fun".to_string(), BOOT.to_string())],
-            "server",
+            EntryRole::Prefix("server".to_string()),
             Box::new(NativePlatform),
         ) {
             Err(err) => err,
             Ok(_) => panic!("unprefixed bindings don't satisfy a prefixed role"),
         };
         assert!(err.contains("serverInit"), "{err}");
+    }
+
+    /// A `{ "file": …, "module": "Server" }` role runs the BLOCK's members as
+    /// its contract on the EMBEDDED producer too (the web/device shells), and
+    /// keeps re-resolving them on every pushed reload: an edit inside the
+    /// block lands with the model preserved, while a push that removes the
+    /// block fails loudly — naming it — and keeps the old program.
+    #[test]
+    fn a_module_role_resolves_and_hot_reloads_on_a_push() {
+        let role_src = |probe: f64| {
+            format!(
+                "{BOOT}module Server {{\n\
+                 let init = {{ n: 7.0 }}\n\
+                 let tick = (m, dt, tts) => m\n\
+                 let draw = (m, tts) => Frame.create(Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), \
+Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
+                 let probe = {probe}.0\n\
+                 }}\n"
+            )
+        };
+        let mut game = FunctorLangEmbeddedGame::create_for_role(
+            vec![("game.fun".to_string(), role_src(1.0))],
+            EntryRole::Module("Server".to_string()),
+            Box::new(NativePlatform),
+        )
+        .expect("module role loads");
+        // The role's contract is the block's, not the file's top level: the
+        // file's own `init` is `{ spin: 0.0 }`.
+        assert_eq!(game.names.tick, "Server.tick");
+        assert!(
+            game.state_debug().contains("n: 7"),
+            "the block's init is the role's model: {}",
+            game.state_debug()
+        );
+        let ft = frame_time(0.016, 0.016);
+        game.tick(ft.clone());
+        let _ = game.render(ft);
+
+        // A push re-resolves the block: the edit lands, the model survives.
+        game.reload_source(&role_src(2.0)).expect("push reloads");
+        assert_eq!(game.names.tick, "Server.tick");
+        assert_eq!(
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
+            "2",
+            "the edit must have landed"
+        );
+        assert!(game.state_debug().contains("n: 7"), "model preserved");
+
+        // Deleting the block fails the reload naming it, keeping the program.
+        let err = game
+            .reload_source(BOOT)
+            .expect_err("a role whose module vanished cannot load");
+        assert!(
+            err.contains("module Server"),
+            "the error names the block: {err}"
+        );
+        assert_eq!(
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
+            "2",
+            "the old program keeps running"
+        );
+    }
+
+    /// An unknown role module is a load error naming the role's file and the
+    /// blocks it DOES declare — the resolver's teaching error, reaching the
+    /// embedded shells' boot path.
+    #[test]
+    fn an_unknown_role_module_lists_the_files_blocks() {
+        let source = format!("{BOOT}module Server {{ let probe = 1.0 }}\n");
+        let err = FunctorLangEmbeddedGame::create_for_role(
+            vec![("game.fun".to_string(), source)],
+            EntryRole::Module("Sever".to_string()),
+            Box::new(NativePlatform),
+        )
+        .err()
+        .expect("an unknown block cannot boot");
+        assert!(
+            err.contains("no inline `module Sever") && err.contains("it declares: Server"),
+            "{err}"
+        );
     }
 
     /// A prefixed role's EFFECTS must fold through the role's own update
@@ -1290,9 +1390,9 @@ let serverTick = (m, dt, tts) =>\n\
   ({ m with ticks: m.ticks + dt }, Effect.now((t) => GotTime(t)))\n\
 let serverDraw = (m, tts) =>\n\
   Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n";
-        let mut game = FunctorLangEmbeddedGame::create_with_prefix(
+        let mut game = FunctorLangEmbeddedGame::create_for_role(
             vec![("game.fun".to_string(), source.to_string())],
-            "server",
+            EntryRole::Prefix("server".to_string()),
             Box::new(NativePlatform),
         )
         .expect("prefixed role loads");

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -181,6 +181,21 @@ pub enum EntryRole {
 }
 
 impl EntryRole {
+    /// The role a config/flag/boot-config PAIR declares. Every carrier of a
+    /// same-file role transports it as two strings — functor.json's
+    /// `module`/`prefix` keys, the runtime's `--entry-module`/`--entry-prefix`
+    /// flags, the web page's `__functorLangEntryModule`/`…Prefix` globals — so
+    /// the "a non-empty module wins, else the prefix (empty = the plain
+    /// contract)" rule lives here once rather than at each seam. The declaring
+    /// layers refuse both at once; this resolves the pair regardless.
+    pub fn from_parts(module: &str, prefix: &str) -> EntryRole {
+        if module.is_empty() {
+            EntryRole::Prefix(prefix.to_string())
+        } else {
+            EntryRole::Module(module.to_string())
+        }
+    }
+
     /// Resolve this role's binding names against the linked `project` whose
     /// entry is the role's file. An inline-module role names a block of THAT
     /// file; an unknown name is an error listing the blocks it does declare.

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1296,15 +1296,10 @@ pub fn run(args: Args) {
     let mut game: Box<dyn Game> = if args.replay {
         Box::new(replay_game::ReplayGame::create(game_path.as_str()))
     } else if args.functor_lang {
-        let role = if args.entry_module.is_empty() {
-            functor_runtime_common::functor_lang_producer::EntryRole::Prefix(
-                args.entry_prefix.clone(),
-            )
-        } else {
-            functor_runtime_common::functor_lang_producer::EntryRole::Module(
-                args.entry_module.clone(),
-            )
-        };
+        let role = functor_runtime_common::functor_lang_producer::EntryRole::from_parts(
+            &args.entry_module,
+            &args.entry_prefix,
+        );
         Box::new(functor_lang_game::FunctorLangGame::create_for_role(
             game_path.as_str(),
             role,

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -117,6 +117,12 @@
       // unprefixed contract. Substituted by the CLI like the entry above.
       window.__functorLangEntryPrefix = "__FUNCTOR_LANG_ENTRY_PREFIX__";
 
+      // The role's inline entry MODULE (same-file entries): the runtime
+      // resolves `Server.init`/`Server.tick`/… as that block's members. Empty
+      // = no module role. Mutually exclusive with the prefix above (the CLI's
+      // config refuses a role declaring both).
+      window.__functorLangEntryModule = "__FUNCTOR_LANG_ENTRY_MODULE__";
+
       // Captured game mouse input defaults on. A project can opt out with
       // mouseCapture: false; programs without captured mouse hooks never show
       // capture chrome. The debug camera owns its input independently.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -184,12 +184,7 @@ fn functor_lang_entry_module() -> String {
 /// the prefix when a module is given), otherwise the binding prefix (empty =
 /// the classic unprefixed contract).
 fn functor_lang_entry_role() -> EntryRole {
-    let module = functor_lang_entry_module();
-    if module.is_empty() {
-        EntryRole::Prefix(functor_lang_entry_prefix())
-    } else {
-        EntryRole::Module(module)
-    }
+    EntryRole::from_parts(&functor_lang_entry_module(), &functor_lang_entry_prefix())
 }
 
 /// Where the runtime's networking goes. Two routings exist: real browser

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use functor_runtime_common::asset::pipelines::TexturePipeline;
 use functor_runtime_common::asset::{AssetCache, AssetLoader};
 use functor_runtime_common::functor_lang_game_embedded::FunctorLangEmbeddedGame;
+use functor_runtime_common::functor_lang_producer::EntryRole;
 use functor_runtime_common::geometry::Geometry;
 use functor_runtime_common::io::load_bytes_async;
 use functor_runtime_common::net::{
@@ -163,6 +164,34 @@ fn functor_lang_entry_prefix() -> String {
         .unwrap_or_default()
 }
 
+/// The role's inline entry MODULE (same-file entries, mirroring the desktop
+/// `--entry-module` flag): the page sets `window.__functorLangEntryModule`
+/// before initializing this module (the CLI's Functor Lang index page
+/// substitutes the role's declared module; the site's player.html reads
+/// `?module=<Ident>`), and the producer resolves every canonical entry
+/// binding as a member of that `module` block (`"Server"` →
+/// `Server.init`/`Server.tick`/…). Absent or empty = no module role.
+fn functor_lang_entry_module() -> String {
+    js_sys::Reflect::get(&window(), &JsValue::from_str("__functorLangEntryModule"))
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default()
+}
+
+/// This page's role, as the producers' shared resolver takes it: an inline
+/// `module` block wins when the page declares one (the two boot keys are
+/// mutually exclusive — the CLI's config refuses both, and player.html drops
+/// the prefix when a module is given), otherwise the binding prefix (empty =
+/// the classic unprefixed contract).
+fn functor_lang_entry_role() -> EntryRole {
+    let module = functor_lang_entry_module();
+    if module.is_empty() {
+        EntryRole::Prefix(functor_lang_entry_prefix())
+    } else {
+        EntryRole::Module(module)
+    }
+}
+
 /// Where the runtime's networking goes. Two routings exist: real browser
 /// WebSockets, and the *embedder* — the page hosting this runtime.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -261,9 +290,9 @@ fn parse_project_files(value: &JsValue) -> Option<Vec<(String, String)>> {
 /// `run_async` to fail loud with.
 async fn create_functor_lang_game(entry: &str) -> Result<FunctorLangEmbeddedGame, String> {
     let sources = load_project_sources(entry).await?;
-    FunctorLangEmbeddedGame::create_with_prefix(
+    FunctorLangEmbeddedGame::create_for_role(
         sources,
-        &functor_lang_entry_prefix(),
+        functor_lang_entry_role(),
         Box::new(WebPlatform::new()),
     )
 }

--- a/site/player.html
+++ b/site/player.html
@@ -210,12 +210,26 @@
         requested && !requested.startsWith("/") && !requested.includes(":")
           ? requested
           : "examples/hero.fun";
-      // ?prefix=<ident>: the role's entry-point binding prefix (same-file
-      // entries) — the runtime resolves clientInit/clientTick/… through it.
-      // Identifier or absent; anything else warns and boots unprefixed (the
-      // scrubber param's fail-visible style).
+      // The role this page plays (same-file entries), in one of two forms —
+      // ?module=<Ident>, the role's inline entry MODULE (the runtime resolves
+      // Server.init/Server.tick/… as that block's members; capitalized
+      // identifier), or ?prefix=<ident>, the role's entry-point binding prefix
+      // (clientInit/clientTick/… through it). Absent or malformed boots the
+      // unprefixed contract with a warning (the scrubber param's fail-visible
+      // style). The two are mutually exclusive — a role declares one form, so
+      // both together is a caller bug: warn, and the module wins.
+      const entryModule = params.get("module");
       const prefix = params.get("prefix");
-      if (prefix !== null) {
+      if (entryModule !== null) {
+        if (/^[A-Z][A-Za-z0-9_]*$/.test(entryModule)) {
+          window.__functorLangEntryModule = entryModule;
+        } else {
+          console.warn(`[player] invalid ?module=${entryModule} (not a capitalized identifier); booting the unprefixed contract`);
+        }
+        if (prefix !== null) {
+          console.warn(`[player] ?module= and ?prefix= are mutually exclusive; ignoring ?prefix=${prefix}`);
+        }
+      } else if (prefix !== null) {
         if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(prefix)) {
           window.__functorLangEntryPrefix = prefix;
         } else {

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -156,7 +156,7 @@ export const EXAMPLES: Example[] = [
     multiplayer: true,
     // The sandbox plays the `client` role, which is the file's ordinary
     // top-level contract (the `server` role lives in its `module Server`
-    // block, a native-only entries form) — so no `prefix` is needed.
+    // block) — so no `prefix`/`module` is needed.
   },
   // The client/server sample: two ROLES over a shared typed protocol, run
   // end-to-end in the pane grid — the client panes and a server pane, wired to

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -45,10 +45,16 @@ export interface Example {
    * The entry-point binding prefix of the role the sandbox plays, for a
    * same-file-entries sample whose role is declared as
    * `{ "file": …, "prefix": "client" }` (resolving clientInit/clientTick/…).
-   * Passed to the player as `?prefix=`. The `{ "file": …, "module": … }`
-   * form is native-only, so a module role cannot be played here.
+   * Passed to the player as `?prefix=`. Mutually exclusive with `module`.
    */
   prefix?: string;
+  /**
+   * The inline entry MODULE of the role the sandbox plays, for a
+   * same-file-entries sample whose role is declared as
+   * `{ "file": …, "module": "Client" }` (resolving Client.init/Client.tick/…).
+   * Passed to the player as `?module=`. Mutually exclusive with `prefix`.
+   */
+  module?: string;
   /**
    * The sample's SERVER role, as a dist path in its own file list. The pane
    * grid mounts a server pane for every example that declares one — booted
@@ -59,8 +65,13 @@ export interface Example {
    * The file must ALSO appear in `siblings`: that is what copies it into the
    * built site and puts it in the fetched project file list. Naming a file
    * here that nothing copies would 404 the server pane.
+   *
+   * `module` is the server ROLE's inline entry module when both roles live in
+   * one file (`{ "file": …, "module": "Server" }`): the server pane derives
+   * its params from the client's, so its role must be stated here rather than
+   * inherited.
    */
-  server?: { file: string };
+  server?: { file: string; module?: string };
 }
 
 /**

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -36,9 +36,8 @@ export interface Example {
   assets?: ExampleCopy[];
   /**
    * Marks a sample that declares a server entry point (the functor.json
-   * `entries` shape, like examples/mp) or is otherwise structured for
-   * multiple clients (like examples/orbs) — the sandbox shows its CLIENTS
-   * control only for those.
+   * `entries` shape — `examples/mp` across files, `examples/orbs` in one) —
+   * the sandbox shows its CLIENTS control only for those.
    */
   multiplayer?: boolean;
   /**
@@ -62,9 +61,10 @@ export interface Example {
    * net coordinator routes the client panes' traffic to it. The editable
    * `source` stays the CLIENT entry.
    *
-   * The file must ALSO appear in `siblings`: that is what copies it into the
-   * built site and puts it in the fetched project file list. Naming a file
-   * here that nothing copies would 404 the server pane.
+   * The file must ALSO be in the example's copied file list — either the
+   * entry itself (`exampleEntryPath(id)`, when both roles share ONE file) or
+   * a `siblings` entry. Naming a file here that nothing copies would 404 the
+   * server pane.
    *
    * `module` is the server ROLE's inline entry module when both roles live in
    * one file (`{ "file": …, "module": "Server" }`): the server pane derives
@@ -146,17 +146,26 @@ export const EXAMPLES: Example[] = [
   // Named `bounce` (not `physics`): the flat copy makes `file = module`, and a
   // module literally named `Physics` collides with the builtin/prelude namespace.
   { id: "bounce", label: "Physics", source: "examples/physics/game.fun" },
-  // The minimal multiplayer-mechanics sample in ONE module (banner sections:
-  // PROTOCOL / SERVER / BOT / CLIENT), so the wire ADT and the authoritative
-  // claim resolution are right there in the editable buffer.
+  // The minimal multiplayer-mechanics sample in ONE file (banner sections:
+  // PROTOCOL / SERVER / BOT / SHARED / the two role blocks), so the wire ADT
+  // and the authoritative claim resolution are right there in the editable
+  // buffer.
   {
     id: "orbs",
     label: "Orbs (multiplayer)",
     source: "examples/orbs/game.fun",
     multiplayer: true,
-    // The sandbox plays the `client` role, which is the file's ordinary
-    // top-level contract (the `server` role lives in its `module Server`
-    // block) — so no `prefix`/`module` is needed.
+    // Both roles are inline modules in the ONE editable buffer, so the client
+    // panes boot `module Client` and the server pane re-enters the SAME file
+    // at `module Server` — no sibling copy needed, since the entry copy is
+    // already in the fetched file list.
+    //
+    // Orbs hosts its world IN-PROCESS (no transport yet), so its panes are
+    // independent sims: the server pane shows the authoritative board, but
+    // the NETWORK view's wires carry no packets until orbs adopts the
+    // transport. mp is the sample with real coordinator traffic.
+    module: "Client",
+    server: { file: exampleEntryPath("orbs"), module: "Server" },
   },
   // The client/server sample: two ROLES over a shared typed protocol, run
   // end-to-end in the pane grid — the client panes and a server pane, wired to

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -36,8 +36,9 @@ export interface Example {
   assets?: ExampleCopy[];
   /**
    * Marks a sample that declares a server entry point (the functor.json
-   * `entries` shape — `examples/mp` across files, `examples/orbs` in one) —
-   * the sandbox shows its CLIENTS control only for those.
+   * `entries` shape, like examples/mp) or is otherwise structured for
+   * multiple clients (like examples/orbs) — the sandbox shows its CLIENTS
+   * control only for those.
    */
   multiplayer?: boolean;
   /**
@@ -61,10 +62,16 @@ export interface Example {
    * net coordinator routes the client panes' traffic to it. The editable
    * `source` stays the CLIENT entry.
    *
-   * The file must ALSO be in the example's copied file list — either the
-   * entry itself (`exampleEntryPath(id)`, when both roles share ONE file) or
-   * a `siblings` entry. Naming a file here that nothing copies would 404 the
-   * server pane.
+   * The file must ALSO appear in `siblings`: that is what copies it into the
+   * built site and puts it in the fetched project file list. Naming a file
+   * here that nothing copies would 404 the server pane.
+   *
+   * Naming the example's own ENTRY here (a same-file sample serving both roles
+   * from one buffer) resolves and boots fine, but the pane grid is not ready
+   * for it: editor pushes reach only the client mirrors (see mp-panes.ts's
+   * server-pane block), so one edit would reload half the roles — and the
+   * `authority` label plus the NETWORK wires assert a coordinator link that a
+   * transport-less sample does not have. See `examples/orbs`.
    *
    * `module` is the server ROLE's inline entry module when both roles live in
    * one file (`{ "file": …, "module": "Server" }`): the server pane derives
@@ -155,17 +162,18 @@ export const EXAMPLES: Example[] = [
     label: "Orbs (multiplayer)",
     source: "examples/orbs/game.fun",
     multiplayer: true,
-    // Both roles are inline modules in the ONE editable buffer, so the client
-    // panes boot `module Client` and the server pane re-enters the SAME file
-    // at `module Server` — no sibling copy needed, since the entry copy is
-    // already in the fetched file list.
+    // Both roles are inline modules of the ONE editable buffer, so the
+    // sandbox plays the client one by name: `?module=Client`.
     //
-    // Orbs hosts its world IN-PROCESS (no transport yet), so its panes are
-    // independent sims: the server pane shows the authoritative board, but
-    // the NETWORK view's wires carry no packets until orbs adopts the
-    // transport. mp is the sample with real coordinator traffic.
+    // No `server` pane, deliberately. The declaration resolves (the entry is
+    // already in the fetched file list, so `{ file: exampleEntryPath("orbs"),
+    // module: "Server" }` boots), but orbs hosts its world IN-PROCESS — there
+    // is no transport yet — so the pane grid would label an unconnected sim
+    // `authority` and draw latency-chipped NETWORK wires carrying no packets.
+    // Editor pushes also reach only the client mirrors, so one edit to this
+    // shared buffer would reload half its roles. Both want site work; revisit
+    // when orbs adopts the transport.
     module: "Client",
-    server: { file: exampleEntryPath("orbs"), module: "Server" },
   },
   // The client/server sample: two ROLES over a shared typed protocol, run
   // end-to-end in the pane grid — the client panes and a server pane, wired to

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -429,6 +429,9 @@ const loadExample = async (id: string) => {
   // A same-file-entries sample plays its declared role: the player boots the
   // prefixed contract (e.g. orbs' clientInit/clientTick/…).
   if (example?.prefix) params.set("prefix", example.prefix);
+  // …or, in the preferred same-file form, the role's inline module (the
+  // player takes one of the two).
+  if (example?.module) params.set("module", example.module);
   frame.src = `player.html?${params}`;
   // A sample with a SERVER role (examples.ts `server`) also boots a server
   // pane: the SAME file list re-entered at the server file. `?file=` is the
@@ -443,6 +446,11 @@ const loadExample = async (id: string) => {
     const serverParams = new URLSearchParams(params);
     serverParams.set("game", serverFile);
     serverParams.delete("file");
+    // The client's ROLE must not leak into the server pane: a same-file
+    // sample states the server's own inline module (absent = the file's plain
+    // top-level contract).
+    serverParams.delete("module");
+    if (example?.server?.module) serverParams.set("module", example.server.module);
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);
     }

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -446,10 +446,11 @@ const loadExample = async (id: string) => {
     const serverParams = new URLSearchParams(params);
     serverParams.set("game", serverFile);
     serverParams.delete("file");
-    // The client's ROLE must not leak into the server pane: a same-file
-    // sample states the server's own inline module (absent = the file's plain
-    // top-level contract).
+    // The client's ROLE must not leak into the server pane — neither form.
+    // A same-file sample states the server's own inline module; absent, the
+    // server file's plain top-level contract is the role.
     serverParams.delete("module");
+    serverParams.delete("prefix");
     if (example?.server?.module) serverParams.set("module", example.server.module);
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);


### PR DESCRIPTION
Stacked on **#623** (`feat/module-roles-wasm`) — base is that branch, not main.
It is the sample migration #623's body reserved: *"No example migrates here —
`examples/orbs` and `examples/mp` move in the stacked follow-up."*

**`examples/orbs` is now fully symmetric.** #601 could only move its `server`
role into a block, because module roles were native-only and the sandbox plays
the `client` role on wasm — so the client stayed the file's plain top-level
contract, and #601's body recorded the gap: *"The natural end state (both roles
as modules) is blocked until the web/embedded producer can boot a role
descriptor."* #623 unblocked it. So:

```json
{ "entries": {
    "client": { "file": "game.fun", "module": "Client" },
    "server": { "file": "game.fun", "module": "Server" }
} }
```

Nothing at the file's top level answers a plain entry any more — every role is a
block, and the protocol, the world step, the bot and the renderer stay shared
bare above them.

## The two canonical shapes

The docs now position the two multiplayer samples as the deliberate pair, so a
reader picks a shape rather than inferring one:

- **`examples/orbs`** — the whole game in ONE file, both roles inline modules of
  it. One buffer, one atomic hot reload.
- **`examples/mp`** — roles as separate FILES (`client.fun` + `server.fun`) over
  a shared `protocol.fun`. **Deliberately not migrated**: it is the shape to
  reach for once roles outgrow one buffer or want independent deploy units.

One paragraph each in the skill's `entries` section, CLAUDE.md's `entries`
paragraph, and a new **Part 10** in `docs/functor-lang.md` (Part 8's line about
orbs is now past-tense rather than falsified).

## The shadowing trap, documented at the trap

#601's body flagged it and this PR hit it again: a block's own `init` shadows
the file's, so `let init = init` inside `module Client` is **self-referential**,
not an alias. The shared values keep distinct names (`initialGame`, `board`) and
each block aliases those. That rule is now in SKILL.md's inline-module section
next to the role contract, not only in a PR body — and the reviewer verified it
empirically rather than trusting the prose (`module M { let base = base + 1.0 }`
next to a top-level `base` gives `error: global M.base used before its
definition`).

## The sweep test now checks CONTRACTS, not just types

`every_shipped_example_typechecks` iterated both orbs roles before this PR — but
only *typechecked* them, and nothing in the file references `Client.init`, so a
role silently losing a binding would sail through. It now also runs `build`'s
exact per-role gate (`check_contract`) for named-`entries` projects. Proven by
breaking it on purpose:

```
orbs[game.fun]: game.fun has no top-level `let Client.init = …`
orbs[game.fun]: game.fun has no top-level `let Server.init = …`
```

## The server pane: evidence-gated, and NOT taken

#623 made `server: { file, module }` declarable, and the task was to add orbs'
server pane *if it worked end to end with no further site work*. **It boots
perfectly and it is still not in this PR**, because two independent reviewers
landed on the same objection and both fixes are site work:

1. **The chrome overstates the sample.** Orbs hosts its world in-process — zero
   `Net`/coordinator traffic. The pane grid labels the pane `authority`, and
   `viewAvailable` enables NETWORK for any example with a server, so the hub
   view draws `Wi-Fi · 45ms` wires with **zero packet dots** while every header
   simultaneously reads `○ waiting`, and the three boards visibly diverge
   (clients `YOU 0 / BOT 4`, server `YOU 1 / BOT 1`).
2. **One edit would reload half the roles.** The server pane deliberately takes
   no editor pushes (`functor-lang-set-source` replaces the ENTRY module's
   source). For mp that is a separate file; for a sample whose whole point is
   *one buffer, one hot reload*, it directly contradicts the lesson.

Both need a distinction the site does not have — "has a server pane" vs. "uses
coordinator networking" — so per the gate it is recorded as a follow-up instead
(in `examples.ts` next to the `server` field, and in Part 10). It fits the "orbs
adopts the transport" arc from #615's roadmap, which lands the packets that
would make the view honest.

`examples.ts` therefore declares only `module: "Client"` (the #623 param, passed
as `?module=Client`; mutually exclusive with `prefix`).

## Verification

- **Native parity — byte-identical.** `--capture-frame --capture-time 3
  --fixed-time 3` against a pristine copy of the pre-migration project, same
  binary, both roles: all four PNGs hash to `df616bcb…`. Wall-clock captures
  (`--capture-time 4`, no fixed time, so the sim actually advances) match
  visually role-for-role, down to the HUD scores — `client` shows the bot
  hunting orbs while you idle, `server` shows both seats bot-steered.
- `functor -d examples/orbs build` ✓ (both roles' contracts), `test` ✓,
  `build wasm` ✓ — the exported page's boot config carries
  `__functorLangEntryModule = "Client"` with an empty prefix.
- `cargo test --no-fail-fast -p functor-cli -p functor_runtime_common
  -p functor-runtime-desktop` — green **except the one pre-existing failure**,
  `scrubber_only_captures_primary_pointer_drags`, which #623 records failing
  identically on this stack's base.
- `npm run check:site` clean. **`npm run test:sandbox-mp` — ALL CHECKS PASSED**,
  including the new orbs section: every pane boots `?module=Client`, the grid
  stays client-only, and both reach live (a dropped role would boot the
  unprefixed contract and fail to load, so "live" IS the assertion).
- `npm run test:site` — every example smoke passes, **`example 'orbs' loads live
  and ticks cleanly` included**; the run then dies in #615's extrapolation
  section (`site-sandbox.mjs:622`, a 3s `waitForFunction`). **The base ref fails
  at the identical line**, verified by stashing this change and re-running — the
  same flake #623 recorded.
- No perf run: nothing here touches a per-frame hot path (an example's `.fun`,
  an example's site metadata, a test, and docs).

## Visuals

**Not a visual change** — both native roles and the sandbox render exactly as
before, which is the point. The parity evidence is the byte-identical capture
hashes above (`df616bcb…` for base-client, base-server, new-client and
new-server alike, same binary, same fixed time). The server-pane screenshots
that argued finding #1 belong to the follow-up that would ship the pane.

## xreview dispositions

Three reviewers over `dbcf040...HEAD`: a Claude subagent, the Codex CLI, and the
de-duplication pass. **Neither engine raised a Critical or High finding.**

| # | Finding | Engine | Disposition |
| --- | --- | --- | --- |
| 1 | **Medium [AGREED]** — declaring orbs' server pane puts a transport-less sample into `authority` + NETWORK chrome that asserts a link it does not have | Claude + Codex | **Fixed by dropping the pane.** Two independent engines on the same objection is the evidence the gate asked for. Recorded as a follow-up in `examples.ts` and Part 10. |
| 2 | **Medium** — the server pane takes no editor pushes, so one edit to the shared buffer reloads the clients and leaves the server on the served build — contradicting the one-buffer claim my own comment made | Codex | **Fixed by the same drop.** The false claim is gone; the gap is documented at the `server` field, so the next same-file sample meets the note before the bug. |
| 3 | **Medium** — the new e2e read the status pill once instead of waiting for it, unlike every other pill assertion in the file | Claude | **Fixed.** The rewritten section `waitForFunction`s on the pill and reports it either way. |
| 4 | **Medium** — `site/manual/index.html` teaches the one-file shape with the PREFIX form and calls orbs a prefixed role | Claude | **Won't fix (pre-existing, out of scope).** That line was already false at the base ref — #601 removed orbs' prefix. It is a rendered docs surface, so correcting it wants before/after screenshots per CLAUDE.md; filed rather than smuggled in here. |
| 5 | **Low** — `game.fun`'s header still said the server section would *become* an `entries` role | Claude | **Fixed.** It says both roles already are, as inline modules, and points at the block. |
| 6 | **Low** — the first e2e assertion's message ("mounts a server pane too") was also satisfiable by two clients | Claude | **Fixed** by the rewrite: it asserts the roles list contains no `server`. |
| 7 | **Low** — `multiplayer: true` is derivable from `server` now | Claude | **Won't fix.** Orbs declares no `server`, so it is not derivable for the sample in question, and it would touch an unrelated consumer. |

Both engines independently confirmed the substance: the four client members
moved **byte-identically** into the block (one comment word reflowed), the only
other `.fun` change is inert top-level reordering, every referenced binding is
still defined above its use, and `sandbox.tsx`'s param derivation is correct
(for a same-file sample `serverFile === files[0]`, so the file list has no
duplicate and nothing 404s). The de-dup pass found nothing:

> No actionable duplication. Coverage: all four strategies ran. S1-names (1
> query over 6998 candidates, min-score 0.3) surfaced only `installProbe` ↔
> `installOverlay`/`probe` at 0.38–0.50, unrelated on read. S2-clones (242
> whole-repo pairs) had 5 touching changed files, **none overlapping the diff's
> line ranges**. S3-index (2943 items) grepped for `EntryRole`, `check_contract`,
> `exampleEntryPath` and friends — all found and all reused rather than
> reimplemented. S4-read covered the full diff.

Re-validated after the fixes: orbs `build`/`test`/`build wasm`, the
byte-identical native captures re-taken on the final tree, the full Rust suite
(same one pre-existing failure), `check:site`, and `test:sandbox-mp` ALL CHECKS
PASSED.

## Rebase note

A future arc ("orbs adopts the transport", #615's roadmap) rewrites this
`game.fun` again, so the diff is kept mechanical: bodies moved verbatim, no
logic touched, no renames beyond the two the shadowing rule forces.
