### PR TITLE
test(cli): the past handle is the fourth primary-button drag guard

### DIFF
--- a/cli/src/util/wasm_dev_server.rs
+++ b/cli/src/util/wasm_dev_server.rs
@@ -261,8 +261,8 @@ mod tests {
         let scrubber = std::str::from_utf8(SCRUBBER_JS).expect("scrubber source is UTF-8");
         assert_eq!(
             scrubber.matches("if (event.button !== 0) return;").count(),
-            3,
-            "playhead, preview, and rail must preserve non-primary compatibility mouse events"
+            4,
+            "playhead, preview, past handle, and rail must preserve non-primary compatibility mouse events"
         );
     }
 


### PR DESCRIPTION
`scrubber_only_captures_primary_pointer_drags` pins the count of `if (event.button !== 0) return;` guards in scrubber.js at 3 (playhead, preview, rail). #608's backward trail added a fourth drag surface — the past handle — with the same guard, so the test has failed on main since. Count updated to 4 with the message naming all four surfaces; `cargo test -p functor-cli` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)