### PR TITLE
feat(time-travel): fade the extrapolation preview in and out

### DIFF
--- a/docs/time-travel.md
+++ b/docs/time-travel.md
@@ -417,8 +417,8 @@ the right edge.
 
 Both scrubbers grow a mirrored endpoint handle, and **either handle sets the one
 shared window** — drag one side and both resize. The seam is unchanged:
-`setPreview({ enabled, seconds, rate, mode })` still takes one `seconds`, now
-read as the per-side window.
+`setPreview({ enabled, seconds, rate, mode, presence })` still takes one
+`seconds`, now read as the per-side window.
 
 **Cost.** The past half runs one `draw` per division and never advances the
 *model* — but for a physics game it is not free: restoring a recorded world seeks
@@ -476,6 +476,68 @@ first and re-records the jump when the anchor has aged out. The click latches
 while that is in flight, since a second pause toggle would leave the demo
 running. The sandbox and IDE pass no
 handler and keep ⏭ unchanged.
+
+### The presence ramp — the overlay arrives, it doesn't pop
+
+Toggling 🔮 used to swap a dense field of marks and copies in or out between two
+consecutive frames. That reads as a glitch rather than a state change, and it
+gives no sense that the overlay is *additional* to the scene. So the whole
+preview now fades: presence eases 0 → 1 (and back) over **0.28 s**, smoothstep
+shaped, driving a multiply on every overlay material's alpha.
+
+**Where presence lives is the load-bearing decision.** Both shells cache a
+*built* `FramePreview` downstream of the forward sim and clone it per frame.
+Presence is therefore:
+
+- **not** in `PreviewOptions`, and **not** in either shell's cache key — it
+  applies to the per-frame clone at apply time (`FramePreview::apply_all_with_presence`),
+  so animating it never re-runs `ghost_frames` / `history_frames`;
+- **not** in the overlay *builders* — a trail mark is still built at alpha 1.0
+  and the walk scales it afterwards, for the same reason;
+- runtime-*loop* state in each shell (`preview_presence` + the last on-mode).
+  The wanted-flags don't move during a fade — the shell keeps computing and
+  applying the **last on-mode** while presence is still above zero, because
+  fading out needs geometry after the toggle already flipped — so the cache
+  stays warm across the whole ramp.
+
+At presence 0 the overlay is *absent*, not transparent: an alpha-0 subtree would
+still write depth and occlude the scene behind it.
+
+**Translucent 3D materials.** The 3D forward pass is otherwise fully opaque, so
+fading needed a blend. A material whose constant color alpha is below 1 enables
+straight-alpha blending for its own subtree and restores after; passes that
+already own the blend state (2D sprites — which have always blended — and the
+transparent-debug mode) are left alone. This is safe to key on because the
+Functor Lang prelude *cannot express* a translucent 3D material (`Color.rgb` has
+no alpha channel), so a translucent 3D material means the runtime's own overlay.
+
+Two known limits are accepted at this tier:
+
+1. **Overlapping overlay parts double-blend.** There is no depth prepass or
+   back-to-front sort, so a mark's crossed arrowheads and its sphere core read
+   slightly denser where they overlap.
+2. **3D marks still cast shadows while fading.** Overlays ride the shared shadow
+   pass, which has no notion of presence.
+
+Both have the same fix, deferred as a follow-up: give the overlay its own
+**constant-alpha pass** after the scene, modeled on the transparent-debug recipe
+(depth prepass with the color mask off, then blend the nearest surface at a
+constant alpha), and exclude the overlay subtree from the shadow pass. That
+removes the double-blend and the shadows together, and makes presence a single
+`glBlendColor` instead of a material walk.
+
+**Overrides.** Tooling can PIN presence and skip the ease, for deterministic
+mid-fade captures: `--preview-presence <f32>` natively and
+`window.__scrub.setPreview({ presence })` on the web. In both, a **negative**
+value means "no pin — resume the runtime's easing".
+
+The ease itself runs on WALL-CLOCK delta and is deliberately *not* suppressed by
+`--fixed-time` / `?fixed-time`, which pin the game's **pose**, not real time.
+Captures stay reproducible anyway: the ramp is 0.28s and `--capture-time`
+defaults to 2s, so the fade is long finished when the shot is taken. Keeping the
+two independent is what makes the ease observable headlessly — sweeping
+`--capture-time` across the ramp with `--fixed-time` held constant renders the
+fade curve against a frozen pose.
 
 ## Deferred follow-ups: keep and reconstruct the old future
 

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -121,8 +121,9 @@ pub use scene3d::*;
 pub use sprite2d::{Camera2D, SpriteLayer};
 pub use terrain::{TerrainDescription, TerrainGeometry, TerrainGrass, TerrainLayers};
 pub use trajectory::{
-    frame_preview, interactive_preview, overlay, scene_preview, trajectory_trail, FramePreview,
-    InteractivePreview, PreviewMode, PreviewOptions, SceneOverlays, ScenePreview, StrobeOptions,
+    frame_preview, interactive_preview, overlay, presence_ease, presence_step, scene_preview,
+    trajectory_trail, FramePreview, InteractivePreview, PreviewMode, PreviewOptions, SceneOverlays,
+    ScenePreview, StrobeOptions, PRESENCE_RAMP_SECONDS,
 };
 pub use viewport::*;
 

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -121,9 +121,9 @@ pub use scene3d::*;
 pub use sprite2d::{Camera2D, SpriteLayer};
 pub use terrain::{TerrainDescription, TerrainGeometry, TerrainGrass, TerrainLayers};
 pub use trajectory::{
-    frame_preview, interactive_preview, overlay, presence_ease, presence_step, scene_preview,
-    trajectory_trail, FramePreview, InteractivePreview, PreviewMode, PreviewOptions, SceneOverlays,
-    ScenePreview, StrobeOptions, PRESENCE_RAMP_SECONDS,
+    frame_preview, interactive_preview, overlay, presence_ease, presence_phase, presence_step,
+    scene_preview, trajectory_trail, FramePreview, InteractivePreview, PreviewMode, PreviewOptions,
+    SceneOverlays, ScenePreview, StrobeOptions, PRESENCE_RAMP_SECONDS,
 };
 pub use viewport::*;
 

--- a/runtime/functor-runtime-common/src/render_context.rs
+++ b/runtime/functor-runtime-common/src/render_context.rs
@@ -122,6 +122,13 @@ pub struct RenderContext<'a> {
     pub lights: &'a [Light],
     /// Which pass is rendering (forward vs. a depth-only shadow pass).
     pub render_pass: RenderPass,
+    /// Whether the ENCLOSING pass already has GL blending configured — the 2D
+    /// sprite pass (straight alpha over) and the transparent-debug pass
+    /// (constant alpha) both do. The ordinary 3D forward pass does not, so a
+    /// translucent material there has to switch blending on for its own
+    /// subtree and switch it back off after. This flag is what stops that
+    /// restore from clobbering a pass that wanted blending all along.
+    pub pass_blends: bool,
     /// The directional shadow map + light matrix, when shadows are active.
     /// `None` during the depth pass and when no light casts shadows.
     pub shadow: Option<ShadowUniforms>,

--- a/runtime/functor-runtime-common/src/render_context.rs
+++ b/runtime/functor-runtime-common/src/render_context.rs
@@ -129,6 +129,15 @@ pub struct RenderContext<'a> {
     /// subtree and switch it back off after. This flag is what stops that
     /// restore from clobbering a pass that wanted blending all along.
     pub pass_blends: bool,
+    /// Whether an ANCESTOR node in this pass already turned blending on for the
+    /// subtree currently being drawn. `Material` nodes nest, so without this a
+    /// translucent inner material would `disable(BLEND)` on the way out and
+    /// leave its outer material's remaining siblings drawing unblended. Only
+    /// the node that actually transitioned blending off→on restores it.
+    ///
+    /// A `Cell` because scene rendering walks an immutably-borrowed context on
+    /// one thread; nothing here is shared across threads.
+    pub blend_active: std::cell::Cell<bool>,
     /// The directional shadow map + light matrix, when shadows are active.
     /// `None` during the depth pass and when no light casts shadows.
     pub shadow: Option<ShadowUniforms>,

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -262,6 +262,7 @@ target frame are ignored (depth 1 only)",
             None,
             None,
             None,
+            false,
         );
         render_sprite_layers(
             gl,
@@ -334,6 +335,7 @@ target frame are ignored (depth 1 only)",
         lod_view.map(|(_, _, projection_scale, _)| projection_scale),
         lod_view.map(|(_, _, _, viewport_height)| viewport_height),
         projection_matrix,
+        false,
     );
 
     render_sprite_layers(
@@ -421,6 +423,9 @@ fn render_sprite_layers(
             None,
             None,
             Some(&projection),
+            // The sprite pass already blends (straight alpha over) — a
+            // translucent sprite material must not switch that back off.
+            true,
         );
     }
 
@@ -571,6 +576,7 @@ pub fn render_composited_frames_with_view(
             None,
             None,
             None,
+            false,
         );
         render_sprite_layers(
             gl,
@@ -677,6 +683,9 @@ fn forward_pass(
     lod_projection_scale: Option<f32>,
     lod_viewport_height: Option<f32>,
     projection_matrix: Option<&Matrix4<f32>>,
+    // True when the CALLER has already enabled GL blending for this pass (the
+    // 2D sprite pass). See `RenderContext::pass_blends`.
+    caller_blends: bool,
 ) {
     let default_lod_projection = lod_camera.projection_matrix(aspect);
     let mut terrain_frusta = [Matrix4::from_scale(1.0); 2];
@@ -695,6 +704,9 @@ fn forward_pass(
         debug_render_mode,
         lights,
         render_pass: RenderPass::Forward,
+        // The transparent-debug pass owns the blend state for the whole scene
+        // (constant alpha); leave it alone there too.
+        pass_blends: caller_blends || debug_render_mode == DebugRenderMode::Transparent,
         shadow,
         fog,
         camera_pos: cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]),

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -707,6 +707,7 @@ fn forward_pass(
         // The transparent-debug pass owns the blend state for the whole scene
         // (constant alpha); leave it alone there too.
         pass_blends: caller_blends || debug_render_mode == DebugRenderMode::Transparent,
+        blend_active: std::cell::Cell::new(false),
         shadow,
         fog,
         camera_pos: cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]),

--- a/runtime/functor-runtime-common/src/scene3d/material_description.rs
+++ b/runtime/functor-runtime-common/src/scene3d/material_description.rs
@@ -74,6 +74,21 @@ impl MaterialDescription {
         MaterialDescription::Texture(tex)
     }
 
+    /// The material's CONSTANT color alpha, when it has a color channel at all
+    /// (a bare `Texture` does not — its opacity lives in the image). The 3D
+    /// forward pass reads this to decide whether a subtree needs blending; a
+    /// texture's per-texel alpha is deliberately not consulted, since that
+    /// would mean blending every textured surface.
+    pub fn color_alpha(&self) -> Option<f32> {
+        match self {
+            MaterialDescription::Color(color)
+            | MaterialDescription::Emissive { color, .. }
+            | MaterialDescription::Lit { color, .. }
+            | MaterialDescription::SpriteTexture { color, .. } => Some(color.w),
+            MaterialDescription::Texture(_) => None,
+        }
+    }
+
     /// A solid self-lit color (neon / UI), no texture.
     pub fn emissive(r: f32, g: f32, b: f32, a: f32) -> MaterialDescription {
         MaterialDescription::Emissive {

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1353,6 +1353,42 @@ named \"{name}\" — {hint}"
 
             SceneObject::Material(material_description, items) => {
                 let material = material_description.get(render_context, scene_context);
+                // The 3D forward pass is otherwise fully opaque — every shader
+                // already writes an alpha, but nothing blends it. A material
+                // whose constant color is translucent switches blending on for
+                // its own subtree and back off after.
+                //
+                // Only the runtime's own overlays reach this: the Functor Lang
+                // prelude cannot express a translucent 3D material (Color.rgb
+                // has no alpha channel), so `color_alpha() < 1` in the 3D pass
+                // means the extrapolation preview's presence ramp
+                // (`trajectory::scale_presence`) or its age fade. `pass_blends`
+                // covers the passes that already own the blend state (2D
+                // sprites, transparent debug) so the restore can't clobber them.
+                //
+                // KNOWN LIMITATION (Tier A): there is no depth prepass or
+                // back-to-front sort, so overlapping translucent overlay parts
+                // — a mark's crossed arrowheads and its sphere core — blend
+                // twice and read slightly denser where they overlap. The Tier B
+                // follow-up (a dedicated constant-alpha overlay pass, modeled
+                // on the transparent-debug recipe in `renderer.rs`) removes
+                // both that and the overlay's shadow-pass contribution.
+                let blend = !depth_pass
+                    && !render_context.pass_blends
+                    && material_description
+                        .color_alpha()
+                        .is_some_and(|alpha| alpha < 1.0);
+                if blend {
+                    unsafe {
+                        render_context.gl.enable(glow::BLEND);
+                        render_context.gl.blend_func_separate(
+                            glow::SRC_ALPHA,
+                            glow::ONE_MINUS_SRC_ALPHA,
+                            glow::ONE,
+                            glow::ONE_MINUS_SRC_ALPHA,
+                        );
+                    }
+                }
                 for item in items.into_iter() {
                     item.render(
                         &render_context,
@@ -1362,6 +1398,11 @@ named \"{name}\" — {hint}"
                         &view_matrix,
                         &material,
                     )
+                }
+                if blend {
+                    unsafe {
+                        render_context.gl.disable(glow::BLEND);
+                    }
                 }
             }
 

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1373,12 +1373,18 @@ named \"{name}\" — {hint}"
                 // follow-up (a dedicated constant-alpha overlay pass, modeled
                 // on the transparent-debug recipe in `renderer.rs`) removes
                 // both that and the overlay's shadow-pass contribution.
+                // Only the node that transitions blending OFF→ON restores it:
+                // `Material` nodes nest, so an inner translucent material must
+                // not disable blending out from under the outer subtree's
+                // remaining siblings.
                 let blend = !depth_pass
                     && !render_context.pass_blends
+                    && !render_context.blend_active.get()
                     && material_description
                         .color_alpha()
                         .is_some_and(|alpha| alpha < 1.0);
                 if blend {
+                    render_context.blend_active.set(true);
                     unsafe {
                         render_context.gl.enable(glow::BLEND);
                         render_context.gl.blend_func_separate(
@@ -1400,6 +1406,7 @@ named \"{name}\" — {hint}"
                     )
                 }
                 if blend {
+                    render_context.blend_active.set(false);
                     unsafe {
                         render_context.gl.disable(glow::BLEND);
                     }

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -202,6 +202,9 @@ pub fn render_shadow_pass(
         debug_render_mode: crate::DebugRenderMode::Default,
         lights,
         render_pass: RenderPass::DepthOnly,
+        // Irrelevant here: the depth pass writes no color, and the
+        // translucent-material blend is skipped outright under `DepthOnly`.
+        pass_blends: false,
         shadow: None,
         // Fog is a forward-pass concern; the depth pass renders no color.
         fog: None,

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -205,6 +205,7 @@ pub fn render_shadow_pass(
         // Irrelevant here: the depth pass writes no color, and the
         // translucent-material blend is skipped outright under `DepthOnly`.
         pass_blends: false,
+        blend_active: std::cell::Cell::new(false),
         shadow: None,
         // Fog is a forward-pass concern; the depth pass renders no color.
         fog: None,

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -1064,6 +1064,16 @@ fn scale_presence(scene: &mut Scene3D, presence: f32) {
             // Scaling every color's alpha by k is EXACTLY the sprite onion-skin
             // fade with no direction tint, so reuse it rather than growing a
             // third copy of the five-variant material rewrite.
+            //
+            // INVARIANT this relies on: no overlay node carries a bare
+            // `MaterialDescription::Texture`. Every overlay material is freshly
+            // produced by `faded_material` / `alpha_faded_material` /
+            // `trail_mark`, none of which emit one. It matters because
+            // `alpha_faded_material` rewrites a bare `Texture` to `Emissive`,
+            // which changes the lighting model — and `apply` skips this walk
+            // entirely at presence 1.0, so such a node would render lit at 1.0
+            // and emissive at 0.999: a pop at exactly the boundary the ramp
+            // exists to remove.
             let faded = alpha_faded_material(Some(material), presence, None);
             if let Some(faded) = faded {
                 *material = faded;

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -1030,14 +1030,133 @@ impl SceneOverlays {
         join(&mut self.strobe, other.strobe);
     }
 
-    fn apply(&self, scene: &mut Scene3D) {
-        if let Some(trail) = &self.trail {
-            overlay(scene, trail.clone());
-        }
-        if let Some(strobe) = &self.strobe {
-            overlay(scene, strobe.clone());
-        }
+    fn apply(&self, scene: &mut Scene3D, presence: f32) {
+        let mut add = |part: Option<&Scene3D>| {
+            let Some(part) = part else { return };
+            let mut part = part.clone();
+            // Exactly 1.0 must leave the overlay byte-identical to the
+            // pre-ramp tree (goldens, `--fixed-time` captures), so the walk
+            // only runs while the fade is actually in flight.
+            if presence < 1.0 {
+                scale_presence(&mut part, presence);
+            }
+            overlay(scene, part);
+        };
+        add(self.trail.as_ref());
+        add(self.strobe.as_ref());
     }
+}
+
+/// Multiply an overlay material's alpha by the presence ramp. Textures and
+/// normal maps ride along untouched — only the constant color's alpha moves. A
+/// bare [`MaterialDescription::Texture`] has no color channel, so (exactly as
+/// [`alpha_faded_material`] does) it becomes a white-tinted emissive texture,
+/// the only form that CAN carry an alpha.
+fn presence_scaled_material(material: &MaterialDescription, presence: f32) -> MaterialDescription {
+    let scale = |mut color: Vector4<f32>| {
+        color.w *= presence;
+        color
+    };
+    match material {
+        MaterialDescription::Color(color) => MaterialDescription::Color(scale(*color)),
+        MaterialDescription::Emissive { color, texture } => MaterialDescription::Emissive {
+            color: scale(*color),
+            texture: texture.clone(),
+        },
+        MaterialDescription::Lit {
+            color,
+            texture,
+            normal_map,
+        } => MaterialDescription::Lit {
+            color: scale(*color),
+            texture: texture.clone(),
+            normal_map: normal_map.clone(),
+        },
+        MaterialDescription::Texture(texture) => MaterialDescription::Emissive {
+            color: vec4(1.0, 1.0, 1.0, presence),
+            texture: Some(texture.clone()),
+        },
+        MaterialDescription::SpriteTexture {
+            color,
+            texture,
+            source_pixels,
+            sampling,
+        } => MaterialDescription::SpriteTexture {
+            color: scale(*color),
+            texture: texture.clone(),
+            source_pixels: *source_pixels,
+            sampling: *sampling,
+        },
+    }
+}
+
+/// Walk an overlay subtree and multiply every material's alpha by `presence`.
+///
+/// This is deliberately an APPLY-TIME transform on the per-frame clone, never a
+/// build-time one: both shells cache a BUILT [`FramePreview`] downstream of the
+/// forward sim, so folding presence into the builders would make every frame of
+/// the fade a cache miss and re-run `ghost_frames`/`history_frames`. Presence is
+/// therefore not part of [`PreviewOptions`] nor of either shell's cache key.
+///
+/// A leaf with no enclosing material — typically a `Model`, which carries its
+/// own internal glTF materials — cannot fade, exactly as it cannot age-fade
+/// today (see [`faded_material`]); it pops instead of easing.
+fn scale_presence(scene: &mut Scene3D, presence: f32) {
+    match &mut scene.obj {
+        SceneObject::Material(material, items) => {
+            *material = presence_scaled_material(material, presence);
+            for item in items {
+                scale_presence(item, presence);
+            }
+        }
+        SceneObject::Group(items) => {
+            for item in items {
+                scale_presence(item, presence);
+            }
+        }
+        SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
+    }
+}
+
+/// How long the preview overlay takes to fade fully in or out when the
+/// extrapolation toggle (🔮) flips — short enough to feel immediate, long
+/// enough that the overlay arrives rather than pops.
+pub const PRESENCE_RAMP_SECONDS: f32 = 0.28;
+
+/// Advance the preview's linear presence PHASE toward `target` (1 = the preview
+/// selects something, 0 = it does not) by `dt` seconds, so a full fade takes
+/// [`PRESENCE_RAMP_SECONDS`] regardless of frame rate. The result is clamped to
+/// `[0, 1]` and never overshoots, so a hitch (or a `dt` longer than the ramp)
+/// lands exactly ON the target rather than past it.
+///
+/// The phase is linear; [`presence_ease`] shapes it into the alpha multiplier.
+/// Keeping the STATE linear is what makes the ramp symmetric — flipping the
+/// target mid-fade retraces the same curve backwards.
+pub fn presence_step(presence: f32, target: f32, dt: f32) -> f32 {
+    let presence = if presence.is_finite() {
+        presence.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let target = target.clamp(0.0, 1.0);
+    if !dt.is_finite() || dt <= 0.0 {
+        return presence;
+    }
+    let step = dt / PRESENCE_RAMP_SECONDS;
+    if target >= presence {
+        (presence + step).min(target)
+    } else {
+        (presence - step).max(target)
+    }
+}
+
+/// Smoothstep shaping of the linear phase — the alpha multiplier the overlay is
+/// actually drawn at. Ease-in-out, so the fade has no visible start/stop edge,
+/// and symmetric (`presence_ease(1 - p) == 1 - presence_ease(p)`), so fading out
+/// looks like fading in played backwards.
+pub fn presence_ease(phase: f32) -> f32 {
+    let p = phase.clamp(0.0, 1.0);
+    p * p * (3.0 - 2.0 * p)
 }
 
 /// A computed preview for the complete render frame. Sprite overlays use the
@@ -1069,14 +1188,30 @@ impl FramePreview {
         self.scene.is_empty() && self.sprite_layers.iter().all(SceneOverlays::is_empty)
     }
 
-    /// Add every requested scene-space overlay to a normal display frame.
+    /// Add every requested scene-space overlay to a normal display frame, at
+    /// full presence.
     pub fn apply_all(&self, frame: &mut Frame) {
-        self.scene.apply(&mut frame.scene);
+        self.apply_all_with_presence(frame, 1.0);
+    }
+
+    /// Add every requested scene-space overlay to a normal display frame, with
+    /// every overlay material's alpha multiplied by `presence` (0 = absent,
+    /// 1 = fully drawn — the presence ramp, see [`presence_step`]).
+    ///
+    /// At `presence <= 0` NOTHING is applied: an alpha-0 overlay would still
+    /// write depth and occlude the scene behind it, so a fully faded-out
+    /// preview has to be absent from the tree, not transparent in it.
+    pub fn apply_all_with_presence(&self, frame: &mut Frame, presence: f32) {
+        if !(presence > 0.0) {
+            return;
+        }
+        let presence = presence.min(1.0);
+        self.scene.apply(&mut frame.scene, presence);
         if frame.sprite_layers.len() != self.sprite_layers.len() {
             return;
         }
         for (layer, overlays) in frame.sprite_layers.iter_mut().zip(&self.sprite_layers) {
-            overlays.apply(&mut layer.scene);
+            overlays.apply(&mut layer.scene, presence);
         }
     }
 }
@@ -1938,5 +2073,222 @@ mod tests {
             SceneObject::Geometry(_) => {}
             other => panic!("expected a bare geometry copy, got {other:?}"),
         }
+    }
+
+    // ---- the presence ramp (the whole overlay's fade in / out) ----
+
+    /// Every material alpha in a scene, depth-first. `overlay` APPENDS, so a
+    /// frame's own materials always come first and the overlay's follow — which
+    /// is what lets the tests below separate them by index.
+    fn material_alphas(scene: &Scene3D, out: &mut Vec<f32>) {
+        match &scene.obj {
+            SceneObject::Material(material, items) => {
+                out.push(material.color_alpha().expect("a color-bearing material"));
+                for item in items {
+                    material_alphas(item, out);
+                }
+            }
+            SceneObject::Group(items) => {
+                for item in items {
+                    material_alphas(item, out);
+                }
+            }
+            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
+        }
+    }
+
+    /// One alpha list PER scene tree — the 3D scene, then each sprite layer.
+    /// Kept separate because each tree gets its own overlay appended, so "the
+    /// frame's own materials first" only holds within a tree.
+    fn frame_material_alphas(frame: &Frame) -> Vec<Vec<f32>> {
+        std::iter::once(&frame.scene)
+            .chain(frame.sprite_layers.iter().map(|layer| &layer.scene))
+            .map(|scene| {
+                let mut out = Vec::new();
+                material_alphas(scene, &mut out);
+                out
+            })
+            .collect()
+    }
+
+    /// A mover carrying its own material, beside a static — in BOTH the 3D
+    /// scene and one sprite layer, so one fixture exercises both overlay paths.
+    fn materialized_frame(x: f32) -> Frame {
+        let scene = |x: f32| Scene3D {
+            obj: SceneObject::Group(vec![
+                Scene3D {
+                    obj: SceneObject::Material(
+                        MaterialDescription::color(1.0, 0.0, 0.0, 1.0),
+                        vec![ball_at(x, 0.0)],
+                    ),
+                    xform: Matrix4::identity(),
+                },
+                ball_at(5.0, 0.0),
+            ]),
+            xform: Matrix4::identity(),
+        };
+        let mut rendered = Frame::new(Camera::default(), scene(x));
+        rendered.sprite_layers.push(SpriteLayer {
+            camera: Camera2D::new(24.0, 13.5),
+            scene: scene(x),
+        });
+        rendered
+    }
+
+    fn moving_preview() -> (Frame, FramePreview) {
+        let frames: Vec<Frame> = (0..=4).map(|i| materialized_frame(i as f32 * 0.5)).collect();
+        let futures: Vec<&Frame> = frames.iter().skip(1).collect();
+        let preview = preview_from_frames(&frames[0], &futures, &preview_options(true, true));
+        assert!(!preview.is_empty(), "the fixture must produce overlays");
+        (frames[0].clone(), preview)
+    }
+
+    #[test]
+    fn presence_step_is_monotone_clamped_and_completes_within_the_ramp() {
+        // Rising: never decreases, never leaves [0, 1], fully there after
+        // exactly one ramp.
+        let dt = PRESENCE_RAMP_SECONDS / 8.0;
+        let mut p = 0.0;
+        for _ in 0..8 {
+            let next = presence_step(p, 1.0, dt);
+            assert!(next >= p, "presence must not go backwards while rising");
+            assert!((0.0..=1.0).contains(&next), "presence escaped [0, 1]: {next}");
+            p = next;
+        }
+        assert!((p - 1.0).abs() < 1e-5, "one ramp must complete the fade in: {p}");
+
+        // Falling: the mirror image.
+        for _ in 0..8 {
+            let next = presence_step(p, 0.0, dt);
+            assert!(next <= p, "presence must not go forwards while falling");
+            assert!((0.0..=1.0).contains(&next), "presence escaped [0, 1]: {next}");
+            p = next;
+        }
+        assert!(p.abs() < 1e-5, "one ramp must complete the fade out: {p}");
+    }
+
+    #[test]
+    fn presence_step_is_robust_to_the_frame_delta() {
+        // Same wall-clock elapsed, very different frame rates → same presence.
+        let mut fast = 0.0;
+        for _ in 0..100 {
+            fast = presence_step(fast, 1.0, PRESENCE_RAMP_SECONDS / 200.0);
+        }
+        let slow = presence_step(0.0, 1.0, PRESENCE_RAMP_SECONDS / 2.0);
+        assert!((fast - slow).abs() < 1e-4, "{fast} vs {slow}");
+
+        // A hitch longer than the whole ramp lands exactly ON the target, never
+        // past it; a non-advancing or non-finite delta is a no-op.
+        assert_eq!(presence_step(0.0, 1.0, 10.0), 1.0);
+        assert_eq!(presence_step(1.0, 0.0, 10.0), 0.0);
+        assert_eq!(presence_step(0.4, 1.0, 0.0), 0.4);
+        assert_eq!(presence_step(0.4, 1.0, -1.0), 0.4);
+        assert_eq!(presence_step(0.4, 1.0, f32::NAN), 0.4);
+        // Out-of-range state is clamped rather than propagated.
+        assert_eq!(presence_step(5.0, 1.0, 0.01), 1.0);
+        assert_eq!(presence_step(-5.0, 0.0, 0.01), 0.0);
+    }
+
+    #[test]
+    fn presence_ease_is_pinned_at_the_ends_and_symmetric() {
+        assert_eq!(presence_ease(0.0), 0.0);
+        assert_eq!(presence_ease(1.0), 1.0);
+        assert_eq!(presence_ease(0.5), 0.5);
+        assert_eq!(presence_ease(-2.0), 0.0);
+        assert_eq!(presence_ease(2.0), 1.0);
+        for i in 0..=10 {
+            let p = i as f32 / 10.0;
+            // Fading out is fading in played backwards.
+            assert!(
+                (presence_ease(1.0 - p) - (1.0 - presence_ease(p))).abs() < 1e-6,
+                "asymmetric at {p}"
+            );
+            assert!(presence_ease(p) >= presence_ease((p - 0.1).max(0.0)));
+        }
+    }
+
+    #[test]
+    fn full_presence_leaves_the_overlay_untouched() {
+        let (anchor, preview) = moving_preview();
+
+        let mut explicit = anchor.clone();
+        preview.apply_all_with_presence(&mut explicit, 1.0);
+        let mut implicit = anchor.clone();
+        preview.apply_all(&mut implicit);
+
+        assert_eq!(
+            format!("{:?}", explicit.scene),
+            format!("{:?}", implicit.scene),
+            "presence 1.0 must be identical to the pre-ramp path (goldens/captures)"
+        );
+    }
+
+    #[test]
+    fn presence_scales_every_overlay_alpha_in_3d_and_sprite_layers() {
+        let (anchor, preview) = moving_preview();
+        let own = frame_material_alphas(&anchor);
+
+        let mut full = anchor.clone();
+        preview.apply_all_with_presence(&mut full, 1.0);
+        let full = frame_material_alphas(&full);
+
+        let mut half = anchor.clone();
+        preview.apply_all_with_presence(&mut half, 0.5);
+        let half = frame_material_alphas(&half);
+
+        assert_eq!(own.len(), 2, "the fixture has a 3D scene and one sprite layer");
+        assert_eq!(full.len(), own.len());
+        assert_eq!(half.len(), own.len());
+
+        for (tree, ((own, full), half)) in own.iter().zip(&full).zip(&half).enumerate() {
+            assert_eq!(full.len(), half.len());
+            assert!(
+                full.len() > own.len(),
+                "tree {tree}'s overlay must contribute materials to scale"
+            );
+            // The game's own materials come first and are never touched...
+            assert_eq!(&full[..own.len()], &own[..], "tree {tree}");
+            assert_eq!(&half[..own.len()], &own[..], "tree {tree}");
+            // ...and every overlay material — 3D marks and copies in tree 0,
+            // sprite ones in tree 1 — is exactly halved.
+            for (i, (one, halved)) in full[own.len()..].iter().zip(&half[own.len()..]).enumerate() {
+                assert!(
+                    (halved - one * 0.5).abs() < 1e-6,
+                    "tree {tree} overlay material {i}: {one} at presence 1.0 but {halved} at 0.5"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn zero_presence_applies_nothing_at_all() {
+        let (anchor, preview) = moving_preview();
+        let before = format!("{:?}", anchor.scene);
+        let sprites_before: Vec<String> = anchor
+            .sprite_layers
+            .iter()
+            .map(|layer| format!("{:?}", layer.scene))
+            .collect();
+
+        let mut faded = anchor.clone();
+        preview.apply_all_with_presence(&mut faded, 0.0);
+
+        // NOT "transparent": ABSENT. An alpha-0 overlay would still write depth
+        // and occlude the scene behind it.
+        assert_eq!(format!("{:?}", faded.scene), before);
+        let sprites_after: Vec<String> = faded
+            .sprite_layers
+            .iter()
+            .map(|layer| format!("{:?}", layer.scene))
+            .collect();
+        assert_eq!(sprites_after, sprites_before);
+
+        // Negative / non-finite presence is treated the same way.
+        let mut negative = anchor.clone();
+        preview.apply_all_with_presence(&mut negative, -1.0);
+        assert_eq!(format!("{:?}", negative.scene), before);
+        let mut nan = anchor.clone();
+        preview.apply_all_with_presence(&mut nan, f32::NAN);
+        assert_eq!(format!("{:?}", nan.scene), before);
     }
 }

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -1047,49 +1047,6 @@ impl SceneOverlays {
     }
 }
 
-/// Multiply an overlay material's alpha by the presence ramp. Textures and
-/// normal maps ride along untouched — only the constant color's alpha moves. A
-/// bare [`MaterialDescription::Texture`] has no color channel, so (exactly as
-/// [`alpha_faded_material`] does) it becomes a white-tinted emissive texture,
-/// the only form that CAN carry an alpha.
-fn presence_scaled_material(material: &MaterialDescription, presence: f32) -> MaterialDescription {
-    let scale = |mut color: Vector4<f32>| {
-        color.w *= presence;
-        color
-    };
-    match material {
-        MaterialDescription::Color(color) => MaterialDescription::Color(scale(*color)),
-        MaterialDescription::Emissive { color, texture } => MaterialDescription::Emissive {
-            color: scale(*color),
-            texture: texture.clone(),
-        },
-        MaterialDescription::Lit {
-            color,
-            texture,
-            normal_map,
-        } => MaterialDescription::Lit {
-            color: scale(*color),
-            texture: texture.clone(),
-            normal_map: normal_map.clone(),
-        },
-        MaterialDescription::Texture(texture) => MaterialDescription::Emissive {
-            color: vec4(1.0, 1.0, 1.0, presence),
-            texture: Some(texture.clone()),
-        },
-        MaterialDescription::SpriteTexture {
-            color,
-            texture,
-            source_pixels,
-            sampling,
-        } => MaterialDescription::SpriteTexture {
-            color: scale(*color),
-            texture: texture.clone(),
-            source_pixels: *source_pixels,
-            sampling: *sampling,
-        },
-    }
-}
-
 /// Walk an overlay subtree and multiply every material's alpha by `presence`.
 ///
 /// This is deliberately an APPLY-TIME transform on the per-frame clone, never a
@@ -1104,7 +1061,13 @@ fn presence_scaled_material(material: &MaterialDescription, presence: f32) -> Ma
 fn scale_presence(scene: &mut Scene3D, presence: f32) {
     match &mut scene.obj {
         SceneObject::Material(material, items) => {
-            *material = presence_scaled_material(material, presence);
+            // Scaling every color's alpha by k is EXACTLY the sprite onion-skin
+            // fade with no direction tint, so reuse it rather than growing a
+            // third copy of the five-variant material rewrite.
+            let faded = alpha_faded_material(Some(material), presence, None);
+            if let Some(faded) = faded {
+                *material = faded;
+            }
             for item in items {
                 scale_presence(item, presence);
             }
@@ -1157,6 +1120,22 @@ pub fn presence_step(presence: f32, target: f32, dt: f32) -> f32 {
 pub fn presence_ease(phase: f32) -> f32 {
     let p = phase.clamp(0.0, 1.0);
     p * p * (3.0 - 2.0 * p)
+}
+
+/// The inverse of [`presence_ease`]: the phase that renders at `alpha`.
+///
+/// A tooling PIN (`--preview-presence`, `setPreview({ presence })`) names a
+/// final alpha, but the runtime's state is a linear phase. Seeding the phase
+/// through this on every pinned frame is what makes RELEASING a pin continuous —
+/// the ease picks up from exactly the opacity that was on screen instead of
+/// jumping to wherever a free-running phase had drifted.
+pub fn presence_phase(alpha: f32) -> f32 {
+    if !alpha.is_finite() {
+        return 0.0;
+    }
+    let a = alpha.clamp(0.0, 1.0);
+    // Closed-form inverse of the smoothstep cubic 3a² - 2a³.
+    0.5 - (((1.0 - 2.0 * a).clamp(-1.0, 1.0)).asin() / 3.0).sin()
 }
 
 /// A computed preview for the complete render frame. Sprite overlays use the
@@ -2205,6 +2184,53 @@ mod tests {
             );
             assert!(presence_ease(p) >= presence_ease((p - 0.1).max(0.0)));
         }
+    }
+
+    #[test]
+    fn presence_phase_inverts_the_ease_so_releasing_a_pin_is_continuous() {
+        // Seeding the phase from a pinned alpha must render at exactly that
+        // alpha, or clearing the pin visibly jumps.
+        for i in 0..=20 {
+            let alpha = i as f32 / 20.0;
+            let phase = presence_phase(alpha);
+            assert!((0.0..=1.0).contains(&phase), "phase escaped [0, 1]: {phase}");
+            assert!(
+                (presence_ease(phase) - alpha).abs() < 1e-4,
+                "pin at {alpha} would resume at {} (phase {phase})",
+                presence_ease(phase)
+            );
+        }
+        // Endpoints land on the ends (within float slop from the trig form).
+        assert!(presence_phase(0.0).abs() < 1e-6, "{}", presence_phase(0.0));
+        assert!((presence_phase(1.0) - 1.0).abs() < 1e-6);
+        // Out of range is clamped, not propagated as NaN.
+        assert!(presence_phase(-3.0).abs() < 1e-6);
+        assert!((presence_phase(3.0) - 1.0).abs() < 1e-6);
+        assert!(presence_phase(f32::NAN).is_finite());
+    }
+
+    #[test]
+    fn nested_overlay_materials_all_scale() {
+        // `Material` nodes nest (a strobe copy of a game subtree that sets its
+        // own material inside another). Every level must fade, not just the
+        // outermost.
+        let mut scene = Scene3D {
+            obj: SceneObject::Material(
+                MaterialDescription::color(1.0, 1.0, 1.0, 1.0),
+                vec![Scene3D {
+                    obj: SceneObject::Material(
+                        MaterialDescription::color(1.0, 0.0, 0.0, 0.5),
+                        vec![Scene3D::sphere()],
+                    ),
+                    xform: Matrix4::identity(),
+                }],
+            ),
+            xform: Matrix4::identity(),
+        };
+        scale_presence(&mut scene, 0.5);
+        let mut alphas = Vec::new();
+        material_alphas(&scene, &mut alphas);
+        assert_eq!(alphas, vec![0.5, 0.25]);
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -2529,7 +2529,14 @@ Escape again to quit"
                 // wherever a free-running phase had drifted to.
                 Some(pinned) => {
                     preview_presence = functor_runtime_common::presence_phase(pinned);
-                    pinned
+                    // A pin overrides the RAMP, not the SELECTION: with the
+                    // preview toggled off there is nothing to show, so a pin
+                    // must not keep the overlay (and its forward sim) alive.
+                    if preview_selects {
+                        pinned
+                    } else {
+                        0.0
+                    }
                 }
                 None => {
                     preview_presence = functor_runtime_common::presence_step(

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -732,6 +732,15 @@ pub struct Args {
     #[arg(long)]
     strobe: bool,
 
+    /// PIN the preview overlay's presence (0.0 = fully faded out, 1.0 = fully
+    /// drawn), skipping the runtime's fade-in/out ease — the deterministic
+    /// escape hatch for capturing a mid-fade frame. A NEGATIVE value (the
+    /// default) means "no override": the runtime eases normally. The same
+    /// convention holds on the web seam (`window.__scrub.setPreview({ presence })`,
+    /// negative to resume easing).
+    #[arg(long, default_value_t = -1.0)]
+    preview_presence: f32,
+
     /// Start with the time-travel scrubber overlay visible (it is otherwise
     /// hidden until summoned with `~`). Useful for demos and captures of the
     /// scrubber itself. NOTE: with the overlay up, previews follow the
@@ -1546,6 +1555,24 @@ Escape releases while captured"
         // as the window resizes: total samples = rate × window).
         let mut preview_window: f32 = 2.0;
         let mut preview_rate: usize = 5;
+        // The PRESENCE RAMP: the overlay fades in and out over
+        // `PRESENCE_RAMP_SECONDS` instead of popping when the preview toggles.
+        //
+        // This is runtime-loop state on purpose. Presence is NOT part of
+        // `PreviewOptions` and NOT part of the cache key below — it multiplies
+        // the alpha of the CACHED preview's per-frame clone at apply time, so
+        // animating it never re-runs the forward sim, and the wanted-flags
+        // don't move during a fade so the cache stays warm.
+        let mut preview_presence: f32 = 0.0;
+        // What the preview last selected while it was ON. Fading OUT needs
+        // geometry after the toggle has already flipped the wanted-flags to
+        // false, so the last on-mode keeps driving the computation until
+        // presence reaches zero.
+        let mut preview_last_on: (bool, bool) = (false, false);
+        // An explicit `--preview-presence` PINS presence and skips the ease
+        // (deterministic mid-fade captures); negative = no override.
+        let preview_presence_override = (args.preview_presence >= 0.0)
+            .then(|| args.preview_presence.clamp(0.0, 1.0));
         // --trajectory/--strobe preview cache. The 32-division forward-sim is
         // the expensive part, and while PAUSED its anchor (scene frame + tts) is
         // frozen — so reuse the computed preview while the anchor key matches,
@@ -2477,6 +2504,33 @@ Escape again to quit"
             } else {
                 (args.trajectory, args.strobe)
             };
+            // Advance the presence ramp toward whether the preview selects
+            // anything, then keep DRIVING the last on-mode while it fades out —
+            // otherwise the toggle would take the geometry away in the same
+            // frame it started the fade.
+            //
+            // The ease runs on WALL-CLOCK delta, independent of `--fixed-time`
+            // (which pins the game's POSE, not real time). Captures stay
+            // reproducible because the ramp is 0.28s and `--capture-time`
+            // defaults to 2s — the fade is long over by the time the shot is
+            // taken. `--preview-presence` pins it outright for an exact
+            // mid-fade frame.
+            let preview_selects = trail_wanted || strobe_wanted;
+            if preview_selects {
+                preview_last_on = (trail_wanted, strobe_wanted);
+            }
+            preview_presence = functor_runtime_common::presence_step(
+                preview_presence,
+                if preview_selects { 1.0 } else { 0.0 },
+                real_delta,
+            );
+            let display_presence = preview_presence_override
+                .unwrap_or_else(|| functor_runtime_common::presence_ease(preview_presence));
+            let (trail_wanted, strobe_wanted) = if preview_selects {
+                (trail_wanted, strobe_wanted)
+            } else {
+                preview_last_on
+            };
             // Forward window/densities. The SIM samples fine (~20/s — the
             // trail's smooth-arc rate) while the preview rate governs STROBE COPIES
             // per second, so dots stay visible between copies and both hold
@@ -2497,6 +2551,7 @@ Escape again to quit"
             // moves every frame, so it would be a full forward-sim per frame
             // and throttle the drain to a crawl) — it snaps back in on arrival.
             let preview_active = (trail_wanted || strobe_wanted)
+                && display_presence > 0.0
                 && args.composite_demo == CompositeDemoArg::Off
                 && clock.pending_frames() == 0
                 && clock.pending_steps() == 0;
@@ -2695,7 +2750,7 @@ Escape again to quit"
             let display_frame = match &preview {
                 Some(p) if !p.is_empty() => {
                     let mut f = frame.clone();
-                    p.apply_all(&mut f);
+                    p.apply_all_with_presence(&mut f, display_presence);
                     Some(f)
                 }
                 _ => None,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1567,8 +1567,9 @@ Escape releases while captured"
         // What the preview last selected while it was ON. Fading OUT needs
         // geometry after the toggle has already flipped the wanted-flags to
         // false, so the last on-mode keeps driving the computation until
-        // presence reaches zero.
-        let mut preview_last_on: (bool, bool) = (false, false);
+        // presence reaches zero. Same type as the web twin uses for the same
+        // state.
+        let mut preview_last_on = functor_runtime_common::InteractivePreview::default();
         // An explicit `--preview-presence` PINS presence and skips the ease
         // (deterministic mid-fade captures); negative = no override.
         let preview_presence_override = (args.preview_presence >= 0.0)
@@ -2517,19 +2518,32 @@ Escape again to quit"
             // mid-fade frame.
             let preview_selects = trail_wanted || strobe_wanted;
             if preview_selects {
-                preview_last_on = (trail_wanted, strobe_wanted);
+                preview_last_on = functor_runtime_common::InteractivePreview {
+                    trail: trail_wanted,
+                    strobe: strobe_wanted,
+                };
             }
-            preview_presence = functor_runtime_common::presence_step(
-                preview_presence,
-                if preview_selects { 1.0 } else { 0.0 },
-                real_delta,
-            );
-            let display_presence = preview_presence_override
-                .unwrap_or_else(|| functor_runtime_common::presence_ease(preview_presence));
+            let display_presence = match preview_presence_override {
+                // A pin HOLDS the phase at the opacity it names, so clearing it
+                // resumes the ease from what was on screen rather than from
+                // wherever a free-running phase had drifted to.
+                Some(pinned) => {
+                    preview_presence = functor_runtime_common::presence_phase(pinned);
+                    pinned
+                }
+                None => {
+                    preview_presence = functor_runtime_common::presence_step(
+                        preview_presence,
+                        if preview_selects { 1.0 } else { 0.0 },
+                        real_delta,
+                    );
+                    functor_runtime_common::presence_ease(preview_presence)
+                }
+            };
             let (trail_wanted, strobe_wanted) = if preview_selects {
                 (trail_wanted, strobe_wanted)
             } else {
-                preview_last_on
+                (preview_last_on.trail, preview_last_on.strobe)
             };
             // Forward window/densities. The SIM samples fine (~20/s — the
             // trail's smooth-arc rate) while the preview rate governs STROBE COPIES

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -14,6 +14,7 @@ import {
   functor_lang_scrub_paused,
   functor_lang_scrub_set_preview,
   functor_lang_scrub_set_preview_config,
+  functor_lang_scrub_set_preview_presence,
   functor_lang_timeline_events,
   functor_lang_timeline_events_gen,
   functor_lang_ui_wants_keyboard,
@@ -374,6 +375,9 @@ export function mountScrubber({ hidden = false } = {}) {
   // this only forwards the wire value). Seam-only config with no chrome, so it
   // is NOT part of the reducer's state.
   let previewMode = 3;
+  // Seam-only presence pin; -1 = "no pin", the runtime eases the overlay in
+  // and out itself (see `setPreview`).
+  let previewPresence = -1;
 
   let state = createTimelineState();
   let pendingSeek = null;
@@ -421,6 +425,9 @@ export function mountScrubber({ hidden = false } = {}) {
     const config = canonicalConfig();
     functor_lang_scrub_set_preview_config(config.seconds, config.rate);
   };
+  // Presence is seam-only: the chrome never pins it, so the toggle keeps its
+  // runtime fade. `-1` is the documented "resume easing" value.
+  const pushPresence = () => functor_lang_scrub_set_preview_presence(previewPresence);
 
   const requestSeek = (frame) => {
     const id = nextSeekId++;
@@ -1096,12 +1103,20 @@ export function mountScrubber({ hidden = false } = {}) {
       );
     },
     // Accepts the timeline-model preview fields plus `mode` (1 trail /
-    // 2 strobe / 3 both; any other index is Off, per `PreviewMode::from_index`).
-    // The mode has no chrome — it is seam-only config — so it lives beside the
-    // reducer's state, not in it.
-    setPreview: ({ mode: nextMode, ...preview }) => {
+    // 2 strobe / 3 both; any other index is Off, per `PreviewMode::from_index`)
+    // and `presence`. Neither has chrome — they are seam-only config — so they
+    // live beside the reducer's state, not in it.
+    //
+    // `presence` PINS the overlay's fade (0 = faded out, 1 = fully drawn),
+    // skipping the runtime's ease so a script can capture an exact mid-fade
+    // frame; a NEGATIVE value clears the pin and resumes easing.
+    setPreview: ({ mode: nextMode, presence: nextPresence, ...preview }) => {
       if (nextMode !== undefined && Number.isFinite(Number(nextMode))) {
         previewMode = Number(nextMode);
+      }
+      if (nextPresence !== undefined && Number.isFinite(Number(nextPresence))) {
+        previewPresence = Number(nextPresence);
+        pushPresence();
       }
       dispatch({ type: "preview-changed", preview });
       pushPreview();

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -565,6 +565,11 @@ pub enum ScrubControl {
         window: f32,
         rate: usize,
     },
+    /// PIN the preview overlay's presence (0 = faded out, 1 = fully drawn),
+    /// skipping the runtime's fade ease — deterministic mid-fade captures and
+    /// demo scripts. A NEGATIVE value clears the pin and resumes easing (the
+    /// same convention as the desktop `--preview-presence` flag).
+    SetPreviewPresence(f32),
 }
 
 #[derive(Default)]
@@ -1107,6 +1112,17 @@ pub fn functor_lang_scrub_set_preview(mode: u32) {
 #[wasm_bindgen]
 pub fn functor_lang_scrub_set_preview_config(window: f32, rate: usize) {
     push_scrub(ScrubControl::SetPreviewConfig { window, rate });
+}
+
+/// Page → runtime: pin the preview overlay's presence, skipping the fade ease
+/// (`window.__scrub.setPreview({ presence })`). 0 = faded out, 1 = fully drawn;
+/// a NEGATIVE value clears the pin and resumes the runtime's easing.
+#[wasm_bindgen]
+pub fn functor_lang_scrub_set_preview_presence(presence: f32) {
+    if !presence.is_finite() {
+        return;
+    }
+    push_scrub(ScrubControl::SetPreviewPresence(presence));
 }
 
 /// Page → runtime: non-destructively scrub to a rendered frame (slider drag).

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1410,6 +1410,21 @@ async fn run_async() -> Result<(), JsValue> {
         )> = None;
         let mut preview_refresh: u32 = 0;
         let mut next_live_preview_refresh: f32 = 0.0;
+        // The PRESENCE RAMP — the overlay eases in/out over
+        // `PRESENCE_RAMP_SECONDS` when 🔮 toggles, instead of popping.
+        //
+        // Runtime-loop state, exactly as on the desktop shell: presence is NOT
+        // in `PreviewOptions` and NOT in the cache key above. It multiplies the
+        // alpha of the CACHED preview's per-frame clone at apply time, so
+        // animating it never re-runs the forward sim, and the wanted-flags hold
+        // still during a fade so the cache stays warm.
+        let mut preview_presence: f32 = 0.0;
+        // What the preview last selected while ON: fading OUT needs geometry
+        // after the toggle has already cleared the wanted-flags.
+        let mut preview_last_on = functor_runtime_common::InteractivePreview::default();
+        // `window.__scrub.setPreview({ presence })` PINS presence and skips the
+        // ease (deterministic captures / demo scripts); negative resumes easing.
+        let mut preview_presence_override: Option<f32> = None;
 
         *g.borrow_mut() = Some(Closure::new(move || {
             // The frame's exclusive borrow of the shared producer.
@@ -1494,6 +1509,9 @@ async fn run_async() -> Result<(), JsValue> {
                         preview_window = window.clamp(0.5, 5.0);
                         preview_rate = rate.clamp(1, 30);
                     }
+                    functor_lang_game::ScrubControl::SetPreviewPresence(presence) => {
+                        preview_presence_override = (presence >= 0.0).then(|| presence.min(1.0));
+                    }
                     functor_lang_game::ScrubControl::SeekTo {
                         frame: f,
                         request_id,
@@ -1541,7 +1559,10 @@ async fn run_async() -> Result<(), JsValue> {
             // capture unchanged); a queued step yields one; paused yields none.
             // `frame_time` is the RENDER frame time — the settled `tts` the frame
             // is drawn / soundscaped / scrub-published at (its `dts` is unused).
-            let sub_frames = clock.fixed_frames((now - last_time) / 1000.0);
+            // Wall-clock seconds since the previous rAF — the sim uses it for
+            // fixed steps, and the preview's presence ramp eases by it.
+            let real_delta = (now - last_time) / 1000.0;
+            let sub_frames = clock.fixed_frames(real_delta);
             last_time = now;
             let frame_time = FrameTime {
                 dts: 0.0,
@@ -1675,9 +1696,34 @@ async fn run_async() -> Result<(), JsValue> {
             let catching_up = clock.pending_frames() > 0;
             let selected =
                 functor_runtime_common::interactive_preview(preview_mode, true, catching_up);
-            let trail_wanted = selected.trail;
-            let strobe_wanted = selected.strobe;
-            let preview = if trail_wanted || strobe_wanted {
+            // Advance the presence ramp toward whether the preview selects
+            // anything, then keep driving the LAST ON mode while it fades out —
+            // otherwise the toggle would take the geometry away in the same
+            // frame it started the fade.
+            //
+            // The ease runs on WALL-CLOCK delta, independent of `?fixed-time`
+            // (which pins the game's POSE, not real time). The golden capture is
+            // unaffected: it screenshots long after the 0.28s ramp, and the web
+            // player starts with the preview OFF anyway.
+            let preview_selects = selected.trail || selected.strobe;
+            if preview_selects {
+                preview_last_on = selected;
+            }
+            preview_presence = functor_runtime_common::presence_step(
+                preview_presence,
+                if preview_selects { 1.0 } else { 0.0 },
+                real_delta,
+            );
+            let display_presence = preview_presence_override
+                .unwrap_or_else(|| functor_runtime_common::presence_ease(preview_presence));
+            let active = if preview_selects {
+                selected
+            } else {
+                preview_last_on
+            };
+            let trail_wanted = active.trail;
+            let strobe_wanted = active.strobe;
+            let preview = if (trail_wanted || strobe_wanted) && display_presence > 0.0 {
                 let key = (
                     game.current_scene_frame(),
                     frame_time.tts.to_bits(),
@@ -1807,7 +1853,7 @@ async fn run_async() -> Result<(), JsValue> {
 
             // Preview overlays go on the live frame.
             if let Some(p) = &preview {
-                p.apply_all(&mut frame);
+                p.apply_all_with_presence(&mut frame, display_presence);
             }
             // Shadow + forward passes, shared with the desktop runtime.
             functor_runtime_common::render_frame_with_view(

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1709,13 +1709,23 @@ async fn run_async() -> Result<(), JsValue> {
             if preview_selects {
                 preview_last_on = selected;
             }
-            preview_presence = functor_runtime_common::presence_step(
-                preview_presence,
-                if preview_selects { 1.0 } else { 0.0 },
-                real_delta,
-            );
-            let display_presence = preview_presence_override
-                .unwrap_or_else(|| functor_runtime_common::presence_ease(preview_presence));
+            let display_presence = match preview_presence_override {
+                // A pin HOLDS the phase at the opacity it names, so clearing it
+                // resumes the ease from what was on screen rather than from
+                // wherever a free-running phase had drifted to.
+                Some(pinned) => {
+                    preview_presence = functor_runtime_common::presence_phase(pinned);
+                    pinned
+                }
+                None => {
+                    preview_presence = functor_runtime_common::presence_step(
+                        preview_presence,
+                        if preview_selects { 1.0 } else { 0.0 },
+                        real_delta,
+                    );
+                    functor_runtime_common::presence_ease(preview_presence)
+                }
+            };
             let active = if preview_selects {
                 selected
             } else {

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1694,8 +1694,13 @@ async fn run_async() -> Result<(), JsValue> {
             // forward-sim per frame would throttle the catch-up to a crawl);
             // it snaps back in on arrival.
             let catching_up = clock.pending_frames() > 0;
-            let selected =
-                functor_runtime_common::interactive_preview(preview_mode, true, catching_up);
+            // The ramp follows the SELECTION only, with catch-up suppression
+            // kept out of it — a catch-up must not read as "the user turned the
+            // preview off" and start a fade. Suppression is a separate term on
+            // the recompute guard below (mirroring the desktop shell), so
+            // presence holds where it is and the overlay snaps back on arrival
+            // instead of fading out and back in.
+            let selected = functor_runtime_common::interactive_preview(preview_mode, true, false);
             // Advance the presence ramp toward whether the preview selects
             // anything, then keep driving the LAST ON mode while it fades out —
             // otherwise the toggle would take the geometry away in the same
@@ -1715,7 +1720,14 @@ async fn run_async() -> Result<(), JsValue> {
                 // wherever a free-running phase had drifted to.
                 Some(pinned) => {
                     preview_presence = functor_runtime_common::presence_phase(pinned);
-                    pinned
+                    // A pin overrides the RAMP, not the SELECTION: with the
+                    // preview toggled off there is nothing to show, so a pin
+                    // must not keep the overlay (and its forward sim) alive.
+                    if preview_selects {
+                        pinned
+                    } else {
+                        0.0
+                    }
                 }
                 None => {
                     preview_presence = functor_runtime_common::presence_step(
@@ -1733,7 +1745,8 @@ async fn run_async() -> Result<(), JsValue> {
             };
             let trail_wanted = active.trail;
             let strobe_wanted = active.strobe;
-            let preview = if (trail_wanted || strobe_wanted) && display_presence > 0.0 {
+            let preview = if (trail_wanted || strobe_wanted) && display_presence > 0.0 && !catching_up
+            {
                 let key = (
                     game.current_scene_frame(),
                     frame_time.tts.to_bits(),

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -59,6 +59,8 @@ interface HeroScrubSeam {
     seconds?: number;
     rate?: number;
     mode?: number;
+    /** Pin the overlay's fade (0..1); negative resumes the runtime's easing. */
+    presence?: number;
   }): void;
   setAttention(attention: { extrapolate?: boolean }): void;
   setReset(handler: (() => void) | null): void;

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -81,6 +81,8 @@ interface ScrubSeam {
     rate?: number;
     /** 1 trail / 2 strobe / 3 both (scrubber.js seam extension). */
     mode?: number;
+    /** Pin the overlay's fade (0..1); negative resumes the runtime's easing. */
+    presence?: number;
   }): void;
 }
 


### PR DESCRIPTION
Toggling 🔮 used to swap a dense field of trail marks and strobe copies in or out between two consecutive frames. That reads as a glitch rather than a state change, and it gives no sense that the overlay is *additional* to the scene. Now the whole preview fades: presence eases 0 → 1 (and back) over **0.28s**, smoothstep shaped, multiplying every overlay material's alpha.

![the fade, hero scene](https://gist.githubusercontent.com/tommy-xr/25c619edc6d747c036f3f689d075ea3b/raw/hero-presence.gif)

![the fade, physics scene](https://gist.githubusercontent.com/tommy-xr/25c619edc6d747c036f3f689d075ea3b/raw/physics-presence.gif)

Stills — no preview / presence 0.5 / presence 1.0:

| no preview | 0.5 | 1.0 |
| --- | --- | --- |
| ![](https://gist.githubusercontent.com/tommy-xr/25c619edc6d747c036f3f689d075ea3b/raw/hero-no-preview.png) | ![](https://gist.githubusercontent.com/tommy-xr/25c619edc6d747c036f3f689d075ea3b/raw/hero-presence-050.png) | ![](https://gist.githubusercontent.com/tommy-xr/25c619edc6d747c036f3f689d075ea3b/raw/hero-presence-100.png) |

## The cache-boundary law

This is the load-bearing decision. Both shells cache a **built** `FramePreview` downstream of the forward sim and clone it per frame, so presence is:

- **not** in `PreviewOptions`, and **not** in either shell's cache key — it applies to the per-frame clone at apply time (`FramePreview::apply_all_with_presence`), so animating it never re-runs `ghost_frames` / `history_frames`;
- **not** in the overlay *builders* — a trail mark is still built at alpha 1.0 and the walk scales it afterwards, for the same reason;
- runtime-**loop** state in each shell (`preview_presence` phase + the last on-mode). The wanted-flags don't move during a fade — the shell keeps computing and applying the **last on-mode** while presence is above zero, because fading out needs geometry after the toggle already flipped — so the cache stays warm across the whole ramp.

At presence 0 the overlay is *absent*, not transparent: an alpha-0 subtree would still write depth and occlude the scene behind it.

## The runtime-loop ease

`presence_step` advances a **linear phase** by wall-clock dt (clamped, never overshooting, so a hitch lands exactly on the target); `presence_ease` shapes it with smoothstep. Keeping the state linear is what makes the ramp symmetric — flipping the target mid-fade retraces the same curve backwards.

The ease is deliberately **not** suppressed by `--fixed-time` / `?fixed-time`, which pin the game's *pose*, not real time. Captures stay reproducible anyway (the ramp is 0.28s; `--capture-time` defaults to 2s), and keeping the two independent is what makes the fade observable headlessly.

## Tier A limitations (accepted, documented in code + `docs/time-travel.md`)

The 3D forward pass was fully opaque, so fading needed a blend: a material whose constant color alpha is below 1 enables straight-alpha blending for its own subtree and restores after. Passes that already own the blend state (2D sprites, transparent-debug) are skipped via `RenderContext::pass_blends`, and nested re-entry via `blend_active`. This is safe to key on because the Functor Lang prelude *cannot express* a translucent 3D material (`Color.rgb` has no alpha channel) — so translucent in the 3D pass means the runtime's own overlay.

Three artifacts are accepted at this tier, all from the same root cause (no depth prepass / back-to-front sort):

1. **Overlapping overlay parts double-blend** — a mark's crossed arrowheads and its sphere core read slightly denser where they overlap.
2. **Translucent copies stop occluding each other**, so *more* overlay detail is visible mid-fade than at full presence. Clearly visible in the physics stills: at 0.5 the ghost boxes reveal the magenta arrows inside them that the opaque copies hide at 1.0. Measured: 82% (physics) / 65% (hero) of overlay pixels sit strictly between the 0.0 and 1.0 frames; the remainder is this de-occlusion, not a blowout.
3. **3D marks still cast shadows while fading** — overlays ride the shared shadow pass, which has no notion of presence.

**Tier B follow-up (not in this PR):** give the overlay its own **constant-alpha pass** after the scene, modeled on the transparent-debug recipe in `renderer.rs` (depth prepass with the color mask off, then blend the nearest surface at a constant alpha), and exclude the overlay subtree from the shadow pass. That removes the double-blend, the de-occlusion inversion, and the shadows together, and makes presence a single `glBlendColor` instead of a material walk.

## Overrides (for tooling)

`--preview-presence <f32>` natively and `window.__scrub.setPreview({ presence })` on the web **pin** presence and skip the ease, for deterministic mid-fade captures. In both, a **negative** value means "no pin — resume the runtime's easing". A pin seeds the phase through `presence_phase` (inverse smoothstep), so *releasing* a pin resumes from exactly the opacity that was on screen instead of jumping to wherever a free-running phase had drifted.

## Verification

**Tests** — `cargo test -p functor_runtime_common`: **655 passed, 0 failed**, including 8 new presence tests (step monotone/clamped/dt-robust/completes-within-the-ramp; ease symmetric and pinned at the ends; `presence_phase` inverts the ease; presence 1.0 identical to the pre-ramp path; 0.5 halves every mark + copy alpha in **both** 3D and sprite layers; nested materials all scale; 0.0 applies nothing at all).

**Captures** (`--trajectory --strobe --fixed-time 2.0`, 800x600):

- presence **0.0 is pixel-identical** to a no-preview capture — max channel diff **0** on both `examples/physics` and the hero scene.
- presence 0.5 sits strictly between 0.0 and 1.0 on sampled mark pixels (82% physics / 65% hero; remainder is the documented de-occlusion).
- Viewed the 0.5 captures: marks half-there, no blowout.

**Goldens** — `npm run test:golden` passes and is **identical to the base ref scenario-for-scenario** (lighting 0.016%, terrain 0.820/0.037/0.032%, every other scenario 0.000%). No golden renders a preview overlay, and the blend change is a strict no-op at alpha 1.0.

**frame_bench** (release, 3× per side, back-to-back on a quiet machine, base `0cb74f0`):

| cells | allocs/frame | bytes/frame | base min µs | branch min µs |
| --- | --- | --- | --- | --- |
| 400 | 13877 → 13877 | 843393 → 843393 | 437.2 | 473.6 |
| 1600 | 54717 → 54717 | 3307233 → 3307233 | 1705.3 | 1829.3 |
| 3136 | 106973 → 106973 | 6460257 → 6460257 | 3377.5 | 3798.3 |

`allocs/frame` and `bytes/frame` are **byte-identical at every size** — the deterministic columns, so this is real parity. That is the expected result: `frame_bench` is headless, constructs no `RenderContext` and applies no preview, so none of the changed code is on its path. The wall-clock min deltas (+8/+7/+12%) sit inside the run-to-run spread of the *same* binary (base's own 1600-cell samples ranged 1705–1997 µs, ~17%; consecutive runs drift as the machine warms), so I read them as noise rather than signal.

**Web** — Playwright against the built site player (explicit non-8080 port), pinned-presence sweep on the canvas, with the scrubber chrome cancelled out of the mask:

| pinned presence | overlay intensity |
| --- | --- |
| 0.0 | **0.00** (absent) |
| 0.25 | 171.69 |
| 0.5 | 236.49 |
| 0.75 | 262.38 |
| 1.0 | 273.34 |

Monotone ✓, pin held past the ramp ✓, negative released back to full ✓.

**Not verified:** a live mid-ramp *capture* of the ease. A cold headless capture run's first frame carries a multi-hundred-ms wall-clock delta, so `presence_step` correctly clamps straight to the target in one step — the ease is real, but not observable that way. The GIFs above are therefore assembled from `--preview-presence` pins at the smoothstep-eased alphas, which is exactly the curve the runtime walks. No Quest was attached, so no device profile was taken; the change adds no per-texel or sampler cost, only a blend enable on overlay-only subtrees.

## Review

`/xreview` (Claude + Codex adversarially, plus a dedicated de-dup pass) with the presence-0.5 captures as media. **No Critical or High findings from either engine.** Dispositioned:

- **Fixed — duplication (de-dup pass, S1-names + S4-read):** my new `presence_scaled_material` was byte-for-byte `alpha_faded_material(m, k, None)` — same five-variant match, same `Texture → Emissive` fallback, tint dead at `None`. Deleted; `scale_presence` now calls the existing helper, so the material rewrite stays at two copies instead of three.
- **Fixed — Medium (Codex):** nested translucent `Material` nodes. Every translucent node saw `pass_blends == false`, enabled blending, then unconditionally disabled it — so an inner translucent material turned blending off for the outer subtree's remaining siblings. Now only the node that transitions blending off→on restores it, tracked by `RenderContext::blend_active`, with a `nested_overlay_materials_all_scale` test.
- **Fixed — Low (Codex):** clearing a web presence pin could jump, because the hidden phase kept stepping while pinned. A pin now seeds the phase via the new `presence_phase` (inverse smoothstep), so release is continuous; covered by `presence_phase_inverts_the_ease_so_releasing_a_pin_is_continuous`.
- **Fixed — consistency (de-dup pass, S4-read):** desktop's `preview_last_on` was a bare `(bool, bool)` while the web twin used the crate's `InteractivePreview` for the same new state. Both now use `InteractivePreview`.

De-dup coverage: all four strategies ran (S1-names 19 queries / 7138 candidates; S2-clones 249 whole-repo pairs, 11 touching changed files, all pre-existing; S3-index 10 domain/behavior terms; S4-read). Checked and explicitly *not* duplication: `presence_ease` (the only other smoothsteps are the Functor Lang builtin, GLSL, and the `.fun` stdlib — other layers), `presence_step` (nearest is `Viewer::move_toward_band`, a band clamp with no time term), `scale_presence` (no `map_materials`-style walk exists), `MaterialDescription::color_alpha` (first accessor of its kind).

A second adversarial pass over the *fixed* code verified all of the above land correctly (the `blend_active` Cell is sound and cannot leak across passes — `RenderContext` isn't `Clone` and is built exactly twice, per pass; `presence_phase` is the correct closed-form inverse; every fragment shader propagates `color.a` so the blend actually does something) and found one more real bug plus polish:

- **Fixed — Medium:** the `preview_last_on` fallback *undid the web shell's catch-up suppression*. During a drag-into-the-future catch-up, `interactive_preview(..., catching_up)` returns "off", so `preview_selects` went false and `last_on` restored the wanted-flags — recomputing a full forward-sim every frame (moving anchor ⇒ guaranteed cache miss) for the whole 0.28s ramp, in exactly the window that optimization exists for. The web shell now mirrors the desktop structure: catch-up is a separate term on the recompute guard, not an input to the ramp, so presence holds and the overlay snaps back on arrival instead of fading out and back in.
- **Fixed — Low:** a pin used to keep the overlay (and its forward sim) alive even after 🔮 was toggled off, because `last_on` still reported a selection. A pin now overrides the **ramp**, not the **selection**.
- **Fixed — Low:** recorded the invariant that makes the `presence < 1.0` short-circuit safe — no overlay node carries a bare `MaterialDescription::Texture` (which `alpha_faded_material` would rewrite to `Emissive`, changing the lighting model and popping at exactly the 1.0 boundary the ramp exists to remove).
- **Won't fix — Low:** GL `BLEND` leaks if a child render *panics* between enable and restore. The arm has no `?`/`return` between them and a panic ends the frame regardless; the reviewer agreed it isn't worth an RAII guard unless that arm grows an early exit.
- **Kept — scope:** the reviewer flagged the presence pin as having no in-repo consumers. It's retained deliberately: it was a requirement of this work, and it is what produced every capture and GIF in this PR and drives the web verification sweep. The consumers are the verification pipeline rather than committed site code.

All fixes were re-validated afterwards: tests (655), goldens (identical to base scenario-for-scenario), the native presence-0.0 pixel-identity invariant (max diff 0, and the 0.5 capture byte-identical to pre-fix), and the web sweep were all re-run against the rebuilt binary and wasm bundle.
