### PR TITLE
feat(vr): module entry roles over the device push protocol

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -456,7 +456,10 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   plain entry. A functor.json ROLE may opt into a block instead —
   `"server": { "file": "game.fun", "module": "Server" }` resolves
   `Server.init`/`Server.tick`/… (see `entries` above). Such a role runs on
-  native and wasm; only vr still refuses it.
+  every shell — on vr it rides the device push's query string
+  (`?module=Server`), which needs a tool APK speaking debug protocol v9 or
+  newer (`run vr` refuses an older one rather than letting it boot the
+  unprefixed contract).
 - **The shadowing trap when a role moves into a block.** A block's own names
   shadow the file's, so `module Client { let init = init }` is
   **self-referential**, not an alias of a top-level `init` — you get

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -250,13 +250,14 @@ shared bare above them, so one buffer hot-reloads both roles atomically (its
 sandbox client and server panes boot the same source at `?module=Client` /
 `?module=Server`). `examples/mp` is the roles-as-FILES reference — the shape
 to reach for once roles outgrow one buffer or want independent deploy units.
-**Both forms run on native and
-wasm**: `run wasm`/`build wasm` bake the
+**Both forms run on every shell.**
+`run wasm`/`build wasm` bake the
 role into the served/exported page's boot config (`window.__functorLangEntryModule`
 / `…EntryPrefix`; the site player takes `?module=<Ident>` or `?prefix=<ident>`,
-one of the two). Only **vr** still refuses a role — its device push path boots
-the APK's embedded producer with the unprefixed contract. `entry` and `entries`
-together are refused.
+one of the two). On **vr** the role rides each device push as a query string
+(`POST /load-project?module=Server` / `?prefix=server`), so the APK's embedded
+producer re-resolves it on every re-push exactly as native re-resolves it on
+every save. `entry` and `entries` together are refused.
 
 ```functor
 // utils.fun                                  // → module Utils

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,10 +248,11 @@ error listing the file's blocks). The transitional form names a binding **prefix
 `"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical entry
 binding through the prefix as camelCase (`serverInit`/`serverTick`/…); a role declares at
 most one of the two. `build` validates every declared role's contract with its resolved
-names. Both forms run on native and wasm — `run wasm`/`build wasm` bake the role into the
-served/exported page's boot config, and the site player takes `?module=<Ident>` or
-`?prefix=<ident>`. Only `run vr` refuses a role (the device push path boots the APK's
-embedded producer with the unprefixed contract). The two multiplayer samples are the
+names. Both forms run on every shell — `run wasm`/`build wasm` bake the role into the
+served/exported page's boot config, the site player takes `?module=<Ident>` or
+`?prefix=<ident>`, and `run vr` DECLARES the role in each device push's query string
+(`POST /load-project?module=Server`), which the APK's embedded producer re-resolves on
+every push. The two multiplayer samples are the
 deliberate pair of shapes: **`examples/orbs`** is the SAME-FILE reference — one `game.fun`
 whose `client` and `server` roles are both inline modules of it (`module Client { … }` /
 `module Server { … }`, with the protocol, the world step and the renderer shared bare above

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -625,32 +625,6 @@ impl FunctorLangProject {
         Ok(())
     }
 
-    /// Can this shell boot this role? Native takes either same-file form
-    /// (`--entry-prefix` / `--entry-module`) and wasm bakes either into the
-    /// served page's boot config, but the vr device push path still boots the
-    /// APK's embedded producer with the unprefixed contract — so running a
-    /// role there would silently play the WRONG role. The test names the
-    /// shells that DO support the forms, so a future environment is refused
-    /// until it is taught them. The config refuses a role declaring both
-    /// forms, so at most one is ever named here.
-    fn check_role_supported(&self, environment: &Environment) -> Result<(), Error> {
-        use functor_runtime_common::functor_lang_producer::EntryRole;
-        match environment {
-            Environment::Native | Environment::Wasm => return Ok(()),
-            Environment::Vr => {}
-        }
-        let shell = environment.as_str();
-        let (form, name) = match self.entry_role() {
-            EntryRole::Prefix(prefix) if prefix.is_empty() => return Ok(()),
-            EntryRole::Prefix(prefix) => ("prefix", prefix),
-            EntryRole::Module(module) => ("module", module),
-        };
-        Err(Error::other(format!(
-            "entry {form} `{name}` is not supported on {shell} yet — run this role with \
-`run native` or `run wasm` (the vr shell loads the unprefixed contract)"
-        )))
-    }
-
     /// Spawn the runner on the entry (`run` and `develop` — hot reload is
     /// built into the producer, so there is no separate watch loop).
     pub async fn run(
@@ -661,7 +635,6 @@ impl FunctorLangProject {
         develop: bool,
     ) -> Result<(), Error> {
         refresh_manifest(working_directory);
-        self.check_role_supported(environment)?;
         if matches!(environment, Environment::Vr) {
             if !runner_args.is_empty() {
                 emit(Event::Warning {
@@ -822,6 +795,10 @@ with --debug-port (and --debug-bind 0.0.0.0 if remote)?"
     async fn run_vr(&self, working_directory: &str) -> Result<(), Error> {
         let entry_path = self.entry_path(working_directory)?;
         let project_root = Path::new(working_directory);
+        // The device has no command line: every push DECLARES this entry's
+        // same-file role, so the APK's producer resolves the same contract
+        // `run native` and `run wasm` do (and re-resolves it on each re-push).
+        let role = self.entry_role();
         let serial = adb_device().await?;
         adb_require_runtime(&serial).await?;
         // `am start` on the running singleTask activity is a no-op resume —
@@ -874,7 +851,7 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         let files = read_project_json(&entry_path)?;
         let mut attempted = None;
         for _ in 0..20 {
-            match post_load_project(&addr, &files) {
+            match post_load_project(&addr, &files, &role) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
                     attempted = Some(files.clone());
@@ -960,7 +937,7 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
             if current == attempted {
                 continue;
             }
-            match post_reload_project(&addr, &current) {
+            match post_reload_project(&addr, &current, &role) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
                     attempted = current;
@@ -1528,15 +1505,34 @@ fn read_project_json(entry_path: &Path) -> Result<String, Error> {
 }
 
 /// POST the whole project file set (the `read_project_json` body) to the
-/// runtime's `/reload-project`.
-fn post_reload_project(addr: &str, files_json: &str) -> Result<(u16, String), Error> {
-    http_post(addr, "/reload-project", "application/json", files_json)
+/// runtime's `/reload-project`, DECLARING this entry's same-file role in the
+/// query string. A device session takes its role from the push (no command
+/// line reaches it), and every push re-declares it, so the plain contract
+/// travels as an explicit empty prefix rather than as silence.
+fn post_reload_project(
+    addr: &str,
+    files_json: &str,
+    role: &functor_runtime_common::functor_lang_producer::EntryRole,
+) -> Result<(u16, String), Error> {
+    let path = format!(
+        "/reload-project{}",
+        functor_runtime_common::debug_protocol::encode_entry_role_query(role)
+    );
+    http_post(addr, &path, "application/json", files_json)
 }
 
 /// Load the first pushed project as a new game, taking its model from `init`.
 /// Later watch-loop edits use `/reload-project` and preserve that model.
-fn post_load_project(addr: &str, files_json: &str) -> Result<(u16, String), Error> {
-    http_post(addr, "/load-project", "application/json", files_json)
+fn post_load_project(
+    addr: &str,
+    files_json: &str,
+    role: &functor_runtime_common::functor_lang_producer::EntryRole,
+) -> Result<(u16, String), Error> {
+    let path = format!(
+        "/load-project{}",
+        functor_runtime_common::debug_protocol::encode_entry_role_query(role)
+    );
+    http_post(addr, &path, "application/json", files_json)
 }
 
 /// Minimal HTTP POST over std::net — one dependency-free request to the
@@ -1957,12 +1953,17 @@ mod tests {
         assert!(err.to_string().contains("valid identifier"), "{err}");
     }
 
-    /// The shells that can boot a same-file ROLE. Both forms run on native
-    /// and wasm (the page's boot config carries the module now); vr still
-    /// boots the unprefixed contract, so a role is refused there with a
-    /// teaching error naming the form.
+    /// Every shell boots either same-file ROLE now. Native and wasm take it
+    /// from a command line / the page's boot config; vr has neither, so the
+    /// device push DECLARES it — this pins the query string `run vr` appends
+    /// to `/load-project` and `/reload-project` for each form, including the
+    /// plain contract's explicit empty prefix (silence would mean "keep the
+    /// role already in force", which cannot switch a live session back).
     #[test]
-    fn a_role_runs_on_native_and_wasm_but_not_vr() {
+    fn every_role_form_declares_itself_on_the_vr_push() {
+        use functor_runtime_common::debug_protocol::{
+            encode_entry_role_query, parse_entry_role_query,
+        };
         let config = named_json(&[
             (
                 "client",
@@ -1974,23 +1975,21 @@ mod tests {
             ),
             ("plain", serde_json::json!("game.fun")),
         ]);
-        for role in ["client", "legacy"] {
-            let project = config.select(Some(role)).unwrap();
-            for env in [Environment::Native, Environment::Wasm] {
-                assert!(
-                    project.check_role_supported(&env).is_ok(),
-                    "`{role}` must boot on {env:?}"
-                );
-            }
-            let err = project
-                .check_role_supported(&Environment::Vr)
-                .unwrap_err()
-                .to_string();
-            assert!(err.contains("not supported on vr yet"), "{err}");
+        for (role, expected) in [
+            ("client", "?module=Client"),
+            ("legacy", "?prefix=legacy"),
+            ("plain", "?prefix="),
+        ] {
+            let declared = config.select(Some(role)).unwrap().entry_role();
+            let query = encode_entry_role_query(&declared);
+            assert_eq!(query, expected, "`{role}` push query");
+            // What the device parses back is the role the CLI resolved.
+            assert_eq!(
+                parse_entry_role_query(query.trim_start_matches('?')).unwrap(),
+                Some(declared),
+                "`{role}` round trip"
+            );
         }
-        // A role with neither form is the plain contract — every shell boots it.
-        let plain = config.select(Some("plain")).unwrap();
-        assert!(plain.check_role_supported(&Environment::Vr).is_ok());
     }
 
     #[test]

--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -308,16 +308,9 @@ camelCase binding prefix (e.g. \"server\" resolves serverInit/serverTick/…)"
             };
             // A prefix concatenates into binding NAMES, so it must itself be a
             // valid identifier — refuse `"my server"` here, not as a baffling
-            // "has no top-level `let my serverInit`" later.
-            let mut chars = prefix.chars();
-            let valid = match chars.next() {
-                None => true,
-                Some(first) => {
-                    (first.is_ascii_alphabetic() || first == '_')
-                        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
-                }
-            };
-            if !valid {
+            // "has no top-level `let my serverInit`" later. The rule is the
+            // shared one every role carrier validates with.
+            if !functor_runtime_common::functor_lang_producer::EntryRole::is_valid_prefix(&prefix) {
                 return Err(Error::other(format!(
                     "functor.json entry `{name}`: \"prefix\" must be a valid identifier \
 (it becomes the binding prefix: `{prefix}Init`, `{prefix}Tick`, …)"
@@ -346,15 +339,7 @@ module holding this role's entry bindings (e.g. \"Server\" resolves Server.init/
             // spelled like one — refuse `"my server"` (or a lowercase name,
             // which the parser rejects at the declaration) here, not as a
             // baffling missing-block error later.
-            let mut chars = module.chars();
-            let valid = match chars.next() {
-                None => true,
-                Some(first) => {
-                    first.is_ascii_uppercase()
-                        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
-                }
-            };
-            if !valid {
+            if !functor_runtime_common::functor_lang_producer::EntryRole::is_valid_module(&module) {
                 return Err(Error::other(format!(
                     "functor.json entry `{name}`: \"module\" must be a Capitalized inline \
 module name (it is the block's own name: `module {module} {{ … }}`)"
@@ -835,6 +820,26 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
             )));
         }
 
+        // The tool APK installs separately from this CLI, so a headset can be
+        // running an older build — and a pre-v9 runtime IGNORES the role query
+        // and boots the unprefixed contract, i.e. silently the wrong game. A
+        // declared role therefore requires a runtime that speaks the form; the
+        // plain contract runs on any of them.
+        use functor_runtime_common::functor_lang_producer::EntryRole;
+        if !matches!(&role, EntryRole::Prefix(prefix) if prefix.is_empty()) {
+            let version = probe_protocol_version(&addr);
+            if version.is_some_and(|version| version < ENTRY_ROLE_PROTOCOL_VERSION) {
+                return Err(Error::other(format!(
+                    "the headset's functor runtime is too old for an entry role (it speaks debug \
+protocol v{}, and roles need v{ENTRY_ROLE_PROTOCOL_VERSION}) — it would ignore the role and boot \
+the unprefixed contract. Reinstall the tool APK (npm run build:oculus:apk && adb install -r \
+target-android/debug/apk/functor_runtime_oculus.apk), or run this role with `run native` / \
+`run wasm`.",
+                    version.unwrap_or(0)
+                )));
+            }
+        }
+
         let mut attempted_assets = project_asset_files(project_root)?;
         let report = sync_project_assets(&addr, &attempted_assets, None)?;
         let mut observed_assets = attempted_assets.clone();
@@ -851,7 +856,7 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
         let files = read_project_json(&entry_path)?;
         let mut attempted = None;
         for _ in 0..20 {
-            match post_load_project(&addr, &files, &role) {
+            match post_project(&addr, "/load-project", &files, &role) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
                     attempted = Some(files.clone());
@@ -937,7 +942,7 @@ is the functor VR runtime running? (`adb logcat -s functor` for its startup log)
             if current == attempted {
                 continue;
             }
-            match post_reload_project(&addr, &current, &role) {
+            match post_project(&addr, "/reload-project", &current, &role) {
                 Ok((200, body)) => {
                     emit(Event::Info { message: body });
                     attempted = current;
@@ -1197,6 +1202,11 @@ const VR_PACKAGE: &str = "dev.functor.runner";
 const VR_COMPONENT: &str = "dev.functor.runner/android.app.NativeActivity";
 /// Its device-loopback push port (`adb forward` bridges it to this machine).
 const VR_PORT: u16 = 8123;
+
+/// The debug protocol version that added the project push's entry-role query.
+/// Older device runtimes ignore it, so a declared role must not be pushed to
+/// one — see the check in `run_vr`.
+const ENTRY_ROLE_PROTOCOL_VERSION: u64 = 9;
 
 /// Run one adb command to completion; stdout on success, a rendered error
 /// (including the "adb isn't installed" case) otherwise.
@@ -1504,32 +1514,22 @@ fn read_project_json(entry_path: &Path) -> Result<String, Error> {
     serde_json::to_string(&files).map_err(Error::other)
 }
 
-/// POST the whole project file set (the `read_project_json` body) to the
-/// runtime's `/reload-project`, DECLARING this entry's same-file role in the
+/// POST the whole project file set (the `read_project_json` body) to one of
+/// the runtime's project routes, DECLARING this entry's same-file role in the
 /// query string. A device session takes its role from the push (no command
 /// line reaches it), and every push re-declares it, so the plain contract
 /// travels as an explicit empty prefix rather than as silence.
-fn post_reload_project(
+///
+/// `/load-project` starts a new game, taking its model from `init`;
+/// `/reload-project` (the watch loop's route) preserves that live model.
+fn post_project(
     addr: &str,
+    route: &str,
     files_json: &str,
     role: &functor_runtime_common::functor_lang_producer::EntryRole,
 ) -> Result<(u16, String), Error> {
     let path = format!(
-        "/reload-project{}",
-        functor_runtime_common::debug_protocol::encode_entry_role_query(role)
-    );
-    http_post(addr, &path, "application/json", files_json)
-}
-
-/// Load the first pushed project as a new game, taking its model from `init`.
-/// Later watch-loop edits use `/reload-project` and preserve that model.
-fn post_load_project(
-    addr: &str,
-    files_json: &str,
-    role: &functor_runtime_common::functor_lang_producer::EntryRole,
-) -> Result<(u16, String), Error> {
-    let path = format!(
-        "/load-project{}",
+        "{route}{}",
         functor_runtime_common::debug_protocol::encode_entry_role_query(role)
     );
     http_post(addr, &path, "application/json", files_json)
@@ -1540,6 +1540,31 @@ fn post_load_project(
 /// keeps the read side trivial (read to EOF, split headers off).
 fn post_reload_source(addr: &str, source: &str) -> Result<(u16, String), Error> {
     http_post(addr, "/reload-source", "text/plain", source)
+}
+
+/// The debug protocol version a runtime reports at `GET /`, or `None` when the
+/// endpoint is unreachable or answers something unexpected.
+fn probe_protocol_version(addr: &str) -> Option<u64> {
+    use std::io::{Read, Write};
+    use std::net::ToSocketAddrs;
+    let timeout = std::time::Duration::from_secs(5);
+    let sockaddr = addr.to_socket_addrs().ok()?.next()?;
+    let mut stream = std::net::TcpStream::connect_timeout(&sockaddr, timeout).ok()?;
+    stream.set_read_timeout(Some(timeout)).ok()?;
+    stream.set_write_timeout(Some(timeout)).ok()?;
+    write!(
+        stream,
+        "GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
+    )
+    .ok()?;
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response).ok()?;
+    let response = String::from_utf8_lossy(&response);
+    let (_, body) = response.split_once("\r\n\r\n")?;
+    serde_json::from_str::<serde_json::Value>(body.trim())
+        .ok()?
+        .get("protocol_version")?
+        .as_u64()
 }
 
 fn http_post(
@@ -1622,7 +1647,6 @@ mod tests {
         manifest_mouse_capture, nth_line, project_asset_files, resolve_debug_args, CursorPolicy,
         FunctorLangConfig, FunctorLangEntries, FunctorLangProject,
     };
-    use crate::Environment;
 
     fn resolve(develop: bool, args: &[&str]) -> (Vec<String>, Option<String>) {
         let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -113,8 +113,8 @@ screenshot run has no reason to grab your mouse.
 | `POST /input` | inject input (see below) |
 | `POST /time` | control the frame clock (see below) |
 | `POST /reload-source` | swap game logic from the request body (see below) |
-| `POST /reload-project` | swap all sibling modules from a JSON array of `[path, source]` pairs, entry first |
-| `POST /load-project` | start a new sibling-module project from the same body, initializing its model from `init` |
+| `POST /reload-project` | swap all sibling modules from a JSON array of `[path, source]` pairs, entry first; `?module=`/`?prefix=` declares the same-file entry role |
+| `POST /load-project` | start a new sibling-module project from the same body, initializing its model from `init`; takes the same role query |
 | `GET /project` | the running program's own `.fun` sources as a JSON array of `[path, source]` pairs, entry first — the read half of the push routes (see below) |
 | `POST /reload-asset` | upload one project-relative texture/model/audio asset as a binary path+bytes envelope |
 | `POST /sync-assets` | finish a sync from a JSON array of current asset paths; uploaded paths absent from the manifest are removed |
@@ -426,6 +426,30 @@ starts with the project's `init` model. Its watch loop then uses
 `/reload-project`, preserving that live model across edits. Both routes carry
 all sibling `.fun`/`.funi` modules, with the same file-as-module behavior as
 desktop.
+
+#### Declaring a same-file entry role (protocol v9)
+
+A device session has no command line, so a project push declares which
+same-file role to boot in the route's **query string** — the same two forms
+functor.json and the web page's boot config carry:
+
+```sh
+curl -X POST --data-binary @project.json \
+  'http://127.0.0.1:8123/load-project?module=Server'   # an inline `module Server { … }`
+curl -X POST --data-binary @project.json \
+  'http://127.0.0.1:8123/reload-project?prefix=server' # serverInit/serverTick/…
+```
+
+The runtime **re-resolves** the role against each pushed program, so an edit
+that renames or deletes the block fails with an error naming it and the old
+program keeps running — under the role it was already running.
+
+Declaring nothing is not the same as declaring the plain contract: a push with
+no role query leaves the role already in force alone (so `functor push` and the
+MCP tools need no revision), while `?prefix=` explicitly selects the unprefixed
+contract. `functor run vr` always declares, including `?prefix=` for a plain
+project. A pre-v9 runtime ignores the query and boots the unprefixed contract;
+a role declared twice, or one that is not an identifier, is a **400**.
 
 ### `GET /project` — read the running sources back (protocol v5)
 

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -725,15 +725,12 @@ snapshots — no GPU, fully agent-verifiable.
       `build wasm` bake into the served/exported index page, and the site
       player takes as `?module=<Ident>` (capitalized identifier; anything
       else warns and boots the unprefixed contract). `run wasm` and
-      `build wasm` no longer refuse a module role; **vr still does**, because
-      its device push path boots the APK's embedded producer with the
-      unprefixed contract and teaching it the form needs a protocol +
-      on-device change. *Verify:* embedded-producer tests (a module role's
-      contract is the block's, a push re-resolves it with the model
-      preserved, a push deleting the block keeps the old program, an unknown
-      block lists the file's blocks), CLI tests for the lifted guards and the
-      page's baked boot config, and a headless `run wasm` browser smoke of a
-      `module Server` role.
+      `build wasm` no longer refuse a module role. *Verify:*
+      embedded-producer tests (a module role's contract is the block's, a
+      push re-resolves it with the model preserved, a push deleting the block
+      keeps the old program, an unknown block lists the file's blocks), CLI
+      tests for the lifted guards and the page's baked boot config, and a
+      headless `run wasm` browser smoke of a `module Server` role.
       **Part 10 — the samples adopt the two canonical shapes — done:**
       `examples/orbs` is now fully symmetric — its functor.json maps BOTH
       roles to blocks of the one `game.fun`
@@ -758,6 +755,24 @@ snapshots — no GPU, fully agent-verifiable.
       project (the exported page carries `__functorLangEntryModule`), and the
       sandbox e2e pinning the module-form panes plus live packet flow between
       the client panes and the authority.
+      **Part 11 — roles over the device push protocol (vr) — done:** the
+      device has no command line, so a project push DECLARES its role in the
+      query string of `POST /load-project` / `POST /reload-project`
+      (`?module=Server` / `?prefix=server`; debug-protocol v9). The Quest
+      shell adopts it before the load, which means the SAME re-resolution
+      Part 9 built runs on every re-push: an edit that deletes the block
+      fails loudly naming it and the old program keeps running, and the role
+      it was running with survives the rejection. Tolerant both ways — a
+      pre-v9 APK ignores the query, and a v9 runtime hearing no query keeps
+      the role already in force (so `functor push` and the MCP tools need no
+      revision), which is why the plain contract travels as an explicit
+      `?prefix=` rather than as silence. **No shell refuses a role now**, so
+      the CLI's per-environment guard is gone. *Verify:* query
+      encode/parse/round-trip tests, an HTTP test that the role reaches the
+      runtime loop (and that a doubly-declared or non-identifier role is a
+      400), an embedded-producer test of the whole boot → re-push → broken
+      push → role-less push sequence, and an on-device run of a `module`
+      role on a Quest 3 (stereo capture, live re-push, deleted-block push).
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -118,7 +118,9 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
     let mut parts = request_line.split_whitespace();
     let method = parts.next().unwrap_or("");
     let path_with_query = parts.next().unwrap_or("");
-    let path = path_with_query.split('?').next().unwrap_or("");
+    let (path, query) = path_with_query
+        .split_once('?')
+        .unwrap_or((path_with_query, ""));
 
     let mut content_length = None;
     let mut origin = None;
@@ -511,10 +513,19 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
                         return Some(());
                     }
                 };
+                // The push may DECLARE its same-file entry role in the query
+                // string; no query means the running role stands.
+                let role = match debug_protocol::parse_entry_role_query(query) {
+                    Ok(role) => role,
+                    Err(error) => {
+                        respond_text(&mut stream, cors_origin, 400, "Bad Request", &error);
+                        return Some(());
+                    }
+                };
                 if path == "/load-project" {
-                    DebugRequest::LoadProject(files, resp_tx)
+                    DebugRequest::LoadProject(files, role, resp_tx)
                 } else {
-                    DebugRequest::ReloadProject(files, resp_tx)
+                    DebugRequest::ReloadProject(files, role, resp_tx)
                 }
             } else {
                 let source = match String::from_utf8(body) {
@@ -721,7 +732,8 @@ mod tests {
         let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
 
         match rx.recv().unwrap() {
-            DebugRequest::ReloadProject(files, response) => {
+            DebugRequest::ReloadProject(files, role, response) => {
+                assert_eq!(role, None);
                 assert_eq!(files, vec![("game.fun".into(), "let init = 1".into())]);
                 response.send(Ok("reloaded project".into())).unwrap();
             }
@@ -795,8 +807,9 @@ mod tests {
         let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
 
         match rx.recv().unwrap() {
-            DebugRequest::LoadProject(files, response) => {
+            DebugRequest::LoadProject(files, role, response) => {
                 assert_eq!(files, vec![("game.fun".into(), "let init = 1".into())]);
+                assert_eq!(role, None, "no query = the running role stands");
                 response.send(Ok("loaded project".into())).unwrap();
             }
             _ => panic!("expected new project load request"),
@@ -806,6 +819,68 @@ mod tests {
         let response = client.join().unwrap();
         assert!(response.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(response.ends_with("loaded project"));
+    }
+
+    /// A project push may DECLARE its same-file entry role in the query
+    /// string — how a device session (which has no command line) learns which
+    /// contract to boot. A malformed declaration is a 400, not a silently
+    /// wrong contract.
+    #[test]
+    fn a_project_push_carries_the_entry_role_it_declares() {
+        use crate::functor_lang_producer::EntryRole;
+        let push = |query: &str| {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let body = r#"[["game.fun","let init = 1"]]"#;
+            let request = format!(
+                "POST /reload-project{query} HTTP/1.1\r\nHost: localhost\r\n\
+Content-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            let client = connect(&listener, request);
+            let (tx, rx) = mpsc::channel();
+            let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+            let role = match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+                Ok(DebugRequest::ReloadProject(_, role, response)) => {
+                    response.send(Ok("reloaded".into())).unwrap();
+                    Some(role)
+                }
+                Ok(_) => panic!("expected a project reload"),
+                // A rejected query never reaches the runtime loop.
+                Err(_) => None,
+            };
+            server.join().unwrap();
+            (role, client.join().unwrap())
+        };
+
+        let (role, response) = push("?module=Server");
+        assert_eq!(role, Some(Some(EntryRole::Module("Server".into()))));
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response}");
+
+        let (role, _) = push("?prefix=server");
+        assert_eq!(role, Some(Some(EntryRole::Prefix("server".into()))));
+
+        // The plain contract declares itself explicitly, so a live role can be
+        // switched back off — unlike silence, which keeps the running role.
+        let (role, _) = push("?prefix=");
+        assert_eq!(role, Some(Some(EntryRole::Prefix(String::new()))));
+
+        let (role, response) = push("?module=Server&prefix=server");
+        assert_eq!(role, None, "a doubly-declared role never loads");
+        assert!(
+            response.starts_with("HTTP/1.1 400 Bad Request\r\n"),
+            "{response}"
+        );
+
+        let (role, response) = push("?module=Ser%20ver");
+        assert_eq!(role, None, "a non-identifier role never loads");
+        assert!(
+            response.starts_with("HTTP/1.1 400 Bad Request\r\n"),
+            "{response}"
+        );
+
+        // An unknown query key is ignored, not fatal (forward tolerance).
+        let (role, _) = push("?module=Server&futureFlag=1");
+        assert_eq!(role, Some(Some(EntryRole::Module("Server".into()))));
     }
 
     /// A clock command the runtime cannot honor must be a LOUD 409, not a `200

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -878,9 +878,14 @@ Content-Length: {}\r\n\r\n{body}",
             "{response}"
         );
 
-        // An unknown query key is ignored, not fatal (forward tolerance).
-        let (role, _) = push("?module=Server&futureFlag=1");
-        assert_eq!(role, Some(Some(EntryRole::Module("Server".into()))));
+        // A typo'd key is a 400, not a silent "declared nothing" that would
+        // keep the running contract while reporting success.
+        let (role, response) = push("?moduel=Server");
+        assert_eq!(role, None, "an unknown role key never loads");
+        assert!(
+            response.starts_with("HTTP/1.1 400 Bad Request\r\n"),
+            "{response}"
+        );
     }
 
     /// A clock command the runtime cannot honor must be a LOUD 409, not a `200

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -50,8 +50,9 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// of `POST /load-project` / `POST /reload-project` (`?module=Server` or
 /// `?prefix=server`; see [`encode_entry_role_query`]). Tolerant in both
 /// directions: a pre-v9 runtime ignores the query and boots the unprefixed
-/// contract, and a v9 runtime treats a push with no role query as "the role
-/// already in force stands".
+/// contract (so `functor run vr` refuses to push a role to one), and a v9
+/// runtime treats a push with no role query as "the role already in force
+/// stands".
 pub const DEBUG_PROTOCOL_VERSION: u32 = 9;
 
 /// The well-known localhost port `functor develop` serves this protocol on
@@ -351,9 +352,17 @@ pub fn encode_entry_role_query(role: &crate::functor_lang_producer::EntryRole) -
 /// Decode [`encode_entry_role_query`]'s query string (the part AFTER `?`).
 ///
 /// `Ok(None)` means the push declared no role at all — the runtime keeps the
-/// role it is already running. An unknown query key is ignored (forward
-/// tolerance); a malformed or doubly-declared role is an error, because
-/// silently booting the wrong contract is worse than a 400.
+/// role it is already running.
+///
+/// Everything else about the query is REFUSED rather than interpreted
+/// loosely: an unknown key (so `?moduel=Client` is a 400 instead of a typo
+/// that silently keeps the previous contract), a key declared twice, both
+/// forms at once, and any name the other role carriers would reject — the
+/// validation is literally theirs ([`EntryRole::is_valid_module`] /
+/// [`EntryRole::is_valid_prefix`]), so this seam cannot boot a role
+/// functor.json or the web page would refuse. Silently running the wrong
+/// contract is the failure this query exists to prevent, and it is worse
+/// than a 400.
 pub fn parse_entry_role_query(
     query: &str,
 ) -> Result<Option<crate::functor_lang_producer::EntryRole>, String> {
@@ -365,7 +374,11 @@ pub fn parse_entry_role_query(
         let slot = match key {
             "module" => &mut module,
             "prefix" => &mut prefix,
-            _ => continue,
+            _ => {
+                return Err(format!(
+                    "unknown entry-role key `{key}` — this push declares `module` or `prefix`"
+                ))
+            }
         };
         if slot.is_some() {
             return Err(format!("the push declares `{key}` more than once"));
@@ -377,13 +390,21 @@ pub fn parse_entry_role_query(
         if value.len() > MAX_ENTRY_ROLE_NAME_BYTES {
             return Err(format!("entry {key} is too long"));
         }
-        if let Some(bad) = value
-            .chars()
-            .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
-        {
-            return Err(format!(
-                "entry {key} `{value}` is not an identifier (at `{bad}`)"
-            ));
+        let valid = match key {
+            "module" => EntryRole::is_valid_module(value),
+            _ => EntryRole::is_valid_prefix(value),
+        };
+        if !valid {
+            return Err(match key {
+                "module" => format!(
+                    "entry module `{value}` must be a Capitalized inline module name \
+(it is the block's own name: `module {value} {{ … }}`)"
+                ),
+                _ => format!(
+                    "entry prefix `{value}` must be a valid identifier \
+(it becomes the binding prefix: `{value}Init`, `{value}Tick`, …)"
+                ),
+            });
         }
     }
     match (module, prefix) {
@@ -557,6 +578,22 @@ mod tests {
         assert!(parse_entry_role_query("prefix=a.b").is_err());
         assert!(parse_entry_role_query("module=A&module=B").is_err());
         assert!(parse_entry_role_query(&format!("module={}", "A".repeat(200))).is_err());
+        // The SAME rules the other role carriers apply: a module names a
+        // Capitalized block, a prefix is an identifier. A name one seam
+        // accepts and another refuses is how a role boots the wrong contract.
+        assert!(parse_entry_role_query("module=server").is_err());
+        assert!(parse_entry_role_query("prefix=9server").is_err());
+        // A typo'd key is refused too — treating it as "declared nothing"
+        // would silently keep the previous contract with a 200.
+        assert!(parse_entry_role_query("moduel=Client").is_err());
+        // The SAME rules the other role carriers apply: a module names a
+        // Capitalized block, a prefix is an identifier. A name one seam
+        // accepts and another refuses is how a role boots the wrong contract.
+        assert!(parse_entry_role_query("module=server").is_err());
+        assert!(parse_entry_role_query("prefix=9server").is_err());
+        // A typo'd key is refused too — treating it as "declared nothing"
+        // would silently keep the previous contract with a 200.
+        assert!(parse_entry_role_query("moduel=Client").is_err());
         // Both declared but only one non-empty is unambiguous, not a conflict.
         assert_eq!(
             parse_entry_role_query("module=Server&prefix="),

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -45,7 +45,14 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 ///
 /// 8 added `POST /time {"type":"cancel"}` so an external driver can abort a
 /// queued batch without leaving clock work behind.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 8;
+///
+/// 9 lets a project push DECLARE its same-file entry role in the query string
+/// of `POST /load-project` / `POST /reload-project` (`?module=Server` or
+/// `?prefix=server`; see [`encode_entry_role_query`]). Tolerant in both
+/// directions: a pre-v9 runtime ignores the query and boots the unprefixed
+/// contract, and a v9 runtime treats a push with no role query as "the role
+/// already in force stands".
+pub const DEBUG_PROTOCOL_VERSION: u32 = 9;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -129,12 +136,12 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "POST",
         path: "/reload-project",
-        description: "swap the whole project from a JSON array of [path, source] pairs (entry first), model preserved — 400 with the load error on a broken push",
+        description: "swap the whole project from a JSON array of [path, source] pairs (entry first), model preserved — 400 with the load error on a broken push; ?module=Server / ?prefix=server declares the same-file entry role",
     },
     DebugRoute {
         method: "POST",
         path: "/load-project",
-        description: "load a new whole project from a JSON array of [path, source] pairs (entry first), model initialized from init — 400 with the load error on a broken push",
+        description: "load a new whole project from a JSON array of [path, source] pairs (entry first), model initialized from init — 400 with the load error on a broken push; ?module=Server / ?prefix=server declares the same-file entry role",
     },
     DebugRoute {
         method: "GET",
@@ -317,6 +324,80 @@ pub enum CaptureError {
 /// A whole-project push: `(path, source)` pairs with the entry first.
 pub type ProjectSources = Vec<(String, String)>;
 
+/// Maximum length of a role name in the project-push query string. Role names
+/// are Functor Lang identifiers; this only exists so a hostile query cannot
+/// make the runtime allocate.
+const MAX_ENTRY_ROLE_NAME_BYTES: usize = 128;
+
+/// Encode a project push's same-file entry ROLE as the query string of
+/// `POST /load-project` / `POST /reload-project` — `"?module=Server"` or
+/// `"?prefix=server"`, the two forms every other role carrier transports
+/// ([`EntryRole::from_parts`](crate::functor_lang_producer::EntryRole::from_parts)).
+///
+/// The role is a *declaration*, so the plain contract encodes explicitly as
+/// `"?prefix="`: a pusher that always declares can switch a live session back
+/// to the unprefixed contract, while a pusher that declares nothing (an older
+/// CLI, `functor push`, the MCP tools) sends no query and leaves the running
+/// role alone. Role names are identifiers, so nothing here needs escaping —
+/// [`parse_entry_role_query`] rejects anything else rather than mangling it.
+pub fn encode_entry_role_query(role: &crate::functor_lang_producer::EntryRole) -> String {
+    use crate::functor_lang_producer::EntryRole;
+    match role {
+        EntryRole::Module(name) => format!("?module={name}"),
+        EntryRole::Prefix(prefix) => format!("?prefix={prefix}"),
+    }
+}
+
+/// Decode [`encode_entry_role_query`]'s query string (the part AFTER `?`).
+///
+/// `Ok(None)` means the push declared no role at all — the runtime keeps the
+/// role it is already running. An unknown query key is ignored (forward
+/// tolerance); a malformed or doubly-declared role is an error, because
+/// silently booting the wrong contract is worse than a 400.
+pub fn parse_entry_role_query(
+    query: &str,
+) -> Result<Option<crate::functor_lang_producer::EntryRole>, String> {
+    use crate::functor_lang_producer::EntryRole;
+    let mut module: Option<&str> = None;
+    let mut prefix: Option<&str> = None;
+    for pair in query.split('&').filter(|pair| !pair.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        let slot = match key {
+            "module" => &mut module,
+            "prefix" => &mut prefix,
+            _ => continue,
+        };
+        if slot.is_some() {
+            return Err(format!("the push declares `{key}` more than once"));
+        }
+        *slot = Some(value);
+    }
+    for (key, value) in [("module", module), ("prefix", prefix)] {
+        let Some(value) = value else { continue };
+        if value.len() > MAX_ENTRY_ROLE_NAME_BYTES {
+            return Err(format!("entry {key} is too long"));
+        }
+        if let Some(bad) = value
+            .chars()
+            .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
+        {
+            return Err(format!(
+                "entry {key} `{value}` is not an identifier (at `{bad}`)"
+            ));
+        }
+    }
+    match (module, prefix) {
+        (None, None) => Ok(None),
+        (Some(module), Some(prefix)) if !module.is_empty() && !prefix.is_empty() => Err(format!(
+            "the push declares both an entry module `{module}` and an entry prefix `{prefix}`"
+        )),
+        (module, prefix) => Ok(Some(EntryRole::from_parts(
+            module.unwrap_or(""),
+            prefix.unwrap_or(""),
+        ))),
+    }
+}
+
 /// One project-relative asset uploaded by `POST /reload-asset`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProjectAsset {
@@ -412,8 +493,18 @@ pub enum DebugRequest {
     /// compiled dylib) — reported as 501 rather than an empty project.
     Project(Sender<Option<ProjectSources>>),
     ReloadSource(String, Sender<Result<String, String>>),
-    ReloadProject(ProjectSources, Sender<Result<String, String>>),
-    LoadProject(ProjectSources, Sender<Result<String, String>>),
+    /// The pushed file set plus the same-file entry role the push DECLARED
+    /// (`None` = it declared none, so the running role stands).
+    ReloadProject(
+        ProjectSources,
+        Option<crate::functor_lang_producer::EntryRole>,
+        Sender<Result<String, String>>,
+    ),
+    LoadProject(
+        ProjectSources,
+        Option<crate::functor_lang_producer::EntryRole>,
+        Sender<Result<String, String>>,
+    ),
     ReloadAsset(ProjectAsset, Sender<Result<String, String>>),
     SyncAssets(ProjectAssetPaths, Sender<Result<String, String>>),
     Rewind(u64, Sender<Result<String, String>>),
@@ -427,6 +518,53 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::*;
+
+    /// The role a project push declares round-trips through its query string,
+    /// and — the point of encoding it at all — the two forms stay DISTINCT
+    /// while an absent declaration stays distinguishable from the plain
+    /// contract's explicit one.
+    #[test]
+    fn a_pushed_entry_role_round_trips_through_the_query_string() {
+        use crate::functor_lang_producer::EntryRole;
+        for role in [
+            EntryRole::Module("Server".to_string()),
+            EntryRole::Prefix("server".to_string()),
+            EntryRole::Prefix(String::new()),
+        ] {
+            let query = encode_entry_role_query(&role);
+            assert_eq!(
+                parse_entry_role_query(query.trim_start_matches('?')),
+                Ok(Some(role.clone())),
+                "{query}"
+            );
+        }
+        // Declaring nothing is NOT declaring the plain contract: a runtime
+        // that hears nothing keeps the role it is already running.
+        assert_eq!(parse_entry_role_query(""), Ok(None));
+        assert_eq!(
+            parse_entry_role_query("prefix="),
+            Ok(Some(EntryRole::Prefix(String::new())))
+        );
+    }
+
+    /// A role that cannot be honored exactly must be REFUSED, never coerced:
+    /// silently booting the wrong contract is the failure this whole query
+    /// exists to prevent.
+    #[test]
+    fn a_malformed_pushed_role_is_refused_rather_than_coerced() {
+        assert!(parse_entry_role_query("module=Server&prefix=server").is_err());
+        assert!(parse_entry_role_query("module=My%20Server").is_err());
+        assert!(parse_entry_role_query("prefix=a.b").is_err());
+        assert!(parse_entry_role_query("module=A&module=B").is_err());
+        assert!(parse_entry_role_query(&format!("module={}", "A".repeat(200))).is_err());
+        // Both declared but only one non-empty is unambiguous, not a conflict.
+        assert_eq!(
+            parse_entry_role_query("module=Server&prefix="),
+            Ok(Some(crate::functor_lang_producer::EntryRole::Module(
+                "Server".to_string()
+            )))
+        );
+    }
 
     #[test]
     fn runtime_state_json_preserves_desktop_shape_and_reports_views() {
@@ -683,6 +821,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 8);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 9);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -642,6 +642,10 @@ impl GameProducer for FunctorLangEmbeddedGame {
         Ok(status)
     }
 
+    fn set_entry_role(&mut self, role: EntryRole) -> Option<EntryRole> {
+        Some(std::mem::replace(&mut self.role, role))
+    }
+
     fn reload_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
         // The multi-file push path: the pusher owns the WHOLE file set, so —
         // unlike `reload_source`, which swaps the entry and keeps the
@@ -1393,6 +1397,81 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
             err.contains("no inline `module Sever") && err.contains("it declares: Server"),
             "{err}"
         );
+    }
+
+    /// The DEVICE path (`functor run vr`): the APK boots its embedded scene
+    /// under the plain contract and learns the role from the push itself.
+    /// This is the whole wire loop minus HTTP — adopt the declared role, load,
+    /// re-push under it, and reject a push that deletes the block.
+    #[test]
+    fn a_pushed_role_boots_re_resolves_and_survives_a_broken_push() {
+        let role_src = |probe: f64| {
+            format!(
+                "let unrelated = 1.0\n\
+                 module Server {{\n\
+                 let init = {{ n: 7.0 }}\n\
+                 let tick = (m, dt, tts) => m\n\
+                 let draw = (m, tts) => Frame.create(Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), \
+Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
+                 let probe = {probe}.0\n\
+                 }}\n"
+            )
+        };
+        // The APK's boot: the unprefixed contract, no role in sight.
+        let mut game = FunctorLangEmbeddedGame::create(
+            vec![("boot.fun".to_string(), BOOT.to_string())],
+            Box::new(NativePlatform),
+        )
+        .expect("boot scene loads");
+        assert_eq!(game.names.tick, "tick");
+
+        // `POST /load-project?module=Server`. The pushed file has NO top-level
+        // contract, so reaching a loaded state at all proves the role resolved.
+        let files = |probe: f64| vec![("game.fun".to_string(), role_src(probe))];
+        crate::protocol::push_with_role(
+            &mut game,
+            Some(EntryRole::Module("Server".to_string())),
+            |game| game.load_project(&files(1.0)),
+        )
+        .expect("the declared role boots on the push");
+        assert_eq!(game.names.tick, "Server.tick");
+        assert!(game.state_debug().contains("n: 7"), "{}", game.state_debug());
+
+        // A re-push re-resolves the same role and preserves the model.
+        crate::protocol::push_with_role(
+            &mut game,
+            Some(EntryRole::Module("Server".to_string())),
+            |game| game.reload_project(&files(2.0)),
+        )
+        .expect("the re-push reloads");
+        assert_eq!(game.names.tick, "Server.tick");
+        assert_eq!(
+            game.session.global("Server.probe").expect("probe").to_string(),
+            "2",
+            "the edit landed"
+        );
+        assert!(game.state_debug().contains("n: 7"), "model preserved");
+
+        // A push that DELETES the block fails loudly naming it; the old
+        // program AND its role keep running, so the next good push works.
+        let err = crate::protocol::push_with_role(
+            &mut game,
+            Some(EntryRole::Module("Server".to_string())),
+            |game| game.reload_project(&[("game.fun".to_string(), "let unrelated = 1.0\n".into())]),
+        )
+        .expect_err("a role whose block vanished cannot load");
+        assert!(err.contains("module Server"), "{err}");
+        assert_eq!(game.names.tick, "Server.tick", "the role is intact");
+        assert_eq!(
+            game.session.global("Server.probe").expect("probe").to_string(),
+            "2",
+            "the old program keeps running"
+        );
+        crate::protocol::push_with_role(&mut game, None, |game| {
+            game.reload_project(&files(3.0))
+        })
+        .expect("a role-less push runs the role already in force");
+        assert_eq!(game.names.tick, "Server.tick");
     }
 
     /// A prefixed role's EFFECTS must fold through the role's own update

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -646,6 +646,10 @@ impl GameProducer for FunctorLangEmbeddedGame {
         Some(std::mem::replace(&mut self.role, role))
     }
 
+    fn entry_role(&self) -> Option<EntryRole> {
+        Some(self.role.clone())
+    }
+
     fn reload_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
         // The multi-file push path: the pusher owns the WHOLE file set, so —
         // unlike `reload_source`, which swaps the entry and keeps the
@@ -1428,7 +1432,7 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
         // `POST /load-project?module=Server`. The pushed file has NO top-level
         // contract, so reaching a loaded state at all proves the role resolved.
         let files = |probe: f64| vec![("game.fun".to_string(), role_src(probe))];
-        crate::protocol::push_with_role(
+        crate::protocol::load_with_role(
             &mut game,
             Some(EntryRole::Module("Server".to_string())),
             |game| game.load_project(&files(1.0)),
@@ -1438,7 +1442,7 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
         assert!(game.state_debug().contains("n: 7"), "{}", game.state_debug());
 
         // A re-push re-resolves the same role and preserves the model.
-        crate::protocol::push_with_role(
+        crate::protocol::reload_with_role(
             &mut game,
             Some(EntryRole::Module("Server".to_string())),
             |game| game.reload_project(&files(2.0)),
@@ -1454,7 +1458,7 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
 
         // A push that DELETES the block fails loudly naming it; the old
         // program AND its role keep running, so the next good push works.
-        let err = crate::protocol::push_with_role(
+        let err = crate::protocol::reload_with_role(
             &mut game,
             Some(EntryRole::Module("Server".to_string())),
             |game| game.reload_project(&[("game.fun".to_string(), "let unrelated = 1.0\n".into())]),
@@ -1467,11 +1471,32 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
             "2",
             "the old program keeps running"
         );
-        crate::protocol::push_with_role(&mut game, None, |game| {
+        crate::protocol::reload_with_role(&mut game, None, |game| {
             game.reload_project(&files(3.0))
         })
         .expect("a role-less push runs the role already in force");
         assert_eq!(game.names.tick, "Server.tick");
+
+        // A DIFFERENT role on the model-preserving route is refused: adopting
+        // it would hand Server's model to the plain contract's `tick`. The
+        // error names the route that does start a new game.
+        let err = crate::protocol::reload_with_role(
+            &mut game,
+            Some(EntryRole::Prefix(String::new())),
+            |game| game.reload_project(&files(4.0)),
+        )
+        .expect_err("a role CHANGE is not a model-preserving reload");
+        assert!(err.contains("/load-project"), "{err}");
+        assert_eq!(game.names.tick, "Server.tick", "the role is untouched");
+
+        // The same change IS a load — a new game, its model from `init`.
+        crate::protocol::load_with_role(
+            &mut game,
+            Some(EntryRole::Prefix(String::new())),
+            |game| game.load_project(&[("boot.fun".to_string(), BOOT.to_string())]),
+        )
+        .expect("a role change loads as a new game");
+        assert_eq!(game.names.tick, "tick");
     }
 
     /// A prefixed role's EFFECTS must fold through the role's own update

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -196,6 +196,35 @@ impl EntryRole {
         }
     }
 
+    /// Is `prefix` spellable as a binding prefix? It concatenates into binding
+    /// NAMES (`server` → `serverInit`), so it must itself be an identifier;
+    /// empty is the plain contract. Every carrier of a role — functor.json,
+    /// the page's boot config, the device push query — validates with THIS,
+    /// so no seam accepts a name another would refuse.
+    pub fn is_valid_prefix(prefix: &str) -> bool {
+        let mut chars = prefix.chars();
+        match chars.next() {
+            None => true,
+            Some(first) => {
+                (first.is_ascii_alphabetic() || first == '_')
+                    && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+            }
+        }
+    }
+
+    /// Is `module` spellable as an inline module name? It names a
+    /// `module Server { … }` block, which the parser only accepts
+    /// Capitalized; empty means no module form is declared.
+    pub fn is_valid_module(module: &str) -> bool {
+        let mut chars = module.chars();
+        match chars.next() {
+            None => true,
+            Some(first) => {
+                first.is_ascii_uppercase() && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+            }
+        }
+    }
+
     /// Resolve this role's binding names against the linked `project` whose
     /// entry is the role's file. An inline-module role names a block of THAT
     /// file; an unknown name is an error listing the blocks it does declare.

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -157,6 +157,26 @@ pub trait GameProducer {
         Err("this producer does not support project loading (not an .fun game)".to_string())
     }
 
+    /// Adopt the same-file entry ROLE a project push declared, returning the
+    /// role it replaced so a rejected push can put it back (see
+    /// [`push_with_role`], which both shells route their project pushes
+    /// through). `None` — the default — is the honest answer for a producer
+    /// with no role concept: the push's declaration is inapplicable, not
+    /// merely equal to what was already there.
+    ///
+    /// A wire-driven session (the Quest APK under `functor run vr`) learns its
+    /// role from the push rather than a command line, and a re-push may change
+    /// it. Adopting it here, before the load, keeps the producers' invariant
+    /// that the role is re-RESOLVED against each pushed program: an edit that
+    /// renames or deletes the `module Server { … }` block fails loudly naming
+    /// the block, and the old program keeps running.
+    fn set_entry_role(
+        &mut self,
+        _role: crate::functor_lang_producer::EntryRole,
+    ) -> Option<crate::functor_lang_producer::EntryRole> {
+        None
+    }
+
     /// The `.fun` sources the program is CURRENTLY running — `(path, source)`
     /// pairs, the entry first, project files only (no bundled prelude
     /// modules). The read half of the push routes above, serving
@@ -454,6 +474,28 @@ pub trait GameProducer {
     fn preload_push_settled(&mut self, _token: u64) {}
 
     fn quit(&mut self);
+}
+
+/// Perform a project push under the same-file entry role that push DECLARED.
+///
+/// `role` is `None` when the push declared none (an older CLI, `functor push`,
+/// the MCP tools): the role already in force stands. A rejected push restores
+/// the previous role, so the live program and the role that produced it stay
+/// in agreement — the next role-less push still runs the role in force rather
+/// than a role the runtime never managed to load.
+pub fn push_with_role(
+    game: &mut dyn GameProducer,
+    role: Option<crate::functor_lang_producer::EntryRole>,
+    load: impl FnOnce(&mut dyn GameProducer) -> Result<String, String>,
+) -> Result<String, String> {
+    let previous = role.and_then(|role| game.set_entry_role(role));
+    let result = load(game);
+    if result.is_err() {
+        if let Some(previous) = previous {
+            game.set_entry_role(previous);
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -159,7 +159,8 @@ pub trait GameProducer {
 
     /// Adopt the same-file entry ROLE a project push declared, returning the
     /// role it replaced so a rejected push can put it back (see
-    /// [`push_with_role`], which both shells route their project pushes
+    /// [`load_with_role`] / [`reload_with_role`], which both shells route their
+    /// project pushes
     /// through). `None` — the default — is the honest answer for a producer
     /// with no role concept: the push's declaration is inapplicable, not
     /// merely equal to what was already there.
@@ -174,6 +175,13 @@ pub trait GameProducer {
         &mut self,
         _role: crate::functor_lang_producer::EntryRole,
     ) -> Option<crate::functor_lang_producer::EntryRole> {
+        None
+    }
+
+    /// The same-file entry role this producer is CURRENTLY running, if it has
+    /// the concept. `reload_with_role` reads it to refuse a role change on the
+    /// model-preserving push.
+    fn entry_role(&self) -> Option<crate::functor_lang_producer::EntryRole> {
         None
     }
 
@@ -476,19 +484,76 @@ pub trait GameProducer {
     fn quit(&mut self);
 }
 
-/// Perform a project push under the same-file entry role that push DECLARED.
+/// `POST /load-project` under the same-file entry role that push DECLARED —
+/// a NEW game, so it may name any role.
 ///
 /// `role` is `None` when the push declared none (an older CLI, `functor push`,
 /// the MCP tools): the role already in force stands. A rejected push restores
 /// the previous role, so the live program and the role that produced it stay
 /// in agreement — the next role-less push still runs the role in force rather
 /// than a role the runtime never managed to load.
-pub fn push_with_role(
+pub fn load_with_role(
     game: &mut dyn GameProducer,
     role: Option<crate::functor_lang_producer::EntryRole>,
     load: impl FnOnce(&mut dyn GameProducer) -> Result<String, String>,
 ) -> Result<String, String> {
-    let previous = role.and_then(|role| game.set_entry_role(role));
+    with_role(game, role, load)
+}
+
+/// `POST /reload-project` under the declared role — the model-PRESERVING
+/// push, so it may only re-declare the role already running.
+///
+/// Adopting a different role here would hand the old role's model to the new
+/// role's `tick`, which is a different game wearing the previous one's state.
+/// That is a `/load-project`, and the error says so.
+pub fn reload_with_role(
+    game: &mut dyn GameProducer,
+    role: Option<crate::functor_lang_producer::EntryRole>,
+    reload: impl FnOnce(&mut dyn GameProducer) -> Result<String, String>,
+) -> Result<String, String> {
+    if let Some(role) = &role {
+        if let Some(current) = game.entry_role() {
+            if &current != role {
+                return Err(format!(
+                    "this push declares {}, but the running program is {} — a role change \
+starts a different game, so push it to /load-project (its model comes from that role's `init`)",
+                    describe_role(role),
+                    describe_role(&current)
+                ));
+            }
+        }
+    }
+    with_role(game, role, reload)
+}
+
+fn describe_role(role: &crate::functor_lang_producer::EntryRole) -> String {
+    use crate::functor_lang_producer::EntryRole;
+    match role {
+        EntryRole::Module(name) => format!("entry module `{name}`"),
+        EntryRole::Prefix(prefix) if prefix.is_empty() => "the unprefixed contract".to_string(),
+        EntryRole::Prefix(prefix) => format!("entry prefix `{prefix}`"),
+    }
+}
+
+fn with_role(
+    game: &mut dyn GameProducer,
+    role: Option<crate::functor_lang_producer::EntryRole>,
+    load: impl FnOnce(&mut dyn GameProducer) -> Result<String, String>,
+) -> Result<String, String> {
+    let previous = match role {
+        None => None,
+        Some(role) => match game.set_entry_role(role) {
+            Some(previous) => Some(previous),
+            // A producer with no role concept cannot honor the declaration.
+            // Refusing beats loading SOMETHING under the wrong contract.
+            None => {
+                return Err(
+                    "this producer cannot boot a same-file entry role (not an .fun game)"
+                        .to_string(),
+                )
+            }
+        },
+    };
     let result = load(game);
     if result.is_err() {
         if let Some(previous) = previous {

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -874,6 +874,10 @@ impl Game for FunctorLangGame {
         Ok(status)
     }
 
+    fn set_entry_role(&mut self, role: EntryRole) -> Option<EntryRole> {
+        Some(std::mem::replace(&mut self.role, role))
+    }
+
     fn reload_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
         if files.is_empty() {
             return Err("a pushed project needs at least the entry file".to_string());

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -878,6 +878,10 @@ impl Game for FunctorLangGame {
         Some(std::mem::replace(&mut self.role, role))
     }
 
+    fn entry_role(&self) -> Option<EntryRole> {
+        Some(self.role.clone())
+    }
+
     fn reload_project(&mut self, files: &[(String, String)]) -> Result<String, String> {
         if files.is_empty() {
             return Err("a pushed project needs at least the entry file".to_string());

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -970,14 +970,14 @@ fn service_debug_request(
             let _ = resp.send(game.reload_source(&source));
         }
         debug_server::DebugRequest::ReloadProject(files, role, resp) => {
-            let _ = resp.send(functor_runtime_common::protocol::push_with_role(
+            let _ = resp.send(functor_runtime_common::protocol::reload_with_role(
                 game,
                 role,
                 |game| game.reload_project(&files),
             ));
         }
         debug_server::DebugRequest::LoadProject(files, role, resp) => {
-            let result = functor_runtime_common::protocol::push_with_role(game, role, |game| {
+            let result = functor_runtime_common::protocol::load_with_role(game, role, |game| {
                 game.load_project(&files)
             });
             if result.is_ok() {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -969,11 +969,17 @@ fn service_debug_request(
         debug_server::DebugRequest::ReloadSource(source, resp) => {
             let _ = resp.send(game.reload_source(&source));
         }
-        debug_server::DebugRequest::ReloadProject(files, resp) => {
-            let _ = resp.send(game.reload_project(&files));
+        debug_server::DebugRequest::ReloadProject(files, role, resp) => {
+            let _ = resp.send(functor_runtime_common::protocol::push_with_role(
+                game,
+                role,
+                |game| game.reload_project(&files),
+            ));
         }
-        debug_server::DebugRequest::LoadProject(files, resp) => {
-            let result = game.load_project(&files);
+        debug_server::DebugRequest::LoadProject(files, role, resp) => {
+            let result = functor_runtime_common::protocol::push_with_role(game, role, |game| {
+                game.load_project(&files)
+            });
             if result.is_ok() {
                 clock.restart();
                 *frame_count = 0;

--- a/runtime/functor-runtime-oculus/README.md
+++ b/runtime/functor-runtime-oculus/README.md
@@ -48,7 +48,13 @@ the whole source project (`POST /load-project` — sibling modules included)
 plus its model/texture/audio files, then re-checks + re-pushes changed source
 or assets on every save while streaming the headset's runtime log into the
 terminal. The initial load takes the model from `init`; later source pushes use
-`POST /reload-project` and preserve it. Assets transfer individually through
+`POST /reload-project` and preserve it. A project that declares a same-file
+entry role (`{"file": "game.fun", "module": "Server"}` or a binding `prefix`)
+gets it DECLARED in each push's query string — `POST /load-project?module=Server`
+— which is how a device with no command line learns which contract to boot.
+The shell re-resolves the role against every pushed program, so an edit that
+deletes the block fails naming it and the old program keeps running. A push
+with no role query leaves the role already in force alone. Assets transfer individually through
 `POST /reload-asset`; a final
 `POST /sync-assets` manifest removes deleted uploads and changed render assets
 are decoded again on the next frame. The pieces also work individually:

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -759,14 +759,14 @@ tracking); use the desktop runtime's --headless/--debug-port path"
             let _ = response.send(game.reload_source(&source));
         }
         DebugRequest::ReloadProject(files, role, response) => {
-            let _ = response.send(functor_runtime_common::protocol::push_with_role(
+            let _ = response.send(functor_runtime_common::protocol::reload_with_role(
                 game,
                 role,
                 |game| game.reload_project(&files),
             ));
         }
         DebugRequest::LoadProject(files, role, response) => {
-            let result = functor_runtime_common::protocol::push_with_role(game, role, |game| {
+            let result = functor_runtime_common::protocol::load_with_role(game, role, |game| {
                 game.load_project(&files)
             });
             if result.is_ok() {

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -758,11 +758,17 @@ tracking); use the desktop runtime's --headless/--debug-port path"
         DebugRequest::ReloadSource(source, response) => {
             let _ = response.send(game.reload_source(&source));
         }
-        DebugRequest::ReloadProject(files, response) => {
-            let _ = response.send(game.reload_project(&files));
+        DebugRequest::ReloadProject(files, role, response) => {
+            let _ = response.send(functor_runtime_common::protocol::push_with_role(
+                game,
+                role,
+                |game| game.reload_project(&files),
+            ));
         }
-        DebugRequest::LoadProject(files, response) => {
-            let result = game.load_project(&files);
+        DebugRequest::LoadProject(files, role, response) => {
+            let result = functor_runtime_common::protocol::push_with_role(game, role, |game| {
+                game.load_project(&files)
+            });
             if result.is_ok() {
                 clock.restart();
                 debug.frame_count = 0;


### PR DESCRIPTION
Follow-up to **#623** (now squash-merged as `a7ce3d1`; this branch was rebased onto `main`
and its base retargeted accordingly). #623 gave the embedded producer
`create_for_role(sources, EntryRole, platform)` and re-resolves the role on every load — and
closed by explicitly deferring vr: *"teaching it the
form means a push-protocol change plus an APK rebuild, and neither is verifiable without a headset
(none attached for this work)."* **A Quest 3 was attached for this one**, so this is that work,
verified on device.

**Both same-file role forms now run on vr.** Prefix roles ride along — the payload carries an
`EntryRole`, not a module name, so #554's prefix-on-vr refusal lifts in the same change.

## The design: the role rides the push, as a query string

A device session has **no command line**. Its game arrives as text over the debug protocol
(`POST /load-project`, then `POST /reload-project` on every save), and that payload carried no
role. So the role is now DECLARED in the route's query string — the same two-string shape every
other carrier uses, reconstructed through the shared `EntryRole::from_parts`:

```
POST /load-project?module=Server      # an inline `module Server { … }`
POST /reload-project?prefix=server    # serverInit/serverTick/…
POST /reload-project?prefix=          # the plain contract, declared explicitly
```

The query string was already stripped before routing, which is what makes this **tolerant in both
directions**:

- **A pre-v9 APK ignores it** and boots the unprefixed contract. That is silent-wrong-role, so
  `run vr` now *probes* `GET /` and refuses to push a declared role to one (review finding #1).
- **A v9 runtime hearing no query keeps the role already in force**, so `functor push`, the MCP
  tools, and the TS SDK need no revision. That is why the plain contract travels as an explicit
  `?prefix=` rather than as silence — silence cannot switch a live session back.

Debug protocol → **v9**.

## What changed

1. **Wire** (`debug_protocol.rs`) — `encode_entry_role_query` / `parse_entry_role_query`, and
   `Option<EntryRole>` on `DebugRequest::LoadProject`/`ReloadProject`. Parsing is strict on
   purpose: an unknown key, a key twice, both forms at once, or a name the *other* carriers would
   refuse is a **400**, never a quietly-different contract. The name rules are literally theirs —
   `EntryRole::is_valid_module` / `is_valid_prefix`, extracted next to `from_parts` and now used by
   the functor.json reader too, so no seam accepts what another rejects.
2. **Producers** — `GameProducer::set_entry_role` / `entry_role` (defaults `None`), implemented by
   both `.fun` producers. Adopting the role *before* the load is what runs #623's re-resolution on
   every push.
3. **Shells** — one line each, through two shared helpers:
   `protocol::load_with_role` (a NEW game, any role) and `protocol::reload_with_role`
   (model-preserving, so it refuses a role **change** — that is a `/load-project`, and the error
   says so). Both restore the previous role if the push is rejected. Desktop wires the identical
   pair: the routes stay isomorphic, which is the vr-device-loop skill's standing rule.
4. **CLI** — `run vr` declares `self.entry_role()` on every push and gates on protocol v9.
   `check_role_supported` is **deleted**: no shell refuses a role now, so an exhaustive match over
   `Environment` had nothing left to say.

## Device verification (Quest 3, `2G0YC5ZF87037Q`, debug APK, Horizon OS 14)

Everything below ran against the **rebuilt APK from this branch**, re-verified **after** the review
fixes. Stereo capture is the raw left+right swapchain readback (3360×1760), before compositor warp.

![module role on the headset](https://gist.githubusercontent.com/tommy-xr/d5b1cfccb3c3e4184e0393f5e4f8517c/raw/quest-module-role.png)

<sub>`functor -d <scratch> run vr --entry server` — both eyes render the `module Server` role's four
red spheres, with the expected horizontal disparity and no vertical disparity. The scratch project's
plain top-level contract draws ONE GREY CUBE at camera z −5; the module role draws the spheres at
z −6, so the wrong contract would be unmistakable.</sub>

The same role rendered natively for comparison (`run native --entry server`, before the edit that
made it four spheres):

![the same role on native](https://gist.githubusercontent.com/tommy-xr/d5b1cfccb3c3e4184e0393f5e4f8517c/raw/native-module-role.png)

| # | Checked on the device | Result |
| --- | --- | --- |
| 1 | **Plain contract unaffected** — `run vr` on `examples/primitives` | loads, 6 geometry nodes, camera `[0, 3.5, −8]` — unchanged |
| 2 | **Module role boots** — `run vr --entry server` | `loaded game.fun … (model initialized)`; `/state` frame advancing; `/scene` = 5 geometry, camera z −6 (the role's, not the file's) |
| 3 | **Stereo render** | `POST /capture` → 3360×1760, both eye panels complete, correct disparity (above) |
| 4 | **Live re-push re-resolves the role, model preserved** | edited the block (3 → 4 spheres) → `reloaded … (model preserved)`; `/scene` 4 → 5 geometry, camera still z −6, `spin` continued 71.8 → 90.6 (not reset) |
| 5 | **A push that DELETES the block fails loudly** | `reload-project?module=Server` with the block gone → **400** `game.fun has no inline module Server { … } for this entry role — it declares no inline modules`; the old program kept running (5 geometry, `spin` still climbing) |
| 6 | **A role-less push runs the role in force** | bare `reload-project` of a 5-sphere edit → 200, 6 geometry, camera still z −6 |
| 7 | **Prefix roles ride along** — `run vr --entry legacy` | model `{t}` from `legacyInit`, 2 geometry, camera z −7 (the green-cylinder scene) |
| 8 | **Role CHANGE on the model-preserving route is refused** | running `prefix legacy`, pushed `?module=Server` → **400** *"a role change starts a different game, so push it to /load-project"* |
| 9 | **…and IS allowed on `/load-project`** | same change to `/load-project?module=Server` → 200, model from `Server.init`, 5 geometry, camera z −6 |
| 10 | **Unknown key refused** | `?moduel=Server` → **400** `unknown entry-role key 'moduel'` |
| 11 | **Cross-carrier name rules enforced** | `?module=server` (lowercase) → **400** *"must be a Capitalized inline module name"* |
| 12 | **v9 gate does not false-positive** | device reports `protocol_version 9`; every role push above passed the gate |

The scratch project is deliberately out of the repo (`examples/orbs` is being migrated in parallel
on a sibling branch, and was not touched). Its `client` role is the file's plain contract, `server`
is a `module Server { … }` block, `legacy` is a `prefix` role — three visually distinct scenes so a
capture identifies the contract that booted.

**Not verified on device:** the pre-v9 **refusal** branch of the new gate. No pre-v9 APK exists to
install any more (the only build on this machine is from this branch), so only the pass side is
device-proven; the refusal is covered by reading `protocol_version` from the same `GET /` the
device answered with `9`.

## Verification

- `cargo test -p functor-lang -p functor_runtime_common -p functor-cli --no-fail-fast` on the
  rebased branch — green except **exactly one** failure,
  `scrubber_only_captures_primary_pointer_drags`, which is **broken on `main`** with a fix open as
  **#635**. Asserted that it is that failure and no other (1 failed / 117 passed in the CLI crate;
  every other crate 0 failed).
  New coverage: `a_pushed_entry_role_round_trips_through_the_query_string` and
  `a_malformed_pushed_role_is_refused_rather_than_coerced` (encode/parse, including that *absent*
  ≠ *plain*), `a_project_push_carries_the_entry_role_it_declares` (HTTP: the role reaches the
  runtime loop; a doubly-declared / non-identifier / unknown-key role is a 400 that never does),
  `a_pushed_role_boots_re_resolves_and_survives_a_broken_push` (the embedded producer's whole wire
  loop — boot plain → declared load → re-push → deleted block → role-less push → refused role
  change → role change as a load), and `every_role_form_declares_itself_on_the_vr_push` (the exact
  query `run vr` appends per form).
- `npm run build:oculus` cross-compiles clean; the APK built, installed, and ran (see above).

## Benchmarks

**`npm run bench:quest` could not run**: it refuses a `DEBUGGABLE` package, and a release
`cargo apk` build needs a locally configured signing key that this environment does not have. Not
papering over it — but nothing here is per-frame: the role is resolved at LOAD, `entry_role()` is
read only when a push declares one, and the frame loop is untouched.

`frame_bench` (release, headless) confirms that on the CPU side. The deterministic columns are
**byte-identical to #623's** — the same base this branch stacks on:

| cells | allocs/frame | bytes/frame | us/frame (min) |
| --- | --- | --- | --- |
| 400 | 13877 (= #623) | 843393 (= #623) | 872.3 |
| 1600 | 54717 (= #623) | 3307233 (= #623) | 2663.8 |
| 3136 | 106973 (= #623) | 6460257 (= #623) | 5802.0 |

`allocs`/`bytes` are the signal and show zero delta. The wall-clock column is **not** comparable to
#623's here — this run shared the machine with a concurrent Android cross-compile, so it is inflated
across the board rather than by any hunk in this diff.

## xreview dispositions

Three reviewers over `origin/feat/module-roles-wasm...HEAD`: a Claude subagent, the Codex CLI, and
the de-duplication pass. Both engines independently raised the stale-APK hazard — the highest-signal
finding in the review — and it is fixed.

| # | Finding | Engine | Disposition |
| --- | --- | --- | --- |
| 1 | **High [AGREED]** — nothing checks the *installed APK's* protocol version. A pre-v9 APK ignores the query and boots the unprefixed contract, returning 200: exactly the silent-wrong-role failure the deleted `check_role_supported` guard existed to prevent, and APK/CLI skew is the normal state | Claude + Codex | **Fixed.** `run vr` probes `GET /` after the readiness probe and refuses a declared role below v9 with a reinstall hint. The plain contract still runs on any runtime. Device-verified on the pass side (#12). |
| 2 | **High** — `reload_with_role` adopting a *different* role preserves the OLD role's model, feeding e.g. client state to `Server.tick` | Codex | **Fixed.** `push_with_role` split into `load_with_role` / `reload_with_role`; the model-preserving route refuses a role change and names `/load-project`. Device-verified (#8, #9) and unit-tested. |
| 3 | **Medium [AGREED]** — the query's name validation was LOOSER than every other carrier's (`?module=server`, `?prefix=9x` accepted here, refused by functor.json and the site player), and unknown keys were ignored so `?moduel=Client` silently meant "declared nothing" | Codex + de-dup (`extract` [S3-index, S4-read]) | **Fixed.** `EntryRole::is_valid_module` / `is_valid_prefix` extracted next to `from_parts`; the query parser AND the functor.json reader now share them (the de-dup pass's exact recommendation), and an unknown key is a 400. Device-verified (#10, #11). |
| 4 | **Low (latent)** — `push_with_role` silently dropped a declared role for a producer using the default `set_entry_role`, so a producer that implements `load_project` but not the role could load under the wrong contract | Claude | **Fixed.** The shared helper now returns `Err("this producer cannot boot a same-file entry role")` instead, restoring at the protocol layer the guarantee the CLI guard used to give. |
| 5 | **Low (dup, `merge` [S1-names])** — `post_reload_project` / `post_load_project` were identical but for the route literal (mutual top hit, 0.62) | de-dup | **Fixed.** One `post_project(addr, route, files_json, role)`. |
| 6 | **Low** — the skill's inline-module section (SKILL.md:444) still said "only vr still refuses it", contradicting the section this PR updated | Codex | **Fixed.** |
| 7 | **Medium** — a role-less `/load-project` inherits the running role; an SDK/MCP client loading an unrelated project into a Server-role session gets Server | Codex | **Won't fix.** Keeping "None = keep" is what makes the change backward-compatible in the other direction, and flipping `/load-project` to "absent = plain" would *regress* desktop today (a `run native --entry server --debug-port` session's MCP `load_project` currently uses the configured role). The role is the producer's *configuration*; a push that wants to change it says so, and `?prefix=` is one token. Every shipped pusher of a role — `run vr` — always declares. |
| 8 | **Low (design) [AGREED]** — thread `Option<EntryRole>` into `load_project`/`reload_project` instead of `set_entry_role` + a free helper, so adoption is atomic with the load rather than eager-then-rollback | Claude + Codex | **Won't fix.** The invariant they were protecting is now *enforced* rather than conventional (findings #2 and #4 turn both leak paths into hard errors), and threading a parameter through the trait touches every producer, every call site, and the web runtime for zero behavior change. Revisit if a third role-bearing route appears. |
| 9 | **Low (dup, `extract`)** — a third hand-rolled `?k=v&k=v` scanner (the web runtime hand-rolls two) | de-dup | **Won't fix**, and the reviewer agreed it was the weakest of its three: this parser needs multi-key collection, duplicate detection, and per-key validation that the web runtime's single-key lookups do not. A shared `query_param` would not serve it. |

Both engines separately confirmed the substance clean: `split_once('?')` preserves the previous path
semantics exactly (route matching and CORS preflight still key off `path`); the 400 body is bounded
(length capped before the echoing error) and `text/plain`, so an echoed value is inert; the desktop
shell honoring the query adds no exposure, since a client that can `POST /load-project` can already
replace the whole program; and every remaining `None` pusher keeps its pre-change behavior.

**De-dup coverage** (verbatim): *all four strategies ran; none unavailable. S1 = 12 queries over
7011 candidates (min-score 0.3). S2 = whole-repo clone report filtered to the 13 changed files — 33
surviving pairs, all but one pre-existing producer twins. S3 = 6 grep families (query parsing,
identifier validation, `from_parts`, boot-config role globals, `?module=`/`?prefix=` carriers,
save/restore). S4 = full read of the 745-line diff plus the 5 candidate sources at their
`file:line`.*

Re-validated after the fixes: the full Rust suite re-run (same one pre-existing failure), the APK
rebuilt and reinstalled, and the **entire device loop re-run** — that is what rows 1–12 above
record.

## CI: the two red jobs were flakes, not this change

`e2e-headless` and `wasm-smoke` went red on the first push. Neither is caused by this diff —
**both passed on a re-run of the byte-identical commit** (no code changed in between):

| Run | Commit | e2e-headless | wasm-smoke |
| --- | --- | --- | --- |
| 1 | `3d476d5` | fail — `editing a NON-entry module hot-reloads…` | fail — `client 1's \`w\` moved its player in CLIENT 2's world` |
| 2 (re-run, same commit) | `3d476d5` | **pass** | **pass** |
| 3 (rebased onto main) | `8312d56` | fail — `two clients connect to a server and converge…` | **pass** |

Three runs, three *different* failing tests, one of them green on an unchanged re-run. Both
underlying races are pre-existing and live in the test harness, not the runtime:

- **`FunctorClient.step()` is fire-and-forget.** `POST /time {advance}` only increments
  `pending_steps`; the desktop loop drains *all* queued debug requests in one
  `while let Ok(req) = rx.try_recv()` pass per frame and runs the queued steps on later frames.
  So three `step()`s plus the following `/state` can be serviced in the SAME frame, and `/state`
  then reports the pre-step model — exactly the observed `base == before == 0.18333334289491177`.
  `stepMany` avoids this by polling `pending_steps === 0`; `step` does not. (Two SDK tests also
  share a default port, `8102`.)
- **`e2e/net-coordinator.mjs` assumes the pane that pressed `w` is `pid 0`**, but the server
  assigns pids in *connection* order across two browser panes. The failure payload shows `pid 1`
  moved and `pid 0` sat at its spawn `z` — the panes connected in the opposite order.

Locally on the rebased branch, on the same machine: the full SDK e2e suite is green, the
`modules-hot-reload` test passes repeatedly, and `multiplayer.e2e` passes 3/3. I have deliberately
**not** changed the shared test harness from a VR PR — the races are worth their own fix (the
`step()`/`pending_steps` asymmetry and the pid-order assumption), and masking them here would hide
them from every other PR.

## Rebase note

`feat/module-roles-wasm` was rebased and then squash-merged, so this branch was replayed onto
`origin/main` with `--onto` (dropping the two now-duplicated #623 commits). The rebase also
**removed a committed merge-conflict marker** that #623's squash left in `CLAUDE.md`'s `entries`
paragraph (`<<<<<<< HEAD` / `=======` / `>>>>>>> 8333093`) — it sits inside the exact paragraph
this change rewrites, so it is resolved here rather than left in `main`. Worth a look: it is
still present in `main` outside that paragraph's blast radius only because nothing else touched it.

## Docs

CLAUDE.md's `entries` paragraph, the `functor-lang` skill (both the `entries` section and the
inline-module section), `docs/functor-lang.md` (new **Part 10**), the oculus README's
remote-develop loop, and `docs/debug-runtime.md` (a new *"Declaring a same-file entry role"*
subsection plus the route table) all say the same thing: every shell boots either role form, on vr
it rides the push's query string, and a pre-v9 runtime is refused rather than allowed to boot the
wrong contract.
