### PR TITLE
feat(lang): branded comparison — 90deg == 90deg, and engine values refuse == at check time

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -24,8 +24,9 @@ The habits that break first, in one place. Each is expanded below.
 - **Operators are exhaustive**: `+ - * /`, `< > <= >= == !=`, `&& || not`.
   There is no `<>` (inequality is `!=` only), no `%` (`Math.mod`), no `^`
   (`Math.pow`), and no string-concatenation operator (use `$"…"`).
-  `+ - * /` also work on BRANDS that declare them — `90deg + 45deg`,
-  `1.5s - 200ms`, `45deg * 2.0` (see Units below); comparisons do not.
+  `+ - * /` and `== != < > <= >=` also work on BRANDS that declare them —
+  `90deg + 45deg`, `1.5s - 200ms`, `45deg * 2.0`, `90deg == 90deg`,
+  `1.5s < 2000ms` (see Units below).
 - **No loops** — iterate with `List.map` / `List.filter` / `List.fold`.
 - **All numbers are `float`** (f64); primitive type names are lowercase
   (`float`, `string`, `bool`), while generic containers are `List<…>` and
@@ -126,6 +127,7 @@ unit px = Px                                  // …with a literal SUFFIX: `16px
 let width = 16px                              //   the suffix must TOUCH the digits (`16 px` is
                                               //   two tokens); `-2.5px` == `Px(-2.5)`
 unit px (+) = addPx                           // …and arithmetic on the brand: `16px + 4px`
+unit px (<) = lessPx                          // …and ordering: `4px < 16px`, plus > <= >=
 let origin: Position = { x: 0.0, y: 0.0 }     // OPTIONAL binding annotation `let name: Type = …`
                                               //   (checked against the value; also on `let … in`)
 let scores = [1.0, 2.0, 3.0]                  // list literal; [x, ..xs] prepends
@@ -575,16 +577,19 @@ that's what `functor test` is for.
 - Expects may freely call engine externals under `functor test`
   (`Scene.*`, `Color.*`, …): no external performs IO or touches GL, and
   `Effect.*` only builds a *descriptor* — nothing is performed. Note that
-  engine values are `HostData`, so `==` on them is a runtime error;
-  assert on numbers/records you derive instead. The highest-value tests
-  are pure logic anyway: model/`tick`/`update` math.
+  opaque engine values (`Scene.t`, `Frame.t`, `Effect.t`, `Color.t`,
+  `Vec3.t`, …) support no `==` — the CHECKER rejects it now, naming the
+  type — so assert on numbers/records you derive instead. Brands DO
+  compare: angles, durations (`90deg == 90deg`, `1.5s < 2000ms`), and
+  `Physics.tag`. The highest-value tests are pure logic anyway:
+  model/`tick`/`update` math.
 
 ## Units: suffixed literals and their operators (`unit`)
 
 A numeric literal may carry a **unit suffix** — `90deg`, `0.5s`, `16px` — which
 is exactly the call the suffix's `unit` declaration names, and a brand may
-declare **arithmetic** on itself (`90deg + 45deg`). Full design:
-`docs/functor-lang-units.md`.
+declare **arithmetic and comparison** on itself (`90deg + 45deg`,
+`1.5s < 2000ms`). Full design: `docs/functor-lang-units.md`.
 
 ```functor
 unit deg = Angle.degrees            // a top-level ITEM, in `.fun` and `.funi`
@@ -624,16 +629,26 @@ let beat = Sub.every(0.5s, Tick)    // == Sub.every(Time.seconds(0.5), Tick)
 ```functor
 type Px = | Px(value: float)
 unit px = Px
-unit px (+) = (a, b) => Px(unwrap(a) + unwrap(b))   // (Px, Px) => Px
-unit px (*) = (a, k) => Px(unwrap(a) * k)           // (Px, float) => Px
+unit px (+)  = (a, b) => Px(unwrap(a) + unwrap(b))  // (Px, Px) => Px
+unit px (*)  = (a, k) => Px(unwrap(a) * k)          // (Px, float) => Px
+unit px (==) = (a, b) => unwrap(a) == unwrap(b)     // (Px, Px) => bool
+unit px (<)  = (a, b) => unwrap(a) < unwrap(b)      // (Px, Px) => bool
 
 let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
+let ordered = 4px < 16px            // …and >, <=, >=, ==, != (all derived)
 ```
 
-- **Only `+` `-` `*` `/`.** `+` and `-` are typechecked as `('t, 't) => 't`;
-  `*` and `/` as the SCALAR `('t, float) => 't` (a brand times a brand would be a different
-  type — Functor Lang does not do dimensional analysis). Comparisons
-  (`==`, `<`, `>`) are NOT declarable.
+- **Six declarable operators: `+` `-` `*` `/` `==` `<`.** `+` and `-` are
+  typechecked as `('t, 't) => 't`; `*` and `/` as the SCALAR `('t, float) => 't`
+  (a brand times a brand would be a different
+  type — Functor Lang does not do dimensional analysis); `==` and `<` as
+  `('t, 't) => bool`. The other four comparisons are **DERIVED**, never
+  declared — `a != b` is `not equals(a, b)`; `a > b` is `less(b, a)`;
+  `a <= b` is `not less(b, a)`; `a >= b` is `not less(a, b)`. Writing
+  `unit px (>) = …` is a parse error naming the base to declare instead. (One
+  honest consequence: for a BRAND, `<=` is the negation of `<`, so a NaN-built
+  brand compares as an ordinary value under `<=`/`>=` where a raw float would
+  be false. Float comparison itself is unchanged.)
 - **The operator belongs to the BRAND, not the suffix.** `s`/`ms`/`us`/`min`/
   `hr` are all `Time.t`, so one declaration serves them all and `1.5s - 200ms`
   works. Declaring the same brand + operator twice — through ANY suffix — is a
@@ -661,12 +676,28 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   decides it for `+`/`-`), `(a, b): float => a + b`,
   `(a) => a + 1.0`, and `(v) => v * v` (the scalar form's operands have
   DIFFERENT types, so one operand twice can only be float) do not.
+  A side already solved to a NON-brand settles the node on the spot, since
+  only `*` (either side) and `/` (left side) can still take a brand there —
+  which is why `Math.abs(d) < step` decides `step` with no annotation.
+- **A comparison is the same, minus the result evidence**: `a < b` answers
+  `bool` whichever way it resolves, so ONLY an operand can decide it and
+  `(a, b) => a < b` asks for an annotation once a brand declares `<`
+  (```<` here could be float comparison or `Angle.t` comparison — annotate an
+  operand``). `(v: float, lo, hi) => …` is the fix. A brand with NO declared
+  `==` keeps structural equality exactly as before.
 - **A brand with no implementation** keeps the old error, now naming what it
   has: ```-` needs float operands, got Angle.t — `Angle.t` declares `+`, `*`, but
-  not `-```. The interpreter says the same thing on the same inputs.
-- **Built-in operators (engine prelude only)**: `+`, `-`, and scalar `*` on
-  BOTH `Angle.t` and `Time.t` (`Angle.add`/`sub`/`scale`, `Time.add`/`sub`/
-  `scale` — all public API in the generated reference). Neither declares `/`.
+  not `-```. It names the DECLARABLE base, so `>` on a brand that lacks `<`
+  reports ``but not `<` ``. The interpreter says the same thing on the same inputs.
+- **Built-in operators (engine prelude only)**: `+`, `-`, scalar `*`, `==`,
+  and `<` on BOTH `Angle.t` and `Time.t` (`Angle.add`/`sub`/`scale`/`equals`/
+  `less`, `Time.add`/`sub`/`scale`/`equals`/`less` — all public API in the
+  generated reference). Neither declares `/`. So `90deg == 90deg`,
+  `45deg < 90deg`, `1.5s < 2000ms`, and `2min > 90s` all work — but note that
+  `==` on an angle or duration is **float equality** on the underlying
+  radians/seconds, so an accumulated value may miss an exact literal by a
+  rounding step (and there is no way back out of the brand to compare with a
+  tolerance — keep the plain float where that matters).
 
 ## Semantics rules that WILL bite you
 
@@ -689,6 +720,17 @@ let total: Px = 16px + 4px          // …and 3px * 2.0, and 2.0 * 3px
   run time. `!=` behaves identically in every respect — it IS `==`
   negated, so it rejects the same operands with the same (reworded)
   errors.
+- **Engine values are opaque and refuse `==` at CHECK time.**
+  ``` `==` on `Scene.t`: engine values are opaque — compare the numbers you
+  derived from them instead ```. That covers every host handle the prelude
+  declares `type t = host` (scenes, frames, cameras, effects, subs, lights,
+  colors, vec3s, render targets, assets, physics shapes/bodies/worlds, UI
+  nodes…) — the runtime error stays as the gradual-seam backstop. Brands
+  over data are NOT affected: `Physics.tag` (a string underneath) and
+  `Sprite.t` compare structurally, and `Angle.t`/`Time.t` compare because
+  they DECLARE `==` (see Units). Nesting: the rule reads the operand's own
+  type and a tuple element's, not a record field — a host value buried in a
+  model still fails at run time.
 - **Comparisons are IEEE**, so NaN (`0.0 / 0.0`) is false against
   everything — including itself — under `<`, `>`, `<=`, `>=`, and `==`;
   `nan != nan` is therefore `true`.

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -728,9 +728,11 @@ let ordered = 4px < 16px            // …and >, <=, >=, ==, != (all derived)
   nodes…) — the runtime error stays as the gradual-seam backstop. Brands
   over data are NOT affected: `Physics.tag` (a string underneath) and
   `Sprite.t` compare structurally, and `Angle.t`/`Time.t` compare because
-  they DECLARE `==` (see Units). Nesting: the rule reads the operand's own
-  type and a tuple element's, not a record field — a host value buried in a
-  model still fails at run time.
+  they DECLARE `==` (see Units). Two limits: the rule walks tuples, map
+  keys/values, and a nominal's type ARGUMENTS but not a record's fields (a
+  host value buried in a model still fails at run time), and it is
+  DIRECT-only — equality is polymorphic, so `let same = (a, b) => a == b`
+  called with two scenes checks clean and fails at run time.
 - **Comparisons are IEEE**, so NaN (`0.0 / 0.0`) is false against
   everything — including itself — under `<`, `>`, `<=`, `>=`, and `==`;
   `nan != nan` is therefore `true`.

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -2,9 +2,10 @@
 
 Functor Lang lets a numeric literal carry a **unit suffix** — `90deg`, `0.5s`,
 `16px` — where a `unit` declaration says what the suffix means, and lets that
-brand carry arithmetic: `90deg + 45deg`, `1.5s - 200ms`, `45deg * 2.0`. This
-document covers both shipped phases — the literals (Phase 1) and the operators
-(Phase 2).
+brand carry arithmetic and comparison: `90deg + 45deg`, `1.5s - 200ms`,
+`45deg * 2.0`, `90deg == 90deg`, `1.5s < 2000ms`. This document covers all
+three shipped phases — the literals (Phase 1), the arithmetic operators
+(Phase 2), and the comparison operators (Phase 3).
 
 Syntax and semantics for day-to-day use live in the `functor-lang` skill; the
 prelude's own suffixes are documented at their source
@@ -89,7 +90,7 @@ They resolve only where the engine prelude does (a runner-hosted project, or
 the headless test seam), like every other prelude name. A project declares its
 own units for its own brands.
 
-## Phase 2 (shipped): operators on units
+## Phase 2 (shipped): arithmetic operators on units
 
 Phase 1 gives a brand a cheap way IN from a number. What it did not give is
 arithmetic: `90deg + 45deg` did not typecheck, because `+` was `(float, float)
@@ -128,8 +129,8 @@ unit px (/) = dividePx               // (Px, float) => Px
   type (`Angle.t`). A record brand carries no tag and a multi-constructor type
   carries a different one per constructor, so an operator on either is a check
   error at the declaration.
-- Comparisons (`<`, `>`, `==`) are deliberately not declarable: `==` is already
-  structural for plain-data brands, and ordering wants its own design pass.
+- Comparisons are declarable too, but only their two BASES (`==` and `<`) —
+  see Phase 3.
 
 > **Deviation from the original design.** The design sketch attached operators
 > to the unit declaration as a block (`unit px = Px { (+) = … }`). Shipping them
@@ -249,13 +250,185 @@ Two consequences worth stating:
 `Time.scale`) declared beside the units in `angle.funi` / `time.funi`. Both are
 public API and appear in the generated reference.
 
+## Phase 3 (shipped): comparison on brands
+
+Phase 2 let a brand add. What it did not let it do is *answer a question*:
+`90deg == 90deg` typechecked and then died at run time with `host values
+cannot be compared`, and `1.5s < 2000ms` did not typecheck at all. Both work
+now, through exactly the Phase 2 machinery.
+
+### Two declarations, six operators
+
+```functor
+type Px = | Px(value: float)
+
+unit px = Px
+unit px (==) = (a, b) => unwrap(a) == unwrap(b)   // (Px, Px) => bool
+unit px (<)  = (a, b) => unwrap(a) < unwrap(b)    // (Px, Px) => bool
+```
+
+Only `==` and `<` are declarable. The other four spellings are **derived**:
+
+| Written | Evaluates as |
+| --- | --- |
+| `a == b` | `equals(a, b)` |
+| `a != b` | `not equals(a, b)` |
+| `a < b` | `less(a, b)` |
+| `a > b` | `less(b, a)` |
+| `a <= b` | `not less(b, a)` |
+| `a >= b` | `not less(a, b)` |
+
+Deriving rather than declaring is the whole design choice, and it is worth
+being explicit about why, because the language's comparison operators do
+**not** share a desugaring today — the parser produces six distinct `BinOp`s
+and the interpreter gives each its own IEEE float closure. So the mapping
+above is new, and it buys three things:
+
+1. **A brand's ordering cannot contradict itself.** With four declarable
+   orderings, a brand could ship `a < b` and `a >= b` that disagree. With one,
+   `<` *is* the order, and the rest are theorems about it.
+2. **Two implementations per brand, not six** — the prelude, and every game
+   brand, writes half as much.
+3. **It matches what a brand is.** A unit brand wraps ONE scalar (radians,
+   seconds, pixels), and a scalar is totally ordered.
+
+The cost is one honest divergence from float semantics, stated plainly: for
+floats, `a <= b` is *not* `not (b < a)` when either side is NaN (`nan <= nan`
+is false; `not (nan < nan)` is true). A brand built from a NaN therefore
+compares as if NaN were an ordinary value under `<=` and `>=`. Float
+comparison itself is untouched — this applies only to a branded operand — and
+a NaN angle or duration is already a bug the engine boundary rejects.
+
+Everything else is Phase 2's rules verbatim:
+
+- The implementations are typed `('t, 't) => bool`, checked **at the
+  declaration** against that shape.
+- The operator belongs to the **BRAND**, not the suffix — one `unit s (<)`
+  covers `s`, `ms`, `us`, `min`, and `hr`, so `1.5s < 2000ms` works.
+- The brand must be **distinguishable at run time** (a single-constructor
+  variant, or a host type), because the interpreter dispatches on the tag.
+- Declaring the same brand + operator twice, through any suffix, is a
+  duplicate error — and `unit px (!=)` / `(>)` / `(<=)` / `(>=)` are parse
+  errors naming the base to declare instead.
+
+### Resolution
+
+Identical to Phase 2's post-inference ad-hoc overloading: zonk the operands,
+let a declaring brand claim the node, otherwise fall through to float, and
+defer a node whose operands are still unsolved. Only the ANSWER differs — a
+comparison is `bool` whichever way it resolves, so unlike `+`/`-` its result
+carries no evidence and only an operand can decide it.
+
+That makes an unannotated comparison ambiguous once a brand declares `<`:
+
+```
+`<` here could be float comparison or `Angle.t` comparison or `Time.t`
+comparison — annotate an operand (e.g. `(a: Angle.t)`) so the operator can be
+resolved
+```
+
+> **This is the same breaking change Phase 2 made, extended to `<`.** A helper
+> like `let clamp = (v, lo, hi) => if v < lo then lo else …` now needs one
+> annotation (`(v: float, lo, hi)`). Three examples in this repository needed
+> exactly that one-word edit; nothing else in the repo moved.
+
+Phase 3 also **narrows** Phase 2's deferral, which strictly reduces how often
+that error can fire. A node only defers while a branded reading is still
+possible, and which side could still be a brand depends on the operator:
+`*` puts the brand on either side, `/` only on the left, and everything
+else — `+`, `-`, and the four orderings — combines or compares like with
+like. So a side already solved to a non-brand settles the node immediately.
+That is what keeps `Math.abs(d) < step` deciding `step` on the spot (and with
+it the `rate * dt` that produced `step`), with no annotation anywhere.
+
+### Runtime
+
+The dispatch table Phase 2 built gains two slots. A comparison whose operands
+are not both numbers looks up the brand's tag, and the derived spellings swap
+and/or negate the one implementation. Two consequences carry over unchanged:
+
+- **Float comparison is untouched** — number/number is still the first match,
+  and the table is consulted only when it fails.
+- **`==` reaches the table before the structural walk**, but only after two
+  cheap gates: no declared operators at all, or an operand with no brand tag
+  (a number, string, record, list, tuple — everything `frame_bench` compares),
+  returns immediately. `frame_bench` shows no allocation or byte change.
+
+A brand with no declared `==` keeps STRUCTURAL equality exactly as before, so
+adding units to a project cannot change what `==` already meant.
+
+### Where the implementations live for prelude brands
+
+`Angle.equals` / `Angle.less` and `Time.equals` / `Time.less`, declared beside
+their units in `angle.funi` / `time.funi`. Both are public API in the
+generated reference, and both document the sharp edge honestly: **`==` on an
+angle or a duration is float equality underneath.** `90deg == 90deg` is true
+because both sides build the same number, but an angle accumulated through
+arithmetic may miss an exact literal by a rounding step, and there is no way
+back out of the brand to compare with a tolerance — so keep the plain float
+where that matters.
+
+## Engine values refuse `==` at CHECK time
+
+The other half of the same story. `myScene == otherScene` used to typecheck
+and die at run time (`host values cannot be compared`). It is now a check
+error:
+
+```
+`==` on `Scene.t`: engine values are opaque — compare the numbers you derived
+from them instead (`Scene.t` supports no `==`)
+```
+
+An interface (`.funi`) file distinguishes the two kinds of abstract type with
+a marker on the `type` item:
+
+```functor
+type t = host        // an opaque HOST value: Scene.t, Frame.t, Effect.t, …
+type tag             // abstract, but ordinary Functor Lang data underneath
+```
+
+`= host` is a contextual keyword in the existing `type <name> = <body>`
+position — the least invasive marker available, since docgen quotes a
+declaration verbatim from its span and therefore renders it with no change at
+all. It is rejected in a `.fun` file: only the host can be responsible for
+what it claims.
+
+The polarity is a deliberate deviation from the obvious one. `type t` stays
+comparable and the OPAQUE case is what gets marked, because not every
+abstract prelude type is a host handle — `Sprite.t` and `Sprite.region` are
+plain Functor Lang data behind an opaque name (documented as comparable in
+`sprite.funi`), and `Physics.tag` is a brand over a STRING that games compare
+constantly:
+
+```functor
+match e.a == ballTag with | true => e.b | false => …    // examples/physics
+onDeck: probe.hit && probe.tag == deckTag               // examples/physics-controller
+```
+
+Marking the opaque types keeps those working by construction. The 30 marked
+types are every abstract type in the engine prelude EXCEPT those three.
+`Angle.t` and `Time.t` are marked too — they are host values — but they are
+exempt from the error because they DECLARE `==`, which is precisely what
+makes them comparable.
+
+Two limits, both deliberate:
+
+- The rule reads the operand's own type and a tuple element's (mirroring the
+  existing "functions cannot be compared" certainty rule), not a record field
+  or a list element. A host value buried inside a model still meets the
+  runtime error, which remains the gradual-seam backstop.
+- **Structural equality for `Scene.t` / `Frame.t` is out of scope.** Whether
+  scenes should compare at all — and as `==` or as `Scene.equals` — is a
+  separate decision. This check-time rejection is exactly the thing that
+  decision would carve an exception into.
+
 ### Still open
 
 - **Mixed literals.** `90deg + 45` is an error (the bare number is not lifted
   through the unit's constructor). Erroring is the conservative start.
 - **Prefix minus.** `-(someAngle)` would want a `negate` declaration, or to
   derive from `(-)` with a zero the brand cannot supply.
-- **Comparisons.** `==`, `<`, `>` on brands are a follow-up.
+- **Structural equality for engine values** — see above.
 
 ### Explicit non-goal: dimensional analysis
 

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -350,9 +350,12 @@ and/or negate the one implementation. Two consequences carry over unchanged:
 - **Float comparison is untouched** — number/number is still the first match,
   and the table is consulted only when it fails.
 - **`==` reaches the table before the structural walk**, but only after two
-  cheap gates: no declared operators at all, or an operand with no brand tag
-  (a number, string, record, list, tuple — everything `frame_bench` compares),
-  returns immediately. `frame_bench` shows no allocation or byte change.
+  cheap gates, ordered cheapest-first: no declared operators at all, then an
+  operand with no brand tag (a number, string, record, list, tuple —
+  everything `frame_bench` compares). Neither reaches the table, and neither
+  even computes an operator slot. `frame_bench` shows byte-identical
+  `allocs/frame` and `bytes/frame` and wall-clock parity against the base ref
+  (three interleaved release runs).
 
 A brand with no declared `==` keeps STRUCTURAL equality exactly as before, so
 adding units to a project cannot change what `==` already meant.
@@ -411,12 +414,21 @@ types are every abstract type in the engine prelude EXCEPT those three.
 exempt from the error because they DECLARE `==`, which is precisely what
 makes them comparable.
 
-Two limits, both deliberate:
+Three limits, all deliberate:
 
-- The rule reads the operand's own type and a tuple element's (mirroring the
-  existing "functions cannot be compared" certainty rule), not a record field
-  or a list element. A host value buried inside a model still meets the
-  runtime error, which remains the gradual-seam backstop.
+- The rule walks exactly what the existing "functions cannot be compared"
+  certainty rule walks — the operand's own type, map keys/values, tuple
+  elements, and a nominal's type ARGUMENTS — not a record's fields. Runtime
+  `==` has precisely two refusals (a function value and a host value), and
+  each certainty rule reports one of them, so they share one traversal
+  policy. A host value buried in a record still meets the runtime error,
+  which remains the gradual-seam backstop.
+- **Equality is polymorphic, so the rule is direct-only.** `let same = (a, b)
+  => a == b` carries no constraint to its call sites, so
+  `same(myScene, other)` still checks clean and fails at run time. Closing
+  that needs constraint-based typeclasses (an `Eq` bound propagated through
+  generalization), which is a much larger design than this change; the
+  limitation is pinned by a test rather than left as a surprise.
 - **Structural equality for `Scene.t` / `Frame.t` is out of scope.** Whether
   scenes should compare at all — and as `==` or as `Scene.equals` — is a
   separate decision. This check-time rejection is exactly the thing that

--- a/examples/hello/game.fun
+++ b/examples/hello/game.fun
@@ -84,7 +84,7 @@ let setHeld = (held, key, isDown) =>
 let input = (model, key, isDown) =>
   { model with held: setHeld(model.held, key, isDown) }
 
-let clamp = (v, lo, hi) =>
+let clamp = (v: float, lo, hi) =>
   match v < lo with
   | true => lo
   | false => (match hi < v with | true => hi | false => v)

--- a/examples/lighting/game.fun
+++ b/examples/lighting/game.fun
@@ -111,7 +111,7 @@ let input = (model, key, isDown) =>
   | Key.B => fireBang(model, isDown)
   | _ => { model with held: setHeld(model.held, key, isDown) }
 
-let clamp = (v, lo, hi) =>
+let clamp = (v: float, lo, hi) =>
   match v < lo with
   | true => lo
   | false => (match hi < v with | true => hi | false => v)

--- a/examples/physics-controller/game.fun
+++ b/examples/physics-controller/game.fun
@@ -30,6 +30,11 @@ let ledgeTag = Physics.tag("ledge")
 let wallTag = Physics.tag("wall")
 let deckTag = Physics.tag("deck")
 
+// `tick` decides `onDeck` by comparing the ground probe's tag against this
+// one, so tag equality is load-bearing here — pinned rather than assumed.
+expect deckTag == Physics.tag("deck")
+expect deckTag != playerTag
+
 // The capsule: half-height 0.5 plus radius 0.4, so the feet sit 0.9 below the
 // body's center. The ground probe's length follows from exactly that number.
 let capsuleHalfHeight = 0.5

--- a/examples/physics/game.fun
+++ b/examples/physics/game.fun
@@ -122,6 +122,13 @@ let otherOf = (e) =>
      | true => e.a
      | false => noTag)
 
+// A `Physics.tag` is a brand over a STRING, so it compares structurally —
+// the whole contact router above rests on that, and on nothing else.
+expect ballTag == Physics.tag("ball")
+expect ballTag != groundTag
+expect otherOf({ started: true, a: ballTag, b: crateTag(2.0), sensor: false }) == crateTag(2.0)
+expect otherOf({ started: true, a: groundTag, b: crateTag(0.0), sensor: false }) == noTag
+
 let subscriptions = (model) => Physics.events(Contact)
 
 // One update, two message kinds. GotHit: the raycast result, post-step

--- a/examples/terrain/game.fun
+++ b/examples/terrain/game.fun
@@ -91,7 +91,7 @@ let setHeld = (held, key, isDown) =>
   | _ => held
 
 
-let clamp = (value, lo, hi) =>
+let clamp = (value: float, lo, hi) =>
   if value < lo then lo else if hi < value then hi else value
 
 let mouseMove = (model, x, y) =>

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -156,6 +156,18 @@ pub enum TypeBody {
     Record(Vec<FieldTy>),
     Variants(Vec<VariantDecl>),
     Abstract,
+    /// `type t = host` — an abstract type whose values are HOST values with
+    /// no observable structure (a `Scene.t`, a `Frame.t`, an `Effect.t`).
+    /// Typing-wise it is exactly [`TypeBody::Abstract`]; the marker adds one
+    /// fact the checker cannot otherwise know — structural equality on such a
+    /// value is a RUNTIME error — so `==`/`!=` on one is refused at check
+    /// time instead (unless the brand declares its own `==`, as `Angle.t` and
+    /// `Time.t` do). Only interface (`.funi`) files may declare it.
+    ///
+    /// A plain `type t` stays comparable: some abstract prelude types
+    /// (`Sprite.t`, `Physics.tag`) are ordinary Functor Lang data behind the
+    /// name and compare structurally today.
+    Host,
 }
 
 /// One `| Ctor(name: Type, …)` / `| Ctor` alternative of a variant type.
@@ -404,6 +416,41 @@ impl BinOp {
     /// typechecker, and the interpreter's dispatch table.
     pub const ARITHMETIC: [BinOp; 4] = [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div];
 
+    /// Every operator a `unit <suffix> (<op>)` may declare, in declaration
+    /// order: the four arithmetic ones, then the two COMPARISON bases. Only
+    /// `==` and `<` are declarable — `!=` derives from `==`, and `>`, `<=`,
+    /// `>=` derive from `<` (see [`BinOp::declarable`]) — so a brand cannot
+    /// declare an ordering that disagrees with itself.
+    pub const DECLARABLE: [BinOp; 6] = [
+        BinOp::Add,
+        BinOp::Sub,
+        BinOp::Mul,
+        BinOp::Div,
+        BinOp::Eq,
+        BinOp::Lt,
+    ];
+
+    /// The declarable operator this one is implemented BY — itself for the
+    /// six in [`BinOp::DECLARABLE`], and the base of a derived comparison
+    /// otherwise. `!=` is `==` negated; `>` is `<` with its operands swapped,
+    /// `<=` is `>` negated, and `>=` is `<` negated. One `('t, 't) => bool`
+    /// implementation per brand therefore answers all four orderings, so a
+    /// brand's ordering is total and self-consistent by construction.
+    pub fn declarable(self) -> BinOp {
+        match self {
+            BinOp::Ne => BinOp::Eq,
+            BinOp::Gt | BinOp::Le | BinOp::Ge => BinOp::Lt,
+            other => other,
+        }
+    }
+
+    /// Is this a comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`)? Comparisons
+    /// answer `bool` whichever brand claims them, where arithmetic answers
+    /// the brand — the one place the two families diverge.
+    pub fn is_comparison(self) -> bool {
+        !matches!(self, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div)
+    }
+
     /// The operator's source spelling — the single source of truth for
     /// diagnostics in the typechecker and the interpreter.
     pub fn symbol(self) -> &'static str {
@@ -431,9 +478,9 @@ impl BinOp {
 pub(crate) fn declared_operators_hint(brand: &str, declared: &[&str], op: BinOp) -> String {
     if declared.is_empty() {
         return format!(
-            " — `{brand}` is a branded value with no arithmetic; declare it with \
+            " — `{brand}` is a branded value with no declared operators; declare one with \
 `unit <suffix> ({}) = …`",
-            op.symbol()
+            op.declarable().symbol()
         );
     }
     format!(
@@ -443,7 +490,8 @@ pub(crate) fn declared_operators_hint(brand: &str, declared: &[&str], op: BinOp)
             .map(|symbol| format!("`{symbol}`"))
             .collect::<Vec<_>>()
             .join(", "),
-        op.symbol()
+        // The DECLARABLE spelling: a derived `>` is missing because `<` is.
+        op.declarable().symbol()
     )
 }
 

--- a/functor-lang/src/ast.rs
+++ b/functor-lang/src/ast.rs
@@ -411,13 +411,10 @@ pub enum BinOp {
 }
 
 impl BinOp {
-    /// The arithmetic operators, in declaration order — the ONE list of what
-    /// a `unit <suffix> (<op>)` may declare, shared by the parser, the
-    /// typechecker, and the interpreter's dispatch table.
-    pub const ARITHMETIC: [BinOp; 4] = [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div];
-
     /// Every operator a `unit <suffix> (<op>)` may declare, in declaration
-    /// order: the four arithmetic ones, then the two COMPARISON bases. Only
+    /// order — the ONE such list, shared by the parser, the typechecker, and
+    /// the interpreter's dispatch table (whose slots ARE these indices). The
+    /// four arithmetic operators, then the two COMPARISON bases. Only
     /// `==` and `<` are declarable — `!=` derives from `==`, and `>`, `<=`,
     /// `>=` derive from `<` (see [`BinOp::declarable`]) — so a brand cannot
     /// declare an ordering that disagrees with itself.
@@ -446,9 +443,14 @@ impl BinOp {
 
     /// Is this a comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`)? Comparisons
     /// answer `bool` whichever brand claims them, where arithmetic answers
-    /// the brand — the one place the two families diverge.
+    /// the brand — the one place the two families diverge. Matched
+    /// POSITIVELY so a future non-comparison operator cannot silently join
+    /// the wrong family. [xreview: Claude Low]
     pub fn is_comparison(self) -> bool {
-        !matches!(self, BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div)
+        matches!(
+            self,
+            BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge | BinOp::Eq | BinOp::Ne
+        )
     }
 
     /// The operator's source spelling — the single source of truth for

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -550,7 +550,7 @@ pub struct Session {
 pub(crate) type BrandOps = Rc<HashMap<String, BrandOpRow>>;
 
 /// One brand's declared operators, indexed by [`op_slot`].
-pub(crate) type BrandOpRow = [Option<OpImpl>; 4];
+pub(crate) type BrandOpRow = [Option<OpImpl>; 6];
 
 /// A declared operator's implementation, kept SYMBOLIC wherever resolving it
 /// could need something this interpreter does not have.
@@ -573,24 +573,25 @@ pub(crate) enum OpImpl {
     Global(String),
 }
 
-/// Which slot of a [`BrandOpRow`] an operator owns — `None` for the
-/// comparisons, which are not declarable.
-fn op_slot(op: crate::ast::BinOp) -> Option<usize> {
+/// Which slot of a [`BrandOpRow`] an operator owns. A DERIVED comparison
+/// shares its base's slot — `>`, `<=`, and `>=` all read the brand's `<`, and
+/// `!=` reads its `==` — so one implementation answers every spelling.
+fn op_slot(op: crate::ast::BinOp) -> usize {
     use crate::ast::BinOp;
-    match op {
-        BinOp::Add => Some(0),
-        BinOp::Sub => Some(1),
-        BinOp::Mul => Some(2),
-        BinOp::Div => Some(3),
-        _ => None,
+    match op.declarable() {
+        BinOp::Add => 0,
+        BinOp::Sub => 1,
+        BinOp::Mul => 2,
+        BinOp::Div => 3,
+        BinOp::Eq => 4,
+        _ => 5,
     }
 }
 
 /// The operator a [`BrandOpRow`] slot holds — the inverse of [`op_slot`],
 /// for the "declares `+`, `*`, but not `-`" teaching error.
 fn slot_op(slot: usize) -> crate::ast::BinOp {
-    use crate::ast::BinOp;
-    [BinOp::Add, BinOp::Sub, BinOp::Mul, BinOp::Div][slot]
+    crate::ast::BinOp::DECLARABLE[slot]
 }
 
 impl Session {
@@ -1036,9 +1037,7 @@ impl Interp<'_> {
                     tag
                 }
             };
-            let Some(slot) = op_slot(unit_op.op) else {
-                continue;
-            };
+            let slot = op_slot(unit_op.op);
             // Names stay symbolic: a global resolves at call time (the defs
             // may not have run), and a HOST external must not be looked up
             // here at all — these same declarations load under a hostless
@@ -1628,16 +1627,22 @@ evaluation depth."
             // Division follows IEEE-754 (x/0 is ±inf/NaN, printed as
             // `inf`/`NaN`) — one number type, no checked division.
             BinOp::Div => self.arith(op, lhs, rhs, span, |a, b| a / b),
-            BinOp::Lt => self.compare(lhs, rhs, span, |a, b| a < b),
-            BinOp::Gt => self.compare(lhs, rhs, span, |a, b| a > b),
+            BinOp::Lt => self.compare(op, lhs, rhs, span, |a, b| a < b),
+            BinOp::Gt => self.compare(op, lhs, rhs, span, |a, b| a > b),
             // IEEE ordering, like `<`/`>`: every comparison with NaN is false.
-            BinOp::Le => self.compare(lhs, rhs, span, |a, b| a <= b),
-            BinOp::Ge => self.compare(lhs, rhs, span, |a, b| a >= b),
+            BinOp::Le => self.compare(op, lhs, rhs, span, |a, b| a <= b),
+            BinOp::Ge => self.compare(op, lhs, rhs, span, |a, b| a >= b),
             // `!=` is the exact negation of `==`: the SAME structural walk,
             // so it errors on functions/host values on exactly the inputs
             // `==` does (and `NaN != NaN` is true, since `NaN == NaN` is
             // false — the IEEE behaviour `<`/`<=` already have).
             BinOp::Eq | BinOp::Ne => {
+                // A brand that declares `==` answers for its own values —
+                // the only way an opaque host value (`Angle.t`) can compare
+                // at all, and what the checker resolved this node to.
+                if let Some(value) = self.brand_compare(op, &lhs, &rhs, span)? {
+                    return Ok(value);
+                }
                 // Charge AFTER the walk (the count isn't known up front):
                 // one comparison can overshoot the budget by at most the
                 // value's size — itself budget-bounded to build — so total
@@ -1679,9 +1684,7 @@ evaluation depth."
         span: Span,
     ) -> Result<Value, RunError> {
         use crate::ast::BinOp;
-        let Some(slot) = op_slot(op) else {
-            unreachable!("only arithmetic reaches brand dispatch")
-        };
+        let slot = op_slot(op);
         let declared = |ops: &BrandOps, value: &Value| {
             brand_tag(value)
                 .and_then(|tag| ops.get(tag))
@@ -1769,22 +1772,98 @@ its definition (a top-level initializer may only use globals defined above it)",
 
     fn compare(
         &mut self,
+        op: crate::ast::BinOp,
         lhs: Value,
         rhs: Value,
         span: Span,
-        op: fn(f64, f64) -> bool,
+        float_compare: fn(f64, f64) -> bool,
     ) -> Result<Value, RunError> {
         match (lhs, rhs) {
-            (Value::Number(a), Value::Number(b)) => Ok(Value::Bool(op(a, b))),
-            (a, b) => Err(RunError {
-                message: format!(
-                    "comparison needs numbers, got {} and {}",
-                    a.kind_name(),
-                    b.kind_name()
-                ),
-                span,
-            }),
+            (Value::Number(a), Value::Number(b)) => Ok(Value::Bool(float_compare(a, b))),
+            // Not two numbers: a branded operand may still declare `<`.
+            (a, b) => match self.brand_compare(op, &a, &b, span)? {
+                Some(value) => Ok(value),
+                None => Err(RunError {
+                    message: format!(
+                        "comparison needs numbers, got {} and {}{}",
+                        a.kind_name(),
+                        b.kind_name(),
+                        self.brand_arith_hint(op, &a, &b)
+                    ),
+                    span,
+                }),
+            },
         }
+    }
+
+    /// A comparison where a BRAND may claim the node: the runtime half of
+    /// `unit <suffix> (==)` / `(<)`.
+    ///
+    /// Only `==` and `<` are declared, so the other four spellings are
+    /// derived from them here — `>` swaps the declared `<`'s operands, `<=`
+    /// and `>=` negate it, and `!=` negates `==`. One implementation
+    /// therefore answers every spelling, and a brand's ordering cannot
+    /// disagree with itself.
+    ///
+    /// `None` means no brand claims the node (every plain-data comparison),
+    /// which leaves the float / structural behaviour exactly as it was.
+    fn brand_compare(
+        &mut self,
+        op: crate::ast::BinOp,
+        lhs: &Value,
+        rhs: &Value,
+        span: Span,
+    ) -> Result<Option<Value>, RunError> {
+        use crate::ast::BinOp;
+        // The overwhelmingly common path: no operator declared anywhere, or
+        // an operand that carries no brand tag at all (a number, string,
+        // record, list…). Neither touches the table.
+        if self.brand_ops.is_empty() {
+            return Ok(None);
+        }
+        let slot = op_slot(op);
+        let Some(implementation) = brand_tag(lhs)
+            .or_else(|| brand_tag(rhs))
+            .and_then(|tag| self.brand_ops.get(tag))
+            .and_then(|row| row[slot].clone())
+        else {
+            return Ok(None);
+        };
+        let implementation = match implementation {
+            OpImpl::Value(value) => value,
+            // Late-bound, exactly like the arithmetic operators.
+            OpImpl::Global(name) => match self.globals.get(&name) {
+                Some(value) => value.clone(),
+                None => {
+                    return Err(RunError {
+                        message: format!(
+                            "`{}` on this branded value calls `{name}`, which is used before its \
+definition (a top-level initializer may only use globals defined above it)",
+                            op.symbol()
+                        ),
+                        span,
+                    })
+                }
+            },
+        };
+        // `>` is the declared `<` with its operands swapped; `<=` and `>=`
+        // are its negations (`a <= b` is `not (b < a)`), and `!=` negates
+        // `==`.
+        let swapped = matches!(op, BinOp::Gt | BinOp::Le);
+        let negated = matches!(op, BinOp::Le | BinOp::Ge | BinOp::Ne);
+        let args = if swapped {
+            vec![rhs.clone(), lhs.clone()]
+        } else {
+            vec![lhs.clone(), rhs.clone()]
+        };
+        let answer = self.call(
+            implementation,
+            args,
+            format!("({})", op.declarable().symbol()),
+            span,
+            None,
+        )?;
+        Ok(Some(Value::Bool(as_bool(&answer, span)? != negated)))
     }
 
     /// Call a value. `label` is the callee's source-level name for the trace

--- a/functor-lang/src/eval.rs
+++ b/functor-lang/src/eval.rs
@@ -577,15 +577,15 @@ pub(crate) enum OpImpl {
 /// shares its base's slot — `>`, `<=`, and `>=` all read the brand's `<`, and
 /// `!=` reads its `==` — so one implementation answers every spelling.
 fn op_slot(op: crate::ast::BinOp) -> usize {
-    use crate::ast::BinOp;
-    match op.declarable() {
-        BinOp::Add => 0,
-        BinOp::Sub => 1,
-        BinOp::Mul => 2,
-        BinOp::Div => 3,
-        BinOp::Eq => 4,
-        _ => 5,
-    }
+    let declarable = op.declarable();
+    // DERIVED from `DECLARABLE`, not a second hardcoded order: `slot_op` is
+    // that array indexed, so hardcoding here would let a reorder silently
+    // point every brand's `+` at some other implementation.
+    // [xreview: Claude Low]
+    crate::ast::BinOp::DECLARABLE
+        .iter()
+        .position(|candidate| *candidate == declarable)
+        .expect("`declarable()` always answers a declarable operator")
 }
 
 /// The operator a [`BrandOpRow`] slot holds — the inverse of [`op_slot`],
@@ -1672,6 +1672,37 @@ evaluation depth."
         }
     }
 
+    /// A declared operator's implementation as a callable VALUE. Shared by
+    /// arithmetic and comparison dispatch: which implementation to use, and
+    /// in what argument order, is what legitimately differs between them —
+    /// resolving one is not.
+    ///
+    /// A named implementation is late-bound like any other global, so it
+    /// obeys the same rule: a top-level initializer may only use globals
+    /// defined ABOVE it.
+    fn resolve_op_impl(
+        &mut self,
+        implementation: OpImpl,
+        op: crate::ast::BinOp,
+        span: Span,
+    ) -> Result<Value, RunError> {
+        match implementation {
+            OpImpl::Value(value) => Ok(value),
+            // A host external is looked up HERE, so a missing host is the
+            // ordinary unknown-external error at the use site rather than a
+            // load failure.
+            OpImpl::External(path) => self.external_value(&path, span),
+            OpImpl::Global(name) => self.globals.get(&name).cloned().ok_or_else(|| RunError {
+                message: format!(
+                    "`{}` on this branded value calls `{name}`, which is used before its \
+definition (a top-level initializer may only use globals defined above it)",
+                    op.symbol()
+                ),
+                span,
+            }),
+        }
+    }
+
     /// Arithmetic where at least one operand is not a number — the runtime
     /// half of unit operators. The implementation is exactly the one the
     /// `unit … (<op>) = …` declaration names, called with the operands in the
@@ -1703,31 +1734,8 @@ evaluation depth."
         };
         let mut call = None;
         if let Some((implementation, first, second)) = found {
-            match implementation {
-                OpImpl::Value(value) => call = Some((value, first, second)),
-                // A host external is looked up HERE, so a missing host is the
-                // ordinary unknown-external error at the use site rather than
-                // a load failure.
-                OpImpl::External(path) => {
-                    call = Some((self.external_value(&path, span)?, first, second))
-                }
-                // A named implementation is late-bound like any global, so it
-                // obeys the same rule: a top-level initializer may only use
-                // globals defined ABOVE it.
-                OpImpl::Global(name) => match self.globals.get(&name) {
-                    Some(value) => call = Some((value.clone(), first, second)),
-                    None => {
-                        return Err(RunError {
-                            message: format!(
-                                "`{}` on this branded value calls `{name}`, which is used before \
-its definition (a top-level initializer may only use globals defined above it)",
-                                op.symbol()
-                            ),
-                            span,
-                        })
-                    }
-                },
-            }
+            let callee = self.resolve_op_impl(implementation, op, span)?;
+            call = Some((callee, first, second));
         }
         match call {
             Some((implementation, first, second)) => self.call(
@@ -1756,9 +1764,14 @@ its definition (a top-level initializer may only use globals defined above it)",
         let Some(tag) = brand_tag(lhs).or_else(|| brand_tag(rhs)) else {
             return String::new();
         };
-        let declared: Vec<&str> = self
-            .brand_ops
-            .get(tag)
+        // `brand_tag` answers for ANY variant, so a plain ADT would otherwise
+        // be told it is "a branded value" and advised to declare an operator
+        // — wrong advice for ordinary data. Only a tag the table actually
+        // knows gets unit advice. [xreview: Claude Medium]
+        let Some(row) = self.brand_ops.get(tag) else {
+            return String::new();
+        };
+        let declared: Vec<&str> = Some(row)
             .into_iter()
             .flat_map(|row| {
                 row.iter()
@@ -1815,37 +1828,24 @@ its definition (a top-level initializer may only use globals defined above it)",
         span: Span,
     ) -> Result<Option<Value>, RunError> {
         use crate::ast::BinOp;
-        // The overwhelmingly common path: no operator declared anywhere, or
-        // an operand that carries no brand tag at all (a number, string,
-        // record, list…). Neither touches the table.
+        // The overwhelmingly common path, gated cheapest-first: no operator
+        // declared anywhere, then an operand that carries no brand tag at all
+        // (a number, string, record, list, tuple — everything `frame_bench`
+        // compares). Neither reaches the table, and neither computes a slot.
         if self.brand_ops.is_empty() {
             return Ok(None);
         }
+        let Some(tag) = brand_tag(lhs).or_else(|| brand_tag(rhs)) else {
+            return Ok(None);
+        };
         let slot = op_slot(op);
-        let Some(implementation) = brand_tag(lhs)
-            .or_else(|| brand_tag(rhs))
+        let Some(implementation) = Some(tag)
             .and_then(|tag| self.brand_ops.get(tag))
             .and_then(|row| row[slot].clone())
         else {
             return Ok(None);
         };
-        let implementation = match implementation {
-            OpImpl::Value(value) => value,
-            // Late-bound, exactly like the arithmetic operators.
-            OpImpl::Global(name) => match self.globals.get(&name) {
-                Some(value) => value.clone(),
-                None => {
-                    return Err(RunError {
-                        message: format!(
-                            "`{}` on this branded value calls `{name}`, which is used before its \
-definition (a top-level initializer may only use globals defined above it)",
-                            op.symbol()
-                        ),
-                        span,
-                    })
-                }
-            },
-        };
+        let implementation = self.resolve_op_impl(implementation, op, span)?;
         // `>` is the declared `<` with its operands swapped; `<=` and `>=`
         // are its negations (`a <= b` is `not (b < a)`), and `!=` negates
         // `==`.

--- a/functor-lang/src/goto.rs
+++ b/functor-lang/src/goto.rs
@@ -270,8 +270,8 @@ fn type_body_fields(body: &TypeBody) -> Vec<&TypeName> {
             .iter()
             .flat_map(|VariantDecl { fields, .. }| fields.iter().map(|f| &f.ty))
             .collect(),
-        // An abstract type has no annotated fields.
-        TypeBody::Abstract => Vec::new(),
+        // An abstract type has no annotated fields (nor does a host one).
+        TypeBody::Abstract | TypeBody::Host => Vec::new(),
     }
 }
 

--- a/functor-lang/src/lower.rs
+++ b/functor-lang/src/lower.rs
@@ -1140,8 +1140,10 @@ with `unit {suffix} = SomeFn` (a `(float) => 't` function), or write the call it
                 .collect()
         };
         Ok(match body {
-            // No fields to canonicalize — an abstract type is opaque.
+            // No fields to canonicalize — an abstract type is opaque, and a
+            // host-valued one is abstract plus one fact for the checker.
             ast::TypeBody::Abstract => ast::TypeBody::Abstract,
+            ast::TypeBody::Host => ast::TypeBody::Host,
             ast::TypeBody::Record(fields) => ast::TypeBody::Record(canon_fields(self, fields)?),
             ast::TypeBody::Variants(variants) => ast::TypeBody::Variants(
                 variants

--- a/functor-lang/src/parser.rs
+++ b/functor-lang/src/parser.rs
@@ -368,9 +368,11 @@ project-wide, so declare them at the top level of the file"
         }))
     }
 
-    /// The tail of `unit <suffix> (<op>) = <target>`, from the `(`. Only the
-    /// four arithmetic operators are declarable — comparisons are deliberately
-    /// not (see `docs/functor-lang-units.md`).
+    /// The tail of `unit <suffix> (<op>) = <target>`, from the `(`. Six
+    /// operators are declarable: the four arithmetic ones, plus `==` and `<`.
+    /// The other comparisons are DERIVED (`!=` from `==`; `>`, `<=`, `>=`
+    /// from `<`), so they are not declarable — see
+    /// `docs/functor-lang-units.md`.
     fn unit_op_decl(
         &mut self,
         kw: Span,
@@ -385,9 +387,30 @@ project-wide, so declare them at the top level of the file"
             TokenKind::Minus => BinOp::Sub,
             TokenKind::Star => BinOp::Mul,
             TokenKind::Slash => BinOp::Div,
+            TokenKind::EqEq => BinOp::Eq,
+            TokenKind::Lt => BinOp::Lt,
+            // The derived comparisons name their base, so the error can be
+            // exact rather than a bare list.
+            TokenKind::BangEq => {
+                return Err(ParseError {
+                    message: "`!=` is derived from `==` — declare `unit <suffix> (==)` and `!=` \
+follows".to_string(),
+                    span: op_span,
+                })
+            }
+            TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq => {
+                return Err(ParseError {
+                    message: "`>`, `<=`, and `>=` are derived from `<` — declare \
+`unit <suffix> (<)` and all three follow"
+                        .to_string(),
+                    span: op_span,
+                })
+            }
             _ => {
-                return self
-                    .error("an operator to declare: `+`, `-`, `*`, or `/` (e.g. `unit deg (+) = Angle.add`)")
+                return self.error(
+                    "an operator to declare: `+`, `-`, `*`, `/`, `==`, or `<` \
+(e.g. `unit deg (+) = Angle.add`)",
+                )
             }
         };
         self.bump();
@@ -563,6 +586,26 @@ rebind surface); `mut` is for `let mut … in …` inside a function"
             });
         }
         self.bump(); // `=`
+        // `type t = host` — an abstract type whose values are opaque HOST
+        // values (see `TypeBody::Host`). Contextual, like `unit`/`open`, so
+        // `host` stays usable as an ordinary name everywhere else.
+        if matches!(self.peek_kind(), TokenKind::Ident(name) if name == "host") {
+            let end = self.bump().span;
+            if !self.interface {
+                return Err(ParseError {
+                    message: "`= host` marks a type whose values come from the ENGINE, so it \
+belongs in an interface (.funi) file — a `.fun` type is ordinary data"
+                        .to_string(),
+                    span: end,
+                });
+            }
+            return Ok(TypeDecl {
+                name,
+                params,
+                body: TypeBody::Host,
+                span: kw.span.to(end),
+            });
+        }
         match self.peek_kind() {
             TokenKind::LBrace => {
                 self.bump();

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -231,12 +231,23 @@ fn brand_name(ty: &Type) -> Option<String> {
     }
 }
 
-/// The type an operator's SECOND operand takes on a given brand: the brand
-/// itself for `+` and `-`, a plain float for the scalar `*` and `/`.
+/// The type an operator's SECOND operand takes on a given brand: a plain
+/// float for the scalar `*` and `/`, and the brand itself for everything else
+/// (`+`/`-` stay inside the brand, and a comparison compares like with like).
 fn operand_type(op: BinOp, brand: &Type) -> Type {
     match op {
-        BinOp::Add | BinOp::Sub => brand.clone(),
-        _ => Type::Float,
+        BinOp::Mul | BinOp::Div => Type::Float,
+        _ => brand.clone(),
+    }
+}
+
+/// What an operator on a brand ANSWERS: `bool` for the comparisons, the brand
+/// itself for arithmetic.
+fn result_type(op: BinOp, brand: &Type) -> Type {
+    if op.is_comparison() {
+        Type::Bool
+    } else {
+        brand.clone()
     }
 }
 
@@ -803,8 +814,10 @@ fn check_impl(
         def_param_names: HashMap::new(),
         match_scrutinees: Vec::new(),
         unit_hints: HashMap::new(),
+        host_types: HashSet::new(),
         brand_ops: HashMap::new(),
         pending_ops: Vec::new(),
+        pending_eq: Vec::new(),
     };
 
     // Record type names first (nominal references may be forward), then
@@ -832,6 +845,16 @@ fn check_impl(
                 checker
                     .variants
                     .insert(decl.name.clone(), (decl.params.len(), Vec::new()));
+            }
+            // `type t = host` — abstract, PLUS the one fact the checker
+            // cannot infer: its values are host values, which structural
+            // equality refuses at run time. Recorded so `==` on one is a
+            // check-time error (see `Checker::host_opaque`).
+            TypeBody::Host => {
+                checker
+                    .variants
+                    .insert(decl.name.clone(), (decl.params.len(), Vec::new()));
+                checker.host_types.insert(decl.name.clone());
             }
         }
     }
@@ -870,7 +893,7 @@ fn check_impl(
                 }
             }
             // Nothing to resolve — an abstract type has no fields or ctors.
-            TypeBody::Abstract => {}
+            TypeBody::Abstract | TypeBody::Host => {}
         }
     }
 
@@ -1150,7 +1173,7 @@ suffix of `{name}` shares one implementation"
         let Some(brand) = brand.clone() else { continue };
         let want = Type::Fn(
             vec![brand.clone(), operand_type(unit_op.op, &brand)],
-            Box::new(brand),
+            Box::new(result_type(unit_op.op, &brand)),
         );
         checker.expect(
             &unit_op.target,
@@ -1352,6 +1375,11 @@ struct Checker<'s> {
     /// diagnostic side channel — it turns "expected Angle.t, got float" into
     /// a message that teaches both spellings.
     unit_hints: HashMap<String, Vec<(String, String)>>,
+    /// Types declared `type t = host` — abstract nominals whose values are
+    /// opaque HOST values. Structural equality on one is a runtime error, so
+    /// `==`/`!=` on one is refused at CHECK time instead (unless the brand
+    /// declares its own `==` — see [`Checker::brand_ops`]).
+    host_types: HashSet<String>,
     /// Declared unit OPERATORS, indexed by the branded type they act on and
     /// the operator: `("Angle.t", BinOp::Add)` → the `unit deg (+)`
     /// declaration. Unlike [`Self::unit_hints`] this is not a side channel —
@@ -1365,6 +1393,11 @@ struct Checker<'s> {
     /// and after each expect/unit target). Ad-hoc overloading is resolved
     /// AFTER inference, never during unification.
     pending_ops: Vec<PendingOp>,
+    /// `==`/`!=` nodes whose operand type was still unsolved when they were
+    /// seen: equality types the same either way (it answers `bool`), so
+    /// nothing about INFERENCE is deferred — only the host-opacity verdict,
+    /// which needs the solved type. Flushed beside [`Self::pending_ops`].
+    pending_eq: Vec<(BinOp, Type, Span)>,
 }
 
 /// A deferred arithmetic node: its operands, the fresh variable standing for
@@ -3111,10 +3144,12 @@ is {other}"
             BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => {
                 self.arithmetic(op, lhs, lhs_span, rhs, rhs_span, node_span)
             }
+            // Ordering goes through the SAME ad-hoc overloading arithmetic
+            // does: a brand that declares `<` claims all four (`>` is `<`
+            // swapped; `<=` and `>=` are the negations), and everything else
+            // is float ordering exactly as before.
             BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge => {
-                self.require_float(op, lhs, lhs_span);
-                self.require_float(op, rhs, rhs_span);
-                Type::Bool
+                self.arithmetic(op, lhs, lhs_span, rhs, rhs_span, node_span)
             }
             // `==` is an error only where the runtime outcome is certain:
             // comparing functions always fails at runtime, and operands whose
@@ -3149,7 +3184,19 @@ is {other}"
                 free_vars_of(rhs, &mut vars);
                 if !vars.is_empty() {
                     self.unify(lhs, rhs, node_span, &format!("`{sym}` operands"));
+                    // Whether the settled type is an OPAQUE engine value is
+                    // not knowable yet, so that verdict alone is deferred
+                    // (inference is not — equality answers `bool` either way).
+                    self.pending_eq.push((op, lhs.clone(), node_span));
                     return Type::Bool;
+                }
+                // An engine value has no structural equality — the runtime
+                // refuses it — so `myScene == other` is an error HERE. One
+                // report per node: both operands are usually the same type.
+                if self.opaque_engine_type(lhs).is_none() {
+                    self.reject_host_equality(op, rhs, node_span);
+                } else {
+                    self.reject_host_equality(op, lhs, node_span);
                 }
                 match (lhs, rhs) {
                     // One known function operand is enough: the runtime
@@ -3244,14 +3291,21 @@ is {other}"
         }
     }
 
-    /// An arithmetic node (`+`, `-`, `*`, `/`) — the ad-hoc overloading seam.
+    /// A node over NUMBERS by default — the four arithmetic operators and
+    /// the four orderings — which is the ad-hoc overloading seam.
     ///
     /// A brand with a declared implementation for this operator wins; a node
-    /// with no brand in sight is plain float arithmetic, exactly as before.
-    /// The in-between case — an operand still unsolved while SOME brand
-    /// declares the operator — cannot be decided yet, so it is DEFERRED to
-    /// [`Self::flush_pending_ops`] (resolution runs after inference, never
+    /// with no brand in sight is plain float arithmetic/ordering, exactly as
+    /// before. The in-between case — an operand still unsolved while SOME
+    /// brand declares the operator — cannot be decided yet, so it is DEFERRED
+    /// to [`Self::flush_pending_ops`] (resolution runs after inference, never
     /// during unification, so it can't make inference order-dependent).
+    ///
+    /// Ordering rides the same path as arithmetic because the ambiguity is
+    /// identical: with `<` declared on a brand, an unannotated `(a, b) => a <
+    /// b` could be either reading. Only its ANSWER differs — a comparison is
+    /// `bool` whichever way it resolves, so its deferred node carries `bool`
+    /// as its result rather than a fresh variable.
     fn arithmetic(
         &mut self,
         op: BinOp,
@@ -3266,10 +3320,37 @@ is {other}"
         if let Some(ty) = self.brand_binary(op, &lhs, lhs_span, &rhs, rhs_span, node_span) {
             return ty;
         }
-        if (matches!(lhs, Type::Var(_)) || matches!(rhs, Type::Var(_)))
-            && self.brand_ops.keys().any(|(_, declared)| *declared == op)
+        let declarable = op.declarable();
+        // Deferring is only worth it while a BRANDED reading is still
+        // possible. `brand_binary` has already tried the solved sides, so
+        // what remains is which unsolved side could still become a brand:
+        //
+        // - `*` puts the brand on either side (scaling commutes), so one
+        //   unsolved operand is enough.
+        // - `/` divides a brand BY a float, so only an unsolved LEFT counts.
+        // - everything else — `+`, `-`, and the orderings — combines or
+        //   compares like with like, so a side already solved to a non-brand
+        //   settles the node as float RIGHT HERE. That matters: `Math.abs(d)
+        //   < step` pins `step` immediately instead of leaving it (and the
+        //   `rate * dt` that produced it) undecided until the flush.
+        let branded_reading_possible = match op {
+            BinOp::Mul => matches!(lhs, Type::Var(_)) || matches!(rhs, Type::Var(_)),
+            BinOp::Div => matches!(lhs, Type::Var(_)),
+            _ => matches!(lhs, Type::Var(_)) && matches!(rhs, Type::Var(_)),
+        };
+        if branded_reading_possible
+            && self
+                .brand_ops
+                .keys()
+                .any(|(_, declared)| *declared == declarable)
         {
-            let result = self.fresh();
+            // A comparison's result is settled (`bool`) even while its
+            // operands are not, so only arithmetic needs a fresh variable.
+            let result = if op.is_comparison() {
+                Type::Bool
+            } else {
+                self.fresh()
+            };
             self.pending_ops.push(PendingOp {
                 op,
                 lhs,
@@ -3283,7 +3364,7 @@ is {other}"
         }
         self.require_float(op, &lhs, lhs_span);
         self.require_float(op, &rhs, rhs_span);
-        Type::Float
+        result_type(op, &Type::Float)
     }
 
     /// Resolve an arithmetic node against the declared unit operators.
@@ -3299,10 +3380,13 @@ is {other}"
         rhs_span: Span,
         node_span: Span,
     ) -> Option<Type> {
+        // A derived comparison resolves through the operator it is
+        // implemented BY: `>`/`<=`/`>=` all look up the brand's `<`.
+        let declarable = op.declarable();
         // The brand on the LEFT is the declared form: `45deg + 45deg`,
         // `45deg * 2.0`.
         if let Some(name) = brand_name(lhs) {
-            if self.brand_ops.contains_key(&(name.clone(), op)) {
+            if self.brand_ops.contains_key(&(name.clone(), declarable)) {
                 let want = operand_type(op, lhs);
                 self.unify(
                     rhs,
@@ -3310,14 +3394,26 @@ is {other}"
                     rhs_span,
                     &format!("the right operand of `{}` on `{name}`", op.symbol()),
                 );
-                return Some(lhs.clone());
+                return Some(result_type(op, lhs));
             }
         }
         let name = brand_name(rhs)?;
-        if !self.brand_ops.contains_key(&(name.clone(), op)) {
+        if !self.brand_ops.contains_key(&(name.clone(), declarable)) {
             return None;
         }
         match op {
+            // An ordering compares like with like, in either direction: the
+            // derived `>` is the declared `<` with its operands swapped, so a
+            // brand on the RIGHT is just as resolvable as one on the left.
+            BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge => {
+                self.unify(
+                    lhs,
+                    rhs,
+                    lhs_span,
+                    &format!("the left operand of `{}` on `{name}`", op.symbol()),
+                );
+                Some(Type::Bool)
+            }
             // `+`/`-` stay inside the brand, so the left operand is one too.
             BinOp::Add | BinOp::Sub => {
                 self.unify(
@@ -3403,46 +3499,112 @@ is {other}"
             let one_operand_twice = matches!((&lhs, &rhs), (Type::Var(a), Type::Var(b)) if a == b);
             let branded_reading_exists =
                 !(one_operand_twice && matches!(node.op, BinOp::Mul | BinOp::Div));
-            // Nothing about the node — neither operand, nor the type its
-            // result flows into — says which arithmetic this is.
+            // Nothing about the node — neither operand, nor (for arithmetic)
+            // the type its result flows into — says which reading this is. A
+            // comparison's result is `bool` either way, so it never carries
+            // evidence and only the operands can decide it.
+            let result_undecided = node.op.is_comparison()
+                || matches!(self.zonk(&node.result), Type::Var(_));
             if branded_reading_exists
                 && matches!(lhs, Type::Var(_))
                 && matches!(rhs, Type::Var(_))
-                && matches!(self.zonk(&node.result), Type::Var(_))
+                && result_undecided
             {
+                let declarable = node.op.declarable();
                 let mut brands: Vec<&str> = self
                     .brand_ops
                     .keys()
-                    .filter(|(_, declared)| *declared == node.op)
+                    .filter(|(_, declared)| *declared == declarable)
                     .map(|(brand, _)| brand.as_str())
                     .collect();
                 brands.sort_unstable();
                 let symbol = node.op.symbol();
+                let kind = if node.op.is_comparison() {
+                    "comparison"
+                } else {
+                    "arithmetic"
+                };
                 self.diag(
                     node.node_span,
                     format!(
-                        "`{symbol}` here could be float arithmetic or {} — annotate an operand \
+                        "`{symbol}` here could be float {kind} or {} — annotate an operand \
 (e.g. `(a: {})`) so the operator can be resolved",
                         brands
                             .iter()
-                            .map(|brand| format!("`{brand}` arithmetic"))
+                            .map(|brand| format!("`{brand}` {kind}"))
                             .collect::<Vec<_>>()
                             .join(" or "),
                         brands.first().copied().unwrap_or("float"),
                     ),
                 );
             }
-            // Either way the node is float arithmetic from here on: the
+            // Either way the node is the float reading from here on: the
             // ambiguous case has already been reported, so this keeps one
             // unannotated operand from cascading through the rest of the def.
             self.require_float(node.op, &lhs, node.lhs_span);
             self.require_float(node.op, &rhs, node.rhs_span);
             self.unify(
-                &Type::Float,
+                &result_type(node.op, &Type::Float),
                 &node.result,
                 node.node_span,
                 &format!("the result of `{}`", node.op.symbol()),
             );
+        }
+        self.flush_pending_eq();
+    }
+
+    /// Resolve every deferred `==`/`!=` node's HOST-OPACITY verdict, now that
+    /// its operand type is known. Nothing about inference waited on this —
+    /// equality answers `bool` regardless — so this only reports.
+    fn flush_pending_eq(&mut self) {
+        for (op, ty, span) in std::mem::take(&mut self.pending_eq) {
+            let ty = self.zonk(&ty);
+            // Still unsolved (a generic helper's `a == b`): equality is
+            // polymorphic, so there is nothing to say.
+            self.reject_host_equality(op, &ty, span);
+        }
+    }
+
+    /// `==`/`!=` on a type whose values are opaque ENGINE values is a runtime
+    /// error, so it is refused here — unless the brand declares its own `==`
+    /// (`Angle.t` and `Time.t` do), which is exactly what makes them
+    /// comparable.
+    fn reject_host_equality(&mut self, op: BinOp, ty: &Type, span: Span) {
+        let Some(name) = self.opaque_engine_type(ty) else {
+            return;
+        };
+        self.diag(
+            span,
+            format!(
+                "`{}` on `{name}`: engine values are opaque — compare the numbers you derived \
+from them instead (`{name}` supports no `==`)",
+                op.symbol()
+            ),
+        );
+    }
+
+    /// The name of an opaque ENGINE type this operand would compare — itself,
+    /// or (like [`contains_fn`], the sibling certainty rule) a TUPLE element,
+    /// since structural equality recurses into one and hits the same runtime
+    /// error. A brand that declares its own `==` is not opaque to equality,
+    /// which is the whole point of declaring it.
+    ///
+    /// Records and collections are deliberately NOT walked: this rule is for
+    /// certain, immediate errors, and the runtime error stays the backstop
+    /// for a host value buried inside a model.
+    fn opaque_engine_type(&self, ty: &Type) -> Option<String> {
+        let opaque = |name: Option<String>| {
+            let name = name?;
+            (self.host_types.contains(&name)
+                && !self.brand_ops.contains_key(&(name.clone(), BinOp::Eq)))
+            .then_some(name)
+        };
+        if let Some(name) = opaque(brand_name(ty)) {
+            return Some(name);
+        }
+        match ty {
+            Type::Tuple(elements) => elements.iter().find_map(|el| opaque(brand_name(el))),
+            _ => None,
         }
     }
 
@@ -3454,7 +3616,7 @@ is {other}"
         };
         // Operator order, not alphabetical — and the same order the
         // interpreter's twin message uses.
-        let declared: Vec<&str> = BinOp::ARITHMETIC
+        let declared: Vec<&str> = BinOp::DECLARABLE
             .into_iter()
             .filter(|declared| self.brand_ops.contains_key(&(name.clone(), *declared)))
             .map(|declared| declared.symbol())

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -3141,16 +3141,18 @@ is {other}"
         node_span: Span,
     ) -> Type {
         match op {
-            BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div => {
-                self.arithmetic(op, lhs, lhs_span, rhs, rhs_span, node_span)
-            }
             // Ordering goes through the SAME ad-hoc overloading arithmetic
             // does: a brand that declares `<` claims all four (`>` is `<`
             // swapped; `<=` and `>=` are the negations), and everything else
-            // is float ordering exactly as before.
-            BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge => {
-                self.arithmetic(op, lhs, lhs_span, rhs, rhs_span, node_span)
-            }
+            // is float arithmetic/ordering exactly as before.
+            BinOp::Add
+            | BinOp::Sub
+            | BinOp::Mul
+            | BinOp::Div
+            | BinOp::Lt
+            | BinOp::Gt
+            | BinOp::Le
+            | BinOp::Ge => self.arithmetic(op, lhs, lhs_span, rhs, rhs_span, node_span),
             // `==` is an error only where the runtime outcome is certain:
             // comparing functions always fails at runtime, and operands whose
             // known types cannot be equal always yield `false`. Runtime
@@ -3583,27 +3585,47 @@ from them instead (`{name}` supports no `==`)",
         );
     }
 
-    /// The name of an opaque ENGINE type this operand would compare — itself,
-    /// or (like [`contains_fn`], the sibling certainty rule) a TUPLE element,
-    /// since structural equality recurses into one and hits the same runtime
-    /// error. A brand that declares its own `==` is not opaque to equality,
-    /// which is the whole point of declaring it.
+    /// The name of an opaque ENGINE type this operand would compare, if any.
     ///
-    /// Records and collections are deliberately NOT walked: this rule is for
-    /// certain, immediate errors, and the runtime error stays the backstop
-    /// for a host value buried inside a model.
+    /// It walks exactly what [`contains_fn`] walks — the type itself, map
+    /// keys/values, tuple elements, and a nominal's type ARGUMENTS — because
+    /// the two are the same rule about the same question: runtime `==` has
+    /// precisely two refusals (a function value and a `HostData`), and each
+    /// certainty rule reports one of them at check time. Anywhere a compared
+    /// function is certainly an error, a compared host value is too. They
+    /// stay separate functions only because they answer differently: a bool
+    /// versus the NAME the diagnostic teaches with.
+    ///
+    /// A record's FIELDS are not walked (neither rule walks them), so a host
+    /// value buried in a model still meets the runtime error — the
+    /// gradual-seam backstop.
+    ///
+    /// `declares_eq` is the ONE asymmetry between the top level and the walk,
+    /// and it is load-bearing. A brand that declares its own `==` is not
+    /// opaque *as an operand*, because the operator node dispatches to that
+    /// implementation. NESTED, it is opaque again: the structural walk
+    /// (`value_eq`) recurses on its own and never consults the brand table,
+    /// so `(90deg, 1.0) == (90deg, 1.0)` really is a certain runtime error
+    /// even though `90deg == 90deg` is fine. [xreview: Claude High]
     fn opaque_engine_type(&self, ty: &Type) -> Option<String> {
-        let opaque = |name: Option<String>| {
-            let name = name?;
-            (self.host_types.contains(&name)
-                && !self.brand_ops.contains_key(&(name.clone(), BinOp::Eq)))
-            .then_some(name)
-        };
-        if let Some(name) = opaque(brand_name(ty)) {
-            return Some(name);
-        }
+        self.opaque_engine_type_at(ty, true)
+    }
+
+    fn opaque_engine_type_at(&self, ty: &Type, operand: bool) -> Option<String> {
+        let nested = |ty: &Type| self.opaque_engine_type_at(ty, false);
         match ty {
-            Type::Tuple(elements) => elements.iter().find_map(|el| opaque(brand_name(el))),
+            Type::Map(key, value) => nested(key).or_else(|| nested(value)),
+            Type::List(element) => nested(element),
+            Type::Tuple(elements) => elements.iter().find_map(nested),
+            Type::Record(_, args) | Type::Variant(_, args) => {
+                // The type's OWN name first — a nominal is opaque before its
+                // (empty, for every host handle) arguments matter.
+                let name = brand_name(ty).filter(|name| {
+                    self.host_types.contains(name)
+                        && !(operand && self.brand_ops.contains_key(&(name.clone(), BinOp::Eq)))
+                });
+                name.or_else(|| args.iter().find_map(nested))
+            }
             _ => None,
         }
     }

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -2152,3 +2152,103 @@ fn a_duplicate_unit_across_files_names_both() {
     assert!(message.contains("duplicate unit `px`"), "{message}");
     assert!(message.contains("game.fun"), "{message}");
 }
+
+// ------------------------------------------ `type t = host` (opaque values)
+
+/// `type t = host` marks an abstract type whose values are opaque HOST
+/// values. Everything about it types exactly like a plain `type t` — it is
+/// still an abstract nominal handed around by host functions — EXCEPT that
+/// `==`/`!=` on one is refused at check time rather than at run time.
+#[test]
+fn a_host_type_refuses_equality_at_check_time() {
+    let project = load(
+        "host-type-eq",
+        &[
+            (
+                "game.fun",
+                "let same = (): bool => Widget.make() == Widget.make()\n",
+            ),
+            (
+                "widget.funi",
+                "type Handle = host\n\
+                 let make : () => Handle\n\
+                 let size : (Handle) => float",
+            ),
+        ],
+    );
+    let diags = project.check();
+    assert!(
+        diags.iter().any(|d| d.message.contains("engine values are opaque")
+            && d.message.contains("`Widget.Handle` supports no `==`")),
+        "{diags:?}"
+    );
+    // `!=` is the exact negation, so it is refused identically…
+    let project = load(
+        "host-type-ne",
+        &[
+            (
+                "game.fun",
+                "let differ = (): bool => Widget.make() != Widget.make()\n",
+            ),
+            (
+                "widget.funi",
+                "type Handle = host\nlet make : () => Handle",
+            ),
+        ],
+    );
+    assert!(
+        project
+            .check()
+            .iter()
+            .any(|d| d.message.contains("`!=` on `Widget.Handle`")),
+        "`!=` should be refused too"
+    );
+    // …while everything ELSE about the type is unchanged: it still passes
+    // through host signatures with no complaint.
+    let project = load(
+        "host-type-ok",
+        &[
+            (
+                "game.fun",
+                "let big = (): bool => Widget.size(Widget.make()) > 1.0\n",
+            ),
+            (
+                "widget.funi",
+                "type Handle = host\n\
+                 let make : () => Handle\n\
+                 let size : (Handle) => float",
+            ),
+        ],
+    );
+    assert!(project.check().is_empty(), "{:?}", project.check());
+}
+
+/// A plain `type t` stays comparable. Not every abstract prelude type is a
+/// host handle — `Sprite.t` and `Physics.tag` are ordinary Functor Lang data
+/// behind an opaque name — so the marker is what distinguishes them, and its
+/// absence must change nothing.
+#[test]
+fn a_plain_abstract_type_still_compares() {
+    let project = load(
+        "abstract-type-eq",
+        &[
+            (
+                "game.fun",
+                "let same = (): bool => Widget.make() == Widget.make()\n",
+            ),
+            ("widget.funi", "type Handle\nlet make : () => Handle"),
+        ],
+    );
+    assert!(project.check().is_empty(), "{:?}", project.check());
+}
+
+/// The marker says something only the HOST can be responsible for, so a `.fun`
+/// may not claim it — its types are ordinary data.
+#[test]
+fn a_host_type_is_rejected_in_an_implementation_file() {
+    let message = load_err(
+        "host-type-in-fun",
+        &[("game.fun", "type Handle = host\nlet main = () => 1.0\n")],
+    );
+    assert!(message.contains("belongs in an interface (.funi) file"), "{message}");
+}

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -417,9 +417,20 @@ fn an_operator_declaration_takes_a_lambda() {
 
 #[test]
 fn malformed_operator_declarations_are_targeted_parse_errors() {
-    // Comparisons are deliberately not declarable (yet).
-    let message = parse_err("unit px (==) = eq\n");
-    assert!(message.contains("`+`, `-`, `*`, or `/`"), "{message}");
+    // Six operators are declarable — the four arithmetic ones, `==`, and `<`.
+    let message = parse_err("unit px (&&) = both\n");
+    assert!(
+        message.contains("`+`, `-`, `*`, `/`, `==`, or `<`"),
+        "{message}"
+    );
+    // The DERIVED comparisons name the base they come from rather than
+    // listing everything again.
+    let message = parse_err("unit px (!=) = ne\n");
+    assert!(message.contains("`!=` is derived from `==`"), "{message}");
+    for src in ["unit px (>) = gt\n", "unit px (<=) = le\n", "unit px (>=) = ge\n"] {
+        let message = parse_err(src);
+        assert!(message.contains("are derived from `<`"), "{message}");
+    }
     let message = parse_err("unit px (+ = add\n");
     assert!(message.contains("`)` after the operator"), "{message}");
     let message = parse_err("unit px (+)\n");
@@ -760,4 +771,108 @@ fn the_interpreter_teaches_when_no_implementation_exists() {
         "{}",
         failure.error.message
     );
+}
+
+// ------------------------------------------------------ comparison on brands
+
+/// A brand that declares the two COMPARISON bases. `unwrap` is the seam every
+/// implementation goes through — the point being that a brand's comparison is
+/// ordinary code, not a privileged builtin.
+const ORD: &str = "type Px = | Px(value: float)\n\
+                   unit px = Px\n\
+                   let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+                   unit px (==) = (a, b) => unwrap(a) == unwrap(b)\n\
+                   unit px (<) = (a, b) => unwrap(a) < unwrap(b)\n";
+
+/// The headline: `==` and `<` resolve on a brand, and the four DERIVED
+/// spellings come from them — `>` swaps `<`, `<=`/`>=` negate it, `!=`
+/// negates `==`. All six are checked AND evaluated here, so a derivation that
+/// disagreed with its base would show up as a wrong answer.
+#[test]
+fn a_brand_compares_and_orders_through_two_declarations() {
+    let src = format!(
+        "{ORD}let main = () => \
+(16px == 16px, 16px == 4px, 16px != 4px, 4px < 16px, 16px > 4px, 4px <= 4px, 4px >= 16px)\n"
+    );
+    assert!(check_src(&src).is_empty(), "{:?}", check_src(&src));
+    assert_eq!(
+        main_result(&src),
+        "(true, false, true, true, true, true, false)"
+    );
+}
+
+/// A comparison answers `bool` whichever way it resolves, so a branded one
+/// flows into `if` with no ceremony and does not infect the surrounding type.
+#[test]
+fn a_branded_comparison_is_an_ordinary_bool() {
+    let src = format!("{ORD}let main = () => if 4px < 16px then 1.0 else 2.0\n");
+    assert!(check_src(&src).is_empty(), "{:?}", check_src(&src));
+    assert_eq!(main_result(&src), "1");
+}
+
+/// Ordering is refused on a brand that declares only equality — with the same
+/// teaching arithmetic gets, naming the DECLARABLE base (`<`, never the
+/// derived `>` the user actually wrote).
+#[test]
+fn an_undeclared_ordering_names_the_declarable_base() {
+    let diags = check_src(
+        "type Px = | Px(value: float)\n\
+         unit px = Px\n\
+         let unwrap = (p: Px): float => match p with | Px(n) => n\n\
+         unit px (==) = (a, b) => unwrap(a) == unwrap(b)\n\
+         let bad = 16px > 4px\n",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("`Px` declares `==`, but not `<`")),
+        "{diags:?}"
+    );
+}
+
+/// A fully unannotated comparison is ambiguous once a brand declares `<` —
+/// the same rule arithmetic has, for the same reason. A comparison's RESULT
+/// is `bool` either way, so only an operand can decide it.
+#[test]
+fn an_unresolvable_comparison_asks_for_an_annotation() {
+    let diags = check_src(&format!("{ORD}let less = (a, b) => a < b\n"));
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.contains("could be float comparison") && d.contains("annotate an operand")),
+        "{diags:?}"
+    );
+    // …and every ordinary way of pinning ONE operand resolves it. A side
+    // already known to be a non-brand settles the node on the spot, which is
+    // what keeps `Math.abs(d) < step` (and the `rate * dt` behind `step`)
+    // decidable without any annotation at all.
+    for tail in [
+        "let less = (a: float, b) => a < b\n",
+        "let less = (a, b: float) => a < b\n",
+        "let less = (a) => a < 1.0\n",
+        "let less = (a: Px, b) => a < b\n",
+    ] {
+        let src = format!("{ORD}{tail}");
+        assert!(check_src(&src).is_empty(), "{tail}: {:?}", check_src(&src));
+    }
+}
+
+/// The interpreter derives the same four spellings from the same two
+/// implementations — `run` skips the checker, so this is the gradual seam
+/// agreeing with the static one.
+#[test]
+fn the_interpreter_derives_the_orderings_too() {
+    let src = format!("{ORD}let main = () => (16px > 4px, 4px <= 4px, 16px != 4px)\n");
+    assert_eq!(main_result(&src), "(true, true, true)");
+}
+
+/// A brand with NO declared `==` keeps STRUCTURAL equality: a plain-data
+/// variant compares as it always did, and nothing about `unit` changed that.
+#[test]
+fn a_brand_without_an_equality_declaration_stays_structural() {
+    let src = "type Px = | Px(value: float)\n\
+               unit px = Px\n\
+               let main = () => (16px == 16px, 16px == 4px)\n";
+    assert!(check_src(src).is_empty(), "{:?}", check_src(src));
+    assert_eq!(main_result(src), "(true, false)");
 }

--- a/functor-lang/tests/units.rs
+++ b/functor-lang/tests/units.rs
@@ -866,6 +866,29 @@ fn the_interpreter_derives_the_orderings_too() {
     assert_eq!(main_result(&src), "(true, true, true)");
 }
 
+/// A plain ADT is not "a branded value". The runtime tag exists for every
+/// variant, so the failure hint must consult the operator TABLE before
+/// advising a `unit` declaration — otherwise `Some(1.0) < Some(2.0)` tells
+/// you to declare an operator on `Option`. [xreview: Claude Medium]
+#[test]
+fn an_ordinary_variant_gets_no_unit_advice() {
+    let src = format!(
+        "{ORD}type Box = | Wrap(v: float)\nlet main = () => Wrap(1.0) < Wrap(2.0)\n"
+    );
+    let program = functor_lang::parse(&src).expect("parses");
+    let module = functor_lang::lower(program).expect("lowers");
+    let message = functor_lang::run(&module, Tracing::Off)
+        .err()
+        .expect("`<` is not declared for Wrap")
+        .error
+        .message;
+    assert!(message.contains("comparison needs numbers"), "{message}");
+    assert!(
+        !message.contains("branded value") && !message.contains("unit <suffix>"),
+        "a plain ADT must get no unit advice: {message}"
+    );
+}
+
 /// A brand with NO declared `==` keeps STRUCTURAL equality: a plain-data
 /// variant compares as it always did, and nothing about `unit` changed that.
 #[test]

--- a/functor-prelude/prelude/angle.funi
+++ b/functor-prelude/prelude/angle.funi
@@ -5,7 +5,7 @@
 //! `Angle.radians`.
 
 /// An opaque angle value.
-type t
+type t = host
 
 /// Construct an angle from degrees.
 let degrees : (float) => t
@@ -20,6 +20,22 @@ let sub : (t, t) => t
 /// It takes the angle FIRST — the shape every declared `*` has — so unlike
 /// most of the prelude it is not written to be piped into.
 let scale : (t, float) => t
+
+/// Are two angles the same? This is what `90deg == 90deg` calls.
+///
+/// It is float equality on the underlying radians, with every consequence
+/// that implies: `90deg == 90deg` is true because both sides build the same
+/// number, but `90deg == 1.5708rad` is false, and an angle accumulated
+/// through arithmetic may miss an exact literal by a rounding step. An angle
+/// is one-way (there is no way back to a number), so where a tolerance
+/// matters, keep the plain float you built it from and compare THAT.
+let equals : (t, t) => bool
+/// Is the first angle smaller than the second? This is what `45deg < 90deg`
+/// calls, and — swapped or negated — `>`, `<=`, and `>=` too.
+///
+/// Angles are ordered by their raw radians, so this is signed magnitude, NOT
+/// a direction on the circle: `-270deg < 90deg` is true.
+let less : (t, t) => bool
 
 /// Degrees as a literal suffix: `90deg` is exactly `Angle.degrees(90.0)`.
 unit deg = Angle.degrees
@@ -36,3 +52,11 @@ unit deg (-) = Angle.sub
 /// `2.0 * 45deg` are both `Angle.scale(45deg, 2.0)`. (Multiplying two angles
 /// would be a different kind of thing — Functor Lang does not model that.)
 unit deg (*) = Angle.scale
+/// `==` on angles: `90deg == 90deg` is `Angle.equals(90deg, 90deg)`, and
+/// `!=` is its negation. Underneath it is FLOAT equality on radians — see
+/// `Angle.equals`.
+unit deg (==) = Angle.equals
+/// `<` on angles: `45deg < 90deg` is `Angle.less(45deg, 90deg)`. `>`, `<=`,
+/// and `>=` derive from it (swapped and/or negated), so all four orderings
+/// come from this one declaration.
+unit deg (<) = Angle.less

--- a/functor-prelude/prelude/anim.funi
+++ b/functor-prelude/prelude/anim.funi
@@ -4,7 +4,7 @@
 //! owns no hidden animation clock and poses rewind and replay deterministically.
 
 /// An opaque animation pose expression.
-type t
+type t = host
 
 /// Sample a named glTF clip at a playhead in seconds.
 ///

--- a/functor-prelude/prelude/asset.funi
+++ b/functor-prelude/prelude/asset.funi
@@ -15,11 +15,11 @@
 //! stay plain strings.)
 
 /// A model asset locator.
-type Model
+type Model = host
 /// A texture asset locator.
-type Texture
+type Texture = host
 /// A sound asset locator.
-type Sound
+type Sound = host
 
 /// Construct a model locator from a relative path or URL.
 let model : (string) => Model

--- a/functor-prelude/prelude/attr.funi
+++ b/functor-prelude/prelude/attr.funi
@@ -3,7 +3,7 @@
 //! Event attributes deliver messages through the game's `update` function.
 
 /// An opaque HTML attribute.
-type t
+type t = host
 
 /// Set the element's CSS class string.
 let class : (string) => t

--- a/functor-prelude/prelude/audio_scene.funi
+++ b/functor-prelude/prelude/audio_scene.funi
@@ -1,7 +1,7 @@
 //! Declarative audio scenes returned by the optional `soundScape` hook.
 
 /// An opaque audio scene.
-type t
+type t = host
 
 /// Create an audio scene from continuous sources.
 let create : (List<AudioSource.t>) => t

--- a/functor-prelude/prelude/audio_source.funi
+++ b/functor-prelude/prelude/audio_source.funi
@@ -4,7 +4,7 @@
 //! live voice instead of restarting it every frame.
 
 /// An opaque continuous audio source.
-type t
+type t = host
 
 /// Create a non-spatial source identified by a stable key.
 let ambient : (string, Asset.Sound) => t

--- a/functor-prelude/prelude/camera2d.funi
+++ b/functor-prelude/prelude/camera2d.funi
@@ -1,7 +1,7 @@
 //! Center-origin, Y-up cameras for `Sprite` scenes.
 
 /// An opaque 2D camera description.
-type t
+type t = host
 
 /// Create a camera with the visible world width and height at zoom 1.
 ///

--- a/functor-prelude/prelude/camera3d.funi
+++ b/functor-prelude/prelude/camera3d.funi
@@ -1,7 +1,7 @@
 //! Cameras for viewing a Y-up, right-handed 3D scene.
 
 /// An opaque camera description.
-type t
+type t = host
 
 /// Create a camera from an eye position and target with a fixed 45° field of view.
 let lookAt : (Vec3.t, Vec3.t) => t

--- a/functor-prelude/prelude/color.funi
+++ b/functor-prelude/prelude/color.funi
@@ -3,7 +3,7 @@
 /// An opaque RGB color.
 ///
 /// Channels are normally in `0..1`; emissive and HDR uses may exceed `1`.
-type t
+type t = host
 
 /// Construct a color from red, green, and blue channels.
 let rgb : (float, float, float) => t

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -4,7 +4,7 @@
 //! Effects remain outside the game's pure functional core.
 
 /// An opaque effect command.
-type t
+type t = host
 
 /// Produce no command.
 let none : () => t

--- a/functor-prelude/prelude/fog.funi
+++ b/functor-prelude/prelude/fog.funi
@@ -5,7 +5,7 @@
 //! otherwise. A skybox is never fogged.
 
 /// An opaque fog description.
-type t
+type t = host
 
 /// Create linear fog between near and far distances.
 ///

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -1,7 +1,7 @@
 //! Complete frame descriptions returned by a game's `draw` function.
 
 /// An opaque frame description.
-type t
+type t = host
 
 /// Create an unlit frame from a camera and scene.
 let create : (Camera3D.t, Scene.t) => t

--- a/functor-prelude/prelude/html.funi
+++ b/functor-prelude/prelude/html.funi
@@ -4,7 +4,7 @@
 //! above the canvas.
 
 /// An opaque HTML node.
-type node
+type node = host
 
 /// Create an escaped text node.
 let text : (string) => node

--- a/functor-prelude/prelude/light.funi
+++ b/functor-prelude/prelude/light.funi
@@ -1,7 +1,7 @@
 //! Lights used by `Frame.createLit`.
 
 /// An opaque light description.
-type t
+type t = host
 
 /// Create uniform ambient light.
 let ambient : (Color.t) => t

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -30,11 +30,11 @@
 //! above 60fps) it waits for the next simulated frame.
 
 /// An opaque collision shape.
-type shape
+type shape = host
 /// An opaque rigid body description.
-type body
+type body = host
 /// An opaque physics world description.
-type world
+type world = host
 /// A stable, branded body identity used throughout the physics API.
 type tag
 

--- a/functor-prelude/prelude/render_target.funi
+++ b/functor-prelude/prelude/render_target.funi
@@ -7,7 +7,7 @@
 //! rendered into shows the PREVIOUS frame's image.
 
 /// An opaque render target identity and size.
-type t
+type t = host
 
 /// Create a stable, named 512×512 render target.
 let named : (string) => t

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -12,7 +12,7 @@
 //! arguments, so a box is `Scene.cube() |> Scene.scaleXYZ(w, h, d)`.
 
 /// An opaque scene node.
-type t
+type t = host
 
 /// Create a unit cube centered at the origin.
 let cube : () => t

--- a/functor-prelude/prelude/skybox.funi
+++ b/functor-prelude/prelude/skybox.funi
@@ -1,7 +1,7 @@
 //! Cubemap skyboxes attached to frames with `Frame.withSkybox`.
 
 /// An opaque cubemap skybox.
-type t
+type t = host
 
 /// Load six cubemap faces in `+X, -X, +Y, -Y, +Z, -Z` order.
 ///

--- a/functor-prelude/prelude/style.funi
+++ b/functor-prelude/prelude/style.funi
@@ -4,7 +4,7 @@
 //! 3D APIs. Use `Html.style` for selectors, pseudo-classes, and keyframes.
 
 /// An opaque inline CSS declaration.
-type t
+type t = host
 
 /// Use horizontal flexbox layout.
 let flexRow : () => t

--- a/functor-prelude/prelude/sub.funi
+++ b/functor-prelude/prelude/sub.funi
@@ -3,7 +3,7 @@
 //! Events become game messages and are folded through `update` before `tick`.
 
 /// An opaque subscription description.
-type t
+type t = host
 
 /// Subscribe to no events.
 let none : () => t

--- a/functor-prelude/prelude/terrain.funi
+++ b/functor-prelude/prelude/terrain.funi
@@ -4,7 +4,7 @@
 //! minimum height and white maps to the maximum height.
 
 /// An immutable terrain descriptor.
-type t
+type t = host
 
 /// Create a terrain centered on the origin and spanning `width` by `depth` in XZ.
 let heightmap : (Asset.Texture, float, float, float, float) => t

--- a/functor-prelude/prelude/texture.funi
+++ b/functor-prelude/prelude/texture.funi
@@ -1,7 +1,7 @@
 //! Texture values accepted by scene material functions.
 
 /// An opaque texture value.
-type t
+type t = host
 
 /// Load an image texture from a path relative to the game directory.
 let file : (string) => t

--- a/functor-prelude/prelude/time.funi
+++ b/functor-prelude/prelude/time.funi
@@ -4,7 +4,7 @@
 //! being mixed accidentally.
 
 /// An opaque duration.
-type t
+type t = host
 
 /// Construct a duration from seconds.
 let seconds : (float) => t
@@ -26,6 +26,18 @@ let sub : (t, t) => t
 /// most of the prelude it is not written to be piped into.
 let scale : (t, float) => t
 
+/// Are two durations the same? This is what `1s == 1000ms` calls.
+///
+/// Durations are stored in seconds, so this is FLOAT equality on that number:
+/// `1s == 1000ms` is true, but a duration accumulated through arithmetic may
+/// miss an exact literal by a rounding step. A duration is one-way (there is
+/// no way back to a number), so where a tolerance matters, keep the plain
+/// float you built it from and compare THAT.
+let equals : (t, t) => bool
+/// Is the first duration shorter than the second? This is what
+/// `200ms < 1.5s` calls, and — swapped or negated — `>`, `<=`, and `>=` too.
+let less : (t, t) => bool
+
 /// Seconds as a literal suffix: `0.5s` is exactly `Time.seconds(0.5)`.
 unit s = Time.seconds
 /// Milliseconds as a literal suffix: `500ms` is exactly `Time.millis(500.0)`.
@@ -46,3 +58,11 @@ unit s (-) = Time.sub
 /// `*` scales a duration by a number, on either side: `0.5s * 2.0` and
 /// `2.0 * 0.5s` are both `Time.scale(0.5s, 2.0)`.
 unit s (*) = Time.scale
+/// `==` on durations: `1s == 1000ms` is `Time.equals(1s, 1000ms)`, and `!=`
+/// is its negation. Underneath it is FLOAT equality on seconds — see
+/// `Time.equals`.
+unit s (==) = Time.equals
+/// `<` on durations: `200ms < 1.5s` is `Time.less(200ms, 1.5s)`. `>`, `<=`,
+/// and `>=` derive from it (swapped and/or negated), so all four orderings
+/// come from this one declaration.
+unit s (<) = Time.less

--- a/functor-prelude/prelude/ui.funi
+++ b/functor-prelude/prelude/ui.funi
@@ -10,9 +10,9 @@
 //! program with interactive UI must define that hook.
 
 /// An opaque UI view.
-type view
+type view = host
 /// An opaque screen anchor.
-type anchor
+type anchor = host
 
 /// Create a text view.
 let text : (string) => view

--- a/functor-prelude/prelude/vec3.funi
+++ b/functor-prelude/prelude/vec3.funi
@@ -25,7 +25,7 @@
 //! rather than an infinity that becomes a NaN and silently blanks the scene.
 
 /// An opaque 3D vector.
-type t
+type t = host
 
 /// Construct a vector from X, Y, and Z components.
 let make : (float, float, float) => t

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -1497,7 +1497,33 @@ fn register_branded_constructors(reg: &mut crate::host_registry::Registry) {
             FunctorLangAngle(Angle::from_radians(a.0.radians() * factor as f32))
         },
     );
+    // Angle comparison — what `unit deg (==)` / `(<)` resolve to. An angle
+    // is an opaque host value with no structure, so this is the ONLY way one
+    // can be compared; underneath it is float equality/ordering on radians
+    // (documented as such in `angle.funi`).
+    reg.fn2(
+        "Angle.equals",
+        "Angle.equals(a, b)",
+        |a: FunctorLangAngle, b: FunctorLangAngle| Value::Bool(a.0.radians() == b.0.radians()),
+    );
+    reg.fn2(
+        "Angle.less",
+        "Angle.less(a, b)",
+        |a: FunctorLangAngle, b: FunctorLangAngle| Value::Bool(a.0.radians() < b.0.radians()),
+    );
     reg.fn1("Time.seconds", "Time.seconds(n)", FunctorLangDuration);
+    // Duration comparison — `unit s (==)` / `(<)` in `time.funi`. Durations
+    // are stored in seconds, so every suffix compares against every other.
+    reg.fn2(
+        "Time.equals",
+        "Time.equals(a, b)",
+        |a: FunctorLangDuration, b: FunctorLangDuration| Value::Bool(a.0 == b.0),
+    );
+    reg.fn2(
+        "Time.less",
+        "Time.less(a, b)",
+        |a: FunctorLangDuration, b: FunctorLangDuration| Value::Bool(a.0 < b.0),
+    );
     // Duration arithmetic — `unit s (+)` / `(-)` / `(*)` in `time.funi`.
     // Durations are stored in seconds, so every suffix shares these.
     reg.fn2(
@@ -5634,6 +5660,23 @@ in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list to
         }
     }
 
+    /// [`eval_with_prelude`] with the CHECKER skipped — the gradual seam
+    /// (`functor-lang run`, a value arriving through an `unknown`), where the
+    /// interpreter's own refusals are the only ones there are.
+    fn eval_with_prelude_unchecked(src: &str) -> Result<Value, String> {
+        let project = functor_lang::project::load_sources_with_bundled_modules(
+            vec![(std::path::PathBuf::from("game.fun"), src.to_string())],
+            &functor_prelude::bundled_modules(),
+        )
+        .map_err(|e| e.message)?;
+        let record = functor_lang::run_with_host(&project.module, Tracing::Off, &mut FunctorHost)
+            .map_err(|f| f.error.message)?;
+        match record.outcome {
+            functor_lang::RunOutcome::Main(value) => Ok(value),
+            _ => Err("expected a main result".to_string()),
+        }
+    }
+
     fn radians(value: &Value) -> f32 {
         angle_of(value, "an Angle", Span::new(0, 0))
             .expect("an Angle")
@@ -5705,6 +5748,64 @@ in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list to
         )
         .expect("runs");
         assert!((radians(&value) - std::f32::consts::FRAC_PI_2 * 1.5).abs() < 1e-6);
+    }
+
+    /// Branded comparison end to end: `90deg == 90deg` is TRUE where it used
+    /// to be a runtime "host values cannot be compared" error, and the four
+    /// derived orderings come from the one declared `<`.
+    #[test]
+    fn angles_and_durations_compare_and_order() {
+        for (src, want) in [
+            ("let main = () => 90deg == 90deg\n", true),
+            ("let main = () => 90deg == 45deg\n", false),
+            ("let main = () => 90deg != 45deg\n", true),
+            ("let main = () => 45deg < 90deg\n", true),
+            ("let main = () => 90deg > 45deg\n", true),
+            ("let main = () => 45deg <= 45deg\n", true),
+            ("let main = () => 45deg >= 90deg\n", false),
+            // One brand, every suffix: seconds against milliseconds.
+            ("let main = () => 1s == 1000ms\n", true),
+            ("let main = () => 1.5s < 2000ms\n", true),
+            ("let main = () => 2min > 90s\n", true),
+            // Arithmetic feeds comparison — both resolve on the same brand.
+            ("let main = () => (90deg + 45deg) > 90deg\n", true),
+        ] {
+            assert_eq!(
+                eval_with_prelude(src).expect(src).to_string(),
+                want.to_string(),
+                "{src}"
+            );
+        }
+    }
+
+    /// The other half of the same story: an engine value that declares NO
+    /// `==` still refuses comparison at run time — the gradual-seam backstop
+    /// behind the check-time error.
+    #[test]
+    fn an_engine_value_still_refuses_equality_at_run_time() {
+        let error = eval_with_prelude_unchecked("let main = () => Scene.cube() == Scene.cube()\n")
+            .err()
+            .expect("a scene cannot be compared");
+        assert!(error.contains("host values cannot be compared"), "{error}");
+    }
+
+    /// A `Physics.tag` is a brand over a STRING, so it compares structurally
+    /// with no declaration at all — what `examples/physics` reads collision
+    /// events with.
+    #[test]
+    fn a_physics_tag_compares_as_its_string() {
+        assert_eq!(
+            eval_with_prelude("let main = () => Physics.tag(\"ball\") == Physics.tag(\"ball\")\n")
+                .expect("runs")
+                .to_string(),
+            "true"
+        );
+        assert_eq!(
+            eval_with_prelude("let main = () => Physics.tag(\"ball\") == Physics.tag(\"wall\")\n")
+                .expect("runs")
+                .to_string(),
+            "false"
+        );
     }
 
     /// The branded result flows on into the APIs that take it — the whole

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5643,32 +5643,27 @@ in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list to
     /// interfaces linked, so unit suffixes and their operators resolve —
     /// `eval` above lowers one bare source, where no `unit` is declared.
     fn eval_with_prelude(src: &str) -> Result<Value, String> {
-        let project = functor_lang::project::load_sources_with_bundled_modules(
-            vec![(std::path::PathBuf::from("game.fun"), src.to_string())],
-            &functor_prelude::bundled_modules(),
-        )
-        .map_err(|e| e.message)?;
-        let diags = functor_lang::check(&project.module);
-        if let Some(first) = diags.first() {
-            return Err(first.message.clone());
-        }
-        let record = functor_lang::run_with_host(&project.module, Tracing::Off, &mut FunctorHost)
-            .map_err(|f| f.error.message)?;
-        match record.outcome {
-            functor_lang::RunOutcome::Main(value) => Ok(value),
-            _ => Err("expected a main result".to_string()),
-        }
+        eval_with_prelude_impl(src, true)
     }
 
     /// [`eval_with_prelude`] with the CHECKER skipped — the gradual seam
     /// (`functor-lang run`, a value arriving through an `unknown`), where the
     /// interpreter's own refusals are the only ones there are.
     fn eval_with_prelude_unchecked(src: &str) -> Result<Value, String> {
+        eval_with_prelude_impl(src, false)
+    }
+
+    fn eval_with_prelude_impl(src: &str, typecheck: bool) -> Result<Value, String> {
         let project = functor_lang::project::load_sources_with_bundled_modules(
             vec![(std::path::PathBuf::from("game.fun"), src.to_string())],
             &functor_prelude::bundled_modules(),
         )
         .map_err(|e| e.message)?;
+        if typecheck {
+            if let Some(first) = functor_lang::check(&project.module).first() {
+                return Err(first.message.clone());
+            }
+        }
         let record = functor_lang::run_with_host(&project.module, Tracing::Off, &mut FunctorHost)
             .map_err(|f| f.error.message)?;
         match record.outcome {

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -389,6 +389,57 @@ fn equality_on_an_engine_value_is_a_check_error() {
     }
 }
 
+/// The rule walks what the sibling "functions cannot be compared" rule walks
+/// — nested tuples, lists, maps, and a nominal's type arguments — so a host
+/// value one level in is caught too. [xreview: Codex Medium, Claude Medium]
+#[test]
+fn equality_on_a_nested_engine_value_is_a_check_error_too() {
+    for (src, ty) in [
+        ("let bad: bool = (Scene.cube(), 1.0) == (Scene.cube(), 1.0)\n", "Scene.t"),
+        (
+            "let bad: bool = ((Scene.cube(), 1.0), true) == ((Scene.cube(), 1.0), true)\n",
+            "Scene.t",
+        ),
+        ("let bad: bool = [Scene.cube()] == [Scene.cube()]\n", "Scene.t"),
+        // A brand that DECLARES `==` is comparable as an operand, but not
+        // nested: the structural walk never consults the brand table, so
+        // this really is a certain runtime error. [xreview: Claude High]
+        ("let bad: bool = (90deg, 1.0) == (90deg, 1.0)\n", "Angle.t"),
+        ("let bad: bool = [1.5s] == [1.5s]\n", "Time.t"),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags
+                .iter()
+                .any(|m| m.contains("engine values are opaque") && m.contains(ty)),
+            "{src}: {diags:?}"
+        );
+    }
+    // …while the same brands still compare fine as OPERANDS.
+    assert!(
+        check("let a: bool = 90deg == 90deg\nlet b: bool = 1.5s == 1.5s\n").is_empty(),
+        "a branded operand must stay comparable"
+    );
+}
+
+/// The KNOWN limit, pinned deliberately rather than left as a surprise:
+/// equality is polymorphic, so a generic helper's `a == b` carries no
+/// constraint to its call sites. `same(Scene.cube(), Scene.cube())` therefore
+/// still checks clean and meets the RUNTIME error — the gradual-seam backstop.
+/// Closing this needs constraint-based typeclasses, which is a much larger
+/// design than this change. [xreview: Codex High — accepted limitation]
+#[test]
+fn polymorphic_equality_is_not_constrained_by_the_opacity_rule() {
+    let diags = check(
+        "let same = (a, b) => a == b\n\
+         let engines: bool = same(Scene.cube(), Scene.cube())\n",
+    );
+    assert!(
+        diags.is_empty(),
+        "an indirect comparison is NOT caught statically (yet): {diags:?}"
+    );
+}
+
 /// …but the brands that DECLARE `==` are exempt, which is the whole point of
 /// declaring it — and `Physics.tag`, a brand over a STRING, was never opaque
 /// and keeps comparing structurally. Games read collision events that way

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -341,6 +341,71 @@ fn prelude_brands_carry_their_declared_arithmetic() {
     assert!(diags.is_empty(), "{diags:?}");
 }
 
+/// Branded COMPARISON under the real prelude: `angle.funi` / `time.funi`
+/// declare `==` and `<`, and the four derived spellings follow — across
+/// suffixes, since an operator belongs to the brand.
+#[test]
+fn prelude_brands_compare_and_order() {
+    let diags = check(
+        "let a: bool = 90deg == 90deg\n\
+         let b: bool = 90deg != 45deg\n\
+         let c: bool = 45deg < 1.5rad\n\
+         let d: bool = 90deg > 45deg\n\
+         let e: bool = 45deg <= 45deg\n\
+         let f: bool = 90deg >= 45deg\n\
+         let g: bool = 1.5s < 2000ms\n\
+         let h: bool = 1s == 1000ms\n\
+         let i: bool = 2min > 90s\n\
+         let j: bool = (90deg + 45deg) > 90deg\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+    // Brands still do not mix: an angle is not a duration.
+    let diags = check("let bad: bool = 90deg < 1.5s\n");
+    assert!(!diags.is_empty(), "an angle below a duration must not check");
+}
+
+/// Half 2: an ENGINE value has no structural equality — the runtime refuses
+/// it — so `==` on one is a CHECK-time error naming the type.
+#[test]
+fn equality_on_an_engine_value_is_a_check_error() {
+    for (src, ty) in [
+        ("let bad: bool = Scene.cube() == Scene.cube()\n", "Scene.t"),
+        (
+            "let bad: bool = Color.rgb(1.0, 0.0, 0.0) == Color.rgb(1.0, 0.0, 0.0)\n",
+            "Color.t",
+        ),
+        (
+            "let bad: bool = Vec3.make(0.0, 0.0, 0.0) != Vec3.make(1.0, 0.0, 0.0)\n",
+            "Vec3.t",
+        ),
+    ] {
+        let diags = check(src);
+        assert!(
+            diags
+                .iter()
+                .any(|m| m.contains("engine values are opaque") && m.contains(ty)),
+            "{src}: {diags:?}"
+        );
+    }
+}
+
+/// …but the brands that DECLARE `==` are exempt, which is the whole point of
+/// declaring it — and `Physics.tag`, a brand over a STRING, was never opaque
+/// and keeps comparing structurally. Games read collision events that way
+/// (`examples/physics`, `examples/physics-controller`), so this is the
+/// regression that must never fire.
+#[test]
+fn brands_and_tags_still_compare() {
+    let diags = check(
+        "let angles: bool = 90deg == 90deg\n\
+         let times: bool = 1s != 500ms\n\
+         let ball = Physics.tag(\"ball\")\n\
+         let hit: bool = ball == Physics.tag(\"ball\")\n\
+         let miss: bool = ball != Physics.tag(\"wall\")\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
 /// …and what they do NOT declare still teaches, now naming what exists.
 #[test]
 fn an_undeclared_prelude_operator_names_the_declared_ones() {

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -821,7 +821,9 @@ functor docs --format json         # the machine-readable shape</pre>
             <code>Physics.tag("ball")</code>, <code>RenderTarget.named("feed")</code> — so a
             mixed-up unit is a check-time error instead of a puzzling frame. Angles and
             durations also read as unit-suffixed literals (<code>90deg</code>,
-            <code>0.5s</code>), which build exactly the same branded values.
+            <code>0.5s</code>), which build exactly the same branded values — and they do
+            arithmetic and comparison without leaving the brand
+            (<code>90deg + 45deg</code>, <code>1.5s &lt; 2000ms</code>).
           </p>
         </section>
 
@@ -858,9 +860,11 @@ functor docs --format json         # the machine-readable shape</pre>
               <strong>Engine values are opaque.</strong> <code>&lt;Scene></code>,
               <code>&lt;Frame></code>, <code>&lt;Camera3D></code> and friends can be passed around
               and composed, but not taken apart, and <code>==</code> on one is a
-              <em>runtime</em> error (the checker does not catch it) — compare the numbers you
-              derived instead.
-              (<code>Sprite.t</code> is the deliberate exception: it is plain data underneath.)
+              <em>check-time</em> error — compare the numbers you derived instead.
+              Branded values do compare: <code>90deg == 90deg</code>,
+              <code>1.5s &lt; 2000ms</code>, and physics tags, all fine.
+              (<code>Sprite.t</code> is the other deliberate exception: it is plain data
+              underneath.)
             </li>
           </ul>
           <p class="docs-footnote">

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 294));
+        assert_eq!(count(ApiGroup::Engine), (27, 302));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
> **Stacked on #628** (`feat/unit-operators`), which is itself stacked on #621 (`ctor-full-arity`). Base is `feat/unit-operators` — review only this slice.

Two halves of one story about what `==` and `<` mean on a branded value.

## Half 1 — brands become comparable and ordered

`unit <suffix> (==) = impl` and `unit <suffix> (<) = impl` extend #628's ad-hoc overloading to comparison. Implementations are typed `('t, 't) => bool` and attach to the **brand**, exactly like #628's arithmetic — same post-inference resolution, same deferral, same teaching error on unsolved variables, same runtime-tag dispatch table for the gradual seam.

**Only two operators are declarable. The other four are derived:**

| Written | Evaluates as |
| --- | --- |
| `a == b` | `equals(a, b)` |
| `a != b` | `not equals(a, b)` |
| `a < b` | `less(a, b)` |
| `a > b` | `less(b, a)` |
| `a <= b` | `not less(b, a)` |
| `a >= b` | `not less(a, b)` |

I investigated first, as asked: the language's comparison operators do **not** share a desugaring today — the parser makes six distinct `BinOp`s and the interpreter gives each its own IEEE float closure. So I declared the minimal set (`==`, `<`) and derived the rest. Justification: (1) a brand's ordering cannot contradict itself, since `<` *is* the order and the rest are theorems about it; (2) two implementations per brand instead of six; (3) it matches what a unit brand is — one scalar, totally ordered. `unit px (>)` / `(<=)` / `(>=)` / `(!=)` are parse errors naming the base to declare instead.

**One honest cost, stated in the docs and the skill:** for floats, `a <= b` is not `not (b < a)` when either side is NaN. A brand built from a NaN therefore compares as an ordinary value under `<=`/`>=`. Float comparison itself is untouched.

Prelude: `Angle.equals` / `Angle.less` / `Time.equals` / `Time.less` in the typed registry, drift test green, `///` documented. So `90deg == 90deg`, `45deg < 90deg`, `1.5s < 2000ms`, `2min > 90s` all work. The `.funi` prose says plainly that **`==` on an angle or duration is float equality underneath**, and that there is no way back out of the brand to compare with a tolerance.

## Half 2 — engine values refuse `==` at check time

```
`==` on `Scene.t`: engine values are opaque — compare the numbers you derived
from them instead (`Scene.t` supports no `==`)
```

`.funi` files mark an abstract type with `type t = host` — a contextual keyword in the existing `type <name> = <body>` position, the least invasive marker available: docgen quotes a declaration verbatim from its span, so it renders `type t = host` with **no docgen change at all** and `--deny-undocumented` is unaffected. It is a parse error in a `.fun` (only the host can be responsible for what it claims).

### Host-opaque inventory — 30 types marked

| Module | Types |
| --- | --- |
| `Angle` | `t` \* |
| `Anim` | `t` |
| `Asset` | `Model`, `Texture`, `Sound` |
| `Attr` | `t` |
| `AudioScene` | `t` |
| `AudioSource` | `t` |
| `Camera2D` | `t` |
| `Camera3D` | `t` |
| `Color` | `t` |
| `Effect` | `t` |
| `Fog` | `t` |
| `Frame` | `t` |
| `Html` | `node` |
| `Light` | `t` |
| `Physics` | `shape`, `body`, `world` |
| `RenderTarget` | `t` |
| `Scene` | `t` |
| `Skybox` | `t` |
| `Style` | `t` |
| `Sub` | `t` |
| `Terrain` | `t` |
| `Texture` | `t` |
| `Time` | `t` \* |
| `Ui` | `view`, `anchor` |
| `Vec3` | `t` |

\* marked, but **exempt** from the error because they declare `==` — which is precisely what makes them comparable.

**Deliberately NOT marked** — the three abstract prelude types that are ordinary Functor Lang data behind an opaque name: **`Physics.tag`** (a string underneath), **`Sprite.t`** and **`Sprite.region`** (documented as comparable in `sprite.funi`).

That is the one **polarity deviation** worth flagging. The brief suggested marking host-opacity, and I did — rather than marking the brand-over-primitive side — because a plain `type t` must stay comparable: marking the opaque set keeps the tag comparisons games rely on working *by construction*:

```functor
match e.a == ballTag with | true => e.b | …     // examples/physics/game.fun:118
onDeck: probe.hit && probe.tag == deckTag        // examples/physics-controller/game.fun:183
```

Both are now pinned by `expect` tests in those example files, plus prelude-level checker and interpreter tests. A new host type added without the marker keeps today's runtime error — no worse than the status quo, and the runtime error stays as the gradual-seam backstop throughout.

**Out of scope, as instructed:** `Scene`/`Frame` STRUCTURAL equality. This rejection is exactly what that follow-up would carve an exception into.

## ⚠️ BREAKING (the same toll #628 paid, extended to `<`)

Because the prelude declares `<` on `Angle.t` and `Time.t`, a fully unannotated comparison helper is now ambiguous and asks for an annotation:

```
`<` here could be float comparison or `Angle.t` comparison or `Time.t` comparison
— annotate an operand (e.g. `(a: Angle.t)`) so the operator can be resolved
```

Three examples needed exactly one word each — `let clamp = (v: float, lo, hi) => …` in `hello`, `lighting`, `terrain`. **All 36 example projects typecheck**; I swept every one.

This PR also **narrows** #628's deferral, which strictly *reduces* how often that error can fire. A node only defers while a branded reading is still possible, and which side could still be a brand depends on the operator: `*` either side, `/` left only, everything else (`+`, `-`, the orderings) needs BOTH operands unsolved. That is what keeps `Math.abs(d) < step` deciding `step` on the spot — and with it the `rate * dt` behind it, which is why `examples/physics-controller` needs no annotation.

## Known limitation (accepted, pinned by a test)

Equality is polymorphic, so the opacity rule is **direct-only**: `let same = (a, b) => a == b` carries no constraint to its call sites, so `same(myScene, other)` still checks clean and meets the runtime error. Closing that needs constraint-based typeclasses — a much larger design. `prelude_typecheck.rs::polymorphic_equality_is_not_constrained_by_the_opacity_rule` pins it so it is visible, not a surprise.

## Verification

- `cargo test -p functor-lang -p functor-docgen -p functor_runtime_common` — green.
- `npm run generate:docs` + `npm run check:docs` — green. Docgen inventory 294 → **302** (Angle/Time × `equals`, `less`, `unit (==)`, `unit (<)`); the `.funi` ≡ registry drift test is green.
- **Empirical probes**, in a scratch dir outside `examples/`: `90deg == 90deg` → true, `1.5s < 2000ms` → true, plus all six spellings across both brands and both tag comparisons (12 expects, all passing). `myScene == myScene` → **check-time error on this branch**, runtime error on the base ref.
- `npm run build:cli:debug`, then `functor build native` over **all 36 examples** — the only failures are pre-existing missing-asset errors (gitignored `.glb`/`.jpg`). `functor test` on `counter` (3), `physics` (4), `physics-controller` (38) — all passing.
- **`frame_bench`** (release, interleaved with the base ref, three pairs). `allocs/frame` and `bytes/frame` are **byte-identical** at every size; wall-clock is at parity (best-of-3 mins):

| cells | base us/frame (min) | branch us/frame (min) | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 400 (20×20) | 435.7 | 436.7 | 13877 → 13877 | 843393 → 843393 |
| 1600 (40×40) | 1708.2 | 1701.9 | 54717 → 54717 | 3307233 → 3307233 |
| 3136 (56×56) | 3350.6 | 3317.5 | 106973 → 106973 | 6460257 → 6460257 |

Comparison dispatch only fires on branded operands: `brand_compare` is gated cheapest-first (no declared operators → return; no brand tag on either operand → return, before an operator slot is even computed), so float compares and every plain-data `==` are untouched.

## Docs

- `docs/functor-lang-units.md` — Phase 3 as shipped: the derivation table and why deriving beats declaring, the NaN divergence, resolution, runtime, the opacity rule, the inventory rationale, and the three limits.
- The **`functor-lang` skill** — declarable set, derivation, comparison ambiguity, the check-time opacity rule and its two limits. Its old "engine values are `HostData`, so `==` on them is a runtime error" line is corrected.
- `angle.funi` / `time.funi` prose now guarantees comparison behavior, including the float-equality caveat.
- The manual's sharp-edges **"Engine values are opaque"** bullet.

### Manual: before / after

The bullet went from "`==` on one is a *runtime* error (the checker does not catch it)" to "*check-time* error", and gained the sentence about branded values comparing. The paragraph above the section also gained the arithmetic/comparison note.

| | Before | After |
| --- | --- | --- |
| **Desktop** (1440×900) | <img src="https://gist.githubusercontent.com/tommy-xr/920b2225351f3977782ef7d2fcc55c75/raw/before-desktop.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/920b2225351f3977782ef7d2fcc55c75/raw/after-desktop.png" width="420"> |
| **Mobile** (390×844) | <img src="https://gist.githubusercontent.com/tommy-xr/920b2225351f3977782ef7d2fcc55c75/raw/before-mobile.png" width="240"> | <img src="https://gist.githubusercontent.com/tommy-xr/920b2225351f3977782ef7d2fcc55c75/raw/after-mobile.png" width="240"> |

*Capture note (per CLAUDE.md's static-render fallback allowance): the AFTER shots come from the real `npm run site:build` output. The BEFORE shots are the base ref's `site/` served statically — `site:build` at that ref needs a wasm-pack build of the web runtime that wasn't worth doing for a static-markup page. The manual's only build-time transformation is a cosmetic version-badge stamp that does not touch this section, so the pair is visually equivalent.*

## Review dispositions (`/xreview`: Claude subagent + Codex + a dedicated dedup pass)

| Severity | Finding | Disposition |
| --- | --- | --- |
| **High (Claude)** | `opaque_engine_type` applied the "declares `==`" exemption at every depth, but `value_eq` never consults the brand table when it recurses — so `(90deg, 1.0) == (90deg, 1.0)` checked clean and died at run time | **Fixed.** The exemption is top-level only: a brand is comparable as an *operand*, opaque when nested. Regression test covers tuples and lists for `Angle.t` and `Time.t`. |
| **High (Codex)** | Polymorphic `==` bypasses the opacity check | **Accepted limitation** — needs constraint-based typeclasses. Pinned by a test and documented (above). |
| **High (Claude)** | The comparison ambiguity is a breaking change whose only in-repo gate is manual (CI builds just `examples/primitives`) | **Accepted, called out** as BREAKING above; blast radius measured by sweeping all 36 examples (3 needed one word each). The CI-coverage gap is pre-existing and left as a follow-up rather than scope creep here. |
| **Medium (Codex + Claude)** | Host opacity inspected only one tuple level deep; `Type::List` not walked at all | **Fixed.** The walk now mirrors `contains_fn` exactly — nested tuples, lists, maps, nominal type arguments. Records still deliberately not walked (neither rule walks them). |
| **Medium (Claude)** | The failure hint called plain ADT variants "a branded value" (`brand_tag` answers for *any* variant), so `Some(1.0) < Some(2.0)` advised declaring an operator on `Option` | **Fixed** — the hint consults the operator table first. Test added. |
| **Medium (Claude) / Low (Codex)** | `brand_compare` on the hot path with no `frame_bench` numbers in the diff | **Measured** (table above) and the gate re-ordered cheapest-first. The docs claim now covers timing, not just allocation. |
| **Low (Claude) ×4** | `BinOp::ARITHMETIC` dead with a stale doc; `op_slot`'s `_ => 5` silently coupled to `DECLARABLE`'s order; `is_comparison` defined negatively; two identical arms in `binary` | **All fixed.** `op_slot` now derives its index from `DECLARABLE`. |
| **Dedup `extract` [S1, S4]** | `OpImpl` → callable resolution duplicated verbatim between `brand_arith` and `brand_compare`, down to a character-identical error string | **Fixed** — shared `resolve_op_impl`. |
| **Dedup `extract` [S2, S4]** | `eval_with_prelude_unchecked` a verbatim copy of `eval_with_prelude` | **Fixed** — one `eval_with_prelude_impl(src, typecheck)`. |
| **Dedup `merge` [S4]** | `opaque_engine_type` re-implements `contains_fn`'s sibling role with a different recursion policy | **Aligned** — same traversal, and the doc comment explains why they remain two functions (one answers a bool, the other the name the diagnostic teaches with). |
| **Dedup `diverged`, low confidence [S4]** | `TypeBody::Host` behaves identically to `TypeBody::Abstract` except one insert | **Kept as-is.** A distinct variant is what makes `goto`/`lower`/docgen handle it explicitly and lets it grow its own typing rules; `Abstract { host: bool }` would hide the distinction at the four sites that must reason about it. |

Dedup coverage, verbatim: *all four strategies ran, none unavailable. S1-names 152 lines / 30 queries over 7204 candidates, min-score 0.3; S2-clones 253 jscpd pairs whole-repo, of which the changed-file intersection was 2 pairs (both the prelude test helper — no clone pair touched the added eval.rs/types.rs/parser.rs regions); S3-index 3573 lines grepped for `host`/`opaque`/`equals`/`compare`/`TypeBody::Abstract`/`pending`; S4 read the full diff (44 files, +1128/-138) plus the real source at `brand_arith`, `brand_compare`, `value_eq`, `contains_fn`, `flush_pending_ops`, and the four `TypeBody` handling sites.*

Both reviewers independently verified: the swap/negate table in `brand_compare` matches what `brand_binary` resolves; `op_slot`/`slot_op` are a correct inverse over all 10 `BinOp`s; structural equality is preserved for brands that don't declare `==` (including `Physics.tag` and plain single-constructor variants); and every `= host`-marked type really is `HostData` at run time — so Half 2 converts only already-broken programs into check errors, and no working program regresses.
