### PR TITLE
feat(scrubber): flash the viewport and glow the marker when a reload lands

### DIFF
--- a/e2e/functor-lang-preview-reload.mjs
+++ b/e2e/functor-lang-preview-reload.mjs
@@ -158,6 +158,25 @@ check(
   `center = rgb(${after})`
 );
 
+// 2b. Reload juice on the runtime's own page, which mounts the scrubber
+//     VISIBLY: the accepted push flashes the viewport cyan AND glows the rail
+//     marker. The marker glow is driven by hand (marker nodes are reused and
+//     same-frame reloads cluster into one), so this is the second surface that
+//     proves the explicit re-trigger rather than a CSS insertion animation.
+const juiceAfterGreen = await page.evaluate(() => {
+  const overlay = document.querySelector(".scrub-reload-juice");
+  return {
+    live: !!overlay && overlay.classList.contains("live"),
+    rejected: !!overlay && overlay.classList.contains("rejected"),
+    glowing: document.querySelectorAll(".scrub-event.born").length,
+  };
+});
+check(
+  "an accepted push flashes the runtime page and glows its marker",
+  juiceAfterGreen.live && !juiceAfterGreen.rejected && juiceAfterGreen.glowing > 0,
+  JSON.stringify(juiceAfterGreen)
+);
+
 // 3. Survival probe: tick errors unless spin > 0.5 — a value only the
 //    PRESERVED model has (a fresh init restarts at 0.0).
 const survived = await push(V_PROBE_SURVIVED);
@@ -193,6 +212,22 @@ check(
   "old program keeps rendering after the broken push",
   stillGreen[1] > 150 && stillGreen[0] < 100,
   `center = rgb(${stillGreen})`
+);
+
+// 5b. The rejection reads as a rejection: the same overlay turns red.
+const juiceAfterBroken = await page
+  .waitForFunction(
+    () => document.querySelector(".scrub-reload-juice")?.classList.contains("rejected"),
+    { timeout: 5000 }
+  )
+  .then(() => true)
+  .catch(() => false);
+check(
+  "a rejected push flashes the runtime page red",
+  juiceAfterBroken,
+  await page.evaluate(
+    () => document.querySelector(".scrub-reload-juice")?.className ?? "absent"
+  )
 );
 
 // 6. A good push after the broken one still lands.

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -515,13 +515,31 @@ const playerFrame = (page) => {
   // gravity is editable in the same region: it must move the projection too.
   const heavyRegion = weakRegion.replace("let gravity = 30.0", "let gravity = 45.0");
   await applyHeroRegion(heavyRegion);
-  const reglow = await heroPlayer.evaluate(() => ({
-    born: document.querySelectorAll(".scrub-event.born").length,
-    markers: document.querySelectorAll(".scrub-event.reload").length,
-  }));
+  const reglow = await heroPlayer.evaluate(() => {
+    const born = [...document.querySelectorAll(".scrub-event.born")];
+    // The glow must land on the cluster holding the newest reload, not merely
+    // on some reload marker: with one marker on the rail a "nearest" search
+    // can't be wrong, so pin the identity explicitly.
+    const reloads = window.__scrub.events().filter((event) => event.kind.startsWith("reload-"));
+    const newestFrame = reloads.length ? reloads[reloads.length - 1].frame : null;
+    const cluster = window.__scrub
+      .view()
+      .eventMarkers.find((m) => m.category === "reload" && m.lastFrame === newestFrame);
+    const glowedId = born[0]?.closest("[data-event-id]")?.dataset.eventId;
+    return {
+      born: born.length,
+      markers: document.querySelectorAll(".scrub-event.reload").length,
+      newestFrame,
+      clusterId: cluster ? String(cluster.id) : null,
+      glowedId: glowedId ?? null,
+    };
+  });
   check(
     "a repeat hero edit re-glows its clustered reload marker",
-    reglow.born > 0 && reglow.markers === markersBeforeReglow,
+    reglow.born === 1 &&
+      reglow.markers === markersBeforeReglow &&
+      reglow.clusterId !== null &&
+      reglow.glowedId === reglow.clusterId,
     JSON.stringify({ markersBeforeReglow, ...reglow })
   );
   const heavyJumpHash = await regionHash(heroPlayer);

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -464,6 +464,18 @@ const playerFrame = (page) => {
     await sleep(700);
   };
 
+  // Reload juice reports EDITS, not history. Staging replayed a whole input
+  // script and loaded the program before any of this ran, so nothing may have
+  // flashed yet — the overlay is built lazily on the first real flash, so its
+  // absence is the baseline guard.
+  check(
+    "hero staging lands without flashing the viewport",
+    await heroPlayer.evaluate(() => !document.querySelector(".scrub-reload-juice")),
+    await heroPlayer.evaluate(
+      () => document.querySelector(".scrub-reload-juice")?.className ?? "absent"
+    )
+  );
+
   // Weakening the jump rebuilds the predicted (pink) future under the edited
   // code. The anchor stays parked, so the recorded (cyan) past is unchanged;
   // only the extrapolated trajectory ahead of it moves.
@@ -477,9 +489,41 @@ const playerFrame = (page) => {
     `${strongJumpHash} -> ${weakJumpHash}`
   );
 
+  check(
+    "an accepted hero edit flashes the viewport cyan",
+    await heroPlayer.evaluate(() => {
+      const overlay = document.querySelector(".scrub-reload-juice");
+      return !!overlay && overlay.classList.contains("live") && !overlay.classList.contains("rejected");
+    }),
+    await heroPlayer.evaluate(
+      () => document.querySelector(".scrub-reload-juice")?.className ?? "absent"
+    )
+  );
+
+  // The clustering case, and the reason the glow is driven by hand: this second
+  // edit lands at the SAME parked frame, so the timeline folds it into the
+  // existing reload marker instead of inserting a node. A CSS insertion
+  // animation would never run again — clearing `born` first proves the code
+  // re-triggers it on the reused node.
+  const markersBeforeReglow = await heroPlayer.evaluate(() => {
+    for (const node of document.querySelectorAll(".scrub-event.born")) {
+      node.classList.remove("born");
+    }
+    return document.querySelectorAll(".scrub-event.reload").length;
+  });
+
   // gravity is editable in the same region: it must move the projection too.
   const heavyRegion = weakRegion.replace("let gravity = 30.0", "let gravity = 45.0");
   await applyHeroRegion(heavyRegion);
+  const reglow = await heroPlayer.evaluate(() => ({
+    born: document.querySelectorAll(".scrub-event.born").length,
+    markers: document.querySelectorAll(".scrub-event.reload").length,
+  }));
+  check(
+    "a repeat hero edit re-glows its clustered reload marker",
+    reglow.born > 0 && reglow.markers === markersBeforeReglow,
+    JSON.stringify({ markersBeforeReglow, ...reglow })
+  );
   const heavyJumpHash = await regionHash(heroPlayer);
   check(
     "editing gravity redraws the projected trajectory",
@@ -509,6 +553,24 @@ const playerFrame = (page) => {
     "hero broken edit keeps the last good projected trajectory",
     brokenJumpHash === wideJumpHash,
     `${wideJumpHash} -> ${brokenJumpHash}`
+  );
+  // The rejection marker publishes on the runtime's next poll, a frame or two
+  // after the panel reports the error; wait for the flash rather than racing it.
+  await heroPlayer
+    .waitForFunction(
+      () => document.querySelector(".scrub-reload-juice")?.classList.contains("rejected"),
+      { timeout: 5000 }
+    )
+    .catch(() => {});
+  check(
+    "a rejected hero edit flashes the viewport red",
+    await heroPlayer.evaluate(() => {
+      const overlay = document.querySelector(".scrub-reload-juice");
+      return !!overlay && overlay.classList.contains("rejected") && !overlay.classList.contains("live");
+    }),
+    await heroPlayer.evaluate(
+      () => document.querySelector(".scrub-reload-juice")?.className ?? "absent"
+    )
   );
 
   // Recover with the original tunables. The deliberately paused timeline
@@ -1026,6 +1088,29 @@ for (const example of examples) {
     .then(() => true)
     .catch(() => false);
   check("timeline renders successful hot-reload boundaries", reloadMarker);
+  // The viewport flash belongs to the SEAM, not the bar: this player mounts
+  // with ?scrubber=hidden (no chrome, no bar stylesheet), and the sandbox edit
+  // above must still light its pane. Proves the flash carries its own styling.
+  const sandboxFlash = await player
+    .waitForFunction(
+      () => document.querySelector(".scrub-reload-juice")?.classList.contains("live"),
+      { timeout: 5000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  const sandboxFlashStyled = await player.evaluate(() => {
+    const overlay = document.querySelector(".scrub-reload-juice");
+    if (!overlay) return null;
+    const style = getComputedStyle(overlay);
+    return { position: style.position, shadow: style.boxShadow.includes("rgb") };
+  });
+  check(
+    "a sandbox edit flashes its hidden-mounted pane",
+    sandboxFlash &&
+      sandboxFlashStyled?.position === "fixed" &&
+      sandboxFlashStyled?.shadow === true,
+    JSON.stringify({ sandboxFlash, sandboxFlashStyled })
+  );
   const rangeAfterSafeReload = await player.evaluate(() => window.__scrub.range());
   check(
     "plain-data history remains seekable across a hot reload",

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -110,7 +110,7 @@ const STYLE = `
 /* A landing reload glows on the rail and settles. The color property mirrors
    the fill so the drop-shadow takes the marker's own hue (violet ok / red
    error), and fill-box keeps the widen centered on the 3px tick, not the viewBox.
-   The class is applied by hand (see reglowMarkerNearest): marker nodes are
+   The class is applied by hand (see reglowMarkerCluster): marker nodes are
    reused, so an insertion-time animation would only ever run once. */
 .scrub-event.reload { color: #b994ff; }
 .scrub-event.reload-error { color: #ff6b7d; }
@@ -372,6 +372,16 @@ const HTML = `
     <button id="scrub-debug-reset" type="button">Reset</button>
   </section>`;
 
+// Install a stylesheet once per document, keyed by id. Two callers: the bar's
+// chrome (visible mounts only) and the viewport flash (any mount).
+const ensureStyle = (id, css) => {
+  if (document.getElementById(id)) return;
+  const style = document.createElement("style");
+  style.id = id;
+  style.textContent = css;
+  document.head.appendChild(style);
+};
+
 // `hidden: true` mounts the SEAM without the chrome: the timeline model, the
 // runtime poll loop, and `window.__scrub` all run exactly as usual, but the
 // bar's DOM is never attached to the document — so nothing renders and
@@ -379,12 +389,7 @@ const HTML = `
 // their own transport UI over the seam (the sandbox's chrono bar) — an
 // honest replacement for hiding the bar with injected CSS.
 export function mountScrubber({ hidden = false } = {}) {
-  if (!hidden && !document.getElementById("functor-scrubber-style")) {
-    const style = document.createElement("style");
-    style.id = "functor-scrubber-style";
-    style.textContent = STYLE;
-    document.head.appendChild(style);
-  }
+  if (!hidden) ensureStyle("functor-scrubber-style", STYLE);
 
   // The element is always BUILT (every internal lookup and render targets
   // it); when hidden it simply stays detached.
@@ -621,12 +626,7 @@ export function mountScrubber({ hidden = false } = {}) {
   // answering the edit rather than a widget lighting up.
   const flashReloadJuice = (kind) => {
     if (!juiceOverlay) {
-      if (!document.getElementById("functor-scrubber-juice-style")) {
-        const style = document.createElement("style");
-        style.id = "functor-scrubber-juice-style";
-        style.textContent = JUICE_STYLE;
-        document.head.appendChild(style);
-      }
+      ensureStyle("functor-scrubber-juice-style", JUICE_STYLE);
       juiceOverlay = document.createElement("div");
       juiceOverlay.className = "scrub-reload-juice";
       juiceOverlay.setAttribute("aria-hidden", "true");
@@ -639,35 +639,29 @@ export function mountScrubber({ hidden = false } = {}) {
     juiceOverlay.classList.add(kind === "reload-error" ? "rejected" : "live");
   };
 
-  // Layer 2 — the rail marker glows and settles. Finding the node by geometry
-  // is deliberate: same-frame reloads CLUSTER into one marker, so the new
-  // reload may carry an id this cluster does not expose. Its rail position is
-  // the reliable handle — match the group's translate-x against where this
-  // frame falls in the current viewport, in the same 0..1000 viewBox units
-  // renderMarkers writes.
-  const reglowMarkerNearest = (frame) => {
-    const range = functor_lang_scene_range();
-    if (range.length !== 2 || range[1] <= range[0]) return;
-    const targetX = ((frame - range[0]) / (range[1] - range[0])) * 1000;
-    let best = null;
-    let bestDist = Infinity;
-    for (const tick of el.querySelectorAll(
-      ".scrub-event.reload, .scrub-event.reload-error"
-    )) {
-      const group = tick.closest("[transform]");
-      const m = group && /translate\(([-\d.]+)/.exec(group.getAttribute("transform"));
-      const dist = m ? Math.abs(Number(m[1]) - targetX) : Infinity;
-      if (dist < bestDist) {
-        bestDist = dist;
-        best = tick;
-      }
-    }
-    if (!best) return;
+  // Layer 2 — the rail marker glows and settles. The cluster this reload landed
+  // in has to be found rather than assumed: same-frame reloads FOLD into an
+  // existing marker, whose `id` stays that of the first event in the bucket.
+  // `lastFrame` is the handle — clustering records the most recent event's
+  // frame, and this reload is by definition the newest, so the cluster carrying
+  // our frame is exactly ours. A reload outside the viewport has no cluster at
+  // all (clustering drops it), and correctly glows nothing.
+  const reglowMarkerCluster = (frame) => {
+    const marker = view().eventMarkers.find(
+      (candidate) => candidate.category === "reload" && candidate.lastFrame === frame
+    );
+    const tick = marker && markerNodes.get(marker.id)?.querySelector(".scrub-event");
+    if (!tick) return;
     // Same restart trick as the flash: a reused node never re-runs an
-    // insertion-time animation on its own.
-    best.classList.remove("born");
-    void best.getBoundingClientRect();
-    best.classList.add("born");
+    // insertion-time animation on its own. Clear it when the glow finishes so a
+    // later DOM move (renderMarkers re-parents groups when clustering order
+    // changes) can't replay a stale marker's animation.
+    tick.classList.remove("born");
+    void tick.getBoundingClientRect();
+    tick.classList.add("born");
+    tick.addEventListener("animationend", () => tick.classList.remove("born"), {
+      once: true,
+    });
   };
 
   // Ticks along the rail: one per second (TIMELINE_FPS frames), heavier every
@@ -1296,15 +1290,20 @@ export function mountScrubber({ hidden = false } = {}) {
         );
         const newest = reloads.length > 0 ? reloads[reloads.length - 1] : null;
         const seeded = lastReloadJuiceId !== null;
-        const newReload = seeded && newest && newest.id !== lastReloadJuiceId ? newest : null;
-        if (newest) lastReloadJuiceId = newest.id;
+        // Strictly GREATER, and the high-water mark only ever rises: marker ids
+        // come from a counter that never decreases, but the log is pruned, not
+        // append-only (seeking back and resuming truncates markers ahead of the
+        // branch point). Comparing for inequality would then see an older
+        // surviving reload as "new" and flash for an edit made long ago.
+        const newReload = seeded && newest && newest.id > lastReloadJuiceId ? newest : null;
+        if (newest) lastReloadJuiceId = Math.max(lastReloadJuiceId ?? -1, newest.id);
         else if (!seeded) lastReloadJuiceId = -1;
         dispatch({ type: "events-published", events: parsed });
         // After the dispatch, so the marker node exists (or has been updated in
         // place) before the glow is re-triggered on it.
         if (newReload) {
           flashReloadJuice(newReload.kind);
-          reglowMarkerNearest(newReload.frame);
+          reglowMarkerCluster(newReload.frame);
         }
       } catch {
         // A malformed marker payload must not stop the runtime poll loop.
@@ -1346,6 +1345,11 @@ export function mountScrubber({ hidden = false } = {}) {
       clearTimeout(toastTimer);
       window.removeEventListener("keydown", onPausedGameKey);
       el.remove();
+      // The flash overlay lives on the document, not inside the bar, so it has
+      // to be taken down by hand — otherwise a remount stacks a second one and
+      // leaves a stale node for `.scrub-reload-juice` lookups to find first.
+      juiceOverlay?.remove();
+      juiceOverlay = null;
       document.documentElement.style.removeProperty("--functor-scrubber-h");
       if (window.__scrub === seam) delete window.__scrub;
     },

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -107,6 +107,27 @@ const STYLE = `
 .scrub-event.input { fill: #ffd166; fill-opacity: 0.75; }
 .scrub-event.reload { fill: #b994ff; }
 .scrub-event.reload-error { fill: #ff6b7d; }
+/* A landing reload glows on the rail and settles. The color property mirrors
+   the fill so the drop-shadow takes the marker's own hue (violet ok / red
+   error), and fill-box keeps the widen centered on the 3px tick, not the viewBox.
+   The class is applied by hand (see reglowMarkerNearest): marker nodes are
+   reused, so an insertion-time animation would only ever run once. */
+.scrub-event.reload { color: #b994ff; }
+.scrub-event.reload-error { color: #ff6b7d; }
+.scrub-event.reload, .scrub-event.reload-error {
+  transform-box: fill-box; transform-origin: center;
+}
+.scrub-event.reload.born, .scrub-event.reload-error.born {
+  animation: scrub-marker-born 0.9s ease-out;
+}
+@keyframes scrub-marker-born {
+  0% {
+    fill-opacity: 1; transform: scaleX(2.6);
+    filter: drop-shadow(0 0 8px currentColor) brightness(2.4);
+  }
+  55% { filter: drop-shadow(0 0 4px currentColor) brightness(1.4); }
+  100% { transform: none; filter: none; }
+}
 .scrub-tick { fill: var(--sb-text); fill-opacity: 0.28; pointer-events: none; }
 .scrub-tick.major { fill: var(--sb-text); fill-opacity: 0.5; }
 .scrub-event-hit { cursor: pointer; outline: none; }
@@ -194,6 +215,9 @@ const STYLE = `
     box-shadow: 0 0 0 2px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.35);
   }
   #scrub-toast.show { animation: none; }
+  /* The marker keeps its final resting look; the reload still reads through
+     the viewport flash, which has its own reduced-motion treatment. */
+  .scrub-event.reload.born, .scrub-event.reload-error.born { animation: none; }
 }
 #scrub-camera.on {
   border-color: var(--sb-accent);
@@ -231,6 +255,50 @@ const STYLE = `
 @media (max-width: 380px) {
   #scrub-main { gap: 4px; }
   #scrubber button { padding: 6px 5px; font-size: 13px; }
+}`;
+
+// The viewport's answer to a hot reload: a brief edge vignette over the whole
+// page, cyan when the edit went live and red when the runtime rejected it.
+//
+// This is deliberately NOT part of STYLE. STYLE dresses the bar's chrome and is
+// only injected for a visible mount, but the flash belongs to the viewport, not
+// the bar — a hidden mount (the sandbox's panes, which dock their own chrono
+// bar over the seam) still runs the poll loop and still deserves the
+// acknowledgement. Keeping it separate lets the flash carry its own styling
+// wherever the seam is mounted. The cyan is the accent's literal value rather
+// than var(--sb-accent), which is scoped to #scrubber.
+const JUICE_STYLE = `
+/* z-index 9 keeps the vignette just UNDER the bar (10): it frames the viewport
+   without washing over the transport, so the marker glow stays crisp. */
+.scrub-reload-juice {
+  position: fixed; inset: 0; z-index: 9; pointer-events: none; opacity: 0;
+}
+/* Success is deliberately quiet. The star of an accepted edit is the redrawn
+   prediction in the scene, so the vignette only has to say "that landed" and
+   get out of the way — a hairline ring and a faint glow, gone in 0.28s. */
+.scrub-reload-juice.live {
+  animation: scrub-juice-flash 0.28s ease-out;
+  box-shadow: inset 0 0 0 1px rgba(65, 216, 230, 0.5),
+    inset 0 0 44px 8px rgba(65, 216, 230, 0.16);
+}
+/* A rejection shouts, and lingers a beat longer: nothing else on the page says
+   the edit was refused, so this is the one the reader must not miss. */
+.scrub-reload-juice.rejected {
+  animation: scrub-juice-flash 0.45s ease-out;
+  box-shadow: inset 0 0 0 2px rgba(255, 107, 125, 0.9),
+    inset 0 0 60px 12px rgba(255, 107, 125, 0.4);
+}
+@keyframes scrub-juice-flash {
+  0% { opacity: 0; }
+  18% { opacity: 1; }
+  100% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Same message, no ramp: the vignette holds once and clears. */
+  .scrub-reload-juice.live, .scrub-reload-juice.rejected {
+    animation: scrub-juice-reduced 0.5s steps(1, end);
+  }
+  @keyframes scrub-juice-reduced { 0% { opacity: 0.6; } 100% { opacity: 0; } }
 }`;
 
 const HTML = `
@@ -380,6 +448,11 @@ export function mountScrubber({ hidden = false } = {}) {
   let nextSeekId = 1;
   let lastSeekResultId = null;
   let lastEventsGeneration = null;
+  // The newest reload marker this mount has already acknowledged. `null` means
+  // no baseline yet: the first events publish seeds it WITHOUT flashing,
+  // because reloads that predate the mount are history, not news.
+  let lastReloadJuiceId = null;
+  let juiceOverlay = null;
   let lastRuntimeSnapshotKey = "";
   let lastDebugSnapshotKey = "";
   let detachedActive = false;
@@ -539,6 +612,62 @@ export function mountScrubber({ hidden = false } = {}) {
     } else {
       eventDetail.style.display = "none";
     }
+  };
+
+  // --- Reload juice: the page acknowledges a hot reload. ---------------------
+
+  // Layer 1 — the viewport flash. The overlay is built once per mount and
+  // lives on the document (not inside the bar), so it reads as the page
+  // answering the edit rather than a widget lighting up.
+  const flashReloadJuice = (kind) => {
+    if (!juiceOverlay) {
+      if (!document.getElementById("functor-scrubber-juice-style")) {
+        const style = document.createElement("style");
+        style.id = "functor-scrubber-juice-style";
+        style.textContent = JUICE_STYLE;
+        document.head.appendChild(style);
+      }
+      juiceOverlay = document.createElement("div");
+      juiceOverlay.className = "scrub-reload-juice";
+      juiceOverlay.setAttribute("aria-hidden", "true");
+      document.body.appendChild(juiceOverlay);
+    }
+    juiceOverlay.classList.remove("live", "rejected");
+    // Reading layout between the remove and the add restarts the animation, so
+    // back-to-back reloads each get their own flash instead of one stuck class.
+    void juiceOverlay.offsetWidth;
+    juiceOverlay.classList.add(kind === "reload-error" ? "rejected" : "live");
+  };
+
+  // Layer 2 — the rail marker glows and settles. Finding the node by geometry
+  // is deliberate: same-frame reloads CLUSTER into one marker, so the new
+  // reload may carry an id this cluster does not expose. Its rail position is
+  // the reliable handle — match the group's translate-x against where this
+  // frame falls in the current viewport, in the same 0..1000 viewBox units
+  // renderMarkers writes.
+  const reglowMarkerNearest = (frame) => {
+    const range = functor_lang_scene_range();
+    if (range.length !== 2 || range[1] <= range[0]) return;
+    const targetX = ((frame - range[0]) / (range[1] - range[0])) * 1000;
+    let best = null;
+    let bestDist = Infinity;
+    for (const tick of el.querySelectorAll(
+      ".scrub-event.reload, .scrub-event.reload-error"
+    )) {
+      const group = tick.closest("[transform]");
+      const m = group && /translate\(([-\d.]+)/.exec(group.getAttribute("transform"));
+      const dist = m ? Math.abs(Number(m[1]) - targetX) : Infinity;
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = tick;
+      }
+    }
+    if (!best) return;
+    // Same restart trick as the flash: a reused node never re-runs an
+    // insertion-time animation on its own.
+    best.classList.remove("born");
+    void best.getBoundingClientRect();
+    best.classList.add("born");
   };
 
   // Ticks along the rail: one per second (TIMELINE_FPS frames), heavier every
@@ -1158,7 +1287,25 @@ export function mountScrubber({ hidden = false } = {}) {
       lastEventsGeneration = eventsGeneration;
       const eventsJson = functor_lang_timeline_events();
       try {
-        dispatch({ type: "events-published", events: JSON.parse(eventsJson) });
+        const parsed = JSON.parse(eventsJson);
+        // Match the runtime's own wire kinds ("reload-ok" / "reload-error"),
+        // never the timeline model's derived "reload" cluster category — the
+        // category cannot tell an accepted edit from a rejected one.
+        const reloads = parsed.filter(
+          (event) => typeof event.kind === "string" && event.kind.startsWith("reload-")
+        );
+        const newest = reloads.length > 0 ? reloads[reloads.length - 1] : null;
+        const seeded = lastReloadJuiceId !== null;
+        const newReload = seeded && newest && newest.id !== lastReloadJuiceId ? newest : null;
+        if (newest) lastReloadJuiceId = newest.id;
+        else if (!seeded) lastReloadJuiceId = -1;
+        dispatch({ type: "events-published", events: parsed });
+        // After the dispatch, so the marker node exists (or has been updated in
+        // place) before the glow is re-triggered on it.
+        if (newReload) {
+          flashReloadJuice(newReload.kind);
+          reglowMarkerNearest(newReload.frame);
+        }
       } catch {
         // A malformed marker payload must not stop the runtime poll loop.
       }


### PR DESCRIPTION
Hot reload currently succeeds in silence: the scene changes, and nothing tells you the runtime
accepted what you typed. This adds two layers of feedback on the web scrubber, both driven off
the timeline's reload markers.

## The two layers

**1. Viewport flash.** A new reload marker raises a fixed-position edge vignette over the page —
cyan for an accepted edit, red for a rejected one. Pointer-events none, `aria-hidden`, and
restartable, so back-to-back reloads each get their own flash instead of one stuck class.

Success is deliberately quiet (0.28s, a 1px ring at 0.5 alpha and a 44px glow at 0.16): on an
accepted edit the star of the moment is the redrawn prediction in the scene, not the frame around
it. Rejection shouts and lingers (0.45s, 2px ring at 0.9, 60px glow at 0.4) — nothing else on the
page says the edit was refused.

Under `prefers-reduced-motion` both collapse to a short static fade with no ramp. The overlay sits
at `z-index: 9`, just under the bar's 10, so it frames the viewport without washing over the
transport.

**2. Marker glow.** The reload marker on the rail glows and settles over 0.9s — a drop-shadow in
the marker's own hue, a brief `scaleX` widen, `transform-box: fill-box` so the widen centers on
the 3px tick rather than the viewBox.

## Wire detail: match the runtime's kinds, not the cluster category

Successful reloads publish `kind: "reload-ok"` and rejected ones `"reload-error"`
(`runtime/functor-runtime-web/src/functor_lang_game.rs`). The hook matches
`kind.startsWith("reload-")` — deliberately **not** the timeline model's derived cluster category
`"reload"` (`timeline-model.js:302`), which folds both into one bucket and so cannot tell an
accepted edit from a rejected one.

## Mechanism: why the glow is driven explicitly

Marker nodes are **reused** across renders, and same-frame reloads are **clustered into an
existing node** (`renderMarkers`). A CSS insertion animation therefore fires exactly once — the
first reload at a given frame — and every subsequent edit at the same parked frame lands silently.
That is the common case on the hero, which parks at a fixed frame and reloads on every edit.

So the glow is driven from the events-publish path: detect the new reload, **dispatch first** so
the node exists and has been updated in place, then find the cluster the reload landed in and
re-trigger `.born` by remove → force reflow → add.

Finding that cluster is exact, not a guess: clustering records `lastFrame` as the most recent
event's frame in the bucket, and the new reload is by definition the newest, so the reload cluster
whose `lastFrame` equals our frame *is* ours. A reload outside the viewport has no cluster at all
and correctly glows nothing.

**Baseline guard.** The first events publish after mount seeds the tracker *without* flashing:
reloads that predate the mount are history, not news.

## Divergences from the approved prototype

1. **The flash stylesheet self-injects, separately from the bar's `STYLE`.** `mountScrubber` only
   injects `STYLE` when `!hidden`, and the sandbox panes boot `?scrubber=hidden`. The prototype
   appended the overlay div there but no rule backed it, so those surfaces would have flashed
   *nothing*. The flash's CSS is now its own `JUICE_STYLE`, injected on first flash — the flash
   belongs to the viewport, not the bar. Marker-glow CSS stays in `STYLE`, where a rail exists to
   glow. There is an e2e check that fails if this regresses.
2. **Newness is tracked by the newest reload's `id` as a monotonic high-water mark**, not by the
   reload count. The log is pruned rather than append-only, so count arithmetic desyncs and cannot
   say *which* reload is new.
3. **The cluster is found from the model, not from SVG geometry.** See the review section.

## Review (`/xreview` — 2 Claude reviewers + Codex)

The second commit fixes everything Medium and above. The two below were raised **independently by
multiple engines**:

- **[AGREED] Wrong coordinate space in the marker lookup.** The first implementation compared a
  rail x computed from `functor_lang_scene_range()` (the runtime's recorded range) against marker
  positions derived from the model's **viewport** — which diverge whenever the timeline is paused
  or riding a generation-continuity window. With an unbounded nearest-match it could glow an
  unrelated marker. Replaced with the exact `lastFrame` cluster lookup described above, which also
  deletes an SVG-`transform` regex parse. The hero e2e could not have caught this (one marker on
  the rail makes "nearest" trivially correct), so that check was strengthened to assert the
  glowing node *is* the cluster holding the newest reload.
- **[AGREED] Log truncation read as a new reload.** Seeking back and resuming truncates markers
  ahead of the branch point; an older surviving reload then compared unequal and flashed for an
  edit made long ago. Now a strict high-water mark that never lowers.
- **Overlay leaked on `destroy()`** (Codex). It lives on the document, not in the bar, so a
  remount stacked a second one and left a stale node for lookups. Now removed explicitly.
- **Simplicity:** extracted `ensureStyle(id, css)` — this change had introduced a second copy of
  the lazy-stylesheet block. The two animation-restart sites were deliberately left separate: they
  now differ materially (HTML `offsetWidth` vs SVG `getBoundingClientRect` plus an `animationend`
  cleanup).

De-dup pass coverage: all four strategies ran — S1 4 queries/7129 candidates, S2 249 clone pairs
with 0 touching this change, S3 grep of the 396KB API index, S4 full read. No pre-existing
flash/vignette overlay exists in `site/`, `player.html` or `index-functor-lang.html`, so this
surface is genuinely new.

## Dispositioned follow-ups (not in this PR)

- **A rejection that clusters into an accepted marker stays violet.** `clusterTimelineEvents`
  keeps the *first* event's kind for a bucket, so a rejected reload folding into an existing
  accepted cluster at the same frame keeps the ok hue. Raised by two reviewers; the real fix is
  error-dominant cluster semantics in the timeline model, and **model/reducer changes are out of
  scope here**. The blast radius is narrow: the **viewport flash is always correct** (it reads the
  raw wire kind), and a rejection at its own frame — the normal live case, green in the
  runtime-page e2e — does glow red. Only the same-frame-cluster case is affected.
- **The playhead covers the glowing marker.** A reload is logged at the frame you are parked on,
  so on the hero — parked, editing repeatedly — the playhead handle sits on top of the very marker
  that glows. I had to seek the playhead aside to photograph layer 2 at all. The flash is
  therefore the load-bearing feedback on the hero; layer 2 pays off where the marker isn't under
  the handle.
- **The sandbox chrono bar's own rail markers don't glow.** `mp-panes` renders its own marker DOM;
  layer 2 needs a rail and the panes' scrubber is hidden. The panes do get the viewport flash
  (verified below).
- **Native parity.** Desktop reload already has console feedback and file-watch semantics; this PR
  is web-only by scope decision.
- **No re-flash suppression window.** The hero pushes an edit per keystroke, and suppression was
  considered. The restart-on-retrigger already reads as one sustained glow rather than a strobe,
  the current feel was approved hands-on, and reduced-motion users get the static fade. Adding a
  window would dampen approved feedback for a problem not observed.
- **Only the newest reload of a publish flashes.** Two pushes landing between rAF ticks show one
  flash, so a rejection can be swallowed by a fast follow-up fix. Accepted as-is.

## Verification

All re-run after the review fixes:

- `npm run build` — green.
- `npm run build:cli:debug` — green. Required for the runtime-page check below to exercise the new
  code, since that page serves the CLI-embedded `scrubber.js`.
- `node --test runtime/functor-runtime-web/timeline-model.test.js` — **24/24**. The timeline model
  is untouched by this PR.
- `node e2e/site-sandbox.mjs` — **140/140, ALL CHECKS PASSED**, including five new checks:
  - `hero staging lands without flashing the viewport` — the baseline guard. The overlay is built
    lazily on the first real flash, so its *absence* is the assertion.
  - `an accepted hero edit flashes the viewport cyan`
  - `a repeat hero edit re-glows its clustered reload marker` — the regression that matters. A
    second edit at the same parked frame re-triggers `.born` on the **same** node; asserted with
    an unchanged marker count *and* that the glowing node is the cluster holding the newest
    reload, so it cannot pass on a wrongly-chosen marker.
  - `a rejected hero edit flashes the viewport red`
  - `a sandbox edit flashes its hidden-mounted pane` — the panes boot `?scrubber=hidden`. Asserts
    the overlay is not merely classed but *computed-styled* (`position: fixed`, a real
    `box-shadow`), which is what proves the self-injected stylesheet reaches a chrome-less mount.
- `node e2e/functor-lang-preview-reload.mjs` — **14/14, ALL CHECKS PASSED**. Drives
  `index-functor-lang.html` (what `functor run wasm` serves, and what the VSCode live preview
  embeds) over the same postMessage seam. It mounts the scrubber *visibly*, so it verifies both
  layers on a second, independent surface: `an accepted push flashes the runtime page and glows
  its marker`, and `a rejected push flashes the runtime page red`.

One note for anyone reproducing these locally: both harnesses bind fixed ports (site 8123,
runtime 8080). If something else holds them — `adb` forwards to 8123, and a stray
`functor run wasm` holds 8080 — the site harness fails to start and the runtime harness silently
talks to the *other* server, producing failures that look like product bugs. Set
`FUNCTOR_SITE_PORT` and check the served `scrubber.js` is the one you just built.

## Visuals

Captured against the built site with Playwright. Animations are frozen mid-flight via the Web
Animations API (`anim.currentTime = N; anim.pause()`) from a MutationObserver armed before the
edit — racing a screenshot against a 280ms animation is not reproducible.

**Accepted edit — the quiet cyan vignette** (frozen at 52ms, the peak of the 0.28s curve):

![accepted edit flashes cyan](https://gist.githubusercontent.com/tommy-xr/d85b6de8a4647d9eb7c675a5b1f6c6a5/raw/juice-flash-live.png)

**Rejected edit — the loud red vignette** (frozen at 90ms of 0.45s), beside the runtime's own
parse-error overlay. Reviewers pixel-probed the pair: 1px `rgb(44,135,154)` for success against
2px `rgb(227,99,119)` and roughly 3× the interior lift for rejection, so the intended asymmetry
is measurable, not just claimed:

![rejected edit flashes red](https://gist.githubusercontent.com/tommy-xr/d85b6de8a4647d9eb7c675a5b1f6c6a5/raw/juice-flash-rejected.png)

**Marker glow** — the clustered reload marker mid-animation, widened and haloed next to the thin
amber input ticks. The playhead was seeked aside for the capture, because a reload is logged at
the frame you are parked on and the handle otherwise covers it (see the dispositioned follow-up):

![reload marker glowing on the rail](https://gist.githubusercontent.com/tommy-xr/d85b6de8a4647d9eb7c675a5b1f6c6a5/raw/juice-marker-glow.png)
