### PR TITLE
feat(engine): Scene.equals and Frame.equals — structural equality for draw-output tests

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -750,6 +750,16 @@ let ordered = 4px < 16px            // …and >, <=, >=, ==, != (all derived)
   host value buried in a model still fails at run time), and it is
   DIRECT-only — equality is polymorphic, so `let same = (a, b) => a == b`
   called with two scenes checks clean and fails at run time.
+- **`Scene.equals` / `Frame.equals` are the escape hatch** — an explicit
+  structural walk over the pure-data `draw` output, which is why the
+  refusal above ends `` — `Scene.equals(a, b)` compares structurally `` for
+  those two. Deliberately a FUNCTION, not `==`: the walk is O(scene size),
+  so it belongs in inline `expect` tests over `draw`, not in per-frame
+  logic. Floats compare exactly (no epsilon), assets compare by LOCATOR
+  rather than loaded content, animation compares as declared (clip name +
+  playhead), and children are ordered. The hint is derived, not
+  special-cased: any host-opaque type whose module declares
+  `equals : (t, t) => bool` gets it.
 - **Comparisons are IEEE**, so NaN (`0.0 / 0.0`) is false against
   everything — including itself — under `<`, `>`, `<=`, `>=`, and `==`;
   `nan != nan` is therefore `true`.
@@ -1025,7 +1035,10 @@ order the source reads). `Physics.rotateX/Y/Z` follows the same rule.
 
 **Opaque vs. plain data.** Most engine values (`<Scene>`, `<Camera3D>`,
 `<Camera2D>`, `<Frame>`, `<Anim>`, `<Effect>`) are opaque: pass them around, but
-they cannot be inspected, compared, or serialized. `Sprite.t` is the deliberate
+they cannot be inspected, compared, or serialized — except that `Scene.t` and
+`Frame.t` compare through the explicit `Scene.equals` / `Frame.equals` (an
+O(size) structural walk meant for `expect` tests over `draw`, not per-frame
+logic). `Sprite.t` is the deliberate
 exception — its abstract type hides a private plain-data picture tree, so sprite
 values DO support structural display/equality, snapshots, and hot reload
 (lowering to 3D happens at `Frame.create2D` / `Frame.with2D`).
@@ -1520,7 +1533,9 @@ Transforms wrap in Group nodes: the **outer call applies last in world
 space** — `s |> Scene.rotateY(r) |> Scene.translate(Vec3.make(x, 0.0, 0.0))` rotates in
 place, then moves (the order the source reads). Most engine values (`<Scene>`,
 `<Camera3D>`, `<Camera2D>`, `<Frame>`) are opaque: they can be passed around but
-not inspected, compared, or serialized. `Sprite.t` is the deliberate
+not inspected, compared, or serialized — `Scene.equals` / `Frame.equals` are the
+explicit exception, an O(size) structural walk for `expect` tests over `draw`.
+`Sprite.t` is the deliberate
 exception: its abstract type hides a private plain-data picture tree, so sprite
 values do support structural display/equality, snapshots, and hot reload.
 

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -379,8 +379,16 @@ error:
 
 ```
 `==` on `Scene.t`: engine values are opaque — compare the numbers you derived
-from them instead (`Scene.t` supports no `==`)
+from them instead (`Scene.t` supports no `==` — `Scene.equals(a, b)` compares
+structurally)
 ```
+
+That trailing clause appears only when the type's own module declares
+`equals : (t, t) => bool` — the EXPLICIT structural walk `Scene.t` and
+`Frame.t` offer for inline `expect` tests over `draw` output. It is derived
+from the interface, not special-cased, so any host-opaque type earns the hint
+by declaring that signature; a type without one (`Color.t`, `Effect.t`) keeps
+the plain message.
 
 An interface (`.funi`) file distinguishes the two kinds of abstract type with
 a marker on the `type` item:

--- a/docs/functor-lang-units.md
+++ b/docs/functor-lang-units.md
@@ -437,10 +437,11 @@ Three limits, all deliberate:
   that needs constraint-based typeclasses (an `Eq` bound propagated through
   generalization), which is a much larger design than this change; the
   limitation is pinned by a test rather than left as a surprise.
-- **Structural equality for `Scene.t` / `Frame.t` is out of scope.** Whether
-  scenes should compare at all — and as `==` or as `Scene.equals` — is a
-  separate decision. This check-time rejection is exactly the thing that
-  decision would carve an exception into.
+- **Structural equality for `Scene.t` / `Frame.t` is an explicit FUNCTION, not
+  an exception to this rule.** That decision has since been made: the two
+  pure-data engine values gained `Scene.equals` / `Frame.equals`, and `==` on
+  them stays a check-time error. Keeping it a call makes the O(size) walk
+  visible where it happens, and the rejection above teaches it.
 
 ### Still open
 

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -3575,14 +3575,37 @@ is {other}"
         let Some(name) = self.opaque_engine_type(ty) else {
             return;
         };
+        let structural = self.structural_equals_hint(&name);
         self.diag(
             span,
             format!(
                 "`{}` on `{name}`: engine values are opaque — compare the numbers you derived \
-from them instead (`{name}` supports no `==`)",
+from them instead (`{name}` supports no `==`{structural})",
                 op.symbol()
             ),
         );
+    }
+
+    /// The one escape hatch a host-opaque type may offer: its own module's
+    /// `equals : (t, t) => bool` (`Scene.equals`, `Frame.equals`), an
+    /// EXPLICIT structural walk. Nothing is special-cased — the hint appears
+    /// exactly when the interface declares that shape, so a module gains it
+    /// by adding the signature.
+    fn structural_equals_hint(&self, name: &str) -> String {
+        let Some((module, _)) = name.rsplit_once('.') else {
+            return String::new();
+        };
+        let path = format!("{module}.equals");
+        let Some(Type::Fn(params, result)) = self.signatures.get(&path).map(|s| &s.ty) else {
+            return String::new();
+        };
+        let is_self =
+            |ty: &Type| matches!(ty, Type::Variant(n, _) | Type::Record(n, _) if n == name);
+        if params.len() == 2 && params.iter().all(is_self) && **result == Type::Bool {
+            format!(" — `{path}(a, b)` compares structurally")
+        } else {
+            String::new()
+        }
     }
 
     /// The name of an opaque ENGINE type this operand would compare, if any.

--- a/functor-lang/src/types.rs
+++ b/functor-lang/src/types.rs
@@ -3575,7 +3575,7 @@ is {other}"
         let Some(name) = self.opaque_engine_type(ty) else {
             return;
         };
-        let structural = self.structural_equals_hint(&name);
+        let structural = self.structural_equals_hint(&name, ty);
         self.diag(
             span,
             format!(
@@ -3591,7 +3591,21 @@ from them instead (`{name}` supports no `==`{structural})",
     /// EXPLICIT structural walk. Nothing is special-cased — the hint appears
     /// exactly when the interface declares that shape, so a module gains it
     /// by adding the signature.
-    fn structural_equals_hint(&self, name: &str) -> String {
+    ///
+    /// `operand` is the type the refused `==` actually compares, and the
+    /// signature must accept **it**, not merely something with the same
+    /// name. That one rule covers both ways the advice could be wrong
+    /// [xreview: Claude Medium + Codex Medium, AGREED]:
+    ///
+    /// - NESTED — `opaque_engine_type` walks into lists/tuples/maps, so
+    ///   `[Scene.cube()] == […]` names `Scene.t` while the operand is
+    ///   `List<Scene.t>`. `Scene.equals` does not apply to a list.
+    /// - GENERIC — an `equals : (Handle<float>, Handle<float>) => bool`
+    ///   does not apply to a `Handle<string>` operand.
+    ///
+    /// In both cases the plain refusal stands on its own; only the
+    /// actionable clause is withheld.
+    fn structural_equals_hint(&self, name: &str, operand: &Type) -> String {
         let Some((module, _)) = name.rsplit_once('.') else {
             return String::new();
         };
@@ -3599,9 +3613,8 @@ from them instead (`{name}` supports no `==`{structural})",
         let Some(Type::Fn(params, result)) = self.signatures.get(&path).map(|s| &s.ty) else {
             return String::new();
         };
-        let is_self =
-            |ty: &Type| matches!(ty, Type::Variant(n, _) | Type::Record(n, _) if n == name);
-        if params.len() == 2 && params.iter().all(is_self) && **result == Type::Bool {
+        if params.len() == 2 && params.iter().all(|param| param == operand) && **result == Type::Bool
+        {
             format!(" — `{path}(a, b)` compares structurally")
         } else {
             String::new()

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -2223,6 +2223,60 @@ fn a_host_type_refuses_equality_at_check_time() {
     assert!(project.check().is_empty(), "{:?}", project.check());
 }
 
+/// A host-opaque type's module may offer an EXPLICIT structural comparison —
+/// `equals : (t, t) => bool` — and when it does, the refusal points at it.
+/// Nothing is special-cased: the hint is derived from the interface, so a
+/// module earns it by declaring that exact signature.
+#[test]
+fn a_host_type_with_an_equals_points_at_it() {
+    let with_equals = load(
+        "host-type-equals",
+        &[
+            (
+                "game.fun",
+                "let same = (): bool => Widget.make() == Widget.make()\n",
+            ),
+            (
+                "widget.funi",
+                "type Handle = host\n\
+                 let make : () => Handle\n\
+                 let equals : (Handle, Handle) => bool",
+            ),
+        ],
+    );
+    assert!(
+        with_equals.check().iter().any(|d| d
+            .message
+            .contains("`Widget.Handle` supports no `==` — `Widget.equals(a, b)` \
+compares structurally")),
+        "{:?}",
+        with_equals.check()
+    );
+    // A DIFFERENTLY-shaped `equals` is not that escape hatch, so it is not
+    // advertised — the refusal stays the plain one.
+    let wrong_shape = load(
+        "host-type-equals-wrong",
+        &[
+            (
+                "game.fun",
+                "let same = (): bool => Widget.make() == Widget.make()\n",
+            ),
+            (
+                "widget.funi",
+                "type Handle = host\n\
+                 let make : () => Handle\n\
+                 let equals : (Handle, float) => bool",
+            ),
+        ],
+    );
+    let diags = wrong_shape.check();
+    assert!(
+        diags.iter().any(|d| d.message.contains("supports no `==`"))
+            && !diags.iter().any(|d| d.message.contains("compares structurally")),
+        "{diags:?}"
+    );
+}
+
 /// A plain `type t` stays comparable. Not every abstract prelude type is a
 /// host handle — `Sprite.t` and `Physics.tag` are ordinary Functor Lang data
 /// behind an opaque name — so the marker is what distinguishes them, and its

--- a/functor-lang/tests/project.rs
+++ b/functor-lang/tests/project.rs
@@ -2277,6 +2277,55 @@ compares structurally")),
     );
 }
 
+/// The hint is only actionable where the signature actually accepts the
+/// operand, so it is withheld in the two places it would teach code that does
+/// not check: a NESTED occurrence (the operands are a list/tuple, not the
+/// handle) and a GENERIC mismatch. The plain refusal still stands.
+/// [xreview: Claude Medium + Codex Medium]
+#[test]
+fn the_equals_hint_is_withheld_where_it_would_not_apply() {
+    const WIDGET: &str = "type Handle = host\n\
+         let make : () => Handle\n\
+         let equals : (Handle, Handle) => bool";
+    for nested in [
+        "let same = (): bool => [Widget.make()] == [Widget.make()]\n",
+        "let same = (): bool => (Widget.make(), 1.0) == (Widget.make(), 1.0)\n",
+    ] {
+        let project = load("host-type-equals-nested", &[("game.fun", nested), ("widget.funi", WIDGET)]);
+        let diags = project.check();
+        assert!(
+            diags.iter().any(|d| d.message.contains("supports no `==`"))
+                && !diags
+                    .iter()
+                    .any(|d| d.message.contains("compares structurally")),
+            "{nested}: {diags:?}"
+        );
+    }
+    // A generic handle whose `equals` is pinned to a DIFFERENT instantiation.
+    let generic = load(
+        "host-type-equals-generic",
+        &[
+            (
+                "game.fun",
+                "let same = (a: Widget.Handle<string>, b: Widget.Handle<string>): bool => a == b\n",
+            ),
+            (
+                "widget.funi",
+                "type Handle<'v> = host\n\
+                 let equals : (Handle<float>, Handle<float>) => bool",
+            ),
+        ],
+    );
+    let diags = generic.check();
+    assert!(
+        diags.iter().any(|d| d.message.contains("supports no `==`"))
+            && !diags
+                .iter()
+                .any(|d| d.message.contains("compares structurally")),
+        "{diags:?}"
+    );
+}
+
 /// A plain `type t` stays comparable. Not every abstract prelude type is a
 /// host handle — `Sprite.t` and `Physics.tag` are ordinary Functor Lang data
 /// behind an opaque name — so the marker is what distinguishes them, and its

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -30,3 +30,16 @@ let withClearColor : (Color.t, t) => t
 /// Layers render in call order, so a second `with2D` draws above the first.
 /// The main frame is last for piping.
 let with2D : (Camera2D.t, Sprite.t, t) => t
+
+/// Compare two frames structurally — the escape hatch for `Frame.t`, which is
+/// opaque and therefore supports no `==`.
+///
+/// Compares every part of the frame: camera, scene, lights, render-target
+/// passes, fog, skybox, clear color, and 2D layers (all ordered). Intended for
+/// inline `expect` tests over `draw` output, NOT for per-frame logic — the
+/// walk is O(frame size).
+///
+/// It inherits `Scene.equals`'s rules: floats compare exactly, assets compare
+/// by locator rather than by loaded content, and animation compares as
+/// declared.
+let equals : (t, t) => bool

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -35,11 +35,14 @@ let with2D : (Camera2D.t, Sprite.t, t) => t
 /// opaque and therefore supports no `==`.
 ///
 /// Compares every part of the frame: camera, scene, lights, render-target
-/// passes, fog, skybox, clear color, and 2D layers (all ordered). Intended for
+/// passes, fog, skybox, clear color, and 2D layers (all ordered). It also
+/// distinguishes HOW the frame was built — a `Frame.create2D` frame is never
+/// equal to a 3D frame carrying the same layer through `with2D`. Intended for
 /// inline `expect` tests over `draw` output, NOT for per-frame logic — the
 /// walk is O(frame size).
 ///
 /// It inherits `Scene.equals`'s rules: floats compare exactly, assets compare
-/// by locator rather than by loaded content, and animation compares as
-/// declared.
+/// by locator rather than by loaded content, animation compares as declared,
+/// and a failing `expect` can only report THAT the two frames differ — assert
+/// over the smallest piece that makes the point.
 let equals : (t, t) => bool

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -81,3 +81,26 @@ let rotateX : (Angle.t, t) => t
 let rotateY : (Angle.t, t) => t
 /// Rotate a scene node around Z.
 let rotateZ : (Angle.t, t) => t
+
+/// Compare two scene nodes structurally — the escape hatch for `Scene.t`,
+/// which is opaque and therefore supports no `==`.
+///
+/// Intended for inline `expect` tests over `draw` output, NOT for per-frame
+/// logic: the walk is O(scene size), which is why it is an explicit call
+/// rather than an operator.
+///
+/// Three things it is literal about:
+///
+/// - Floats compare EXACTLY — transforms, colors, and playheads. There is no
+///   epsilon, so build both sides of a test from the same arithmetic. (The
+///   comparison happens after the engine boundary's narrowing to 32-bit, so
+///   two numbers that narrow to the same float are equal.)
+/// - Assets compare by LOCATOR, not by loaded content: the same path or URL
+///   (and the same `Asset.whilePending` chain) is equal, whether or not either
+///   has finished loading.
+/// - Animation compares as DECLARED — the clip name and playhead seconds in
+///   the attached pose, never a sampled skeleton.
+///
+/// Children are ordered, so two groups holding the same nodes in a different
+/// order are not equal.
+let equals : (t, t) => bool

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -103,4 +103,9 @@ let rotateZ : (Angle.t, t) => t
 ///
 /// Children are ordered, so two groups holding the same nodes in a different
 /// order are not equal.
+///
+/// The answer is a bare `bool`, so a failing `expect` reports only that the
+/// two scenes differ — scene values are opaque and cannot be printed. Write
+/// the assertion over the smallest node that makes the point, or bisect by
+/// comparing sub-scenes, rather than one `expect` over a whole frame.
 let equals : (t, t) => bool

--- a/runtime/functor-runtime-common/src/anim.rs
+++ b/runtime/functor-runtime-common/src/anim.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{JointPose, Model, Pose, Skeleton};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum AnimExpr {
     /// Sample the clip named `name` at `playhead` seconds. The playhead wraps
     /// by the clip's duration (negative playheads wrap backwards from the

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -144,7 +144,7 @@ pub(crate) struct CameraBasis {
 /// (so it serializes cleanly across the wasm boundary); the runtime turns it
 /// into view/projection matrices at render time via `view_matrix` /
 /// `projection_matrix`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Camera {
     pub eye: [f32; 3],
     pub target: [f32; 3],

--- a/runtime/functor-runtime-common/src/frame.rs
+++ b/runtime/functor-runtime-common/src/frame.rs
@@ -13,7 +13,7 @@ fn is_false(value: &bool) -> bool {
 /// A named offscreen pass: `frame` (its own camera/scene/lights) is rendered
 /// into `target`'s texture before the owning frame's main pass, and sampled via
 /// `TextureDescription::RenderTarget(target.id)`.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct RenderTargetPass {
     pub target: RenderTargetDescriptor,
     pub frame: Frame,
@@ -22,7 +22,13 @@ pub struct RenderTargetPass {
 /// What a game's `draw` returns each frame: a 3D pass plus any ordered 2D
 /// sprite layers. Intentionally a growable record (post-processing etc. can be
 /// added later) so the render boundary signature doesn't churn.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+///
+/// `PartialEq` is the structural walk behind `Frame.equals`: every field —
+/// camera, scene, lights (ordered), render-target passes (ordered), fog,
+/// skybox, clear color, 2D layers (ordered), and the `pure_2d` marker. It
+/// inherits [`Scene3D`]'s rules: floats compare exactly, assets compare by
+/// locator, and animation compares as declared.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Frame {
     pub camera: Camera,
     pub scene: Scene3D,

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2219,6 +2219,14 @@ row 0 has {cols} heights, row {r} has {}",
             transformed(scene, Matrix4::from_angle_z(angle))
         },
     );
+    // Structural equality, as an explicit call rather than `==` — `Scene.t` is
+    // host-opaque, and the O(scene-size) walk should be visible at the call
+    // site. It exists for inline `expect` tests over `draw` output.
+    reg.fn2(
+        "Scene.equals",
+        "Scene.equals(a, b)",
+        |a: FunctorLangScene, b: FunctorLangScene| Value::Bool(a.0 == b.0),
+    );
 }
 
 fn register_camera(reg: &mut crate::host_registry::Registry) {
@@ -2450,6 +2458,12 @@ frame's main pass",
             let (r, g, b) = color.0;
             FunctorLangFrame(Frame::with_clear_color(frame.0, r, g, b))
         },
+    );
+    // See `Scene.equals` — the same explicit structural walk, one level up.
+    reg.fn2(
+        "Frame.equals",
+        "Frame.equals(a, b)",
+        |a: FunctorLangFrame, b: FunctorLangFrame| Value::Bool(a.0 == b.0),
     );
 }
 
@@ -7677,6 +7691,135 @@ Vec3.make(x, y, z)"
         assert!(json.contains("\"Blend\""), "json: {json}");
         let back: Scene3D = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // --- Scene.equals / Frame.equals (structural equality for draw tests) ---
+
+    /// Evaluate a `Scene.equals`/`Frame.equals` expression to its bool.
+    fn equality(expr: &str) -> bool {
+        match eval(&format!("let main = () => {expr}")) {
+            Value::Bool(b) => b,
+            other => panic!("expected a bool from `{expr}`, got {other}"),
+        }
+    }
+
+    /// The shape of the walk: identical constructions are equal, and each
+    /// axis of a scene node — transform, material, children, and their ORDER
+    /// — makes it unequal on its own.
+    #[test]
+    fn scene_equals_compares_structurally() {
+        assert!(equality("Scene.equals(Scene.cube(), Scene.cube())"));
+        assert!(!equality("Scene.equals(Scene.cube(), Scene.sphere())"));
+        // Transform.
+        assert!(equality(
+            "Scene.equals(Scene.cube() |> Scene.translate(Vec3.make(1.0, 0.0, 0.0)),\n\
+                          Scene.cube() |> Scene.translate(Vec3.make(1.0, 0.0, 0.0)))"
+        ));
+        assert!(!equality(
+            "Scene.equals(Scene.cube() |> Scene.translate(Vec3.make(1.0, 0.0, 0.0)),\n\
+                          Scene.cube() |> Scene.translate(Vec3.make(2.0, 0.0, 0.0)))"
+        ));
+        // Material.
+        assert!(!equality(
+            "Scene.equals(Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)),\n\
+                          Scene.cube() |> Scene.color(Color.rgb(0.0, 1.0, 0.0)))"
+        ));
+        // Children, and their order.
+        assert!(equality(
+            "Scene.equals(Scene.group([Scene.cube(), Scene.sphere()]),\n\
+                          Scene.group([Scene.cube(), Scene.sphere()]))"
+        ));
+        assert!(!equality(
+            "Scene.equals(Scene.group([Scene.cube(), Scene.sphere()]),\n\
+                          Scene.group([Scene.sphere(), Scene.cube()]))"
+        ));
+    }
+
+    /// Floats compare EXACTLY — there is no epsilon, so a difference far
+    /// below any visible one is still a difference. (The comparison happens
+    /// after the boundary's f64 → f32 narrowing, so it is f32-exact: a
+    /// difference the cast erases, like `0.1 + 0.2` against `0.3`, is gone
+    /// before equality ever sees it.)
+    #[test]
+    fn scene_equals_compares_floats_exactly() {
+        assert!(!equality(
+            "Scene.equals(Scene.cube() |> Scene.scale(1.0),\n\
+                          Scene.cube() |> Scene.scale(1.000001))"
+        ));
+        assert!(equality(
+            "Scene.equals(Scene.cube() |> Scene.scale(0.1 + 0.2),\n\
+                          Scene.cube() |> Scene.scale(0.3))"
+        ));
+    }
+
+    /// An asset compares by LOCATOR, not by loaded content — nothing has been
+    /// loaded here, so two nodes naming the same model are equal and two
+    /// naming different files are not.
+    #[test]
+    fn scene_equals_compares_assets_by_locator() {
+        assert!(equality(
+            "Scene.equals(Scene.model(Asset.model(\"Xbot.glb\")),\n\
+                          Scene.model(Asset.model(\"Xbot.glb\")))"
+        ));
+        assert!(!equality(
+            "Scene.equals(Scene.model(Asset.model(\"Xbot.glb\")),\n\
+                          Scene.model(Asset.model(\"Ybot.glb\")))"
+        ));
+    }
+
+    /// Animation compares as DECLARED: the clip name plus the playhead
+    /// seconds, so the same model at two times is two different scenes.
+    #[test]
+    fn scene_equals_compares_animation_as_declared() {
+        assert!(equality(
+            "Scene.equals(\n\
+               Scene.model(Asset.model(\"Xbot.glb\")) |> Scene.animate(Anim.clip(\"walk\", 0.5)),\n\
+               Scene.model(Asset.model(\"Xbot.glb\")) |> Scene.animate(Anim.clip(\"walk\", 0.5)))"
+        ));
+        assert!(!equality(
+            "Scene.equals(\n\
+               Scene.model(Asset.model(\"Xbot.glb\")) |> Scene.animate(Anim.clip(\"walk\", 0.5)),\n\
+               Scene.model(Asset.model(\"Xbot.glb\")) |> Scene.animate(Anim.clip(\"walk\", 0.75)))"
+        ));
+        assert!(!equality(
+            "Scene.equals(\n\
+               Scene.model(Asset.model(\"Xbot.glb\")) |> Scene.animate(Anim.clip(\"walk\", 0.5)),\n\
+               Scene.model(Asset.model(\"Xbot.glb\")) |> Scene.animate(Anim.clip(\"run\", 0.5)))"
+        ));
+    }
+
+    /// `Frame.equals` is the same walk one level up: it compares the camera,
+    /// the scene, the lights, and the frame's optional decorations.
+    #[test]
+    fn frame_equals_compares_the_whole_frame() {
+        const CAMERA: &str =
+            "Camera3D.lookAt(Vec3.make(0.0, 1.0, -4.0), Vec3.make(0.0, 0.0, 0.0))";
+        assert!(equality(&format!(
+            "Frame.equals(Frame.create({CAMERA}, Scene.cube()),\n\
+                          Frame.create({CAMERA}, Scene.cube()))"
+        )));
+        // The scene differs.
+        assert!(!equality(&format!(
+            "Frame.equals(Frame.create({CAMERA}, Scene.cube()),\n\
+                          Frame.create({CAMERA}, Scene.cube() |> Scene.rotateY(Angle.degrees(90.0))))"
+        )));
+        // The camera differs.
+        assert!(!equality(&format!(
+            "Frame.equals(Frame.create({CAMERA}, Scene.cube()),\n\
+             Frame.create(Camera3D.lookAt(Vec3.make(0.0, 2.0, -4.0), Vec3.make(0.0, 0.0, 0.0)), \
+Scene.cube()))"
+        )));
+        // The lights differ.
+        assert!(!equality(&format!(
+            "Frame.equals(Frame.createLit({CAMERA}, Scene.cube(), [Light.ambient(Color.rgb(1.0, 1.0, 1.0))]),\n\
+                          Frame.createLit({CAMERA}, Scene.cube(), [Light.ambient(Color.rgb(0.5, 0.5, 0.5))]))"
+        )));
+        // A decoration only one side carries.
+        assert!(!equality(&format!(
+            "Frame.equals(Frame.create({CAMERA}, Scene.cube()),\n\
+                          Frame.create({CAMERA}, Scene.cube()) \
+|> Frame.withClearColor(Color.rgb(0.0, 0.0, 0.0)))"
+        )));
     }
 
     // The Angle rule for animations: a bare clip name teaches Anim.clip.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -7822,6 +7822,63 @@ Scene.cube()))"
         )));
     }
 
+    /// The rest of the frame's fields, one assertion each — the ones a future
+    /// refactor that stops deriving would silently drop.
+    /// [xreview: Claude Low]
+    #[test]
+    fn frame_equals_covers_every_decoration() {
+        const CAMERA: &str =
+            "Camera3D.lookAt(Vec3.make(0.0, 1.0, -4.0), Vec3.make(0.0, 0.0, 0.0))";
+        const CAM2D: &str = "Camera2D.create(16.0, 9.0)";
+        let differs = |a: &str, b: &str| {
+            assert!(
+                !equality(&format!("Frame.equals({a}, {b})")),
+                "expected {a} != {b}"
+            );
+        };
+        let base = format!("Frame.create({CAMERA}, Scene.cube())");
+        // Fog.
+        differs(
+            &base,
+            &format!(
+                "{base} |> Frame.withFog(Fog.linear(5.0, 50.0, Color.rgb(0.1, 0.1, 0.2)))"
+            ),
+        );
+        // Skybox.
+        differs(
+            &base,
+            &format!(
+                "{base} |> Frame.withSkybox(Skybox.files(\"px.png\", \"nx.png\", \"py.png\", \
+\"ny.png\", \"pz.png\", \"nz.png\"))"
+            ),
+        );
+        // Render-target passes.
+        let target = "RenderTarget.named(\"feed\") |> RenderTarget.sized(64.0, 64.0)";
+        differs(
+            &base,
+            &format!("{base} |> Frame.withRenderTarget({target}, {base})"),
+        );
+        // 2D layers — present vs absent, and their content.
+        let dot = "Sprite.circle(Color.rgb(1.0, 1.0, 1.0), 1.0)";
+        differs(&base, &format!("{base} |> Frame.with2D({CAM2D}, {dot})"));
+        differs(
+            &format!("{base} |> Frame.with2D({CAM2D}, {dot})"),
+            &format!("{base} |> Frame.with2D({CAM2D}, Sprite.blank())"),
+        );
+        // The `Frame.create2D` marker: a pure 2D frame is not the 3D frame
+        // that happens to carry the same layer.
+        differs(
+            &format!("Frame.create2D({CAM2D}, {dot})"),
+            &format!(
+                "Frame.create({CAMERA}, Scene.group([])) |> Frame.with2D({CAM2D}, {dot})"
+            ),
+        );
+        // …and each of those still equals itself.
+        assert!(equality(&format!(
+            "Frame.equals(Frame.create2D({CAM2D}, {dot}), Frame.create2D({CAM2D}, {dot}))"
+        )));
+    }
+
     // The Angle rule for animations: a bare clip name teaches Anim.clip.
     #[test]
     fn bare_strings_are_not_anims() {

--- a/runtime/functor-runtime-common/src/light.rs
+++ b/runtime/functor-runtime-common/src/light.rs
@@ -7,7 +7,7 @@ use crate::RenderContext;
 
 /// A light source. Pure data in the `Frame`, so lights serialize for `/scene`
 /// introspection. Colors/directions are plain `[f32; 3]` (Serialize-friendly).
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Light {
     /// Uniform light from every direction: its color is added to every lit
     /// surface regardless of orientation.

--- a/runtime/functor-runtime-common/src/scene3d/material_description.rs
+++ b/runtime/functor-runtime-common/src/scene3d/material_description.rs
@@ -19,7 +19,7 @@ pub enum SpriteSampling {
     Nearest,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MaterialDescription {
     #[serde(
         serialize_with = "serialize_vec4",

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -935,7 +935,7 @@ skybox disabled for this set",
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Shape {
     Cube,
     Sphere,
@@ -959,7 +959,7 @@ pub enum Shape {
     ConvexPolygon { points: Vec<[f32; 2]> },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SceneObject {
     Geometry(Shape),
     Model(ModelDescription),
@@ -968,7 +968,22 @@ pub enum SceneObject {
     Group(Vec<Scene3D>),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A scene node: what it draws, under a transform.
+///
+/// `PartialEq` is the structural walk behind `Scene.equals`, and it is
+/// deliberately literal about three things:
+///
+/// - **Floats compare exactly** (transform entries, colors, playheads). Two
+///   nodes built by different arithmetic that lands a bit apart are unequal.
+/// - **Assets compare by LOCATOR, not by loaded content** — the path/URL
+///   string in [`ModelHandle`] / [`TextureDescription`] (and the
+///   `while_pending` chain beside it). Nothing here has been loaded, so
+///   "equal" means "names the same asset".
+/// - **Animation compares as DECLARED** — [`crate::anim::AnimExpr`]'s clip
+///   name and playhead seconds, not a sampled pose.
+///
+/// Children are ordered: a group's list must match element-wise.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scene3D {
     pub obj: SceneObject,
     #[serde(

--- a/runtime/functor-runtime-common/src/scene3d/model_description.rs
+++ b/runtime/functor-runtime-common/src/scene3d/model_description.rs
@@ -7,7 +7,7 @@ use crate::anim::AnimExpr;
 use crate::scene3d::deserialize_matrix;
 use crate::scene3d::serialize_matrix;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ModelHandle {
     File(String),
 }
@@ -16,12 +16,12 @@ pub enum ModelHandle {
 // shape the renderer consumes; the F#-era authoring constructors
 // (`MeshSelector::all` / `MeshOverride::material` / `ModelDescription::modify`)
 // were removed with the F# framework — Functor Lang builds models with empty `overrides`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MeshSelector {
     All,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MeshOverride {
     Material(MaterialDescription),
     #[serde(
@@ -31,7 +31,7 @@ pub enum MeshOverride {
     Transform(Matrix4<f32>),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelDescription {
     pub handle: ModelHandle,
     pub overrides: Vec<(MeshSelector, MeshOverride)>,

--- a/runtime/functor-runtime-common/src/sprite2d.rs
+++ b/runtime/functor-runtime-common/src/sprite2d.rs
@@ -154,7 +154,7 @@ impl Camera2D {
 
 /// One ordered 2D pass attached to a frame. Layers render after the 3D pass,
 /// in declaration order; later layers appear on top.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct SpriteLayer {
     pub camera: Camera2D,
     pub scene: Scene3D,

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -389,6 +389,45 @@ fn equality_on_an_engine_value_is_a_check_error() {
     }
 }
 
+/// The two pure-data engine values offer an explicit structural walk instead,
+/// so their refusal names it. Every other opaque type has no such hatch and
+/// keeps the plain message.
+#[test]
+fn scene_and_frame_refusals_point_at_equals() {
+    for (src, hint) in [
+        (
+            "let bad: bool = Scene.cube() == Scene.cube()\n",
+            "`Scene.equals(a, b)` compares structurally",
+        ),
+        (
+            "let camera = Camera3D.lookAt(Vec3.make(0.0, 1.0, -4.0), Vec3.make(0.0, 0.0, 0.0))\n\
+             let bad: bool = Frame.create(camera, Scene.cube()) == Frame.create(camera, Scene.cube())\n",
+            "`Frame.equals(a, b)` compares structurally",
+        ),
+    ] {
+        let diags = check(src);
+        assert!(diags.iter().any(|m| m.contains(hint)), "{src}: {diags:?}");
+    }
+    // A type with no `equals` is unchanged.
+    let diags = check("let bad: bool = Color.rgb(1.0, 0.0, 0.0) == Color.rgb(1.0, 0.0, 0.0)\n");
+    assert!(
+        !diags.iter().any(|m| m.contains("compares structurally")),
+        "{diags:?}"
+    );
+}
+
+/// The escape hatch itself checks clean and answers `bool`.
+#[test]
+fn scene_and_frame_equals_check_clean() {
+    let diags = check(
+        "let camera = Camera3D.lookAt(Vec3.make(0.0, 1.0, -4.0), Vec3.make(0.0, 0.0, 0.0))\n\
+         let sameScene: bool = Scene.equals(Scene.cube(), Scene.cube())\n\
+         let sameFrame: bool = Frame.equals(Frame.create(camera, Scene.cube()),\n\
+                                            Frame.create(camera, Scene.cube()))\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
 /// The rule walks what the sibling "functions cannot be compared" rule walks
 /// — nested tuples, lists, maps, and a nominal's type arguments — so a host
 /// value one level in is caught too. [xreview: Codex Medium, Claude Medium]

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -862,7 +862,9 @@ functor docs --format json         # the machine-readable shape</pre>
               <strong>Engine values are opaque.</strong> <code>&lt;Scene></code>,
               <code>&lt;Frame></code>, <code>&lt;Camera3D></code> and friends can be passed around
               and composed, but not taken apart, and <code>==</code> on one is a
-              <em>check-time</em> error — compare the numbers you derived instead.
+              <em>check-time</em> error — compare the numbers you derived instead, or
+              compare structurally with <code>Scene.equals</code> /
+              <code>Frame.equals</code> (meant for tests over <code>draw</code>).
               Branded values do compare: <code>90deg == 90deg</code>,
               <code>1.5s &lt; 2000ms</code>, and physics tags, all fine.
               (<code>Sprite.t</code> is the other deliberate exception: it is plain data

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 302));
+        assert_eq!(count(ApiGroup::Engine), (27, 304));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
> **Stacked.** Base is #633 (`feat/branded-comparison`), itself stacked on #628 ← #621. Review only this branch's two commits.

`draw` returns pure data, but `Scene.t` / `Frame.t` are host-opaque — and #633 just made `==` on a host-opaque type a check-time error. That rule stays **uniform**: no exception is carved for scenes. Instead the two pure-data engine values gain an **explicit** structural comparison, so the O(size) walk is visible at the call site:

```functor
expect Frame.equals(draw(init, 0.0), draw(init, 0.0))
expect not Frame.equals(draw(init, 0.0), draw({ angle: 90.0 }, 0.0))
```

The motivating use case is inline `expect` tests over `draw` output — LLM-verifiable, headless, no GPU (CLAUDE.md design principle 2).

`Camera3D.equals` / `Camera2D.equals` are **not** included: `Frame.equals` compares cameras through Rust `PartialEq`, so nothing about the Functor-Lang-level surface fell out naturally. Two functions, not four.

## Equality semantics (the decisions)

Derived Rust `PartialEq` down the scene/frame tree is the walk. It is deliberately literal about four things, documented on the Rust types **and** in the `.funi` prose:

| Question | Decision |
| --- | --- |
| **Floats** | **Exact**, no epsilon. Comparison happens after the boundary's f64 → f32 narrowing, so it is f32-exact: a difference the cast erases (`0.1 + 0.2` vs `0.3`) is gone before equality sees it, while `1.0` vs `1.000001` is a difference. Build both sides of a test from the same arithmetic. |
| **Assets** | **Locator equality, not loaded-content equality.** The path/URL string in `ModelHandle` / `TextureDescription`, plus the `Asset.whilePending` chain beside it. Nothing has been loaded at comparison time, so "equal" means "names the same asset". |
| **Animation** | **As declared** — `AnimExpr`'s clip name and playhead seconds, never a sampled skeleton. Same model at two playheads = two different scenes. |
| **Children** | **Ordered.** Two groups holding the same nodes in a different order are unequal. `Frame`'s lights, render-target passes, and 2D layers likewise. |

Two more worth stating:

- **NaN cannot break reflexivity.** `Scene.equals(s, s)` is always true, because the engine boundary rejects non-finite numbers (`FromArg for f64`, `host_registry.rs:84`) — `Scene.scale(0.0 / 0.0)` fails with `expected a finite number, got NaN` before a scene is ever built. Verified empirically by both reviewers.
- **`Frame.equals` distinguishes how the frame was built.** A `Frame.create2D` frame is never equal to a 3D frame carrying the same layer through `with2D` — the `pure_2d` marker is part of the frame.

`PartialEq` was derived on `Scene3D`, `SceneObject`, `Shape`, `MaterialDescription`, `ModelHandle`/`MeshSelector`/`MeshOverride`/`ModelDescription`, `AnimExpr`, `Light`, `Camera`, `SpriteLayer`, `RenderTargetPass`, `Frame`. The inner material/texture/terrain/fog/skybox/render-target types already had it (`AudioScene` is the existing precedent). No `Rc`/handle/GPU state anywhere in the tree, so no identity-vs-value surprise.

## The upgraded refusal

```
`==` on `Scene.t`: engine values are opaque — compare the numbers you derived from
them instead (`Scene.t` supports no `==` — `Scene.equals(a, b)` compares structurally)
```

The clause is **derived, not special-cased**: it appears exactly when the type's own module declares `equals : (t, t) => bool` accepting that operand type. Any host-opaque type earns it by adding the signature; `Color.t` / `Effect.t` keep the plain message.

It is **withheld** where it would teach code that does not check (both reviewers, independently):

- **Nested** — `[Scene.cube()] == [Scene.cube()]` names `Scene.t` but compares a `List<Scene.t>`, which `Scene.equals` cannot take.
- **Generic** — an `equals : (Handle<float>, Handle<float>) => bool` does not apply to a `Handle<string>` operand.

One rule covers both: the signature must accept the **operand** type, not merely something with the same name.

## Docs

- `scene.funi` / `frame.funi` — full `///` prose: the exact-float caveat, the O(size) "tests, not per-frame logic" warning, asset-locator semantics, and the failure-shape caveat (a failing `expect` reports only *that* two values differ, so assert over the smallest piece that makes the point).
- `functor-lang` skill — the opaque-values rule gains the equals escape hatch, in all three places it is stated.
- `docs/functor-lang-units.md` — #633's comparison section listed structural equality as "out of scope" and "still open". Both are now false; rewritten as decided.
- The manual's sharp-edges "Engine values are opaque" bullet gains one clause.

### Manual, before/after

The only rendered surface this touches. Desktop (1440×900) and mobile (390×844), `#sharp-edges` section:

| | Before | After |
| --- | --- | --- |
| **Desktop** | <img src="https://gist.githubusercontent.com/tommy-xr/0c2586569de7f473c8bdaa75ffd17345/raw/before-desktop.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/0c2586569de7f473c8bdaa75ffd17345/raw/after-desktop.png" width="420"> |
| **Mobile** | <img src="https://gist.githubusercontent.com/tommy-xr/0c2586569de7f473c8bdaa75ffd17345/raw/before-mobile.png" width="230"> | <img src="https://gist.githubusercontent.com/tommy-xr/0c2586569de7f473c8bdaa75ffd17345/raw/after-mobile.png" width="230"> |

No rendering change, so there is no game GIF/PNG to capture — the walk never runs on a frame.

## Verification

- `cargo test -p functor-lang -p functor-docgen -p functor_runtime_common` — **19/19 targets green** (re-run after the review fixes).
- `npm run generate:docs` + `npm run check:docs` — green; the docgen inventory pin moved 302 → 304 engine items (the two new signatures).
- `npm run build:cli:debug`, then on a scratch project outside `examples/`: `functor test` → **4 expects passed** (`Frame.equals(draw(init, 0.0), draw(init, 0.0))` true, a rotated variant false, plus the `Scene.equals` half incl. child order).
- `functor build` on a sibling scratch project pins that `==` on a scene is **still** a check-time error, with the upgraded hint (exact output quoted above).
- `functor build` on `examples/primitives` and `examples/physics`, `functor test` on `examples/counter` — all green.
- Rust unit tests: equal scenes, differing transform, differing material, differing children order, asset locator vs same model, animated node time, exact-float behavior, and every `Frame` decoration (camera / lights / fog / skybox / render targets / 2D layers / `pure_2d`).

### frame_bench (release, interleaved, same machine)

Equality is **not** on the per-frame path — nothing calls it per frame — but registry registration touches prelude init, so it was measured anyway.

| cells | | us/frame (min) | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 400 | base | 432.4 | 13877 | 843393 |
| 400 | change | 433.5 | 13877 | 843393 |
| 1600 | base | 1695.1 | 54717 | 3307233 |
| 1600 | change | 1700.6 | 54717 | 3307233 |
| 3136 | base | 3304.2 | 106973 | 6460257 |
| 3136 | change | 3339.7 | 106973 | 6460257 |

**`allocs/frame` and `bytes/frame` are byte-identical** at every size — the deterministic columns, so the delta is exactly zero. Wall-clock is within run-to-run spread (base 432.4–438.0 and change 429.9–440.0 at 400 cells across 3 runs each).

## xreview dispositions

Two engines (Claude subagent + Codex CLI) plus a dedicated de-duplication pass. **No Critical or High findings from either engine.**

| # | Finding | Engines | Disposition |
| --- | --- | --- | --- |
| 1 | Medium — the `.equals` hint fires for NESTED opaque types (`[Scene.t]`, `(Scene.t, float)`), where the suggested call does not typecheck | **[AGREED]** Claude + Codex | **Fixed.** The hint now requires the signature to accept the operand type. Negative test added. |
| 2 | Medium — generic arguments ignored: `equals : (Handle<float>, …)` advertised for a `Handle<string>` operand | Codex | **Fixed by the same rule** (exact operand-type match), with its own negative test. |
| 3 | Medium — `docs/functor-lang-units.md` still declares structural equality "out of scope" / "still open", contradicting this branch's own added paragraph | Claude | **Fixed.** Rewritten as decided; the "Still open" entry removed. |
| 4 | Medium — a failing `expect Scene.equals(a, b)` prints only "expected true, got false"; scene values are opaque so there is no diff to show | Claude | **Fixed (option a, documented).** Both `.funi`s now state the caveat and tell the author to assert over the smallest piece / bisect by sub-scene. A structural-diff surface is a separate, larger feature. |
| 5 | Low — `frame.funi`'s "every part of the frame" list omitted `pure_2d`, which the walk does compare | **[AGREED]** Claude + Codex | **Fixed** in the prose, and pinned by a test. |
| 6 | Low — `Frame` test coverage missed `sprite_layers`, `render_targets`, `fog`, `skybox`, `pure_2d` | Claude | **Fixed.** `frame_equals_covers_every_decoration` covers all five. |
| 7 | Low — the registry's `handle_arg!` deep-clones both scenes before comparing them | Claude | **Accepted, not fixed.** Avoiding it means taking raw `Value`s and hand-writing the mismatch message, giving up the registry's typed teaching errors — the wrong trade for a function that is explicitly documented as test-only and never runs on a frame. |
| 8 | Low — "compares structurally" asserts semantics a `.funi` signature cannot guarantee for an arbitrary user module | Codex | **Accepted, not fixed.** The wording is the specified teaching text, and a module declaring `equals : (t, t) => bool` on its own host-opaque type is claiming exactly that role. The two prelude types that carry it document the semantics precisely. |

**De-duplication pass: "No actionable duplication."** All four strategies ran (S1-names 4 queries / 7220 candidates; S2-clones 253-line whole-repo report filtered to the 18 changed files — 30 pairs touched them, zero overlapping the added regions; S3-index 3573-line API index grepped for equal/structural/compare/same_scene/diff; S4-read full diff). Candidates checked and rejected with reasons: `Angle.equals`/`Time.equals` (the intentional API family this joins), `brand_operator_hint`/`unit_hint`/`greedy_arm_hint` (same shape, different table and question), and `eval.rs`'s `value_eq` (the complement — it *refuses* `HostData`, which is why the host-side walk exists). No pre-existing scene/frame structural comparison anywhere in the repo.
