### PR TITLE
feat(lang): unit operators — 90deg + 45deg, resolved by ad-hoc overloading

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -637,9 +637,9 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   `hr` are all `Time.t`, so one declaration serves them all and `1.5s - 200ms`
   works. Declaring the same brand + operator twice — through ANY suffix — is a
   duplicate error.
-- **The implementation is an expression**: a name, or a lambda (a `.funi` has
-  no bodies, so prelude declarations name host externals). It is checked
-  against the shape above at the DECLARATION.
+- **The implementation is an expression**: a name, or a lambda (the prelude's
+  `.funi` declarations name host externals). It is checked against the shape
+  above at the DECLARATION.
 - **Scaling commutes, division does not**: `2.0 * 45deg` works (same call,
   arguments swapped); `2.0 / 45deg` is an error.
 - **Resolution is ad-hoc overloading AFTER inference**: a node whose operand
@@ -648,8 +648,9 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   unsolved is a teaching error asking for an annotation, never a silent float
   guess — ```+` here could be float arithmetic or `Px` arithmetic — annotate an
   operand (e.g. `(a: Px)`)``. So `(a, b) => a + b` needs an annotation in a
-  project that declares `+` on a brand, while `(a, b): float => a + b` and
-  `(a) => a + 1.0` do not.
+  project that declares `+` on a brand, while `(a, b): float => a + b`,
+  `(a) => a + 1.0`, and `(v) => v * v` (the scalar form's operands have
+  DIFFERENT types, so one operand twice can only be float) do not.
 - **A brand with no implementation** keeps the old error, now naming what it
   has: ```-` needs float operands, got Angle.t — `Angle.t` declares `*`, `+`, but
   not `-```. The interpreter says the same thing on the same inputs.

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -653,7 +653,8 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   unsolved is a teaching error asking for an annotation, never a silent float
   guess — ```+` here could be float arithmetic or `Px` arithmetic — annotate an
   operand (e.g. `(a: Px)`)``. So `(a, b) => a + b` needs an annotation in a
-  project that declares `+` on a brand, while `(a, b): float => a + b`,
+  project that declares `+` on a brand, while `(a, b): Px => a + b` (the RESULT
+  decides it for `+`/`-`), `(a, b): float => a + b`,
   `(a) => a + 1.0`, and `(v) => v * v` (the scalar form's operands have
   DIFFERENT types, so one operand twice can only be float) do not.
 - **A brand with no implementation** keeps the old error, now naming what it

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -639,8 +639,11 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   duplicate error.
 - **The implementation is an expression**: a name, or a lambda (the prelude's
   `.funi` declarations name host externals). It is checked against the shape
-  above at the DECLARATION. A NAME is late-bound like any global, so it must be
-  defined above any top-level constant that uses the operator.
+  above at the DECLARATION, and RESOLVED only when the operator dispatches — a
+  name is late-bound like any global (so it must be defined above any top-level
+  constant that uses the operator), and a host external is looked up at the use
+  site, so these declarations still load under the plain, hostless
+  interpreter.
 - **The brand must be distinguishable at run time** — a single-constructor
   variant, or a host type like `Angle.t`. A record brand or a multi-constructor
   type is a check error at the declaration (the interpreter dispatches on a

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -24,6 +24,8 @@ The habits that break first, in one place. Each is expanded below.
 - **Operators are exhaustive**: `+ - * /`, `< > <= >= == !=`, `&& || not`.
   There is no `<>` (inequality is `!=` only), no `%` (`Math.mod`), no `^`
   (`Math.pow`), and no string-concatenation operator (use `$"…"`).
+  `+ - * /` also work on BRANDS that declare them — `90deg + 45deg`,
+  `1.5s - 200ms`, `45deg * 2.0` (see Units below); comparisons do not.
 - **No loops** — iterate with `List.map` / `List.filter` / `List.fold`.
 - **All numbers are `float`** (f64); primitive type names are lowercase
   (`float`, `string`, `bool`), while generic containers are `List<…>` and
@@ -123,6 +125,7 @@ type Px = | Px(value: float)                  // a single-ctor brand…
 unit px = Px                                  // …with a literal SUFFIX: `16px` == `Px(16.0)`
 let width = 16px                              //   the suffix must TOUCH the digits (`16 px` is
                                               //   two tokens); `-2.5px` == `Px(-2.5)`
+unit px (+) = addPx                           // …and arithmetic on the brand: `16px + 4px`
 let origin: Position = { x: 0.0, y: 0.0 }     // OPTIONAL binding annotation `let name: Type = …`
                                               //   (checked against the value; also on `let … in`)
 let scores = [1.0, 2.0, 3.0]                  // list literal; [x, ..xs] prepends
@@ -575,11 +578,12 @@ that's what `functor test` is for.
   assert on numbers/records you derive instead. The highest-value tests
   are pure logic anyway: model/`tick`/`update` math.
 
-## Unit-suffix literals (`unit`)
+## Units: suffixed literals and their operators (`unit`)
 
 A numeric literal may carry a **unit suffix** — `90deg`, `0.5s`, `16px` — which
-is exactly the call the suffix's `unit` declaration names. Design and the
-Phase 2 (operators) plan: `docs/functor-lang-units.md`.
+is exactly the call the suffix's `unit` declaration names, and a brand may
+declare **arithmetic** on itself (`90deg + 45deg`). Full design:
+`docs/functor-lang-units.md`.
 
 ```functor
 unit deg = Angle.degrees            // a top-level ITEM, in `.fun` and `.funi`
@@ -592,8 +596,8 @@ let beat = Sub.every(0.5s, Tick)    // == Sub.every(Time.seconds(0.5), Tick)
 - **Adjacency is the rule**: the suffix must touch the digits. `90 deg` is
   still a number and a name; `16px2` is one suffix (`px2`), never a split.
 - **A prefix minus folds in**: `-90deg` is `Angle.degrees(-90.0)`, not a
-  negation of the branded value (branded values have no arithmetic — that is
-  Phase 2). Binary subtraction is untouched.
+  negation of the branded value (unary minus on a brand is not declarable).
+  Binary subtraction is untouched.
 - **Units are project-wide**, like constructors: a suffix declared in ANY
   module means the same thing in every module, and declaring one twice
   anywhere in the project is an error.
@@ -613,6 +617,45 @@ let beat = Sub.every(0.5s, Tick)    // == Sub.every(Time.seconds(0.5), Tick)
   under the runner host, not in a plain `functor-lang run`.
 - **`unit` is contextual** (the `open` / `expect` / `module` rule): only item
   position declares one, so the name stays usable everywhere else.
+
+### Operators on a brand (`unit px (+) = …`)
+
+```functor
+type Px = | Px(value: float)
+unit px = Px
+unit px (+) = (a, b) => Px(unwrap(a) + unwrap(b))   // (Px, Px) => Px
+unit px (*) = (a, k) => Px(unwrap(a) * k)           // (Px, float) => Px
+
+let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
+```
+
+- **Only `+` `-` `*` `/`.** `+` and `-` are typechecked as `('t, 't) => 't`;
+  `*` and `/` as the SCALAR `('t, float) => 't` (a brand times a brand would be a different
+  type — Functor Lang does not do dimensional analysis). Comparisons
+  (`==`, `<`, `>`) are NOT declarable.
+- **The operator belongs to the BRAND, not the suffix.** `s`/`ms`/`us`/`min`/
+  `hr` are all `Time.t`, so one declaration serves them all and `1.5s - 200ms`
+  works. Declaring the same brand + operator twice — through ANY suffix — is a
+  duplicate error.
+- **The implementation is an expression**: a name, or a lambda (a `.funi` has
+  no bodies, so prelude declarations name host externals). It is checked
+  against the shape above at the DECLARATION.
+- **Scaling commutes, division does not**: `2.0 * 45deg` works (same call,
+  arguments swapped); `2.0 / 45deg` is an error.
+- **Resolution is ad-hoc overloading AFTER inference**: a node whose operand
+  resolves to a brand with that operator becomes that call; everything else is
+  float arithmetic exactly as before. A node whose operands AND result all stay
+  unsolved is a teaching error asking for an annotation, never a silent float
+  guess — ```+` here could be float arithmetic or `Px` arithmetic — annotate an
+  operand (e.g. `(a: Px)`)``. So `(a, b) => a + b` needs an annotation in a
+  project that declares `+` on a brand, while `(a, b): float => a + b` and
+  `(a) => a + 1.0` do not.
+- **A brand with no implementation** keeps the old error, now naming what it
+  has: ```-` needs float operands, got Angle.t — `Angle.t` declares `*`, `+`, but
+  not `-```. The interpreter says the same thing on the same inputs.
+- **Built-in operators (engine prelude only)**: `+`, `-`, and scalar `*` on
+  BOTH `Angle.t` and `Time.t` (`Angle.add`/`sub`/`scale`, `Time.add`/`sub`/
+  `scale` — all public API in the generated reference). Neither declares `/`.
 
 ## Semantics rules that WILL bite you
 

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -657,7 +657,7 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   `(a) => a + 1.0`, and `(v) => v * v` (the scalar form's operands have
   DIFFERENT types, so one operand twice can only be float) do not.
 - **A brand with no implementation** keeps the old error, now naming what it
-  has: ```-` needs float operands, got Angle.t — `Angle.t` declares `*`, `+`, but
+  has: ```-` needs float operands, got Angle.t — `Angle.t` declares `+`, `*`, but
   not `-```. The interpreter says the same thing on the same inputs.
 - **Built-in operators (engine prelude only)**: `+`, `-`, and scalar `*` on
   BOTH `Angle.t` and `Time.t` (`Angle.add`/`sub`/`scale`, `Time.add`/`sub`/

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -639,7 +639,12 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   duplicate error.
 - **The implementation is an expression**: a name, or a lambda (the prelude's
   `.funi` declarations name host externals). It is checked against the shape
-  above at the DECLARATION.
+  above at the DECLARATION. A NAME is late-bound like any global, so it must be
+  defined above any top-level constant that uses the operator.
+- **The brand must be distinguishable at run time** — a single-constructor
+  variant, or a host type like `Angle.t`. A record brand or a multi-constructor
+  type is a check error at the declaration (the interpreter dispatches on a
+  value's tag).
 - **Scaling commutes, division does not**: `2.0 * 45deg` works (same call,
   arguments swapped); `2.0 / 45deg` is an error.
 - **Resolution is ad-hoc overloading AFTER inference**: a node whose operand

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -123,6 +123,11 @@ unit px (/) = dividePx               // (Px, float) => Px
   the brand is named: `s`, `ms`, `us`, `min`, and `hr` are all `Time.t`, so ONE
   `unit s (+) = Time.add` makes `1.5s - 200ms` work. Declaring the same brand +
   operator twice — through any suffix — is a duplicate error.
+- **The brand must be distinguishable at run time**, because the interpreter
+  dispatches on a value's tag: a single-constructor variant, or an opaque host
+  type (`Angle.t`). A record brand carries no tag and a multi-constructor type
+  carries a different one per constructor, so an operator on either is a check
+  error at the declaration.
 - Comparisons (`<`, `>`, `==`) are deliberately not declarable: `==` is already
   structural for plain-data brands, and ordering wants its own design pass.
 
@@ -172,7 +177,17 @@ different types, so no branded reading exists; it can only be float. (`v + v`
 *does* have a branded reading, so it still asks.)
 
 Note how narrow that leaves the error: it needs BOTH operands *and* the result
-to be unconstrained, and a branded reading to be possible at all. `(a, b) => a + b` in a project that declares an operator for `+`
+to be unconstrained, and a branded reading to be possible at all.
+
+> **This is a breaking change, and deliberately so.** The engine prelude always
+> declares `+`, `-`, and `*` on `Angle.t` and `Time.t`, so a helper like
+> `let plus = (a, b) => a + b` — which used to infer as float — now asks for an
+> annotation, even in a game that never touches a brand. That is the price of
+> resolving operators deterministically instead of guessing; the alternative
+> (default to float, and report the mismatch at the call site instead) was
+> rejected in the design. Every example in this repository typechecks
+> unchanged, so the practical blast radius is small, but existing user code with
+> fully unannotated numeric helpers needs one annotation each. `(a, b) => a + b` in a project that declares an operator for `+`
 is ambiguous and says so; `(a, b): float => a + b`, `(a) => a + 1.0`, and every
 `+` in a project with no operator declarations infer and run exactly as they
 did before. And a brand with no implementation for the operator keeps the old
@@ -198,10 +213,17 @@ Two consequences worth stating:
 - **Plain float arithmetic is untouched.** The number/number case is still the
   first match in the same `match`; the table is consulted only when an operand
   is not a number. `frame_bench` shows no allocation or byte change.
-- **`functor-lang run` (which does not typecheck) behaves identically to the
-  checked path**, and so does a fake/plain prelude: both roads end at exactly
-  the call the declaration names. An operand with no implementation gets the
-  same teaching text at runtime that the checker gives at check time.
+- **The table exists before the module's defs are evaluated**, so a top-level
+  constant may use branded arithmetic (`let turn: Angle.t = 90deg + 45deg`). A
+  named implementation stays LATE-BOUND, like every other global, so it obeys
+  the same rule as any initializer: it must be defined above the constant that
+  uses it.
+- **`functor-lang run` (which does not typecheck) behaves like the checked
+  path**, and so does a fake/plain prelude: both roads end at exactly the call
+  the declaration names, and both refuse a duplicate declaration. An operand
+  with no implementation gets the same teaching sentence at runtime the checker
+  gives at check time — naming the brand as that side knows it (the checker has
+  the type, `Angle.t`; the interpreter has the runtime tag, `Angle`).
 
 ### Where the implementations live for prelude brands
 

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -187,14 +187,15 @@ to be unconstrained, and a branded reading to be possible at all.
 > (default to float, and report the mismatch at the call site instead) was
 > rejected in the design. Every example in this repository typechecks
 > unchanged, so the practical blast radius is small, but existing user code with
-> fully unannotated numeric helpers needs one annotation each. `(a, b) => a + b` in a project that declares an operator for `+`
-is ambiguous and says so; `(a, b): float => a + b`, `(a) => a + 1.0`, and every
-`+` in a project with no operator declarations infer and run exactly as they
-did before. And a brand with no implementation for the operator keeps the old
-teaching error, now naming what the brand *does* declare:
+> fully unannotated numeric helpers needs one annotation each.
+
+Everything else infers and runs exactly as before: `(a, b): float => a + b`,
+`(a) => a + 1.0`, and every `+` in a project with no operator declarations. And
+a brand with no implementation for the operator keeps the old teaching error,
+now naming what the brand *does* declare:
 
 ```
-`-` needs float operands, got Angle.t — `Angle.t` declares `*`, `+`, but not `-`
+`-` needs float operands, got Angle.t — `Angle.t` declares `+`, `*`, but not `-`
 ```
 
 ### Runtime
@@ -203,10 +204,9 @@ Unlike a suffixed literal, an operator is **not** desugared at lowering — the
 operand types are not known there. So the interpreter dispatches too: an
 arithmetic node whose operands are not both numbers consults a table of the
 declared implementations, keyed by the operand's runtime tag (a variant's
-constructor, or an opaque host value's type name). The table is built once when
-a session loads, by applying each unit's own constructor to a probe value and
-reading the tag off the result — which works for every unit target shape
-without any type information.
+constructor, or an opaque host value's type name). It is built by applying each
+unit's own constructor to a probe value and reading the tag off the result —
+which works for every unit target shape without any type information.
 
 Two consequences worth stating:
 

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -117,8 +117,8 @@ unit px (/) = dividePx               // (Px, float) => Px
   is dimensional analysis — see the non-goal below.
 - Each implementation is typechecked against the shape above **at the
   declaration**, exactly as Phase 1 typechecks the constructor. It is an
-  ordinary expression: a name, or a lambda (a `.funi` has no bodies, so a
-  prelude declaration always names a host external).
+  ordinary expression: a name, or a lambda. The prelude's `.funi` interfaces
+  name host externals.
 - **The operator belongs to the BRAND, not the suffix.** The suffix is only how
   the brand is named: `s`, `ms`, `us`, `min`, and `hr` are all `Time.t`, so ONE
   `unit s (+) = Time.add` makes `1.5s - 200ms` work. Declaring the same brand +
@@ -166,8 +166,13 @@ an annotation, never a silent float guess:
 (e.g. `(a: Px)`) so the operator can be resolved
 ```
 
-Note how narrow that is: the error needs BOTH operands *and* the result to be
-unconstrained. `(a, b) => a + b` in a project that declares an operator for `+`
+One more case is decided rather than reported: `v * v` — the SAME unsolved
+operand on both sides of a scalar operator. The scalar form's operands have
+different types, so no branded reading exists; it can only be float. (`v + v`
+*does* have a branded reading, so it still asks.)
+
+Note how narrow that leaves the error: it needs BOTH operands *and* the result
+to be unconstrained, and a branded reading to be possible at all. `(a, b) => a + b` in a project that declares an operator for `+`
 is ambiguous and says so; `(a, b): float => a + b`, `(a) => a + 1.0`, and every
 `+` in a project with no operator declarations infer and run exactly as they
 did before. And a brand with no implementation for the operator keeps the old

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -162,6 +162,11 @@ Scaling commutes, so a brand may sit on either side of `*` (`2.0 * 45deg` is
 the declared call with its arguments swapped). Division does not: `2.0 / 45deg`
 is refused, because the scalar form divides a branded value BY a number.
 
+The node's RESULT counts as evidence too: `+` and `-` stay inside their brand,
+so an annotated `(a, b): Px => a + b` resolves with no operand annotation at
+all. (The scalar `*` and `/` cannot be decided that way — which SIDE is the
+brand would still be unknown.)
+
 The critical rule is what happens when the deferred node is *still* undecided —
 both operands and its result unsolved. That is a **teaching error** asking for
 an annotation, never a silent float guess:
@@ -217,7 +222,9 @@ Two consequences worth stating:
   constant may use branded arithmetic (`let turn: Angle.t = 90deg + 45deg`). A
   named implementation stays LATE-BOUND, like every other global, so it obeys
   the same rule as any initializer: it must be defined above the constant that
-  uses it.
+  uses it. A unit whose own *constructor* is a top-level `let` cannot be probed
+  that early, so the table is completed as the defs land — the first
+  initializer that could use it already can.
 - **`functor-lang run` (which does not typecheck) behaves like the checked
   path**, and so does a fake/plain prelude: both roads end at exactly the call
   the declaration names, and both refuse a duplicate declaration. An operand

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -1,9 +1,10 @@
 # Unit-suffix literals
 
 Functor Lang lets a numeric literal carry a **unit suffix** — `90deg`, `0.5s`,
-`16px` — where a `unit` declaration says what the suffix means. This document
-covers what shipped (Phase 1) and the design for operators on branded units
-(Phase 2), which is **not** implemented.
+`16px` — where a `unit` declaration says what the suffix means, and lets that
+brand carry arithmetic: `90deg + 45deg`, `1.5s - 200ms`, `45deg * 2.0`. This
+document covers both shipped phases — the literals (Phase 1) and the operators
+(Phase 2).
 
 Syntax and semantics for day-to-day use live in the `functor-lang` skill; the
 prelude's own suffixes are documented at their source
@@ -88,77 +89,129 @@ They resolve only where the engine prelude does (a runner-hosted project, or
 the headless test seam), like every other prelude name. A project declares its
 own units for its own brands.
 
-## Phase 2 (designed, not implemented): operators on units
+## Phase 2 (shipped): operators on units
 
-Phase 1 gives a brand a cheap way IN from a number. What it does not give is
-arithmetic: `90deg + 45deg` does not typecheck, because `+` is `(float, float)
-=> float`. Today the answer is to unwrap, add, and rebrand — which is exactly
-the ceremony the suffix removed.
+Phase 1 gives a brand a cheap way IN from a number. What it did not give is
+arithmetic: `90deg + 45deg` did not typecheck, because `+` was `(float, float)
+=> float`, so the answer was to unwrap, add, and rebrand — exactly the ceremony
+the suffix removed. It typechecks now.
 
 ### The declaration
 
-A unit may declare operator implementations beside itself:
+An operator is its own top-level item, naming the suffix whose brand it acts
+on:
 
 ```functor
 type Px = | Px(value: float)
 
-unit px = Px {
-  (+) = addPx        // (Px, Px) => Px
-  (-) = subPx        // (Px, Px) => Px
-  (*) = scalePx      // (Px, float) => Px   — the scalar form
-  (/) = dividePx     // (Px, float) => Px
-}
+unit px = Px
+unit px (+) = addPx                  // (Px, Px) => Px
+unit px (-) = subPx                  // (Px, Px) => Px
+unit px (*) = (a, k) => scalePx(a, k)   // (Px, float) => Px — the scalar form
+unit px (/) = dividePx               // (Px, float) => Px
 ```
 
 - `+` and `-` take `('t, 't) => 't`: adding two lengths gives a length.
 - `*` and `/` take `('t, float) => 't`: scaling a length by a number gives a
   length. A brand-by-brand product would be a *different* type (an area), which
   is dimensional analysis — see the non-goal below.
-- Every implementation is an ordinary named function, typechecked against the
-  shape above at the declaration, exactly as Phase 1 typechecks the constructor.
-- Comparisons (`<`, `>`, `==`) are deliberately out of this list for now: `==`
-  is already structural for plain-data brands, and ordering wants its own
-  design pass.
+- Each implementation is typechecked against the shape above **at the
+  declaration**, exactly as Phase 1 typechecks the constructor. It is an
+  ordinary expression: a name, or a lambda (a `.funi` has no bodies, so a
+  prelude declaration always names a host external).
+- **The operator belongs to the BRAND, not the suffix.** The suffix is only how
+  the brand is named: `s`, `ms`, `us`, `min`, and `hr` are all `Time.t`, so ONE
+  `unit s (+) = Time.add` makes `1.5s - 200ms` work. Declaring the same brand +
+  operator twice — through any suffix — is a duplicate error.
+- Comparisons (`<`, `>`, `==`) are deliberately not declarable: `==` is already
+  structural for plain-data brands, and ordering wants its own design pass.
+
+> **Deviation from the original design.** The design sketch attached operators
+> to the unit declaration as a block (`unit px = Px { (+) = … }`). Shipping them
+> as separate items keeps the `.funi` prelude honest — `Angle` and `Time`
+> declare their suffixes and their operators in the same flat item list the rest
+> of an interface uses, docgen renders each one with its own `///` prose, and
+> a project can add an operator to a brand without touching the (possibly
+> already-published) unit declaration.
 
 ### Resolution: ad-hoc overloading, after inference
 
-Operator selection happens **after** ordinary Hindley–Milner inference has run
-and the operand types are zonked — never during unification, which would make
-inference order-dependent:
+Operator selection happens **after** ordinary Hindley–Milner inference has
+solved the operand types — never during unification, which would make inference
+order-dependent:
 
-1. Infer the whole program as today, with `+` constrained as usual.
-2. Post-zonk, walk each arithmetic node. If an operand's solved type is a brand
-   that declares that operator, replace the node with a call to the declared
-   implementation.
-3. If neither operand is a declaring brand, the node stays the float operator
-   and its ordinary `float` constraint applies.
+1. Infer as today, with `+` constrained as usual.
+2. At each arithmetic node, zonk the operands. If either resolved type is a
+   brand that declares that operator, the node IS that implementation: the
+   other operand is checked against the implementation's signature (the same
+   brand for `+`/`-`, a plain float for the scalar side of `*` and `/`) and the
+   node's type is the brand.
+3. If neither operand is a declaring brand, the node is float arithmetic and
+   its ordinary `float` constraint applies — unchanged.
+4. A node whose operands are *still unsolved* when it is first seen is
+   **deferred** to a pass that runs when the enclosing definition group has
+   settled, then re-resolved by the same rules. That is what lets a brand that
+   only becomes known later still reach the node.
 
-The critical rule is what happens when the operand type is still an **unsolved
-type variable** at that point: that is a *teaching error* asking for an
-annotation, never a silent guess.
+Scaling commutes, so a brand may sit on either side of `*` (`2.0 * 45deg` is
+the declared call with its arguments swapped). Division does not: `2.0 / 45deg`
+is refused, because the scalar form divides a branded value BY a number.
+
+The critical rule is what happens when the deferred node is *still* undecided —
+both operands and its result unsolved. That is a **teaching error** asking for
+an annotation, never a silent float guess:
 
 ```
-`+` here could be float addition or `Px` addition — annotate the operand
+`+` here could be float arithmetic or `Px` arithmetic — annotate an operand
 (e.g. `(a: Px)`) so the operator can be resolved
 ```
 
-This keeps two properties: a program either resolves every operator
-deterministically or says so, and code that never uses a unit operator infers
-and runs exactly as it does today.
+Note how narrow that is: the error needs BOTH operands *and* the result to be
+unconstrained. `(a, b) => a + b` in a project that declares an operator for `+`
+is ambiguous and says so; `(a, b): float => a + b`, `(a) => a + 1.0`, and every
+`+` in a project with no operator declarations infer and run exactly as they
+did before. And a brand with no implementation for the operator keeps the old
+teaching error, now naming what the brand *does* declare:
 
-Because resolution is a post-pass rewrite, the IR again ends up with an
-ordinary call — the Phase 1 property that there is no second evaluation path is
-preserved, so the interpreter is untouched and there is no per-frame cost.
+```
+`-` needs float operands, got Angle.t — `Angle.t` declares `*`, `+`, but not `-`
+```
 
-### Open questions for Phase 2
+### Runtime
 
-- **Mixed literals.** `90deg + 45` — is the bare number an error, or is it
-  lifted through the unit's constructor? Erroring is the conservative start.
-- **Prefix minus.** `-(someAngle)` would want a `negate` in the same block, or
-  to derive from `(-)` with a zero the brand cannot supply.
-- **Where the implementations live** for prelude brands: `Angle` and `Time` are
-  host types, so their operator impls are host externals, not Functor Lang
-  functions. The declaration form is the same; only the target is.
+Unlike a suffixed literal, an operator is **not** desugared at lowering — the
+operand types are not known there. So the interpreter dispatches too: an
+arithmetic node whose operands are not both numbers consults a table of the
+declared implementations, keyed by the operand's runtime tag (a variant's
+constructor, or an opaque host value's type name). The table is built once when
+a session loads, by applying each unit's own constructor to a probe value and
+reading the tag off the result — which works for every unit target shape
+without any type information.
+
+Two consequences worth stating:
+
+- **Plain float arithmetic is untouched.** The number/number case is still the
+  first match in the same `match`; the table is consulted only when an operand
+  is not a number. `frame_bench` shows no allocation or byte change.
+- **`functor-lang run` (which does not typecheck) behaves identically to the
+  checked path**, and so does a fake/plain prelude: both roads end at exactly
+  the call the declaration names. An operand with no implementation gets the
+  same teaching text at runtime that the checker gives at check time.
+
+### Where the implementations live for prelude brands
+
+`Angle` and `Time` are host types, so their implementations are host externals
+(`Angle.add` / `Angle.sub` / `Angle.scale`, `Time.add` / `Time.sub` /
+`Time.scale`) declared beside the units in `angle.funi` / `time.funi`. Both are
+public API and appear in the generated reference.
+
+### Still open
+
+- **Mixed literals.** `90deg + 45` is an error (the bare number is not lifted
+  through the unit's constructor). Erroring is the conservative start.
+- **Prefix minus.** `-(someAngle)` would want a `negate` declaration, or to
+  derive from `(-)` with a zero the brand cannot supply.
+- **Comparisons.** `==`, `<`, `>` on brands are a follow-up.
 
 ### Explicit non-goal: dimensional analysis
 

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -225,6 +225,16 @@ Two consequences worth stating:
   uses it. A unit whose own *constructor* is a top-level `let` cannot be probed
   that early, so the table is completed as the defs land — the first
   initializer that could use it already can.
+- **Nothing is resolved until it is needed.** A declaration's *implementation*
+  stays symbolic at load: a host external (`Angle.add`) is looked up only when
+  the operator actually dispatches, and a top-level name is late-bound like any
+  global. This is not an optimization — the same declarations load under the
+  PLAIN, hostless interpreter (the editor's expect gutter runs a project's defs
+  that way with the engine `.funi` interfaces linked), where `Angle.add` has no
+  implementation and must not be an error until something uses it. For the same
+  reason, a brand whose constructor cannot run in this interpreter simply gets
+  no entry rather than failing the load: with no host you cannot build one of
+  its values either, so nothing can dispatch on it.
 - **`functor-lang run` (which does not typecheck) behaves like the checked
   path**, and so does a fake/plain prelude: both roads end at exactly the call
   the declaration names, and both refuse a duplicate declaration. An operand

--- a/functor-lang/examples/functions.ir
+++ b/functor-lang/examples/functions.ir
@@ -572,4 +572,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/inline_modules.ir
+++ b/functor-lang/examples/inline_modules.ir
@@ -433,4 +433,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/lists.ir
+++ b/functor-lang/examples/lists.ir
@@ -578,4 +578,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/pure_pipeline.ir
+++ b/functor-lang/examples/pure_pipeline.ir
@@ -361,4 +361,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/records.ir
+++ b/functor-lang/examples/records.ir
@@ -745,4 +745,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/shapes.ir
+++ b/functor-lang/examples/shapes.ir
@@ -847,4 +847,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/strings.ir
+++ b/functor-lang/examples/strings.ir
@@ -751,4 +751,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/examples/tuples.ir
+++ b/functor-lang/examples/tuples.ir
@@ -810,4 +810,5 @@ Module {
     signatures: [],
     expects: [],
     units: [],
+    unit_ops: [],
 }

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -399,6 +399,11 @@ pub enum BinOp {
 }
 
 impl BinOp {
+    /// The arithmetic operators, in declaration order — the ONE list of what
+    /// a `unit <suffix> (<op>)` may declare, shared by the parser, the
+    /// typechecker, and the interpreter's dispatch table.
+    pub const ARITHMETIC: [BinOp; 4] = [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div];
+
     /// The operator's source spelling — the single source of truth for
     /// diagnostics in the typechecker and the interpreter.
     pub fn symbol(self) -> &'static str {
@@ -415,6 +420,31 @@ impl BinOp {
             BinOp::Ne => "!=",
         }
     }
+}
+
+/// What a "this needs float operands" / "arithmetic needs numbers" error adds
+/// once a UNIT BRAND is in play: which operators that brand does declare, or
+/// how to declare one. Written once so the typechecker's and the interpreter's
+/// twin messages cannot drift (they differ only in how the brand is named:
+/// the checker knows the type, `Angle.t`; the interpreter knows the runtime
+/// tag, `Angle`).
+pub fn declared_operators_hint(brand: &str, declared: &[&str], op: BinOp) -> String {
+    if declared.is_empty() {
+        return format!(
+            " — `{brand}` is a branded value with no arithmetic; declare it with \
+`unit <suffix> ({}) = …`",
+            op.symbol()
+        );
+    }
+    format!(
+        " — `{brand}` declares {}, but not `{}`",
+        declared
+            .iter()
+            .map(|symbol| format!("`{symbol}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        op.symbol()
+    )
 }
 
 /// The short-circuiting boolean operators. `And` binds tighter than `Or`;

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -58,8 +58,9 @@ pub struct UnitDecl {
 /// an error.
 ///
 /// `+` and `-` take `('t, 't) => 't`; `*` and `/` take the SCALAR form
-/// `('t, float) => 't`. The target is an ordinary expression (a name in a
-/// `.funi`, which has no bodies; a name or a lambda in a `.fun`).
+/// `('t, float) => 't`. The target is an ordinary expression — a name (what
+/// the prelude's `.funi` interfaces use, naming a host external) or a
+/// lambda.
 #[derive(Debug)]
 pub struct UnitOpDecl {
     /// The suffix whose brand this operator belongs to (`deg`, `px`).

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -428,7 +428,7 @@ impl BinOp {
 /// twin messages cannot drift (they differ only in how the brand is named:
 /// the checker knows the type, `Angle.t`; the interpreter knows the runtime
 /// tag, `Angle`).
-pub fn declared_operators_hint(brand: &str, declared: &[&str], op: BinOp) -> String {
+pub(crate) fn declared_operators_hint(brand: &str, declared: &[&str], op: BinOp) -> String {
     if declared.is_empty() {
         return format!(
             " — `{brand}` is a branded value with no arithmetic; declare it with \

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -26,6 +26,9 @@ pub enum Item {
     /// `unit deg = Angle.degrees` — declares the literal suffix `deg`, so
     /// `90deg` desugars to `Angle.degrees(90.0)` (see [`UnitDecl`]).
     Unit(UnitDecl),
+    /// `unit deg (+) = Angle.add` — an OPERATOR implementation for the brand
+    /// the suffix builds (see [`UnitOpDecl`]).
+    UnitOp(UnitOpDecl),
 }
 
 /// `unit <suffix> = <name>` — a unit-suffixed literal's meaning: which
@@ -43,6 +46,30 @@ pub struct UnitDecl {
     pub target: Vec<String>,
     /// The target name's own span (what a resolution error points at).
     pub target_span: Span,
+    /// The whole declaration.
+    pub span: Span,
+}
+
+/// `unit <suffix> (<op>) = <target>` — an arithmetic operator on the BRAND a
+/// unit builds. The op attaches to the brand TYPE (resolved through the
+/// suffix's declared target), so every suffix of one brand shares it: `s` and
+/// `ms` are both `Time.t`, so `1.5s - 200ms` uses the one `(-)` declared for
+/// `Time`. Declaring the same brand + operator twice (through any suffix) is
+/// an error.
+///
+/// `+` and `-` take `('t, 't) => 't`; `*` and `/` take the SCALAR form
+/// `('t, float) => 't`. The target is an ordinary expression (a name in a
+/// `.funi`, which has no bodies; a name or a lambda in a `.fun`).
+#[derive(Debug)]
+pub struct UnitOpDecl {
+    /// The suffix whose brand this operator belongs to (`deg`, `px`).
+    pub suffix: String,
+    pub suffix_span: Span,
+    /// The operator — only `+`, `-`, `*`, `/` (comparisons are not declarable).
+    pub op: BinOp,
+    pub op_span: Span,
+    /// The implementation.
+    pub target: Expr,
     /// The whole declaration.
     pub span: Span,
 }
@@ -354,7 +381,7 @@ pub struct Param {
     pub span: Span,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinOp {
     Add,
     Sub,

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -371,6 +371,7 @@ pub fn run_with_host(
         depth: 0,
         call_depth: 0,
         fuel: None,
+        brand_ops: BrandOps::default(),
         host,
     };
     match interp.run_module(module) {
@@ -497,9 +498,13 @@ pub fn run_expects_budgeted(
         depth: 0,
         call_depth: 0,
         fuel: budget.map(Fuel::new),
+        brand_ops: BrandOps::default(),
         host,
     };
-    if let Err(error) = interp.eval_defs(module) {
+    if let Err(error) = interp
+        .eval_defs(module)
+        .and_then(|_| interp.load_brand_ops(module).map(|ops| interp.brand_ops = ops))
+    {
         return Err(RunFailure {
             error,
             trace: interp.trace,
@@ -526,6 +531,42 @@ pub fn run_expects_budgeted(
 /// swap the session and keep the model; docs/functor-lang.md C3).
 pub struct Session {
     globals: HashMap<String, Value>,
+    brand_ops: BrandOps,
+}
+
+/// Declared unit operators, resolved to callable VALUES and keyed by the
+/// runtime tag of the brand they act on ([`brand_tag`]) — one row of four
+/// slots, `+` `-` `*` `/`, so dispatch is a BORROWED lookup that allocates
+/// nothing on the operand path.
+///
+/// The checker resolves `90deg + 45deg` statically, but the interpreter must
+/// dispatch too: `check` is not on every path (`functor-lang run` skips it),
+/// and a value can reach an operator through a gradual `unknown` seam. Both
+/// roads lead to exactly the call the declaration names — under a fake or
+/// plain prelude the behaviour is the handwritten call's, precisely.
+pub(crate) type BrandOps = Rc<HashMap<String, BrandOpRow>>;
+
+/// One brand's declared operators, indexed by [`op_slot`].
+pub(crate) type BrandOpRow = [Option<Value>; 4];
+
+/// Which slot of a [`BrandOpRow`] an operator owns — `None` for the
+/// comparisons, which are not declarable.
+fn op_slot(op: crate::ast::BinOp) -> Option<usize> {
+    use crate::ast::BinOp;
+    match op {
+        BinOp::Add => Some(0),
+        BinOp::Sub => Some(1),
+        BinOp::Mul => Some(2),
+        BinOp::Div => Some(3),
+        _ => None,
+    }
+}
+
+/// The operator a [`BrandOpRow`] slot holds — the inverse of [`op_slot`],
+/// for the "declares `+`, `*`, but not `-`" teaching error.
+fn slot_op(slot: usize) -> crate::ast::BinOp {
+    use crate::ast::BinOp;
+    [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div][slot]
 }
 
 impl Session {
@@ -542,11 +583,16 @@ impl Session {
             depth: 0,
             call_depth: 0,
             fuel: None,
+            brand_ops: BrandOps::default(),
             host,
         };
-        match interp.eval_defs(module) {
-            Ok(_) => Ok(Session {
+        let loaded = interp
+            .eval_defs(module)
+            .and_then(|_| interp.load_brand_ops(module));
+        match loaded {
+            Ok(brand_ops) => Ok(Session {
                 globals: interp.globals,
+                brand_ops,
             }),
             Err(error) => Err(RunFailure {
                 error,
@@ -581,6 +627,7 @@ impl Session {
             depth: 0,
             call_depth: 0,
             fuel: None,
+            brand_ops: self.brand_ops.clone(),
             host,
         };
         interp.call(callee, args, name.to_string(), Span::new(0, 0), None)
@@ -605,6 +652,7 @@ impl Session {
             depth: 0,
             call_depth: 0,
             fuel: None,
+            brand_ops: self.brand_ops.clone(),
             host,
         };
         interp.call(callee, args, label.to_string(), Span::new(0, 0), None)
@@ -636,6 +684,7 @@ impl Session {
             depth: 0,
             call_depth: 0,
             fuel: None,
+            brand_ops: self.brand_ops.clone(),
             host,
         };
         let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
@@ -676,6 +725,7 @@ impl Session {
             depth: 0,
             call_depth: 0,
             fuel: None,
+            brand_ops: self.brand_ops.clone(),
             host,
         };
         let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
@@ -760,6 +810,11 @@ struct Interp<'h> {
     /// norm — every game-loop path) means zero cost beyond one branch per
     /// eval step, the same hot-path cost class as `recorder`.
     fuel: Option<Fuel>,
+    /// Declared unit operators, keyed by an operand's runtime brand tag
+    /// (see [`brand_tag`]). Empty for every program that declares none, and
+    /// consulted ONLY when an arithmetic operand is not a number — so plain
+    /// float math costs exactly what it did before.
+    brand_ops: BrandOps,
     host: &'h mut dyn Host,
 }
 
@@ -829,10 +884,72 @@ impl Interp<'_> {
 
     fn run_module(&mut self, module: &Module) -> Result<RunOutcome, RunError> {
         let bindings = self.eval_defs(module)?;
+        self.brand_ops = self.load_brand_ops(module)?;
         match module.defs.iter().find(|def| def.name == "main") {
             Some(main_def) => Ok(RunOutcome::Main(self.call_main(main_def)?)),
             None => Ok(RunOutcome::Bindings(bindings)),
         }
+    }
+
+    /// Resolve every `unit <suffix> (<op>) = <impl>` declaration into the
+    /// dispatch table, once, after the module's defs exist.
+    ///
+    /// A brand's runtime identity is taken from a value it actually BUILDS:
+    /// the suffix's own constructor is applied to `1.0` and the result's tag
+    /// ([`brand_tag`]) becomes the key. That works for every unit target
+    /// shape — a host function (`Angle.degrees`), a variant constructor
+    /// (`Px`), or an ordinary Functor Lang function — with no type
+    /// information, which the interpreter does not have.
+    fn load_brand_ops(&mut self, module: &Module) -> Result<BrandOps, RunError> {
+        if module.unit_ops.is_empty() {
+            return Ok(BrandOps::default());
+        }
+        let mut tags: HashMap<&str, String> = HashMap::new();
+        let mut ops: HashMap<String, BrandOpRow> = HashMap::new();
+        for unit_op in &module.unit_ops {
+            let tag = match tags.get(unit_op.suffix.as_str()) {
+                Some(tag) => tag.clone(),
+                None => {
+                    let Some(unit) = module
+                        .units
+                        .iter()
+                        .find(|unit| unit.suffix == unit_op.suffix)
+                    else {
+                        // Lowering refuses an operator on an undeclared
+                        // suffix, so this is unreachable in a loaded project.
+                        continue;
+                    };
+                    let ctor = self.eval(&unit.target, &Env::empty())?;
+                    let probe = self.call(
+                        ctor,
+                        vec![Value::Number(1.0)],
+                        unit.suffix.clone(),
+                        unit_op.span,
+                        None,
+                    )?;
+                    let Some(tag) = brand_tag(&probe).map(str::to_string) else {
+                        return Err(RunError {
+                            message: format!(
+                                "`unit {} ({})` needs a unit whose values carry a runtime tag — \
+`{}` builds {}, which nothing can dispatch on (use a constructor, or a host value)",
+                                unit_op.suffix,
+                                unit_op.op.symbol(),
+                                unit_op.suffix,
+                                probe.kind_name()
+                            ),
+                            span: unit_op.span,
+                        });
+                    };
+                    tags.insert(unit_op.suffix.as_str(), tag.clone());
+                    tag
+                }
+            };
+            let implementation = self.eval(&unit_op.target, &Env::empty())?;
+            if let Some(slot) = op_slot(unit_op.op) {
+                ops.entry(tag).or_default()[slot] = Some(implementation);
+            }
+        }
+        Ok(Rc::new(ops))
     }
 
     fn call_main(&mut self, def: &Def) -> Result<Value, RunError> {
@@ -1377,12 +1494,12 @@ evaluation depth."
     ) -> Result<Value, RunError> {
         use crate::ast::BinOp;
         match op {
-            BinOp::Add => self.arith(lhs, rhs, span, |a, b| a + b),
-            BinOp::Sub => self.arith(lhs, rhs, span, |a, b| a - b),
-            BinOp::Mul => self.arith(lhs, rhs, span, |a, b| a * b),
+            BinOp::Add => self.arith(op, lhs, rhs, span, |a, b| a + b),
+            BinOp::Sub => self.arith(op, lhs, rhs, span, |a, b| a - b),
+            BinOp::Mul => self.arith(op, lhs, rhs, span, |a, b| a * b),
             // Division follows IEEE-754 (x/0 is ±inf/NaN, printed as
             // `inf`/`NaN`) — one number type, no checked division.
-            BinOp::Div => self.arith(lhs, rhs, span, |a, b| a / b),
+            BinOp::Div => self.arith(op, lhs, rhs, span, |a, b| a / b),
             BinOp::Lt => self.compare(lhs, rhs, span, |a, b| a < b),
             BinOp::Gt => self.compare(lhs, rhs, span, |a, b| a > b),
             // IEEE ordering, like `<`/`>`: every comparison with NaN is false.
@@ -1408,22 +1525,104 @@ evaluation depth."
 
     fn arith(
         &mut self,
+        op: crate::ast::BinOp,
         lhs: Value,
         rhs: Value,
         span: Span,
-        op: fn(f64, f64) -> f64,
+        arith: fn(f64, f64) -> f64,
     ) -> Result<Value, RunError> {
         match (lhs, rhs) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(op(a, b))),
-            (a, b) => Err(RunError {
+            (Value::Number(a), Value::Number(b)) => Ok(Value::Number(arith(a, b))),
+            // Not two numbers: a branded operand may still have a declared
+            // implementation for this operator.
+            (a, b) => self.brand_arith(op, a, b, span),
+        }
+    }
+
+    /// Arithmetic where at least one operand is not a number — the runtime
+    /// half of unit operators. The implementation is exactly the one the
+    /// `unit … (<op>) = …` declaration names, called with the operands in the
+    /// declared order.
+    fn brand_arith(
+        &mut self,
+        op: crate::ast::BinOp,
+        lhs: Value,
+        rhs: Value,
+        span: Span,
+    ) -> Result<Value, RunError> {
+        use crate::ast::BinOp;
+        let Some(slot) = op_slot(op) else {
+            unreachable!("only arithmetic reaches brand dispatch")
+        };
+        let declared = |ops: &BrandOps, value: &Value| {
+            brand_tag(value)
+                .and_then(|tag| ops.get(tag))
+                .and_then(|row| row[slot].clone())
+        };
+        // The declared form takes the branded value FIRST. Scaling commutes,
+        // so `2.0 * 45deg` is the same call with its arguments swapped —
+        // matching what the checker resolves (`/` deliberately does not).
+        let call = match declared(&self.brand_ops, &lhs) {
+            Some(implementation) => Some((implementation, lhs.clone(), rhs.clone())),
+            None if matches!(op, BinOp::Mul) && matches!(lhs, Value::Number(_)) => {
+                declared(&self.brand_ops, &rhs)
+                    .map(|implementation| (implementation, rhs.clone(), lhs.clone()))
+            }
+            None => None,
+        };
+        match call {
+            Some((implementation, first, second)) => self.call(
+                implementation,
+                vec![first, second],
+                format!("({})", op.symbol()),
+                span,
+                None,
+            ),
+            None => Err(RunError {
                 message: format!(
-                    "arithmetic needs numbers, got {} and {}",
-                    a.kind_name(),
-                    b.kind_name()
+                    "arithmetic needs numbers, got {} and {}{}",
+                    lhs.kind_name(),
+                    rhs.kind_name(),
+                    self.brand_arith_hint(op, &lhs, &rhs)
                 ),
                 span,
             }),
         }
+    }
+
+    /// What a failed branded arithmetic adds to its error: which operators
+    /// the brand DOES declare, or how to declare one — the same teaching the
+    /// checker gives, for the paths that reach the interpreter first.
+    fn brand_arith_hint(&self, op: crate::ast::BinOp, lhs: &Value, rhs: &Value) -> String {
+        let Some(tag) = brand_tag(lhs).or_else(|| brand_tag(rhs)) else {
+            return String::new();
+        };
+        let declared: Vec<&str> = self
+            .brand_ops
+            .get(tag)
+            .into_iter()
+            .flat_map(|row| {
+                row.iter()
+                    .enumerate()
+                    .filter(|(_, implementation)| implementation.is_some())
+                    .map(|(slot, _)| slot_op(slot).symbol())
+            })
+            .collect();
+        if declared.is_empty() {
+            return format!(
+                " — `{tag}` declares no arithmetic; declare it with `unit <suffix> ({}) = …`",
+                op.symbol()
+            );
+        }
+        format!(
+            " — `{tag}` declares {}, but not `{}`",
+            declared
+                .iter()
+                .map(|symbol| format!("`{symbol}`"))
+                .collect::<Vec<_>>()
+                .join(", "),
+            op.symbol()
+        )
     }
 
     fn compare(
@@ -2794,6 +2993,18 @@ got edge0 {edge0} and edge1 {edge1}"
                 ),
             },
         }
+    }
+}
+
+/// A value's BRAND identity for unit-operator dispatch: a variant's
+/// constructor, or an opaque host value's type name (`Angle`, `Duration`).
+/// Everything else — numbers, strings, records, collections — carries no tag
+/// an operator could be declared against, so it never dispatches.
+pub(crate) fn brand_tag(value: &Value) -> Option<&str> {
+    match value {
+        Value::Variant { ctor, .. } => Some(ctor),
+        Value::HostData(host) => Some(host.type_name()),
+        _ => None,
     }
 }
 

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -372,6 +372,7 @@ pub fn run_with_host(
         call_depth: 0,
         fuel: None,
         brand_ops: BrandOps::default(),
+        brand_ops_complete: true,
         host,
     };
     match interp.run_module(module) {
@@ -499,16 +500,13 @@ pub fn run_expects_budgeted(
         call_depth: 0,
         fuel: budget.map(Fuel::new),
         brand_ops: BrandOps::default(),
+        brand_ops_complete: true,
         host,
     };
     if let Err(error) = interp
-        .load_brand_ops(module, false)
-        .and_then(|ops| {
-            interp.brand_ops = ops;
-            interp.eval_defs(module)
-        })
-        .and_then(|_| interp.load_brand_ops(module, true))
-        .map(|ops| interp.brand_ops = ops)
+        .load_unit_operators(module)
+        .and_then(|_| interp.eval_defs(module))
+        .and_then(|_| interp.settle_unit_operators(module))
     {
         return Err(RunFailure {
             error,
@@ -602,19 +600,17 @@ impl Session {
             call_depth: 0,
             fuel: None,
             brand_ops: BrandOps::default(),
+            brand_ops_complete: true,
             host,
         };
         let loaded = interp
-            .load_brand_ops(module, false)
-            .and_then(|ops| {
-                interp.brand_ops = ops;
-                interp.eval_defs(module)
-            })
-            .and_then(|_| interp.load_brand_ops(module, true));
+            .load_unit_operators(module)
+            .and_then(|_| interp.eval_defs(module))
+            .and_then(|_| interp.settle_unit_operators(module));
         match loaded {
-            Ok(brand_ops) => Ok(Session {
+            Ok(()) => Ok(Session {
+                brand_ops: interp.brand_ops.clone(),
                 globals: interp.globals,
-                brand_ops,
             }),
             Err(error) => Err(RunFailure {
                 error,
@@ -650,6 +646,7 @@ impl Session {
             call_depth: 0,
             fuel: None,
             brand_ops: self.brand_ops.clone(),
+            brand_ops_complete: true,
             host,
         };
         interp.call(callee, args, name.to_string(), Span::new(0, 0), None)
@@ -675,6 +672,7 @@ impl Session {
             call_depth: 0,
             fuel: None,
             brand_ops: self.brand_ops.clone(),
+            brand_ops_complete: true,
             host,
         };
         interp.call(callee, args, label.to_string(), Span::new(0, 0), None)
@@ -707,6 +705,7 @@ impl Session {
             call_depth: 0,
             fuel: None,
             brand_ops: self.brand_ops.clone(),
+            brand_ops_complete: true,
             host,
         };
         let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
@@ -748,6 +747,7 @@ impl Session {
             call_depth: 0,
             fuel: None,
             brand_ops: self.brand_ops.clone(),
+            brand_ops_complete: true,
             host,
         };
         let result = interp.call(callee, args, name.to_string(), Span::new(0, 0), None)?;
@@ -837,6 +837,10 @@ struct Interp<'h> {
     /// consulted ONLY when an arithmetic operand is not a number — so plain
     /// float math costs exactly what it did before.
     brand_ops: BrandOps,
+    /// Whether every declared operator in [`Self::brand_ops`] found its brand.
+    /// False only while a unit's own constructor is still an unevaluated def
+    /// (see [`Interp::load_brand_ops`]).
+    brand_ops_complete: bool,
     host: &'h mut dyn Host,
 }
 
@@ -849,6 +853,16 @@ impl Interp<'_> {
             let value = self.eval(&def.value, &Env::empty())?;
             self.globals.insert(def.name.clone(), value.clone());
             bindings.push((def.name.clone(), value));
+            // A unit whose own constructor is a top-level `let` could not be
+            // probed before the defs ran; retry as soon as more globals exist,
+            // so the very next initializer can use its operators. Normal
+            // programs (every prelude unit) resolve up front and never enter
+            // this branch.
+            if !self.brand_ops_complete {
+                let (ops, complete) = self.load_brand_ops(module, false)?;
+                self.brand_ops = ops;
+                self.brand_ops_complete = complete;
+            }
         }
         Ok(bindings)
     }
@@ -904,10 +918,32 @@ impl Interp<'_> {
         }
     }
 
+    /// Build the operator table before the defs run (see
+    /// [`Interp::load_brand_ops`]).
+    fn load_unit_operators(&mut self, module: &Module) -> Result<(), RunError> {
+        let (ops, complete) = self.load_brand_ops(module, false)?;
+        self.brand_ops = ops;
+        self.brand_ops_complete = complete;
+        Ok(())
+    }
+
+    /// The final attempt, once every def exists: only needed when something
+    /// could not be resolved earlier, and it reports why instead of leaving
+    /// the operator silently missing.
+    fn settle_unit_operators(&mut self, module: &Module) -> Result<(), RunError> {
+        if self.brand_ops_complete {
+            return Ok(());
+        }
+        let (ops, complete) = self.load_brand_ops(module, true)?;
+        self.brand_ops = ops;
+        self.brand_ops_complete = complete;
+        Ok(())
+    }
+
     fn run_module(&mut self, module: &Module) -> Result<RunOutcome, RunError> {
-        self.brand_ops = self.load_brand_ops(module, false)?;
+        self.load_unit_operators(module)?;
         let bindings = self.eval_defs(module)?;
-        self.brand_ops = self.load_brand_ops(module, true)?;
+        self.settle_unit_operators(module)?;
         match module.defs.iter().find(|def| def.name == "main") {
             Some(main_def) => Ok(RunOutcome::Main(self.call_main(main_def)?)),
             None => Ok(RunOutcome::Bindings(bindings)),
@@ -924,16 +960,25 @@ impl Interp<'_> {
     /// (`Px`), or an ordinary Functor Lang function — with no type
     /// information, which the interpreter does not have.
     ///
-    /// It runs TWICE: once before the module's defs are evaluated, so a
-    /// top-level constant may itself use branded arithmetic
-    /// (`let turn: Angle.t = 90deg + 45deg`), and once after, to pick up the
-    /// rare unit whose own constructor is a top-level `let` and so could not
-    /// be probed yet. The first pass is best-effort (a suffix it cannot probe
-    /// yet is simply absent); the second reports what is still broken.
-    fn load_brand_ops(&mut self, module: &Module, strict: bool) -> Result<BrandOps, RunError> {
+    /// It is built BEFORE the module's defs are evaluated, so a top-level
+    /// constant may itself use branded arithmetic
+    /// (`let turn: Angle.t = 90deg + 45deg`). A unit whose own constructor is
+    /// a top-level `let` cannot be probed that early; the build reports
+    /// itself INCOMPLETE and [`Interp::eval_defs`] retries as the defs land,
+    /// so such a unit works from the first initializer that could use it.
+    /// `strict` (the final attempt) reports what is still unresolvable
+    /// instead of leaving it silently absent.
+    ///
+    /// Returns the table and whether every declared operator found its brand.
+    fn load_brand_ops(
+        &mut self,
+        module: &Module,
+        strict: bool,
+    ) -> Result<(BrandOps, bool), RunError> {
         if module.unit_ops.is_empty() {
-            return Ok(BrandOps::default());
+            return Ok((BrandOps::default(), true));
         }
+        let mut complete = true;
         let mut tags: HashMap<&str, String> = HashMap::new();
         let mut ops: HashMap<String, BrandOpRow> = HashMap::new();
         for unit_op in &module.unit_ops {
@@ -949,10 +994,6 @@ impl Interp<'_> {
                         // suffix, so this is unreachable in a loaded project.
                         continue;
                     };
-                    // A brand whose values carry no tag (a record) cannot be
-                    // dispatched on; the CHECKER refuses that declaration, so
-                    // here it is simply left out of the table rather than
-                    // failing the whole load.
                     let probed = self
                         .eval(&unit.target, &Env::empty())
                         .and_then(|ctor| {
@@ -967,9 +1008,30 @@ impl Interp<'_> {
                         .map(|probe| brand_tag(&probe).map(str::to_string));
                     let tag = match probed {
                         Ok(Some(tag)) => tag,
-                        // Untagged, or (before the defs are evaluated) not yet
-                        // buildable: skip it. The post-def pass retries.
-                        Ok(None) | Err(_) => continue,
+                        // A brand whose values carry no runtime tag (a record)
+                        // cannot be dispatched on — the CHECKER refuses that
+                        // declaration, and the final attempt says so too.
+                        Ok(None) if strict => {
+                            return Err(RunError {
+                                message: format!(
+                                    "`unit {} ({})` needs a brand whose values carry a runtime \
+tag — `{}` builds a value nothing can dispatch on; use a single-constructor variant, or a host \
+type",
+                                    unit_op.suffix,
+                                    unit_op.op.symbol(),
+                                    unit_op.suffix
+                                ),
+                                span: unit_op.span,
+                            })
+                        }
+                        // Not buildable YET (its constructor is a def that has
+                        // not been evaluated): leave it out and report the
+                        // build incomplete, so `eval_defs` retries.
+                        Err(error) if strict => return Err(error),
+                        Ok(None) | Err(_) => {
+                            complete = false;
+                            continue;
+                        }
                     };
                     tags.insert(unit_op.suffix.as_str(), tag.clone());
                     tag
@@ -989,9 +1051,6 @@ impl Interp<'_> {
             // operator; `run` skips the checker, so refuse it here too rather
             // than silently picking the last one.
             if row[slot].is_some() {
-                if !strict {
-                    continue;
-                }
                 return Err(RunError {
                     message: format!(
                         "duplicate operator: `{}` is declared more than once for the brand \
@@ -1004,7 +1063,7 @@ implementation",
             }
             row[slot] = Some(implementation);
         }
-        Ok(Rc::new(ops))
+        Ok((Rc::new(ops), complete))
     }
 
     fn call_main(&mut self, def: &Def) -> Result<Value, RunError> {

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -502,8 +502,13 @@ pub fn run_expects_budgeted(
         host,
     };
     if let Err(error) = interp
-        .eval_defs(module)
-        .and_then(|_| interp.load_brand_ops(module).map(|ops| interp.brand_ops = ops))
+        .load_brand_ops(module, false)
+        .and_then(|ops| {
+            interp.brand_ops = ops;
+            interp.eval_defs(module)
+        })
+        .and_then(|_| interp.load_brand_ops(module, true))
+        .map(|ops| interp.brand_ops = ops)
     {
         return Err(RunFailure {
             error,
@@ -547,7 +552,20 @@ pub struct Session {
 pub(crate) type BrandOps = Rc<HashMap<String, BrandOpRow>>;
 
 /// One brand's declared operators, indexed by [`op_slot`].
-pub(crate) type BrandOpRow = [Option<Value>; 4];
+pub(crate) type BrandOpRow = [Option<OpImpl>; 4];
+
+/// A declared operator's implementation. A top-level NAME stays late-bound,
+/// exactly like every other global reference in the language: the table is
+/// built before the module's defs are evaluated (so a top-level constant may
+/// use branded arithmetic), and hot-reload's rebinding then reaches the
+/// operator for free.
+#[derive(Clone)]
+pub(crate) enum OpImpl {
+    /// An external, a constructor, or a lambda — self-contained.
+    Value(Value),
+    /// A top-level `let`, resolved from the globals at dispatch.
+    Global(String),
+}
 
 /// Which slot of a [`BrandOpRow`] an operator owns — `None` for the
 /// comparisons, which are not declarable.
@@ -587,8 +605,12 @@ impl Session {
             host,
         };
         let loaded = interp
-            .eval_defs(module)
-            .and_then(|_| interp.load_brand_ops(module));
+            .load_brand_ops(module, false)
+            .and_then(|ops| {
+                interp.brand_ops = ops;
+                interp.eval_defs(module)
+            })
+            .and_then(|_| interp.load_brand_ops(module, true));
         match loaded {
             Ok(brand_ops) => Ok(Session {
                 globals: interp.globals,
@@ -883,8 +905,9 @@ impl Interp<'_> {
     }
 
     fn run_module(&mut self, module: &Module) -> Result<RunOutcome, RunError> {
+        self.brand_ops = self.load_brand_ops(module, false)?;
         let bindings = self.eval_defs(module)?;
-        self.brand_ops = self.load_brand_ops(module)?;
+        self.brand_ops = self.load_brand_ops(module, true)?;
         match module.defs.iter().find(|def| def.name == "main") {
             Some(main_def) => Ok(RunOutcome::Main(self.call_main(main_def)?)),
             None => Ok(RunOutcome::Bindings(bindings)),
@@ -892,7 +915,7 @@ impl Interp<'_> {
     }
 
     /// Resolve every `unit <suffix> (<op>) = <impl>` declaration into the
-    /// dispatch table, once, after the module's defs exist.
+    /// dispatch table.
     ///
     /// A brand's runtime identity is taken from a value it actually BUILDS:
     /// the suffix's own constructor is applied to `1.0` and the result's tag
@@ -900,7 +923,14 @@ impl Interp<'_> {
     /// shape — a host function (`Angle.degrees`), a variant constructor
     /// (`Px`), or an ordinary Functor Lang function — with no type
     /// information, which the interpreter does not have.
-    fn load_brand_ops(&mut self, module: &Module) -> Result<BrandOps, RunError> {
+    ///
+    /// It runs TWICE: once before the module's defs are evaluated, so a
+    /// top-level constant may itself use branded arithmetic
+    /// (`let turn: Angle.t = 90deg + 45deg`), and once after, to pick up the
+    /// rare unit whose own constructor is a top-level `let` and so could not
+    /// be probed yet. The first pass is best-effort (a suffix it cannot probe
+    /// yet is simply absent); the second reports what is still broken.
+    fn load_brand_ops(&mut self, module: &Module, strict: bool) -> Result<BrandOps, RunError> {
         if module.unit_ops.is_empty() {
             return Ok(BrandOps::default());
         }
@@ -919,35 +949,60 @@ impl Interp<'_> {
                         // suffix, so this is unreachable in a loaded project.
                         continue;
                     };
-                    let ctor = self.eval(&unit.target, &Env::empty())?;
-                    let probe = self.call(
-                        ctor,
-                        vec![Value::Number(1.0)],
-                        unit.suffix.clone(),
-                        unit_op.span,
-                        None,
-                    )?;
-                    let Some(tag) = brand_tag(&probe).map(str::to_string) else {
-                        return Err(RunError {
-                            message: format!(
-                                "`unit {} ({})` needs a unit whose values carry a runtime tag — \
-`{}` builds {}, which nothing can dispatch on (use a constructor, or a host value)",
-                                unit_op.suffix,
-                                unit_op.op.symbol(),
-                                unit_op.suffix,
-                                probe.kind_name()
-                            ),
-                            span: unit_op.span,
-                        });
+                    // A brand whose values carry no tag (a record) cannot be
+                    // dispatched on; the CHECKER refuses that declaration, so
+                    // here it is simply left out of the table rather than
+                    // failing the whole load.
+                    let probed = self
+                        .eval(&unit.target, &Env::empty())
+                        .and_then(|ctor| {
+                            self.call(
+                                ctor,
+                                vec![Value::Number(1.0)],
+                                unit.suffix.clone(),
+                                unit_op.span,
+                                None,
+                            )
+                        })
+                        .map(|probe| brand_tag(&probe).map(str::to_string));
+                    let tag = match probed {
+                        Ok(Some(tag)) => tag,
+                        // Untagged, or (before the defs are evaluated) not yet
+                        // buildable: skip it. The post-def pass retries.
+                        Ok(None) | Err(_) => continue,
                     };
                     tags.insert(unit_op.suffix.as_str(), tag.clone());
                     tag
                 }
             };
-            let implementation = self.eval(&unit_op.target, &Env::empty())?;
-            if let Some(slot) = op_slot(unit_op.op) {
-                ops.entry(tag).or_default()[slot] = Some(implementation);
+            let Some(slot) = op_slot(unit_op.op) else {
+                continue;
+            };
+            // A name stays late-bound (globals resolve at call time, and the
+            // defs may not be evaluated yet); anything else is a value.
+            let implementation = match &unit_op.target.kind {
+                ExprKind::Global(name) => OpImpl::Global(name.clone()),
+                _ => OpImpl::Value(self.eval(&unit_op.target, &Env::empty())?),
+            };
+            let row = ops.entry(tag.clone()).or_default();
+            // The checker rejects a second declaration for one brand and
+            // operator; `run` skips the checker, so refuse it here too rather
+            // than silently picking the last one.
+            if row[slot].is_some() {
+                if !strict {
+                    continue;
+                }
+                return Err(RunError {
+                    message: format!(
+                        "duplicate operator: `{}` is declared more than once for the brand \
+`{tag}` builds — an operator belongs to the brand, so every suffix of it shares one \
+implementation",
+                        unit_op.op.symbol()
+                    ),
+                    span: unit_op.span,
+                });
             }
+            row[slot] = Some(implementation);
         }
         Ok(Rc::new(ops))
     }
@@ -1562,7 +1617,7 @@ evaluation depth."
         // The declared form takes the branded value FIRST. Scaling commutes,
         // so `2.0 * 45deg` is the same call with its arguments swapped —
         // matching what the checker resolves (`/` deliberately does not).
-        let call = match declared(&self.brand_ops, &lhs) {
+        let found = match declared(&self.brand_ops, &lhs) {
             Some(implementation) => Some((implementation, lhs.clone(), rhs.clone())),
             None if matches!(op, BinOp::Mul) && matches!(lhs, Value::Number(_)) => {
                 declared(&self.brand_ops, &rhs)
@@ -1570,6 +1625,28 @@ evaluation depth."
             }
             None => None,
         };
+        let mut call = None;
+        if let Some((implementation, first, second)) = found {
+            match implementation {
+                OpImpl::Value(value) => call = Some((value, first, second)),
+                // A named implementation is late-bound like any global, so it
+                // obeys the same rule: a top-level initializer may only use
+                // globals defined ABOVE it.
+                OpImpl::Global(name) => match self.globals.get(&name) {
+                    Some(value) => call = Some((value.clone(), first, second)),
+                    None => {
+                        return Err(RunError {
+                            message: format!(
+                                "`{}` on this branded value calls `{name}`, which is used before \
+its definition (a top-level initializer may only use globals defined above it)",
+                                op.symbol()
+                            ),
+                            span,
+                        })
+                    }
+                },
+            }
+        }
         match call {
             Some((implementation, first, second)) => self.call(
                 implementation,
@@ -1608,21 +1685,7 @@ evaluation depth."
                     .map(|(slot, _)| slot_op(slot).symbol())
             })
             .collect();
-        if declared.is_empty() {
-            return format!(
-                " — `{tag}` declares no arithmetic; declare it with `unit <suffix> ({}) = …`",
-                op.symbol()
-            );
-        }
-        format!(
-            " — `{tag}` declares {}, but not `{}`",
-            declared
-                .iter()
-                .map(|symbol| format!("`{symbol}`"))
-                .collect::<Vec<_>>()
-                .join(", "),
-            op.symbol()
-        )
+        crate::ast::declared_operators_hint(tag, &declared, op)
     }
 
     fn compare(

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -552,15 +552,23 @@ pub(crate) type BrandOps = Rc<HashMap<String, BrandOpRow>>;
 /// One brand's declared operators, indexed by [`op_slot`].
 pub(crate) type BrandOpRow = [Option<OpImpl>; 4];
 
-/// A declared operator's implementation. A top-level NAME stays late-bound,
-/// exactly like every other global reference in the language: the table is
-/// built before the module's defs are evaluated (so a top-level constant may
-/// use branded arithmetic), and hot-reload's rebinding then reaches the
-/// operator for free.
+/// A declared operator's implementation, kept SYMBOLIC wherever resolving it
+/// could need something this interpreter does not have.
+///
+/// Nothing here is resolved at defs-load time. A top-level NAME is late-bound
+/// exactly like every other global reference; a HOST external is looked up
+/// only when the operator actually dispatches — because the very same defs
+/// (the engine prelude's `.funi` interfaces, `unit deg (+) = Angle.add`
+/// included) are loaded under the PLAIN, hostless interpreter by the editor's
+/// expect gutter, where `Angle.add` has no implementation and must not be an
+/// error until something tries to use it.
 #[derive(Clone)]
 pub(crate) enum OpImpl {
-    /// An external, a constructor, or a lambda — self-contained.
+    /// A constructor or a lambda — self-contained, and building it needs no
+    /// host, so it is resolved once at load.
     Value(Value),
+    /// A host external (`Angle.add`), resolved at dispatch.
+    External(Vec<String>),
     /// A top-level `let`, resolved from the globals at dispatch.
     Global(String),
 }
@@ -859,7 +867,7 @@ impl Interp<'_> {
             // programs (every prelude unit) resolve up front and never enter
             // this branch.
             if !self.brand_ops_complete {
-                let (ops, complete) = self.load_brand_ops(module, false)?;
+                let (ops, complete) = self.load_brand_ops(module)?;
                 self.brand_ops = ops;
                 self.brand_ops_complete = complete;
             }
@@ -921,20 +929,21 @@ impl Interp<'_> {
     /// Build the operator table before the defs run (see
     /// [`Interp::load_brand_ops`]).
     fn load_unit_operators(&mut self, module: &Module) -> Result<(), RunError> {
-        let (ops, complete) = self.load_brand_ops(module, false)?;
+        let (ops, complete) = self.load_brand_ops(module)?;
         self.brand_ops = ops;
         self.brand_ops_complete = complete;
         Ok(())
     }
 
-    /// The final attempt, once every def exists: only needed when something
-    /// could not be resolved earlier, and it reports why instead of leaving
-    /// the operator silently missing.
+    /// The final attempt, once every def exists — needed only when something
+    /// could not be resolved earlier. Like every other pass it cannot fail the
+    /// load: an operator that stays unresolved is absent, and reports itself
+    /// at its use site.
     fn settle_unit_operators(&mut self, module: &Module) -> Result<(), RunError> {
         if self.brand_ops_complete {
             return Ok(());
         }
-        let (ops, complete) = self.load_brand_ops(module, true)?;
+        let (ops, complete) = self.load_brand_ops(module)?;
         self.brand_ops = ops;
         self.brand_ops_complete = complete;
         Ok(())
@@ -966,15 +975,19 @@ impl Interp<'_> {
     /// a top-level `let` cannot be probed that early; the build reports
     /// itself INCOMPLETE and [`Interp::eval_defs`] retries as the defs land,
     /// so such a unit works from the first initializer that could use it.
-    /// `strict` (the final attempt) reports what is still unresolvable
-    /// instead of leaving it silently absent.
+    ///
+    /// **An operator that cannot be RESOLVED here never fails the load.** A
+    /// brand whose constructor this interpreter cannot run — the engine
+    /// prelude's units under a HOSTLESS interpreter, which is exactly what the
+    /// editor's expect gutter loads through `functor-lang-wasm` — simply gets
+    /// no entry: with no host there is no way to build one of its values
+    /// either, so nothing can dispatch on it. What is genuinely wrong surfaces
+    /// at the operator's use site, where the teaching errors live. (A
+    /// DUPLICATE declaration is different: it is a program error that needs no
+    /// host to detect, and it still refuses the load.)
     ///
     /// Returns the table and whether every declared operator found its brand.
-    fn load_brand_ops(
-        &mut self,
-        module: &Module,
-        strict: bool,
-    ) -> Result<(BrandOps, bool), RunError> {
+    fn load_brand_ops(&mut self, module: &Module) -> Result<(BrandOps, bool), RunError> {
         if module.unit_ops.is_empty() {
             return Ok((BrandOps::default(), true));
         }
@@ -1008,26 +1021,12 @@ impl Interp<'_> {
                         .map(|probe| brand_tag(&probe).map(str::to_string));
                     let tag = match probed {
                         Ok(Some(tag)) => tag,
-                        // A brand whose values carry no runtime tag (a record)
-                        // cannot be dispatched on — the CHECKER refuses that
-                        // declaration, and the final attempt says so too.
-                        Ok(None) if strict => {
-                            return Err(RunError {
-                                message: format!(
-                                    "`unit {} ({})` needs a brand whose values carry a runtime \
-tag — `{}` builds a value nothing can dispatch on; use a single-constructor variant, or a host \
-type",
-                                    unit_op.suffix,
-                                    unit_op.op.symbol(),
-                                    unit_op.suffix
-                                ),
-                                span: unit_op.span,
-                            })
-                        }
-                        // Not buildable YET (its constructor is a def that has
-                        // not been evaluated): leave it out and report the
-                        // build incomplete, so `eval_defs` retries.
-                        Err(error) if strict => return Err(error),
+                        // Untagged (a record brand — the CHECKER refuses that
+                        // declaration), not buildable YET (its constructor is
+                        // a def that has not been evaluated), or not buildable
+                        // AT ALL in this interpreter (a host constructor with
+                        // no host). Leave it out and mark the build
+                        // incomplete, so `eval_defs` retries as globals land.
                         Ok(None) | Err(_) => {
                             complete = false;
                             continue;
@@ -1040,11 +1039,22 @@ type",
             let Some(slot) = op_slot(unit_op.op) else {
                 continue;
             };
-            // A name stays late-bound (globals resolve at call time, and the
-            // defs may not be evaluated yet); anything else is a value.
+            // Names stay symbolic: a global resolves at call time (the defs
+            // may not have run), and a HOST external must not be looked up
+            // here at all — these same declarations load under a hostless
+            // interpreter. A lambda or constructor needs neither, so it is
+            // built once; if even that fails, the entry is skipped rather than
+            // failing the load.
             let implementation = match &unit_op.target.kind {
                 ExprKind::Global(name) => OpImpl::Global(name.clone()),
-                _ => OpImpl::Value(self.eval(&unit_op.target, &Env::empty())?),
+                ExprKind::External(path) => OpImpl::External(path.clone()),
+                _ => match self.eval(&unit_op.target, &Env::empty()) {
+                    Ok(value) => OpImpl::Value(value),
+                    Err(_) => {
+                        complete = false;
+                        continue;
+                    }
+                },
             };
             let row = ops.entry(tag.clone()).or_default();
             // The checker rejects a second declaration for one brand and
@@ -1064,6 +1074,27 @@ implementation",
             row[slot] = Some(implementation);
         }
         Ok((Rc::new(ops), complete))
+    }
+
+    /// Resolve an [`ExprKind::External`] path to its value: a builtin, or the
+    /// host's function. Shared with unit-operator dispatch, which resolves its
+    /// implementation the same way — and, crucially, only when it dispatches
+    /// (see [`OpImpl`]).
+    fn external_value(&mut self, path: &[String], span: Span) -> Result<Value, RunError> {
+        let joined = path.join(".");
+        match builtin(path) {
+            // `Math.pi` is a constant, not a callable — resolve it straight to
+            // its value (every other builtin is a function).
+            Some(Builtin::MathPi) => Ok(Value::Number(std::f64::consts::PI)),
+            Some(b) => Ok(Value::Builtin(b)),
+            None if self.host.provides(&joined) => Ok(Value::HostFn(Rc::from(joined.as_str()))),
+            // `#[cold]` helper: the message formatting must not enlarge this
+            // hot frame (eval recursion sits near the stack budget at the
+            // 128-depth cap — the call_curried rule; adding the formatting
+            // inline here overflowed the deep-recursion test's 2MB stack in
+            // debug).
+            None => Err(unknown_external_error(path, joined, span)),
+        }
     }
 
     fn call_main(&mut self, def: &Def) -> Result<Value, RunError> {
@@ -1266,24 +1297,7 @@ evaluation depth."
                 self.record_ref(name, expr.span, &value);
                 Ok(value)
             }
-            ExprKind::External(path) => {
-                let joined = path.join(".");
-                match builtin(path) {
-                    // `Math.pi` is a constant, not a callable — resolve it
-                    // straight to its value (every other builtin is a function).
-                    Some(Builtin::MathPi) => Ok(Value::Number(std::f64::consts::PI)),
-                    Some(b) => Ok(Value::Builtin(b)),
-                    None if self.host.provides(&joined) => {
-                        Ok(Value::HostFn(Rc::from(joined.as_str())))
-                    }
-                    // `#[cold]` helper: the message formatting must not
-                    // enlarge this hot frame (eval recursion sits near the
-                    // stack budget at the 128-depth cap — the call_curried
-                    // rule; adding the formatting inline here overflowed the
-                    // deep-recursion test's 2MB stack in debug).
-                    None => Err(unknown_external_error(path, joined, expr.span)),
-                }
-            }
+            ExprKind::External(path) => self.external_value(path, expr.span),
             // Container CONSTRUCTION charges one step (the depth invariant
             // behind run_expects_budgeted's stack contract: every level of a
             // value's nesting was constructed once, so value depth ≤ budget.
@@ -1688,6 +1702,12 @@ evaluation depth."
         if let Some((implementation, first, second)) = found {
             match implementation {
                 OpImpl::Value(value) => call = Some((value, first, second)),
+                // A host external is looked up HERE, so a missing host is the
+                // ordinary unknown-external error at the use site rather than
+                // a load failure.
+                OpImpl::External(path) => {
+                    call = Some((self.external_value(&path, span)?, first, second))
+                }
                 // A named implementation is late-bound like any global, so it
                 // obeys the same rule: a top-level initializer may only use
                 // globals defined ABOVE it.

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -113,6 +113,10 @@ pub struct UnitDef {
 pub struct UnitOpDef {
     pub suffix: String,
     pub op: crate::ast::BinOp,
+    /// The declaring module's canonical prefix (`"Utils"`; empty for the
+    /// entry) — the checker scopes the implementation's bare record literals
+    /// by it, exactly as it does a def's or an expect's.
+    pub module: String,
     pub target: Expr,
     /// The `(<op>)` span — what an operator diagnostic points at.
     pub op_span: Span,

--- a/functor-lang/src/ir.rs
+++ b/functor-lang/src/ir.rs
@@ -85,6 +85,11 @@ pub struct Module {
     /// `(float) => 't` function and can teach the suffix form in
     /// branded-value errors. Evaluation ignores them.
     pub units: Vec<UnitDef>,
+    /// `unit deg (+) = Angle.add` declarations, in file order — the arithmetic
+    /// operators declared on unit BRANDS. Read by the checker (which resolves
+    /// a branded `+` to the implementation here) and by the interpreter (which
+    /// dispatches on a branded operand value).
+    pub unit_ops: Vec<UnitOpDef>,
 }
 
 /// One lowered `unit <suffix> = <name>` declaration: the suffix, and the
@@ -94,6 +99,23 @@ pub struct Module {
 pub struct UnitDef {
     pub suffix: String,
     pub target: Expr,
+    pub span: Span,
+}
+
+/// One lowered `unit <suffix> (<op>) = <target>` declaration: which suffix's
+/// BRAND gains the operator, and the implementation as an ordinary expression
+/// (a resolved name, or a lambda). Unlike a suffixed literal, an operator use
+/// is NOT desugared at lowering — the operand types are not known there — so
+/// both the checker (which resolves `90deg + 45deg` to this implementation)
+/// and the interpreter (which dispatches on a branded operand value) read
+/// these.
+#[derive(Debug)]
+pub struct UnitOpDef {
+    pub suffix: String,
+    pub op: crate::ast::BinOp,
+    pub target: Expr,
+    /// The `(<op>)` span — what an operator diagnostic points at.
+    pub op_span: Span,
     pub span: Span,
 }
 

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -149,8 +149,9 @@ pub(crate) fn exports_of(items: &[ast::Item]) -> Exports {
             // An expect binds nothing.
             ast::Item::Expect(_) => {}
             // A unit declares a literal SUFFIX, not a name — units are
-            // project-wide and collected separately (see `unit_decls`).
-            ast::Item::Unit(_) => {}
+            // project-wide and collected separately (see `unit_decls`). An
+            // operator declaration binds nothing at all.
+            ast::Item::Unit(_) | ast::Item::UnitOp(_) => {}
             // An inline module's members belong to ITS namespace, not the
             // file's: the caller calls `exports_of` again on its own items.
             ast::Item::Module(_) => {}
@@ -310,8 +311,9 @@ fn collect_names(items: &[ast::Item]) -> Result<Names, LowerError> {
             ast::Item::Open(_) => {}
             // An expect declares no names.
             ast::Item::Expect(_) => {}
-            // A unit declares a suffix, not a name (no namespace collision).
-            ast::Item::Unit(_) => {}
+            // A unit declares a suffix, not a name (no namespace collision);
+            // an operator declaration declares no name either.
+            ast::Item::Unit(_) | ast::Item::UnitOp(_) => {}
             // Inline modules are their own namespaces, collected separately
             // (and checked against these names by the caller).
             ast::Item::Module(_) => {}
@@ -421,6 +423,7 @@ are project-wide, like constructors)"
         signatures: Vec::new(),
         expects: Vec::new(),
         units: Vec::new(),
+        unit_ops: Vec::new(),
     };
     for item in program.items {
         match item {
@@ -444,6 +447,7 @@ are project-wide, like constructors)"
         signatures,
         expects,
         units,
+        unit_ops,
     } = out;
     let bases = IdBases {
         def: next_def,
@@ -457,6 +461,7 @@ are project-wide, like constructors)"
             signatures,
             expects,
             units,
+            unit_ops,
         },
         bases,
         lowerer.deps,
@@ -670,6 +675,7 @@ struct Lowered {
     signatures: Vec<Signature>,
     expects: Vec<ExpectDef>,
     units: Vec<UnitDef>,
+    unit_ops: Vec<UnitOpDef>,
 }
 
 /// Which module a dotted reference's leading segments named.
@@ -1019,6 +1025,27 @@ with `unit {suffix} = SomeFn` (a `(float) => 't` function), or write the call it
                 out.units.push(UnitDef {
                     suffix: decl.suffix,
                     target,
+                    span: decl.span,
+                });
+            }
+            // An operator on a unit's brand: the suffix must be declared
+            // (project-wide, like any unit use), and the implementation
+            // lowers as an ordinary expression — a name, or a lambda. Which
+            // BRAND it lands on, and whether the implementation has the right
+            // shape, are the checker's job (both need types).
+            ast::Item::UnitOp(decl) => {
+                if !self.units.contains_key(&decl.suffix) {
+                    return Err(LowerError {
+                        message: self.unknown_unit(&decl.suffix),
+                        span: decl.suffix_span,
+                    });
+                }
+                let target = self.expr(decl.target)?;
+                out.unit_ops.push(UnitOpDef {
+                    suffix: decl.suffix,
+                    op: decl.op,
+                    target,
+                    op_span: decl.op_span,
                     span: decl.span,
                 });
             }

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -1040,10 +1040,15 @@ with `unit {suffix} = SomeFn` (a `(float) => 't` function), or write the call it
                         span: decl.suffix_span,
                     });
                 }
+                let module = self
+                    .current_path()
+                    .map(|path| self.canonical_prefix(&path))
+                    .unwrap_or_default();
                 let target = self.expr(decl.target)?;
                 out.unit_ops.push(UnitOpDef {
                     suffix: decl.suffix,
                     op: decl.op,
+                    module,
                     target,
                     op_span: decl.op_span,
                     span: decl.span,

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -234,7 +234,7 @@ impl Parser {
                 // …and `unit` (a literal-suffix declaration). Contextual too:
                 // `unit` stays usable as an ordinary name.
                 TokenKind::Ident(name) if name == "unit" => {
-                    items.push(Item::Unit(self.unit_decl()?))
+                    items.push(self.unit_item()?)
                 }
                 _ => {
                     return self
@@ -316,10 +316,12 @@ project-wide, so declare them at the top level of the file"
         })
     }
 
-    /// `unit deg = Angle.degrees` — a literal-suffix declaration. The target
-    /// is a possibly module-qualified NAME (never an arbitrary expression):
-    /// the function or constructor a suffixed literal calls.
-    fn unit_decl(&mut self) -> Result<UnitDecl, ParseError> {
+    /// `unit deg = Angle.degrees` — a literal-suffix declaration — or
+    /// `unit deg (+) = Angle.add`, an operator on the brand that suffix
+    /// builds. A literal's target is a possibly module-qualified NAME (never
+    /// an arbitrary expression); an operator's is an ordinary expression (a
+    /// name, or a lambda in a `.fun`).
+    fn unit_item(&mut self) -> Result<Item, ParseError> {
         let kw = self.bump();
         let (suffix, suffix_span) = match self.peek_kind() {
             TokenKind::Ident(name) => {
@@ -342,6 +344,11 @@ project-wide, so declare them at the top level of the file"
                 span: suffix_span,
             });
         }
+        // `unit deg (…)` — an operator declaration rather than the suffix's
+        // own target.
+        if self.peek_kind() == &TokenKind::LParen {
+            return Ok(Item::UnitOp(self.unit_op_decl(kw.span, suffix, suffix_span)?));
+        }
         self.expect(TokenKind::Eq, "`=` after the unit suffix")?;
         let (mut segment, mut span) =
             self.expect_ident("the name a unit literal calls (e.g. `Angle.degrees`)")?;
@@ -353,11 +360,48 @@ project-wide, so declare them at the top level of the file"
             span = span.to(next_span);
             target.push(segment);
         }
-        Ok(UnitDecl {
+        Ok(Item::Unit(UnitDecl {
             suffix,
             target,
             target_span: span,
             span: kw.span.to(span),
+        }))
+    }
+
+    /// The tail of `unit <suffix> (<op>) = <target>`, from the `(`. Only the
+    /// four arithmetic operators are declarable — comparisons are deliberately
+    /// not (see `docs/functor-lang-units.md`).
+    fn unit_op_decl(
+        &mut self,
+        kw: Span,
+        suffix: String,
+        suffix_span: Span,
+    ) -> Result<UnitOpDecl, ParseError> {
+        self.bump();
+        let op_token = self.peek();
+        let op_span = op_token.span;
+        let op = match op_token.kind {
+            TokenKind::Plus => BinOp::Add,
+            TokenKind::Minus => BinOp::Sub,
+            TokenKind::Star => BinOp::Mul,
+            TokenKind::Slash => BinOp::Div,
+            _ => {
+                return self
+                    .error("an operator to declare: `+`, `-`, `*`, or `/` (e.g. `unit deg (+) = Angle.add`)")
+            }
+        };
+        self.bump();
+        self.expect(TokenKind::RParen, "`)` after the operator")?;
+        self.expect(TokenKind::Eq, "`=` after the declared operator")?;
+        let target = self.expr()?;
+        let span = kw.to(target.span);
+        Ok(UnitOpDecl {
+            suffix,
+            suffix_span,
+            op,
+            op_span,
+            target,
+            span,
         })
     }
 

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -1028,6 +1028,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         signatures: Vec::new(),
         expects: Vec::new(),
         units: Vec::new(),
+        unit_ops: Vec::new(),
     };
     let mut by_module: HashMap<String, Module> = files
         .iter()
@@ -1041,6 +1042,7 @@ allowed (within one file, definitions may still be mutually recursive)",
         merged.signatures.extend(module.signatures);
         merged.expects.extend(module.expects);
         merged.units.extend(module.units);
+        merged.unit_ops.extend(module.unit_ops);
     }
 
     Ok(Project {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -3353,9 +3353,17 @@ is {other}"
                 );
                 continue;
             }
+            // `v * v` (the SAME unsolved operand twice) can only be float:
+            // the scalar form's operands have different types, so no brand
+            // reading exists to be ambiguous with. `v + v` has one, and stays
+            // ambiguous.
+            let one_operand_twice = matches!((&lhs, &rhs), (Type::Var(a), Type::Var(b)) if a == b);
+            let branded_reading_exists =
+                !(one_operand_twice && matches!(node.op, BinOp::Mul | BinOp::Div));
             // Nothing about the node — neither operand, nor the type its
             // result flows into — says which arithmetic this is.
-            if matches!(lhs, Type::Var(_))
+            if branded_reading_exists
+                && matches!(lhs, Type::Var(_))
                 && matches!(rhs, Type::Var(_))
                 && matches!(self.zonk(&node.result), Type::Var(_))
             {

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -946,8 +946,8 @@ fn check_impl(
         // type is nominal, so a `.funi` signature's return type or a
         // constructor's owning type already says which brand it is.
         let branded = |ty: &Type| match ty {
-            Type::Variant(name, args) | Type::Record(name, args) if args.is_empty() => {
-                Some((name.clone(), ty.clone()))
+            Type::Variant(_, args) | Type::Record(_, args) if args.is_empty() => {
+                brand_name(ty).map(|name| (name, ty.clone()))
             }
             _ => None,
         };
@@ -1015,10 +1015,36 @@ to a branded type, so the unit's target must be a constructor or a function with
             );
             continue;
         };
-        let name = match &brand {
-            Type::Variant(name, _) | Type::Record(name, _) => name.clone(),
-            _ => continue,
+        let Some(name) = brand_name(&brand) else {
+            continue;
         };
+        // The interpreter dispatches on a VALUE's runtime tag — a variant's
+        // constructor, or an opaque host value's type name. A record carries
+        // no tag, and a multi-constructor type carries a different one per
+        // constructor while the brand (and so the operator) is one. Both are
+        // refused here rather than checking clean and failing at run time.
+        let dispatchable = match &brand {
+            Type::Variant(_, _) => match checker.variants.get(&name) {
+                Some((_, ctors)) => ctors.len() <= 1,
+                // Not a variant declared in this project — an opaque `.funi`
+                // type like `Angle.t`, whose values the host tags itself.
+                None => true,
+            },
+            _ => false,
+        };
+        if !dispatchable {
+            checker.diag(
+                unit_op.span,
+                format!(
+                    "`unit {} ({})` needs a brand whose values are distinguishable at run time — \
+`{name}` is a record, or has several constructors, so an operator on it could not be dispatched; \
+use a single-constructor variant (`type Px = | Px(value: float)`)",
+                    unit_op.suffix,
+                    unit_op.op.symbol()
+                ),
+            );
+            continue;
+        }
         if let Some(previous) = checker.brand_ops.get(&(name.clone(), unit_op.op)) {
             let previous = format!(
                 "`{}` already declares `{}` (through `unit {}`)",
@@ -1119,7 +1145,7 @@ suffix of `{name}` shares one implementation"
     // an operator resolves to never depends on inference order.
     for (unit_op, brand) in module.unit_ops.iter().zip(&op_brands) {
         checker.annot_vars.clear();
-        checker.current_module = String::new();
+        checker.current_module = unit_op.module.clone();
         let Some(brand) = brand.clone() else { continue };
         let want = Type::Fn(
             vec![brand.clone(), operand_type(unit_op.op, &brand)],
@@ -3411,30 +3437,17 @@ is {other}"
         };
         // Operator order, not alphabetical — and the same order the
         // interpreter's twin message uses.
-        let declared: Vec<&str> = [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div]
+        let declared: Vec<&str> = BinOp::ARITHMETIC
             .into_iter()
             .filter(|declared| self.brand_ops.contains_key(&(name.clone(), *declared)))
             .map(|declared| declared.symbol())
             .collect();
-        if !declared.is_empty() {
-            return format!(
-                " — `{name}` declares {}, but not `{}`",
-                declared
-                    .iter()
-                    .map(|symbol| format!("`{symbol}`"))
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                op.symbol()
-            );
+        // A type nothing knows as a brand gets no unit advice at all — only
+        // declared units (which the hint table indexes) can carry operators.
+        if declared.is_empty() && !self.unit_hints.contains_key(&name) {
+            return String::new();
         }
-        match self.unit_hints.get(&name).and_then(|units| units.first()) {
-            Some((suffix, _)) => format!(
-                " — `{name}` is a branded value with no arithmetic; declare it with \
-`unit {suffix} ({}) = …`",
-                op.symbol()
-            ),
-            None => String::new(),
-        }
+        crate::ast::declared_operators_hint(&name, &declared, op)
     }
 
     /// Constrain an operand of a boolean operator (`&&`, `||`, `not`) to

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -1052,8 +1052,9 @@ use a single-constructor variant (`type Px = | Px(value: float)`)",
                 unit_op.op.symbol(),
                 previous
             );
+            // Point at the `(<op>)` itself — the part that is the duplicate.
             checker.diag(
-                unit_op.span,
+                unit_op.op_span,
                 format!(
                     "duplicate operator: {previous} — an operator belongs to the BRAND, so every \
 suffix of `{name}` shares one implementation"
@@ -3361,8 +3362,24 @@ is {other}"
     /// float (the rule that makes `unit` operators safe to add).
     fn flush_pending_ops(&mut self) {
         for node in std::mem::take(&mut self.pending_ops) {
-            let lhs = self.zonk(&node.lhs);
-            let rhs = self.zonk(&node.rhs);
+            let mut lhs = self.zonk(&node.lhs);
+            let mut rhs = self.zonk(&node.rhs);
+            // The RESULT can decide the node on its own: an annotated
+            // `(a, b): Px => a + b` says the operands are `Px`, because `+`
+            // stays inside its brand. (`*`//` cannot be decided this way —
+            // which SIDE is the brand would still be unknown.)
+            let result = self.zonk(&node.result);
+            if matches!(node.op, BinOp::Add | BinOp::Sub) {
+                if let Some(name) = brand_name(&result) {
+                    if self.brand_ops.contains_key(&(name.clone(), node.op)) {
+                        let what = format!("an operand of `{}` on `{name}`", node.op.symbol());
+                        self.unify(&lhs, &result, node.lhs_span, &what);
+                        self.unify(&rhs, &result, node.rhs_span, &what);
+                        lhs = self.zonk(&node.lhs);
+                        rhs = self.zonk(&node.rhs);
+                    }
+                }
+            }
             if let Some(ty) = self.brand_binary(
                 node.op,
                 &lhs,

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -221,6 +221,25 @@ pub fn compatible(a: &Type, b: &Type) -> bool {
     }
 }
 
+/// The nominal name a BRAND could be declared on — a declared record or
+/// variant type (an opaque `type t` is a variant with no constructors, which
+/// is exactly what `Angle.t` is). Everything else can carry no unit operator.
+fn brand_name(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Record(name, _) | Type::Variant(name, _) => Some(name.clone()),
+        _ => None,
+    }
+}
+
+/// The type an operator's SECOND operand takes on a given brand: the brand
+/// itself for `+` and `-`, a plain float for the scalar `*` and `/`.
+fn operand_type(op: BinOp, brand: &Type) -> Type {
+    match op {
+        BinOp::Add | BinOp::Sub => brand.clone(),
+        _ => Type::Float,
+    }
+}
+
 /// Does this type (or, for products, any element) denote a function?
 /// Runtime `==` errors on functions at any depth it actually compares, so a
 /// known function anywhere in a compared tuple is a certain runtime error.
@@ -784,6 +803,8 @@ fn check_impl(
         def_param_names: HashMap::new(),
         match_scrutinees: Vec::new(),
         unit_hints: HashMap::new(),
+        brand_ops: HashMap::new(),
+        pending_ops: Vec::new(),
     };
 
     // Record type names first (nominal references may be forward), then
@@ -915,42 +936,109 @@ fn check_impl(
     // signature's return type, or a constructor's owning type); the units
     // themselves are TYPE-CHECKED after inference, once their targets have
     // real types.
+    //
+    // The brand TYPE (not just its name) is kept per suffix, because operator
+    // declarations resolve through it: `unit deg (+)` acts on whatever
+    // `Angle.degrees` returns.
+    let mut unit_brands: HashMap<String, Type> = HashMap::new();
     for unit in &module.units {
-        // Only the branded type's NAME is needed (the hint keys on it), so
-        // this reads the declared shape rather than inferring anything.
-        let named = |ty: &Type| match ty {
-            Type::Variant(name, _) | Type::Record(name, _) => Some(name.clone()),
+        // The declared shape is read here rather than inferred: a branded
+        // type is nominal, so a `.funi` signature's return type or a
+        // constructor's owning type already says which brand it is.
+        let branded = |ty: &Type| match ty {
+            Type::Variant(name, args) | Type::Record(name, args) if args.is_empty() => {
+                Some((name.clone(), ty.clone()))
+            }
             _ => None,
         };
         let (result, call) = match &unit.target.kind {
             ExprKind::External(path) => {
                 let call = path.join(".");
                 let result = match checker.signatures.get(&call).map(|s| &s.ty) {
-                    Some(Type::Fn(_, ret)) => named(ret),
+                    Some(Type::Fn(_, ret)) => branded(ret),
                     _ => None,
                 };
                 (result, call)
             }
-            ExprKind::Ctor { name, .. } => (
-                checker.ctors.get(name).map(|(owner, _, _)| owner.clone()),
-                name.clone(),
-            ),
+            // A constructor's brand is its own (non-generic) variant type.
+            ExprKind::Ctor { name, .. } => {
+                let result = checker.ctors.get(name).and_then(|(owner, params, _)| {
+                    (*params == 0).then(|| (owner.clone(), Type::Variant(owner.clone(), Vec::new())))
+                });
+                (result, name.clone())
+            }
             ExprKind::Global(name) => {
                 let result = match checker.globals.get(name) {
-                    Some(Type::Fn(_, ret)) => named(ret),
+                    Some(Type::Fn(_, ret)) => branded(ret),
                     _ => None,
                 };
                 (result, name.clone())
             }
             _ => (None, String::new()),
         };
-        if let Some(name) = result {
+        if let Some((name, brand)) = result {
+            unit_brands.insert(unit.suffix.clone(), brand);
             checker
                 .unit_hints
                 .entry(name)
                 .or_default()
                 .push((unit.suffix.clone(), call));
         }
+    }
+
+    // Declared unit OPERATORS, indexed by (brand, operator) — also before any
+    // def is inferred, so `90deg + 45deg` resolves while the body containing
+    // it is being checked. An operator attaches to the BRAND, so every suffix
+    // of one brand shares it, and a second declaration of the same brand +
+    // operator (through any suffix) is a duplicate.
+    //
+    // `op_brands` runs alongside `module.unit_ops` (None where a declaration
+    // was rejected here), so the implementation check further down uses
+    // exactly the brand resolution recorded now.
+    let mut op_brands: Vec<Option<Type>> = Vec::with_capacity(module.unit_ops.len());
+    for unit_op in &module.unit_ops {
+        op_brands.push(None);
+        let Some(brand) = unit_brands.get(&unit_op.suffix).cloned() else {
+            // The suffix exists (lowering checked that) but its target's
+            // brand is not knowable from a declaration — an unannotated
+            // function target, or a generic type.
+            checker.diag(
+                unit_op.span,
+                format!(
+                    "`unit {} ({})` cannot tell which type `{}` builds — an operator attaches \
+to a branded type, so the unit's target must be a constructor or a function with a declared \
+(non-generic) return type",
+                    unit_op.suffix,
+                    unit_op.op.symbol(),
+                    unit_op.suffix
+                ),
+            );
+            continue;
+        };
+        let name = match &brand {
+            Type::Variant(name, _) | Type::Record(name, _) => name.clone(),
+            _ => continue,
+        };
+        if let Some(previous) = checker.brand_ops.get(&(name.clone(), unit_op.op)) {
+            let previous = format!(
+                "`{}` already declares `{}` (through `unit {}`)",
+                name,
+                unit_op.op.symbol(),
+                previous
+            );
+            checker.diag(
+                unit_op.span,
+                format!(
+                    "duplicate operator: {previous} — an operator belongs to the BRAND, so every \
+suffix of `{name}` shares one implementation"
+                ),
+            );
+            continue;
+        }
+        *op_brands.last_mut().expect("pushed above") = Some(brand.clone());
+        checker
+            .brand_ops
+            .insert((name, unit_op.op), unit_op.suffix.clone());
     }
 
     // Infer in dependency order, one strongly-connected component at a
@@ -990,6 +1078,10 @@ fn check_impl(
                 );
             }
         }
+        // Inference for this group has settled — resolve its deferred
+        // operators BEFORE generalization, so a brand that only became known
+        // through a sibling def still reaches the node that needs it.
+        checker.flush_pending_ops();
         for &i in &group {
             let def = &module.defs[i];
             let ty = checker
@@ -1020,6 +1112,27 @@ fn check_impl(
         );
     }
 
+    // `unit … (<op>)` declarations: the implementation must have exactly the
+    // operator's shape for that brand — `('t, 't) => 't` for `+` and `-`, the
+    // scalar `('t, float) => 't` for `*` and `/`. Checked against the DECLARED
+    // shape (not the implementation's inferred type), so which implementation
+    // an operator resolves to never depends on inference order.
+    for (unit_op, brand) in module.unit_ops.iter().zip(&op_brands) {
+        checker.annot_vars.clear();
+        checker.current_module = String::new();
+        let Some(brand) = brand.clone() else { continue };
+        let want = Type::Fn(
+            vec![brand.clone(), operand_type(unit_op.op, &brand)],
+            Box::new(brand),
+        );
+        checker.expect(
+            &unit_op.target,
+            &want,
+            &format!("`unit {} ({})`", unit_op.suffix, unit_op.op.symbol()),
+        );
+    }
+    checker.flush_pending_ops();
+
     // `expect` tests: each must be a bool. Checked after every def has
     // generalized, so an expect instantiates the same schemes a later def
     // would (`expect id(1.0) == 1.0` beside `id` used at string elsewhere).
@@ -1027,6 +1140,7 @@ fn check_impl(
         checker.annot_vars.clear();
         checker.current_module = exp.module.clone();
         checker.expect(&exp.expr, &Type::Bool, "an `expect` test");
+        checker.flush_pending_ops();
     }
 
     checker.diags.sort_by_key(|d| d.span.start);
@@ -1211,6 +1325,31 @@ struct Checker<'s> {
     /// diagnostic side channel — it turns "expected Angle.t, got float" into
     /// a message that teaches both spellings.
     unit_hints: HashMap<String, Vec<(String, String)>>,
+    /// Declared unit OPERATORS, indexed by the branded type they act on and
+    /// the operator: `("Angle.t", BinOp::Add)` → the `unit deg (+)`
+    /// declaration. Unlike [`Self::unit_hints`] this is not a side channel —
+    /// it is what resolves `90deg + 45deg` (see [`Checker::brand_binary`]).
+    /// The value is the SUFFIX the operator was declared through (`deg`),
+    /// which only diagnostics need — brands are shared across suffixes.
+    brand_ops: HashMap<(String, BinOp), String>,
+    /// Arithmetic nodes whose operands were still unsolved when they were
+    /// first seen, deferred to [`Checker::flush_pending_ops`] (which runs at
+    /// every point where inference has settled: the end of each SCC group,
+    /// and after each expect/unit target). Ad-hoc overloading is resolved
+    /// AFTER inference, never during unification.
+    pending_ops: Vec<PendingOp>,
+}
+
+/// A deferred arithmetic node: its operands, the fresh variable standing for
+/// its result, and the spans its diagnostics need.
+struct PendingOp {
+    op: BinOp,
+    lhs: Type,
+    lhs_span: Span,
+    rhs: Type,
+    rhs_span: Span,
+    result: Type,
+    node_span: Span,
 }
 
 /// An under-applied call's provenance: enough to say `` `shift` is applied to
@@ -2943,9 +3082,7 @@ is {other}"
     ) -> Type {
         match op {
             BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => {
-                self.require_float(op, lhs, lhs_span);
-                self.require_float(op, rhs, rhs_span);
-                Type::Float
+                self.arithmetic(op, lhs, lhs_span, rhs, rhs_span, node_span)
             }
             BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge => {
                 self.require_float(op, lhs, lhs_span);
@@ -3072,10 +3209,223 @@ is {other}"
             return;
         }
         if !compatible(&ty, &Type::Float) {
+            let teaching = self.brand_operator_hint(op, &ty);
             self.diag(
                 span,
-                format!("`{}` needs float operands, got {ty}", op.symbol()),
+                format!("`{}` needs float operands, got {ty}{teaching}", op.symbol()),
             );
+        }
+    }
+
+    /// An arithmetic node (`+`, `-`, `*`, `/`) — the ad-hoc overloading seam.
+    ///
+    /// A brand with a declared implementation for this operator wins; a node
+    /// with no brand in sight is plain float arithmetic, exactly as before.
+    /// The in-between case — an operand still unsolved while SOME brand
+    /// declares the operator — cannot be decided yet, so it is DEFERRED to
+    /// [`Self::flush_pending_ops`] (resolution runs after inference, never
+    /// during unification, so it can't make inference order-dependent).
+    fn arithmetic(
+        &mut self,
+        op: BinOp,
+        lhs: &Type,
+        lhs_span: Span,
+        rhs: &Type,
+        rhs_span: Span,
+        node_span: Span,
+    ) -> Type {
+        let lhs = self.zonk(lhs);
+        let rhs = self.zonk(rhs);
+        if let Some(ty) = self.brand_binary(op, &lhs, lhs_span, &rhs, rhs_span, node_span) {
+            return ty;
+        }
+        if (matches!(lhs, Type::Var(_)) || matches!(rhs, Type::Var(_)))
+            && self.brand_ops.keys().any(|(_, declared)| *declared == op)
+        {
+            let result = self.fresh();
+            self.pending_ops.push(PendingOp {
+                op,
+                lhs,
+                lhs_span,
+                rhs,
+                rhs_span,
+                result: result.clone(),
+                node_span,
+            });
+            return result;
+        }
+        self.require_float(op, &lhs, lhs_span);
+        self.require_float(op, &rhs, rhs_span);
+        Type::Float
+    }
+
+    /// Resolve an arithmetic node against the declared unit operators.
+    /// `Some` means a brand claimed it (and the other operand has been
+    /// constrained to the implementation's signature); `None` means no brand
+    /// declares this operator for either operand's type.
+    fn brand_binary(
+        &mut self,
+        op: BinOp,
+        lhs: &Type,
+        lhs_span: Span,
+        rhs: &Type,
+        rhs_span: Span,
+        node_span: Span,
+    ) -> Option<Type> {
+        // The brand on the LEFT is the declared form: `45deg + 45deg`,
+        // `45deg * 2.0`.
+        if let Some(name) = brand_name(lhs) {
+            if self.brand_ops.contains_key(&(name.clone(), op)) {
+                let want = operand_type(op, lhs);
+                self.unify(
+                    rhs,
+                    &want,
+                    rhs_span,
+                    &format!("the right operand of `{}` on `{name}`", op.symbol()),
+                );
+                return Some(lhs.clone());
+            }
+        }
+        let name = brand_name(rhs)?;
+        if !self.brand_ops.contains_key(&(name.clone(), op)) {
+            return None;
+        }
+        match op {
+            // `+`/`-` stay inside the brand, so the left operand is one too.
+            BinOp::Add | BinOp::Sub => {
+                self.unify(
+                    lhs,
+                    rhs,
+                    lhs_span,
+                    &format!("the left operand of `{}` on `{name}`", op.symbol()),
+                );
+                Some(rhs.clone())
+            }
+            // Scaling commutes, so `2.0 * 45deg` is the declared call with
+            // its arguments swapped…
+            BinOp::Mul => {
+                self.unify(
+                    lhs,
+                    &Type::Float,
+                    lhs_span,
+                    &format!("the scalar operand of `*` on `{name}`"),
+                );
+                Some(rhs.clone())
+            }
+            // …but division does not: the scalar form divides a branded value
+            // BY a number, and `2.0 / 45deg` is a different (dimensional)
+            // thing Functor Lang deliberately does not model.
+            BinOp::Div => {
+                self.diag(
+                    node_span,
+                    format!(
+                        "`/` on `{name}` divides a branded value by a float — write \
+`x / 2.0`, not `2.0 / x`"
+                    ),
+                );
+                Some(Type::Unknown)
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolve every deferred arithmetic node, now that inference has
+    /// settled. A node whose operands are ALL still unsolved is genuinely
+    /// ambiguous — it asks for an annotation rather than silently guessing
+    /// float (the rule that makes `unit` operators safe to add).
+    fn flush_pending_ops(&mut self) {
+        for node in std::mem::take(&mut self.pending_ops) {
+            let lhs = self.zonk(&node.lhs);
+            let rhs = self.zonk(&node.rhs);
+            if let Some(ty) = self.brand_binary(
+                node.op,
+                &lhs,
+                node.lhs_span,
+                &rhs,
+                node.rhs_span,
+                node.node_span,
+            ) {
+                self.unify(
+                    &ty,
+                    &node.result,
+                    node.node_span,
+                    &format!("the result of `{}`", node.op.symbol()),
+                );
+                continue;
+            }
+            // Nothing about the node — neither operand, nor the type its
+            // result flows into — says which arithmetic this is.
+            if matches!(lhs, Type::Var(_))
+                && matches!(rhs, Type::Var(_))
+                && matches!(self.zonk(&node.result), Type::Var(_))
+            {
+                let mut brands: Vec<&str> = self
+                    .brand_ops
+                    .keys()
+                    .filter(|(_, declared)| *declared == node.op)
+                    .map(|(brand, _)| brand.as_str())
+                    .collect();
+                brands.sort_unstable();
+                let symbol = node.op.symbol();
+                self.diag(
+                    node.node_span,
+                    format!(
+                        "`{symbol}` here could be float arithmetic or {} — annotate an operand \
+(e.g. `(a: {})`) so the operator can be resolved",
+                        brands
+                            .iter()
+                            .map(|brand| format!("`{brand}` arithmetic"))
+                            .collect::<Vec<_>>()
+                            .join(" or "),
+                        brands.first().copied().unwrap_or("float"),
+                    ),
+                );
+            }
+            // Either way the node is float arithmetic from here on: the
+            // ambiguous case has already been reported, so this keeps one
+            // unannotated operand from cascading through the rest of the def.
+            self.require_float(node.op, &lhs, node.lhs_span);
+            self.require_float(node.op, &rhs, node.rhs_span);
+            self.unify(
+                &Type::Float,
+                &node.result,
+                node.node_span,
+                &format!("the result of `{}`", node.op.symbol()),
+            );
+        }
+    }
+
+    /// What a branded type adds to a "needs float operands" diagnostic: which
+    /// operators that brand DOES declare, or how to declare one.
+    fn brand_operator_hint(&self, op: BinOp, ty: &Type) -> String {
+        let Some(name) = brand_name(ty) else {
+            return String::new();
+        };
+        // Operator order, not alphabetical — and the same order the
+        // interpreter's twin message uses.
+        let declared: Vec<&str> = [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div]
+            .into_iter()
+            .filter(|declared| self.brand_ops.contains_key(&(name.clone(), *declared)))
+            .map(|declared| declared.symbol())
+            .collect();
+        if !declared.is_empty() {
+            return format!(
+                " — `{name}` declares {}, but not `{}`",
+                declared
+                    .iter()
+                    .map(|symbol| format!("`{symbol}`"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                op.symbol()
+            );
+        }
+        match self.unit_hints.get(&name).and_then(|units| units.first()) {
+            Some((suffix, _)) => format!(
+                " — `{name}` is a branded value with no arithmetic; declare it with \
+`unit {suffix} ({}) = …`",
+                op.symbol()
+            ),
+            None => String::new(),
         }
     }
 

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -577,6 +577,20 @@ fn an_unresolvable_operator_asks_for_an_annotation() {
     assert!(diags.is_empty(), "{diags:?}");
 }
 
+/// `v * v` is not ambiguous even with a scalar `*` declared: the scalar form's
+/// operands have DIFFERENT types, so one unsolved operand used twice can only
+/// be float. (`v + v` genuinely could be either, and still asks.)
+#[test]
+fn squaring_one_unsolved_operand_is_not_ambiguous() {
+    let diags = check_src(&format!("{PX}let sq = (v) => v * v\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    let diags = check_src(&format!("{PX}let double = (v) => v + v\n"));
+    assert!(
+        diags.iter().any(|d| d.contains("annotate an operand")),
+        "{diags:?}"
+    );
+}
+
 /// With no operator declared anywhere, arithmetic infers exactly as it always
 /// has: the ambiguity error can only fire where an ambiguity exists.
 #[test]

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -382,3 +382,238 @@ fn a_plain_function_target_works() {
                let main = () => 21x\n";
     assert_eq!(main_result(src), "42");
 }
+
+// -------------------------------------------------- operators (`unit px (+)`)
+
+/// The declaration form: a suffix, an operator in parens, and an
+/// implementation (a name, or — in a `.fun` — a lambda).
+#[test]
+fn an_operator_declaration_parses_with_a_name_target() {
+    let program = functor_lang::parse("unit deg (+) = Angle.add\n").expect("parses");
+    let Item::UnitOp(decl) = &program.items[0] else {
+        panic!("expected a unit operator item, got {:?}", program.items[0]);
+    };
+    assert_eq!((decl.suffix.as_str(), decl.op.symbol()), ("deg", "+"));
+}
+
+#[test]
+fn all_four_arithmetic_operators_are_declarable() {
+    for symbol in ["+", "-", "*", "/"] {
+        let src = format!("unit px ({symbol}) = f\n");
+        let program = functor_lang::parse(&src).expect("parses");
+        let Item::UnitOp(decl) = &program.items[0] else {
+            panic!("expected a unit operator item");
+        };
+        assert_eq!(decl.op.symbol(), symbol);
+    }
+}
+
+/// A lambda implementation is an ordinary expression, so it parses like one.
+#[test]
+fn an_operator_declaration_takes_a_lambda() {
+    let program = functor_lang::parse("unit px (+) = (a, b) => a\n").expect("parses");
+    assert!(matches!(&program.items[0], Item::UnitOp(_)));
+}
+
+#[test]
+fn malformed_operator_declarations_are_targeted_parse_errors() {
+    // Comparisons are deliberately not declarable (yet).
+    let message = parse_err("unit px (==) = eq\n");
+    assert!(message.contains("`+`, `-`, `*`, or `/`"), "{message}");
+    let message = parse_err("unit px (+ = add\n");
+    assert!(message.contains("`)` after the operator"), "{message}");
+    let message = parse_err("unit px (+)\n");
+    assert!(
+        message.contains("`=` after the declared operator"),
+        "{message}"
+    );
+}
+
+/// An operator on a suffix nobody declared fails at the declaration, with the
+/// same teaching the literal gets.
+#[test]
+fn an_operator_on_an_unknown_suffix_is_a_lowering_error() {
+    let message = lower_err(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         unit em (+) = Px\n",
+    );
+    assert!(message.contains("unknown unit `em`"), "{message}");
+}
+
+const PX: &str = "type Px = | Px(value: float)\n\
+                  unit px = Px\n\
+                  let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+                  unit px (+) = (a, b) => Px(unwrap(a) + unwrap(b))\n\
+                  unit px (*) = (a, k) => Px(unwrap(a) * k)\n";
+
+/// The headline: a declared operator resolves on both operand positions and
+/// evaluates to exactly the implementation's call.
+#[test]
+fn a_declared_operator_resolves_and_evaluates() {
+    let src = format!("{PX}let main = () => 16px + 4px\n");
+    assert!(check_src(&src).is_empty(), "{:?}", check_src(&src));
+    assert_eq!(main_result(&src), "Px(20)");
+}
+
+/// The scalar form takes the brand on the left; multiplication also commutes,
+/// so a bare number may lead.
+#[test]
+fn the_scalar_form_works_from_either_side_of_a_product() {
+    let src = format!("{PX}let main = () => (3px * 2.0, 2.0 * 3px)\n");
+    assert!(check_src(&src).is_empty(), "{:?}", check_src(&src));
+    assert_eq!(main_result(&src), "(Px(6), Px(6))");
+}
+
+/// A branded operand keeps its brand: the result flows into a branded
+/// position with no unwrapping.
+#[test]
+fn an_operator_result_keeps_the_brand() {
+    let diags = check_src(&format!("{PX}let total: Px = 1px + 2px\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    let diags = check_src(&format!("{PX}let total: float = 1px + 2px\n"));
+    assert!(
+        diags.iter().any(|d| d.contains("expected float, got Px")),
+        "{diags:?}"
+    );
+}
+
+/// An operator the brand does NOT declare keeps the old teaching error, now
+/// naming what the brand does have.
+#[test]
+fn an_undeclared_operator_names_the_declared_ones() {
+    let diags = check_src(&format!("{PX}let bad = 1px - 2px\n"));
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("`Px` declares `+`, `*`, but not `-`")),
+        "{diags:?}"
+    );
+}
+
+/// The operator belongs to the BRAND, not the suffix — so two suffixes of one
+/// brand share one implementation, and declaring it twice is an error.
+#[test]
+fn one_brand_declares_each_operator_once() {
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         unit em = Px\n\
+         unit px (+) = add\n\
+         unit em (+) = add\n\
+         let add = (a: Px, b: Px): Px => a\n",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("duplicate operator") && d.contains("through `unit px`")),
+        "{diags:?}"
+    );
+
+    // …and the OTHER suffix of that brand uses the one declaration.
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         unit em = Px\n\
+         unit px (+) = add\n\
+         let add = (a: Px, b: Px): Px => a\n\
+         let total: Px = 1px + 2em\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+/// The implementation is checked against the operator's declared SHAPE, so a
+/// wrong one is an error at the declaration rather than a puzzle at a use.
+#[test]
+fn a_wrong_shaped_implementation_is_rejected() {
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         unit px (+) = scale\n\
+         let scale = (a: Px, k: float): Px => a\n",
+    );
+    assert!(
+        diags.iter().any(|d| d.contains("`unit px (+)`")),
+        "{diags:?}"
+    );
+
+    // The scalar form is the mirror image: `*` does NOT take two brands.
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         unit px (*) = add\n\
+         let add = (a: Px, b: Px): Px => a\n",
+    );
+    assert!(
+        diags.iter().any(|d| d.contains("`unit px (*)`")),
+        "{diags:?}"
+    );
+}
+
+/// Ad-hoc overloading has one hard rule: a node whose operands inference
+/// never pinned down is a teaching error asking for an annotation — never a
+/// silent float guess.
+#[test]
+fn an_unresolvable_operator_asks_for_an_annotation() {
+    let diags = check_src(&format!("{PX}let add = (a, b) => a + b\n"));
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("could be float arithmetic or `Px` arithmetic")
+                && d.contains("annotate an operand")),
+        "{diags:?}"
+    );
+
+    // The annotation the message asks for fixes it, on either operand.
+    let diags = check_src(&format!("{PX}let add = (a: Px, b) => a + b\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    let diags = check_src(&format!("{PX}let add = (a, b: Px) => a + b\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    // …and so does anything else that pins a type — an annotated result, or
+    // a float operand — so ordinary float code stays untouched.
+    let diags = check_src(&format!("{PX}let add = (a, b): float => a + b\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    let diags = check_src(&format!("{PX}let add = (a) => a + 1.0\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+/// With no operator declared anywhere, arithmetic infers exactly as it always
+/// has: the ambiguity error can only fire where an ambiguity exists.
+#[test]
+fn unannotated_arithmetic_is_untouched_without_unit_operators() {
+    let diags = check_src("let add = (a, b) => a + b\nlet main = () => add(1.0, 2.0)\n");
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+/// A brand's operator is dispatched by the INTERPRETER too (`run` does not
+/// typecheck), and it produces the same value the handwritten call does.
+#[test]
+fn the_interpreter_dispatches_on_a_branded_operand() {
+    let src = format!("{PX}let main = () => 16px + 4px\n");
+    assert_eq!(
+        main_result(&src),
+        main_result(&format!(
+            "{PX}let main = () => Px(unwrap(16px) + unwrap(4px))\n"
+        ))
+    );
+}
+
+/// …and a brand with no implementation for the operator errors at runtime
+/// with the same teaching the checker gives.
+#[test]
+fn the_interpreter_teaches_when_no_implementation_exists() {
+    let src = format!("{PX}let main = () => 16px - 4px\n");
+    let program = functor_lang::parse(&src).expect("parses");
+    let module = functor_lang::lower(program).expect("lowers");
+    let failure = functor_lang::run(&module, Tracing::Off)
+        .err()
+        .expect("`-` is not declared for Px");
+    assert!(
+        failure
+            .error
+            .message
+            .contains("`Px` declares `+`, `*`, but not `-`"),
+        "{}",
+        failure.error.message
+    );
+}

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -599,6 +599,84 @@ fn unannotated_arithmetic_is_untouched_without_unit_operators() {
     assert!(diags.is_empty(), "{diags:?}");
 }
 
+/// Top-level constants are evaluated EAGERLY, before anything else runs, so
+/// the dispatch table has to exist by then: branded arithmetic in a top-level
+/// initializer must work, not die at load. [xreview: Critical]
+#[test]
+fn a_top_level_constant_may_use_branded_arithmetic() {
+    let src = format!("{PX}let total = 16px + 4px\nlet main = () => unwrap(total)\n");
+    assert!(check_src(&src).is_empty(), "{:?}", check_src(&src));
+    assert_eq!(main_result(&src), "20");
+}
+
+/// …including when the implementation is a top-level NAME rather than a
+/// lambda: like every other global reference it stays late-bound, so it obeys
+/// exactly the same "an initializer may only use globals defined above it"
+/// rule — and says so when it doesn't.
+#[test]
+fn a_named_implementation_is_late_bound_like_any_global() {
+    let px = "type Px = | Px(value: float)\n\
+              unit px = Px\n\
+              unit px (+) = addPx\n\
+              let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+              let addPx = (a: Px, b: Px): Px => Px(unwrap(a) + unwrap(b))\n";
+    let src = format!("{px}let total = 16px + 4px\nlet main = () => unwrap(total)\n");
+    assert!(check_src(&src).is_empty(), "{:?}", check_src(&src));
+    assert_eq!(main_result(&src), "20");
+
+    // The implementation defined BELOW the constant that uses it: the
+    // language's ordinary eager-initializer rule, with a message that says so.
+    let src = "type Px = | Px(value: float)\n\
+               unit px = Px\n\
+               unit px (+) = addPx\n\
+               let total = 16px + 4px\n\
+               let addPx = (a: Px, b: Px): Px => a\n";
+    let program = functor_lang::parse(src).expect("parses");
+    let module = functor_lang::lower(program).expect("lowers");
+    let failure = functor_lang::run(&module, Tracing::Off)
+        .err()
+        .expect("`addPx` is not defined yet");
+    assert!(
+        failure.error.message.contains("used before its definition"),
+        "{}",
+        failure.error.message
+    );
+}
+
+/// The interpreter dispatches on a value's runtime TAG, so a brand whose
+/// values carry none (a record) or carry several (a multi-constructor type)
+/// is refused at the declaration instead of checking clean and failing at
+/// run time. [xreview: High]
+#[test]
+fn a_brand_must_be_distinguishable_at_run_time() {
+    let diags = check_src(
+        "type Length = | Px(value: float) | Em(value: float)\n\
+         unit px = Px\n\
+         unit px (+) = add\n\
+         let add = (a: Length, b: Length): Length => a\n",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("distinguishable at run time") && d.contains("`Length`")),
+        "{diags:?}"
+    );
+
+    let diags = check_src(
+        "type Px = { value: float }\n\
+         let px = (n: float): Px => { value: n }\n\
+         unit px2 = px\n\
+         unit px2 (+) = add\n\
+         let add = (a: Px, b: Px): Px => a\n",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("distinguishable at run time")),
+        "{diags:?}"
+    );
+}
+
 /// A brand's operator is dispatched by the INTERPRETER too (`run` does not
 /// typecheck), and it produces the same value the handwritten call does.
 #[test]

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -690,6 +690,28 @@ fn the_interpreter_dispatches_on_a_branded_operand() {
     );
 }
 
+/// The unchecked path refuses a duplicate declaration too, rather than
+/// silently picking whichever came last. [xreview: Medium]
+#[test]
+fn the_interpreter_refuses_a_duplicate_declaration() {
+    let src = "type Px = | Px(value: float)\n\
+               unit px = Px\n\
+               unit em = Px\n\
+               let add = (a: Px, b: Px): Px => a\n\
+               unit px (+) = add\n\
+               unit em (+) = add\n";
+    let program = functor_lang::parse(src).expect("parses");
+    let module = functor_lang::lower(program).expect("lowers");
+    let failure = functor_lang::run(&module, Tracing::Off)
+        .err()
+        .expect("`+` is declared twice for one brand");
+    assert!(
+        failure.error.message.contains("duplicate operator"),
+        "{}",
+        failure.error.message
+    );
+}
+
 /// …and a brand with no implementation for the operator errors at runtime
 /// with the same teaching the checker gives.
 #[test]

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -643,6 +643,36 @@ fn a_named_implementation_is_late_bound_like_any_global() {
     );
 }
 
+/// An annotated RESULT decides the node on its own: `+` stays inside its
+/// brand, so `(a, b): Px => a + b` needs no operand annotation. [xreview:
+/// High]
+#[test]
+fn an_annotated_result_resolves_the_operands() {
+    let diags = check_src(&format!("{PX}let add = (a, b): Px => a + b\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    // A binding annotation on the def works the same way.
+    let diags = check_src(&format!("{PX}let add: (Px, Px) => Px = (a, b) => a + b\n"));
+    assert!(diags.is_empty(), "{diags:?}");
+    // (A helper whose type is only pinned by a LATER call site is still
+    // ambiguous — it generalizes first, the ordinary let-polymorphism rule.)
+}
+
+/// A unit whose own constructor is a top-level `let` cannot be probed before
+/// the defs run — the table is completed as the defs land, so an initializer
+/// below the constructor still gets its operators. [xreview: High]
+#[test]
+fn a_unit_built_by_a_top_level_function_still_dispatches() {
+    let src = "type Px = | Px(value: float)\n\
+               let make = (n: float): Px => Px(n)\n\
+               unit px = make\n\
+               let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+               unit px (+) = (a, b) => make(unwrap(a) + unwrap(b))\n\
+               let total = 1px + 2px\n\
+               let main = () => unwrap(total)\n";
+    assert!(check_src(src).is_empty(), "{:?}", check_src(src));
+    assert_eq!(main_result(src), "3");
+}
+
 /// The interpreter dispatches on a value's runtime TAG, so a brand whose
 /// values carry none (a record) or carry several (a multi-constructor type)
 /// is refused at the declaration instead of checking clean and failing at

--- a/functor-prelude/prelude/angle.funi
+++ b/functor-prelude/prelude/angle.funi
@@ -12,7 +12,25 @@ let degrees : (float) => t
 /// Construct an angle from radians.
 let radians : (float) => t
 
+/// Add two angles. This is what `90deg + 45deg` calls.
+let add : (t, t) => t
+/// Subtract one angle from another. This is what `90deg - 45deg` calls.
+let sub : (t, t) => t
+/// Scale an angle by a plain number. This is what `45deg * 2.0` calls.
+let scale : (t, float) => t
+
 /// Degrees as a literal suffix: `90deg` is exactly `Angle.degrees(90.0)`.
 unit deg = Angle.degrees
 /// Radians as a literal suffix: `0.5rad` is exactly `Angle.radians(0.5)`.
 unit rad = Angle.radians
+
+/// `+` on angles: `90deg + 45deg` is `Angle.add(90deg, 45deg)`. An operator
+/// belongs to the BRAND, so it covers every angle suffix — `90deg + 1.5rad`
+/// adds too.
+unit deg (+) = Angle.add
+/// `-` on angles: `90deg - 45deg` is `Angle.sub(90deg, 45deg)`.
+unit deg (-) = Angle.sub
+/// `*` scales an angle by a number, on either side: `45deg * 2.0` and
+/// `2.0 * 45deg` are both `Angle.scale(45deg, 2.0)`. (Multiplying two angles
+/// would be a different kind of thing — Functor Lang does not model that.)
+unit deg (*) = Angle.scale

--- a/functor-prelude/prelude/angle.funi
+++ b/functor-prelude/prelude/angle.funi
@@ -17,6 +17,8 @@ let add : (t, t) => t
 /// Subtract one angle from another. This is what `90deg - 45deg` calls.
 let sub : (t, t) => t
 /// Scale an angle by a plain number. This is what `45deg * 2.0` calls.
+/// It takes the angle FIRST — the shape every declared `*` has — so unlike
+/// most of the prelude it is not written to be piped into.
 let scale : (t, float) => t
 
 /// Degrees as a literal suffix: `90deg` is exactly `Angle.degrees(90.0)`.

--- a/functor-prelude/prelude/time.funi
+++ b/functor-prelude/prelude/time.funi
@@ -17,6 +17,13 @@ let minutes : (float) => t
 /// Construct a duration from hours.
 let hours : (float) => t
 
+/// Add two durations. This is what `1.5s + 200ms` calls.
+let add : (t, t) => t
+/// Subtract one duration from another. This is what `1.5s - 200ms` calls.
+let sub : (t, t) => t
+/// Scale a duration by a plain number. This is what `0.5s * 2.0` calls.
+let scale : (t, float) => t
+
 /// Seconds as a literal suffix: `0.5s` is exactly `Time.seconds(0.5)`.
 unit s = Time.seconds
 /// Milliseconds as a literal suffix: `500ms` is exactly `Time.millis(500.0)`.
@@ -27,3 +34,13 @@ unit us = Time.micros
 unit min = Time.minutes
 /// Hours as a literal suffix: `1hr` is exactly `Time.hours(1.0)`.
 unit hr = Time.hours
+
+/// `+` on durations: `1.5s + 200ms` is `Time.add(1.5s, 200ms)`. An operator
+/// belongs to the BRAND, so every duration suffix shares it — seconds and
+/// milliseconds add directly.
+unit s (+) = Time.add
+/// `-` on durations: `1.5s - 200ms` is `Time.sub(1.5s, 200ms)`.
+unit s (-) = Time.sub
+/// `*` scales a duration by a number, on either side: `0.5s * 2.0` and
+/// `2.0 * 0.5s` are both `Time.scale(0.5s, 2.0)`.
+unit s (*) = Time.scale

--- a/functor-prelude/prelude/time.funi
+++ b/functor-prelude/prelude/time.funi
@@ -22,6 +22,8 @@ let add : (t, t) => t
 /// Subtract one duration from another. This is what `1.5s - 200ms` calls.
 let sub : (t, t) => t
 /// Scale a duration by a plain number. This is what `0.5s * 2.0` calls.
+/// It takes the duration FIRST — the shape every declared `*` has — so unlike
+/// most of the prelude it is not written to be piped into.
 let scale : (t, float) => t
 
 /// Seconds as a literal suffix: `0.5s` is exactly `Time.seconds(0.5)`.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -974,6 +974,13 @@ impl HostData for FunctorLangAnim {
 /// discipline, carried across the boundary).
 pub struct FunctorLangAngle(pub Angle);
 
+/// An angle in radians — the canonical scalar `Angle.add`/`sub`/`scale` work
+/// in (degrees and radians are the same value, differently spelled).
+fn radians_of(angle: FunctorLangAngle) -> f32 {
+    let radians: cgmath::Rad<f32> = angle.0.into();
+    radians.0
+}
+
 /// An RGB color as an opaque Functor Lang value — made by `Color.rgb(r, g, b)`.
 /// Material/light/fog/UI color parameters accept ONLY this, never three bare
 /// floats, so channel swaps and argument miscounts are unrepresentable (the
@@ -1473,7 +1480,47 @@ fn register_branded_constructors(reg: &mut crate::host_registry::Registry) {
     reg.fn1("Angle.radians", "Angle.radians(n)", |n: f64| {
         FunctorLangAngle(Angle::from_radians(n as f32))
     });
+    // Angle arithmetic — what `unit deg (+)` / `(-)` / `(*)` in `angle.funi`
+    // resolve to, so `90deg + 45deg` is exactly `Angle.add(90deg, 45deg)`.
+    reg.fn2(
+        "Angle.add",
+        "Angle.add(a, b)",
+        |a: FunctorLangAngle, b: FunctorLangAngle| {
+            FunctorLangAngle(Angle::from_radians(radians_of(a) + radians_of(b)))
+        },
+    );
+    reg.fn2(
+        "Angle.sub",
+        "Angle.sub(a, b)",
+        |a: FunctorLangAngle, b: FunctorLangAngle| {
+            FunctorLangAngle(Angle::from_radians(radians_of(a) - radians_of(b)))
+        },
+    );
+    reg.fn2(
+        "Angle.scale",
+        "Angle.scale(angle, factor)",
+        |a: FunctorLangAngle, factor: f64| {
+            FunctorLangAngle(Angle::from_radians(radians_of(a) * factor as f32))
+        },
+    );
     reg.fn1("Time.seconds", "Time.seconds(n)", FunctorLangDuration);
+    // Duration arithmetic — `unit s (+)` / `(-)` / `(*)` in `time.funi`.
+    // Durations are stored in seconds, so every suffix shares these.
+    reg.fn2(
+        "Time.add",
+        "Time.add(a, b)",
+        |a: FunctorLangDuration, b: FunctorLangDuration| FunctorLangDuration(a.0 + b.0),
+    );
+    reg.fn2(
+        "Time.sub",
+        "Time.sub(a, b)",
+        |a: FunctorLangDuration, b: FunctorLangDuration| FunctorLangDuration(a.0 - b.0),
+    );
+    reg.fn2(
+        "Time.scale",
+        "Time.scale(duration, factor)",
+        |a: FunctorLangDuration, factor: f64| FunctorLangDuration(a.0 * factor),
+    );
     reg.fn1("Time.millis", "Time.millis(n)", |n: f64| {
         FunctorLangDuration(n / 1000.0)
     });
@@ -5543,6 +5590,109 @@ mod tests {
     // (`90deg`, `0.5s`), but the suffixes themselves are declared in the
     // `.funi` prelude, which this crate cannot read at runtime. Pin the two
     // together so renaming or dropping a `unit` fails here instead of leaving
+    /// Evaluate a `main` under the prelude WITH the engine's `.funi`
+    /// interfaces linked, so unit suffixes and their operators resolve —
+    /// `eval` above lowers one bare source, where no `unit` is declared.
+    fn eval_with_prelude(src: &str) -> Result<Value, String> {
+        let project = functor_lang::project::load_sources_with_bundled_modules(
+            vec![(std::path::PathBuf::from("game.fun"), src.to_string())],
+            &functor_prelude::bundled_modules(),
+        )
+        .map_err(|e| e.message)?;
+        let diags = functor_lang::check(&project.module);
+        if let Some(first) = diags.first() {
+            return Err(first.message.clone());
+        }
+        let record = functor_lang::run_with_host(&project.module, Tracing::Off, &mut FunctorHost)
+            .map_err(|f| f.error.message)?;
+        match record.outcome {
+            functor_lang::RunOutcome::Main(value) => Ok(value),
+            _ => Err("expected a main result".to_string()),
+        }
+    }
+
+    fn radians(value: &Value) -> f32 {
+        match value {
+            Value::HostData(data) => radians_of(FunctorLangAngle(
+                data.as_any()
+                    .downcast_ref::<FunctorLangAngle>()
+                    .expect("an Angle")
+                    .0,
+            )),
+            other => panic!("expected an Angle, got {other}"),
+        }
+    }
+
+    fn seconds(value: &Value) -> f64 {
+        match value {
+            Value::HostData(data) => {
+                data.as_any()
+                    .downcast_ref::<FunctorLangDuration>()
+                    .expect("a Duration")
+                    .0
+            }
+            other => panic!("expected a Duration, got {other}"),
+        }
+    }
+
+    /// The headline: branded arithmetic, resolved through the `unit deg (+)`
+    /// declaration in `angle.funi`, is exactly the handwritten call.
+    #[test]
+    fn angles_add_and_subtract_through_their_declared_operators() {
+        let sum = eval_with_prelude("let main = () => 90deg + 45deg\n").expect("runs");
+        assert!((radians(&sum) - radians(&
+            eval_with_prelude("let main = () => Angle.add(Angle.degrees(90.0), Angle.degrees(45.0))\n")
+                .expect("runs"))).abs() < 1e-6);
+        let difference = eval_with_prelude("let main = () => 90deg - 1.5rad\n").expect("runs");
+        assert!(
+            (radians(&difference) - (std::f32::consts::FRAC_PI_2 - 1.5)).abs() < 1e-6,
+            "mixed suffixes share one brand, so they subtract"
+        );
+    }
+
+    /// Every suffix of one brand shares the operator: seconds and
+    /// milliseconds are both `Time.t`, so they add and subtract directly.
+    #[test]
+    fn durations_of_different_suffixes_share_one_operator() {
+        let value = eval_with_prelude("let main = () => 1.5s - 200ms\n").expect("runs");
+        assert!((seconds(&value) - 1.3).abs() < 1e-9, "{}", seconds(&value));
+        let value = eval_with_prelude("let main = () => 2min + 30s\n").expect("runs");
+        assert_eq!(seconds(&value), 150.0);
+    }
+
+    /// Scaling commutes, so the brand may sit on either side of `*`.
+    #[test]
+    fn scaling_works_from_either_side() {
+        for src in [
+            "let main = () => 45deg * 2.0\n",
+            "let main = () => 2.0 * 45deg\n",
+        ] {
+            let value = eval_with_prelude(src).expect("runs");
+            assert!((radians(&value) - std::f32::consts::FRAC_PI_2).abs() < 1e-6, "{src}");
+        }
+        let value = eval_with_prelude("let main = () => 0.5s * 3.0\n").expect("runs");
+        assert_eq!(seconds(&value), 1.5);
+    }
+
+    /// A branded value still refuses arithmetic nobody declared — with a
+    /// message that names what the brand DOES have.
+    #[test]
+    fn an_undeclared_operator_on_a_brand_teaches_what_exists() {
+        let error = eval_with_prelude("let main = () => 90deg / 2.0\n")
+            .err()
+            .expect("`/` is not declared on angles");
+        assert!(error.contains("`Angle.t` declares"), "{error}");
+        assert!(error.contains("but not `/`"), "{error}");
+    }
+
+    /// The branded result flows on into the APIs that take it — the whole
+    /// point of keeping arithmetic inside the brand.
+    #[test]
+    fn a_branded_sum_flows_into_a_branded_parameter() {
+        eval_with_prelude("let main = () => Scene.cube() |> Scene.rotateY(90deg + 45deg)\n")
+            .expect("a summed angle is still an Angle");
+    }
+
     // a message that teaches a suffix nobody can write.
     #[test]
     fn prelude_units_match_the_teaching_errors() {

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -974,12 +974,6 @@ impl HostData for FunctorLangAnim {
 /// discipline, carried across the boundary).
 pub struct FunctorLangAngle(pub Angle);
 
-/// An angle in radians — the canonical scalar `Angle.add`/`sub`/`scale` work
-/// in (degrees and radians are the same value, differently spelled).
-fn radians_of(angle: FunctorLangAngle) -> f32 {
-    let radians: cgmath::Rad<f32> = angle.0.into();
-    radians.0
-}
 
 /// An RGB color as an opaque Functor Lang value — made by `Color.rgb(r, g, b)`.
 /// Material/light/fog/UI color parameters accept ONLY this, never three bare
@@ -1486,21 +1480,21 @@ fn register_branded_constructors(reg: &mut crate::host_registry::Registry) {
         "Angle.add",
         "Angle.add(a, b)",
         |a: FunctorLangAngle, b: FunctorLangAngle| {
-            FunctorLangAngle(Angle::from_radians(radians_of(a) + radians_of(b)))
+            FunctorLangAngle(Angle::from_radians(a.0.radians() + b.0.radians()))
         },
     );
     reg.fn2(
         "Angle.sub",
         "Angle.sub(a, b)",
         |a: FunctorLangAngle, b: FunctorLangAngle| {
-            FunctorLangAngle(Angle::from_radians(radians_of(a) - radians_of(b)))
+            FunctorLangAngle(Angle::from_radians(a.0.radians() - b.0.radians()))
         },
     );
     reg.fn2(
         "Angle.scale",
         "Angle.scale(angle, factor)",
         |a: FunctorLangAngle, factor: f64| {
-            FunctorLangAngle(Angle::from_radians(radians_of(a) * factor as f32))
+            FunctorLangAngle(Angle::from_radians(a.0.radians() * factor as f32))
         },
     );
     reg.fn1("Time.seconds", "Time.seconds(n)", FunctorLangDuration);
@@ -5590,6 +5584,35 @@ mod tests {
     // (`90deg`, `0.5s`), but the suffixes themselves are declared in the
     // `.funi` prelude, which this crate cannot read at runtime. Pin the two
     // together so renaming or dropping a `unit` fails here instead of leaving
+    // a message that teaches a suffix nobody can write.
+    #[test]
+    fn prelude_units_match_the_teaching_errors() {
+        use std::collections::BTreeSet;
+        let mut suffixes: BTreeSet<String> = BTreeSet::new();
+        for (module, src) in functor_prelude::modules() {
+            let program = functor_lang::parse_interface(&src)
+                .unwrap_or_else(|e| panic!("prelude module `{module}` must parse: {}", e.message));
+            for item in &program.items {
+                if let functor_lang::ast::Item::Unit(decl) = item {
+                    assert!(
+                        suffixes.insert(decl.suffix.clone()),
+                        "unit `{}` is declared more than once in the prelude",
+                        decl.suffix
+                    );
+                }
+            }
+        }
+        let expected: BTreeSet<String> = ["deg", "rad", "s", "ms", "us", "min", "hr"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(
+            suffixes, expected,
+            "the prelude's unit suffixes changed — update the Angle/Duration teaching errors \
+in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list together"
+        );
+    }
+
     /// Evaluate a `main` under the prelude WITH the engine's `.funi`
     /// interfaces linked, so unit suffixes and their operators resolve —
     /// `eval` above lowers one bare source, where no `unit` is declared.
@@ -5612,27 +5635,13 @@ mod tests {
     }
 
     fn radians(value: &Value) -> f32 {
-        match value {
-            Value::HostData(data) => radians_of(FunctorLangAngle(
-                data.as_any()
-                    .downcast_ref::<FunctorLangAngle>()
-                    .expect("an Angle")
-                    .0,
-            )),
-            other => panic!("expected an Angle, got {other}"),
-        }
+        angle_of(value, "an Angle", Span::new(0, 0))
+            .expect("an Angle")
+            .radians()
     }
 
     fn seconds(value: &Value) -> f64 {
-        match value {
-            Value::HostData(data) => {
-                data.as_any()
-                    .downcast_ref::<FunctorLangDuration>()
-                    .expect("a Duration")
-                    .0
-            }
-            other => panic!("expected a Duration, got {other}"),
-        }
+        duration_of(value, "a Duration", Span::new(0, 0)).expect("a Duration")
     }
 
     /// The headline: branded arithmetic, resolved through the `unit deg (+)`
@@ -5685,41 +5694,25 @@ mod tests {
         assert!(error.contains("but not `/`"), "{error}");
     }
 
+    /// Top-level constants evaluate eagerly, before anything else runs, so
+    /// branded arithmetic has to work there too — the shape a game's tuning
+    /// constants and `init` actually take. [xreview: Critical]
+    #[test]
+    fn a_top_level_constant_may_use_branded_arithmetic() {
+        let value = eval_with_prelude(
+            "let quarter: Angle.t = 90deg + 45deg\n\
+             let main = () => quarter\n",
+        )
+        .expect("runs");
+        assert!((radians(&value) - std::f32::consts::FRAC_PI_2 * 1.5).abs() < 1e-6);
+    }
+
     /// The branded result flows on into the APIs that take it — the whole
     /// point of keeping arithmetic inside the brand.
     #[test]
     fn a_branded_sum_flows_into_a_branded_parameter() {
         eval_with_prelude("let main = () => Scene.cube() |> Scene.rotateY(90deg + 45deg)\n")
             .expect("a summed angle is still an Angle");
-    }
-
-    // a message that teaches a suffix nobody can write.
-    #[test]
-    fn prelude_units_match_the_teaching_errors() {
-        use std::collections::BTreeSet;
-        let mut suffixes: BTreeSet<String> = BTreeSet::new();
-        for (module, src) in functor_prelude::modules() {
-            let program = functor_lang::parse_interface(&src)
-                .unwrap_or_else(|e| panic!("prelude module `{module}` must parse: {}", e.message));
-            for item in &program.items {
-                if let functor_lang::ast::Item::Unit(decl) = item {
-                    assert!(
-                        suffixes.insert(decl.suffix.clone()),
-                        "unit `{}` is declared more than once in the prelude",
-                        decl.suffix
-                    );
-                }
-            }
-        }
-        let expected: BTreeSet<String> = ["deg", "rad", "s", "ms", "us", "min", "hr"]
-            .into_iter()
-            .map(str::to_string)
-            .collect();
-        assert_eq!(
-            suffixes, expected,
-            "the prelude's unit suffixes changed — update the Angle/Duration teaching errors \
-in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list together"
-        );
     }
 
     // Drift guard: a HARD BIJECTION between the `functor-prelude` `.funi`

--- a/runtime/functor-runtime-common/src/math/angle.rs
+++ b/runtime/functor-runtime-common/src/math/angle.rs
@@ -17,6 +17,12 @@ impl Angle {
             ang: cgmath::Rad(angle),
         }
     }
+
+    /// The angle in radians — the canonical scalar it is stored as, and what
+    /// angle arithmetic (`Angle.add` / `sub` / `scale`) works in.
+    pub fn radians(self) -> f32 {
+        self.ang.0
+    }
 }
 
 impl Into<Rad<f32>> for Angle {

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -323,6 +323,54 @@ fn a_project_unit_lives_beside_the_prelude_units() {
     assert!(diags.is_empty(), "{diags:?}");
 }
 
+/// Branded arithmetic under the real prelude: the declarations in
+/// `angle.funi` / `time.funi` make `+`, `-`, and scalar `*` typecheck on
+/// angles and durations — across suffixes, since an operator belongs to the
+/// brand.
+#[test]
+fn prelude_brands_carry_their_declared_arithmetic() {
+    let diags = check(
+        "let turn: Angle.t = 90deg + 45deg\n\
+         let back: Angle.t = 90deg - 1.5rad\n\
+         let wide: Angle.t = 45deg * 2.0\n\
+         let also: Angle.t = 2.0 * 45deg\n\
+         let wait: Time.t = 1.5s - 200ms\n\
+         let long: Time.t = 2min + 30s\n\
+         let twice: Time.t = 0.5s * 2.0\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+/// …and what they do NOT declare still teaches, now naming what exists.
+#[test]
+fn an_undeclared_prelude_operator_names_the_declared_ones() {
+    let diags = check("let bad: Angle.t = 90deg / 2.0\n");
+    assert!(
+        diags
+            .iter()
+            .any(|m| m.contains("`Angle.t` declares") && m.contains("but not `/`")),
+        "{diags:?}"
+    );
+    // Mixing brands is still a type error: an angle is not a duration.
+    let diags = check("let bad: Angle.t = 90deg + 1.5s\n");
+    assert!(!diags.is_empty(), "an angle plus a duration must not check");
+}
+
+/// A project declares operators on its OWN brand beside the prelude's, with
+/// lambda implementations (a `.fun` may write bodies; a `.funi` may not).
+#[test]
+fn a_project_declares_operators_on_its_own_brand() {
+    let diags = check(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+         unit px (+) = (a, b) => Px(unwrap(a) + unwrap(b))\n\
+         let total: Px = 16px + 4px\n\
+         let turn: Angle.t = 45deg + 45deg\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
 /// Redeclaring a prelude suffix is refused — one meaning per suffix, project
 /// wide, exactly like a constructor name.
 #[test]

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -356,6 +356,54 @@ fn an_undeclared_prelude_operator_names_the_declared_ones() {
     assert!(!diags.is_empty(), "an angle plus a duration must not check");
 }
 
+/// The prelude's `unit … (<op>)` declarations must LOAD under the plain,
+/// hostless interpreter — the editor's expect gutter runs a project's defs
+/// that way with the engine `.funi` interfaces linked, so an operator that
+/// resolved its brand or its implementation eagerly failed every load with
+/// ``unknown external `Angle.degrees` ``. Nothing about a unit operator may
+/// need a host until it actually dispatches.
+#[test]
+fn prelude_unit_operators_load_under_the_plain_interpreter() {
+    let hostless = |src: &str| {
+        let project = functor_lang::project::load_sources_with_bundled_modules(
+            vec![(std::path::PathBuf::from("game.fun"), src.to_string())],
+            &functor_prelude::bundled_modules(),
+        )
+        .unwrap_or_else(|e| panic!("loads: {}", e.message));
+        functor_lang::run_expects_budgeted(
+            &project.module,
+            &mut functor_lang::NoHost,
+            Some(1_000_000),
+        )
+        .map(|reports| {
+            reports
+                .iter()
+                .map(|report| report.outcome.status().0.to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|failure| panic!("defs must load hostlessly: {}", failure.error.message))
+    };
+
+    assert_eq!(
+        hostless("let area = (w, h) => w * h\nexpect area(3.0, 4.0) == 12.0\n"),
+        ["pass"]
+    );
+
+    // …and a USER brand's operators still dispatch there, because building one
+    // of its values needs no host: the hostless path degrades only where it
+    // must.
+    assert_eq!(
+        hostless(
+            "type Px = | Px(value: float)\n\
+             unit px = Px\n\
+             let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+             unit px (+) = (a, b) => Px(unwrap(a) + unwrap(b))\n\
+             expect unwrap(16px + 4px) == 20.0\n"
+        ),
+        ["pass"]
+    );
+}
+
 /// The cost of ad-hoc overloading, pinned deliberately: because the prelude
 /// always declares `+`/`-`/`*` on `Angle.t` and `Time.t`, a helper whose
 /// operands inference never pins down is now ambiguous and asks for an

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -356,6 +356,33 @@ fn an_undeclared_prelude_operator_names_the_declared_ones() {
     assert!(!diags.is_empty(), "an angle plus a duration must not check");
 }
 
+/// The cost of ad-hoc overloading, pinned deliberately: because the prelude
+/// always declares `+`/`-`/`*` on `Angle.t` and `Time.t`, a helper whose
+/// operands inference never pins down is now ambiguous and asks for an
+/// annotation instead of silently defaulting to float. This is a BREAKING
+/// change for existing unannotated helpers (`docs/functor-lang-units.md`), so
+/// it is a test rather than a surprise.
+#[test]
+fn a_fully_unannotated_helper_asks_for_an_annotation() {
+    let diags = check("let plus = (a, b) => a + b\n");
+    assert!(
+        diags
+            .iter()
+            .any(|m| m.contains("could be float arithmetic") && m.contains("annotate an operand")),
+        "{diags:?}"
+    );
+    // Any of the ordinary ways of pinning a type resolves it.
+    for src in [
+        "let plus = (a: float, b) => a + b\n",
+        "let plus = (a, b): float => a + b\n",
+        "let bump = (a) => a + 1.0\n",
+        "let square = (v) => v * v\n",
+    ] {
+        let diags = check(src);
+        assert!(diags.is_empty(), "{src}: {diags:?}");
+    }
+}
+
 /// A project declares operators on its OWN brand beside the prelude's, with
 /// lambda implementations (a `.fun` may write bodies; a `.funi` may not).
 #[test]

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -145,6 +145,10 @@ pub enum ApiItemKind {
     /// A `unit` declaration: the literal suffix a number may carry
     /// (`90deg` → `Angle.degrees(90.0)`).
     Unit,
+    /// A `unit <suffix> (<op>)` declaration: an arithmetic operator on the
+    /// brand that suffix builds (`90deg + 45deg` → `Angle.add(…)`).
+    #[serde(rename = "unit-operator")]
+    UnitOperator,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -504,6 +508,15 @@ fn extract_module(
                     .ok_or_else(|| error_at(decl.span, invalid_span(&decl.suffix)))?;
                 (decl.suffix, ApiItemKind::Unit, decl.span, declaration)
             }
+            // An operator on a unit's brand is public API too — it is what
+            // makes `90deg + 45deg` mean anything — and it documents beside
+            // the implementation it names.
+            Item::UnitOp(decl) => {
+                let declaration = declaration_at(&source, decl.span)
+                    .ok_or_else(|| error_at(decl.span, invalid_span(&decl.suffix)))?;
+                let name = format!("{} ({})", decl.suffix, decl.op.symbol());
+                (name, ApiItemKind::UnitOperator, decl.span, declaration)
+            }
             Item::Let(_) | Item::Open(_) | Item::Expect(_) | Item::Module(_) => continue,
         };
         items.push(ApiItem {
@@ -656,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 282));
+        assert_eq!(count(ApiGroup::Engine), (27, 294));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -896,6 +896,25 @@ mod tests {
         assert_eq!(rows[0]["state"], "pass");
     }
 
+    // The gutter runs the defs under the PLAIN interpreter (`NoHost`) while
+    // the engine prelude's `.funi` interfaces are linked, so nothing the
+    // prelude DECLARES may need a host merely to load. `unit deg (+) =
+    // Angle.add` is the case that broke this: resolving the operator's brand
+    // or its implementation eagerly made every expect in every project report
+    // `defs failed to load: unknown external \`Angle.degrees\``.
+    #[test]
+    fn prelude_unit_operators_do_not_break_a_hostless_defs_load() {
+        let files = files_json(&[(
+            "game.fun",
+            "let area = (w, h) => w * h\nexpect area(3.0, 4.0) == 12.0\n",
+        )]);
+        let out = parse(&expects_project_json(&files, "game.fun", 1_000_000));
+        let rows = out["rows"].as_array().unwrap();
+        assert_eq!(rows.len(), 1, "{out}");
+        assert_eq!(rows[0]["state"], "pass", "{out}");
+        assert!(rows[0]["detail"].is_null(), "{out}");
+    }
+
     // Unloadable input is `rows: null` (keep the previous gutter), never an
     // exception; a loadable project with no expects is an EMPTY rows array
     // (authoritative clear).

--- a/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
@@ -17,7 +17,10 @@ import { findRepoRoot, FunctorRunner, waitFor } from "../src/index.js";
 const e2eEnabled = process.env.FUNCTOR_E2E === "1";
 const headless = process.env.FUNCTOR_E2E_HEADLESS === "1";
 
-const game = (body: string) => `let makeSpin = (k) => (dt) => ${body}
+// `k` is annotated because the engine prelude declares `*` on `Angle.t` and
+// `Time.t`: an operator whose operands inference never pins down asks for an
+// annotation rather than silently guessing float (docs/functor-lang-units.md).
+const game = (body: string) => `let makeSpin = (k: float) => (dt) => ${body}
 let init = { vel: makeSpin(2.0), x: 0.0 }
 let tick = (m, dt, tts) => { m with x: m.x + m.vel(dt) }
 let draw = (m, tts) =>


### PR DESCRIPTION
**Stack:** base is `ctor-full-arity` (#621), which is stacked on the now-merged
#617 (unit-suffix literals). Review/merge #621 first.

Phase 2 of units, per `docs/functor-lang-units.md`: a unit brand can declare
arithmetic, so `90deg + 45deg`, `1.5s - 200ms`, and `45deg * 2.0` typecheck and
evaluate — resolved by ad-hoc overloading after inference.

```functor
type Px = | Px(value: float)
unit px = Px
unit px (+) = (a, b) => Px(unwrap(a) + unwrap(b))   // (Px, Px) => Px
unit px (*) = (a, k) => Px(unwrap(a) * k)           // (Px, float) => Px
```

The engine prelude declares `+`, `-`, and scalar `*` on both `Angle.t` and
`Time.t` — new host externals `Angle.add`/`sub`/`scale` and `Time.add`/`sub`/
`scale` in the typed registry, declared beside the units in `angle.funi` /
`time.funi` (the `.funi` ≡ registry drift test stays green).

**Before → after**, pinned empirically by checking the same source under the
engine prelude on both refs (`let turn = 90deg + 45deg`, `let wait = 1.5s - 200ms`):

| ref | diagnostics |
| --- | --- |
| `ctor-full-arity` (base) | 4 — ``` `+` needs float operands, got Angle.t ``` ×2, ``` `-` needs float operands, got Time.t ``` ×2 |
| this branch | 0 |

## How it works

- **Declaration** — `unit <suffix> (<op>) = <impl>` is its own top-level item in
  `.fun` and `.funi`. Only `+ - * /`. `+`/`-` are checked as `('t, 't) => 't`,
  `*` and `/` as the scalar `('t, float) => 't`, against the DECLARED shape — so
  which implementation an operator resolves to never depends on inference order.
- **The operator belongs to the BRAND, not the suffix** — `s`/`ms`/`us`/`min`/
  `hr` are all `Time.t`, so one `unit s (+) = Time.add` makes `1.5s - 200ms`
  work; a second declaration for the same brand + operator through any suffix is
  a duplicate error (on the checked *and* the unchecked path).
- **Resolution** — infer as today; at each arithmetic node zonk the operands and
  hand the node to the brand's implementation if either side is a declaring
  brand, checking the other operand against that implementation's signature.
  Nodes whose operands are still unsolved are deferred to a pass that runs when
  the enclosing SCC group settles. Scaling commutes (`2.0 * 45deg`); division
  does not (`2.0 / 45deg` is refused).
- **Unresolvable is a teaching error, never a float guess** — ``` `+` here could
  be float arithmetic or `Px` arithmetic — annotate an operand (e.g. `(a: Px)`)
  ``` — fired only when both operands AND the result are unconstrained and a
  branded reading is possible at all.
- **Nothing resolves until it dispatches** — a declaration's implementation stays
  symbolic at load: a host external (`Angle.add`) is looked up at the use site,
  a top-level name is late-bound like any global. This is required, not an
  optimization: the editor's expect gutter loads a project's defs through
  `tools/functor-lang-wasm` under the PLAIN, hostless interpreter with the
  engine `.funi` interfaces linked, so `unit deg (+) = Angle.add` must not need
  a host merely to load.
- **Runtime** — the evaluator's arithmetic arms consult a brand-ops table when an
  operand isn't a number, so `functor-lang run` (which skips the checker) and
  gradual `unknown` seams end at exactly the call the declaration names. The
  table is keyed by the operand's runtime tag (variant ctor / host `type_name`),
  read off a probe value the unit's own constructor builds — no type information
  needed. It is built *before* the module's defs are evaluated, so a top-level
  constant may use branded arithmetic; a named implementation stays late-bound
  like any global.

## Breaking change (deliberate, per the design)

Because the prelude always declares `+`/`-`/`*` on `Angle.t` and `Time.t`, a
fully unannotated helper — `let plus = (a, b) => a + b` — is now ambiguous and
asks for one annotation, even in a game that never touches a brand. That is the
price of resolving deterministically instead of guessing; the alternative
(default to float and report the mismatch at the call site) was rejected in the
signed-off design. Mitigations: the error needs both operands *and* the result
unconstrained, and `v * v` is decided as float (the scalar form's operands have
different types, so it has no branded reading). **Every example in the repo
typechecks unchanged** — swept all of them, 0 diagnostics — and the behaviour is
pinned by a test rather than left as a surprise.

## Deviations from the design doc

1. **Separate items, not a block.** The doc sketched `unit px = Px { (+) = … }`.
   Shipped as separate `unit px (+) = …` items: `.funi` interfaces stay a flat
   item list, docgen renders each with its own `///` prose, and a project can add
   an operator without touching an already-published unit declaration.
2. **The interpreter is NOT untouched.** The doc predicted a post-pass IR rewrite
   would keep evaluation single-path. The checker is a non-mutating pass over a
   shared `Module`, and `run` / `unknown` seams skip it, so the evaluator
   dispatches too (the task asked for exactly this). The cost is confined to the
   non-number operand path — see frame_bench.
3. **`v * v` is decided, not reported** (above).
4. **Operators need a knowable, run-time-distinguishable brand.** A `unit` whose
   target is an unannotated function can't say which type it builds before
   inference; a record brand carries no runtime tag, and a multi-constructor type
   carries a different one per constructor while the brand is one. All three are
   check errors at the declaration rather than a surprise later.

Out of scope as specified: comparisons on brands (`==`, `<`, `>`), dimensional
analysis, user-facing unit conversion.

## Verification

- `cargo test -p functor-lang -p functor-docgen -p functor_runtime_common` — all
  green, re-run after every review fix (47 tests in `functor-lang/tests/units.rs`;
  runtime 653 lib + 22 prelude-typecheck + 14 docgen).
- `npm run generate:docs` + `npm run check:docs` — clean; the reference renders
  the operator declarations, and the docgen inventory pin moves 282 → 294
  (6 signatures + 6 operator declarations). `--deny-undocumented` covers them.
- `npm run build:cli:debug`, then: `functor -d examples/counter test` (3/3
  expects pass), `functor -d examples/ui test`, and `functor build` on
  `examples/primitives`, `examples/orbs`, `examples/physics-controller` — all
  clean. (`examples/asteroids` / `examples/lighting` fail their *asset* gate on
  this machine — gitignored `.glb`s needing `npm run fetch:assets` — but both
  typecheck: "✓ checked game.fun".)
- A scratch probe project outside `examples/` (engine prelude: branded constants,
  `model.spin + 30deg * dt` in `tick`, a user brand with lambda implementations,
  3 expects) passes `functor test`.
- Every example project typechecked under the engine prelude via a temporary
  sweep: **0 diagnostics**.
- `frame_bench` (release, interleaved runs, min column):

  | ref | us/frame (min) | allocs/frame | bytes/frame |
  | --- | --- | --- | --- |
  | `ctor-full-arity` (base) | 546.7 | 13877 | 843393 |
  | this branch | 448.8 | 13877 | 843393 |

  Re-run after the review fixes (3 more interleaved pairs): base min 758.1,
  branch min 641.2, same allocs/bytes.

  **`allocs/frame` and `bytes/frame` are byte-identical**, which is the number
  that matters: resolution happens at check time, and the eval table is consulted
  only when an arithmetic operand is not a number, so steady-state float math is
  untouched. Wall clock is noise-dominated here (the same binary ranged
  448–1053 us across runs while other builds shared the machine); the two were
  run interleaved from the same two binaries, and the branch's min came out
  *below* the base's.

## Review dispositions (`/xreview`: Claude + Codex + a dedicated de-dup pass)

Three reviewers: a Claude adversarial subagent (A), the Codex CLI (B), and a
dedicated de-dup pass (C). Everything Critical/High from both engines is
**fixed**, with a regression test each.

**Reviewer A (Claude):**

| # | Sev | Finding | Disposition |
| --- | --- | --- | --- |
| 1 | Critical | The dispatch table was built *after* `eval_defs`, so a top-level constant using branded arithmetic checked clean and died at load (`let turn: Angle.t = 90deg + 45deg`). | **Fixed** — the table is built before the defs (and again after, for the rare unit whose own constructor is a top-level `let`); a named implementation is now late-bound like any global. Tests: `a_top_level_constant_may_use_branded_arithmetic` (language + engine prelude), `a_named_implementation_is_late_bound_like_any_global`. |
| 2 | High | The checker keyed brands by TYPE while the interpreter keyed by CONSTRUCTOR, so a multi-constructor brand checked clean and failed at run time with no way to fix it. | **Fixed** — an operator now requires a run-time-distinguishable brand (single-constructor variant, or a host type); anything else is a check error at the declaration. Test: `a_brand_must_be_distinguishable_at_run_time`. |
| 3 | High | A record-typed brand checked clean, then killed the session at load. | **Fixed** by the same rule (records carry no runtime tag), and the loader now skips an untagged unit instead of failing the whole load. Same test. |
| 4 | High | The ambiguity rule makes ordinary unannotated helpers (`(a, b) => a + b`) check errors in every game, because the prelude always declares brand operators. | **Kept, deliberately** — it is the signed-off design ("never a silent float guess"), and reverting to float-defaulting would delete the feature's whole safety story. Mitigated (`v * v` decided; result-type pins count), documented as a breaking change in `docs/functor-lang-units.md`, swept across every example (0 diagnostics), and pinned by `a_fully_unannotated_helper_asks_for_an_annotation` so it is intentional rather than a surprise. |
| 5 | Medium | No duplicate detection on the unchecked path — last declaration silently won. | **Fixed** — the loader refuses it too. Test: `the_interpreter_refuses_a_duplicate_declaration`. |
| 6 | Medium | Operator implementations were checked with an empty `current_module`, so a lambda in a sibling module lost its record-literal scope. | **Fixed** — `UnitOpDef` carries its declaring module, like `ExpectDef`. |
| 7 | Low | New tests were inserted into the middle of an existing comment block. | **Fixed** — block moved, comment restored. |
| 8 | Low | The checker's and the interpreter's "declares X, but not Y" sentences were built twice and had drifted. | **Fixed** — one `declared_operators_hint` formatter in `ast.rs`, plus `BinOp::ARITHMETIC` as the single operator list. |
| 9 | Low | The doc overclaimed that `run` behaves identically to the checked path. | **Fixed** — reworded, and now true for programs that pass the checker. |

De-dup pass: `reuse` — the new test helpers now call the crate's own `angle_of` /
`duration_of`, `brand_name` is used at its two previously-inlined sites, and
`radians_of` became `Angle::radians()` beside `from_radians`/`from_degrees`.
Not taken (justified): pointing the pre-existing
`bundled_animator_executes_against_anim_host` test at the new
`eval_with_prelude` helper (unrelated test, out of scope), and refactoring the
~10 existing inline `Rad<f32>` conversions onto the new accessor (adjacent code
this PR doesn't touch). Coverage: all four strategies ran — S1 names (218-line
report, 41 queries), S2 clones (253 pairs; **no pair overlapped any added
range**), S3 index (3568-line API index), S4 reading.

**Reviewer B (Codex)** — reviewed the fixed tree and found three more, all
addressed:

| # | Sev | Finding | Disposition |
| --- | --- | --- | --- |
| B1 | High | A unit whose own constructor is a top-level `let` could not be probed before the defs ran, and the retry only happened *after* `eval_defs` — so `let make = …` / `unit px = make` / `let total = 1px + 2px` failed at a valid ordering. | **Fixed** — the table now completes incrementally as the defs land, so the first initializer that could use the operator already can (normal programs resolve up front and never enter that branch). Test: `a_unit_built_by_a_top_level_function_still_dispatches`. |
| B2 | High | Deferred resolution ignored an already-solved branded RESULT, so `(a, b): Px => a + b` was reported ambiguous and defaulted to float — contradicting the documented rule. | **Fixed** — `+`/`-` stay inside their brand, so a branded result now resolves both operands (`*`//` deliberately cannot: the brand's side would still be unknown). Test: `an_annotated_result_resolves_the_operands`. |
| B3 | Medium | The "strict" final probe silently swallowed constructor failures and untagged results, so unchecked `run` installed nothing and only failed later, misleadingly. | **Fixed** — the final attempt propagates the constructor's error and rejects an untagged brand with the declaration's context. |
| B4 | Medium | The probe executes each unit constructor twice per load/reload. | **Fixed** — the second pass now runs only when the first was incomplete, so the normal case (every prelude unit) probes exactly once. The remaining "a `unit` target is executed at load" property is inherent to dispatching without types and is documented. |
| B5 | Low | `UnitOpDef::op_span` was dead data. | **Fixed** — the duplicate-operator diagnostic now points at the `(<op>)` itself. |

One API-shape note the de-dup pass surfaced and worth a reviewer's eye:
`Angle.scale` / `Time.scale` are `(t, float) => t` — the operator's declared
shape — which is subject-FIRST, unlike every other `scale` in the prelude. Their
`///` docs say so explicitly.

## CI fixes (post-review)

### 2 — `e2e-headless`: the breaking change hit an SDK fixture

`functor-lang-closure-rebind.e2e.test.ts` builds its game from
`let makeSpin = (k) => (dt) => k * dt`, which is exactly the documented
migration case: both operands unsolved, so the operator asks for an
annotation and `functor run` exits 1 with a type error (the harness reports it
as "process exited early"). Not a crash, and not the dispatch fix — this job
failed on the previous commit (07456da) too.

Fixed by annotating the fixture (`(k: float)`), the one-line migration the docs
prescribe, with a comment pointing at `docs/functor-lang-units.md`. Verified:
the test fails before the annotation with that exact diagnostic and passes
after.

I then swept **every** `.fun` project in the repo under the engine prelude —
not just `examples/`, which is the gap that let this through — covering
`cli/templates`, `site/examples`, editor and SDK fixtures, and the bench corpus.
After this fixture, **nothing else in the repo is affected**: the only other
hit was `functor-lang/benches/corpus/adt.fun`, and its real harness runs under
the PLAIN prelude where no brand operators exist (`functor-lang check` on it is
clean).

**Worth a maintainer's call:** both in-repo casualties so far (`examples/asteroids`'s
`v * v`, now decided as float, and this `k * dt`) are the SCALAR operator with
two unsolved operands. Since a branded scaling always has its brand pinned
somewhere — you must have constructed the branded value — the ambiguity error
for `*`//` may be earning its tax only on float code, while `+`/`-` (same-brand
on both sides) is where it carries real weight. Narrowing it to `+`/`-` would be
a one-line change; I have NOT made that call unilaterally since the "never a
silent float guess" rule is the signed-off design.

### 1 — `wasm-smoke`: unit operators must not resolve at defs load

`wasm-smoke`'s IDE-page job failed with
``defs failed to load: unknown external `Angle.degrees` ``. Root cause: the
operator table was built **eagerly at defs load** — it probed each unit's own
constructor (`Angle.degrees(1.0)`) to learn the brand's runtime tag and
evaluated the implementation target — and a "strict" second pass (added for
Codex finding B3) *propagated* that failure. Under the hostless interpreter the
editor's expect gutter uses, those prelude externals do not exist, so every
project's expects reported a load error.

Fix — nothing about a unit operator may execute or resolve host code at defs
load:

- implementations are kept **symbolic** (`OpImpl::External` / `Global`) and
  resolved only when the operator dispatches, sharing eval's own external
  resolver;
- a brand whose constructor this interpreter cannot run simply gets **no entry**
  instead of failing the load — with no host you cannot build one of its values
  either, so nothing can dispatch on it;
- the strict-at-load reporting from B3 is **reverted**: the use site is the
  right seam for that error, and CI proved reporting at load is wrong. (A
  duplicate declaration still refuses the load — detecting it needs no host.)

Regression tests at both levels, which is exactly the gap the original suite
had — it never ran `cargo test -p functor-lang-wasm`:

- `tools/functor-lang-wasm`: `prelude_unit_operators_do_not_break_a_hostless_defs_load`
  asserts the gutter payload for an ordinary project is `pass`, not an error row.
- `runtime/functor-runtime-common`: `prelude_unit_operators_load_under_the_plain_interpreter`
  runs the prelude-linked defs under `NoHost` and also proves a USER brand's
  operators still dispatch there (a constructor needs no host).

Verified locally: the two pre-existing `functor-lang-wasm` gutter tests that my
change had broken now pass, `npm run build:lang-wasm` + `site:build` +
`npm run test:ide-page` is **RESULT: PASS**, and the four-crate suite
(`functor-lang`, `functor-docgen`, `functor_runtime_common`, `functor-lang-wasm`)
is green.

## Docs

- `docs/functor-lang-units.md` — Phase 2 moved from "designed" to "as shipped":
  resolution rules, the unsolved-variable teaching error, the runtime table, the
  breaking-change callout, and the deviations above.
- The `functor-lang` skill — units section, operator semantics, the new teaching
  errors.
- The manual teaches branded VALUES and their literal suffixes but no branded
  arithmetic, so it is untouched; its sharp-edges section belongs to #616.
  Mentioning operator support in that bullet is a post-merge follow-up.


