### PR TITLE
feat(scrubber): peek the extrapolation on a paused edit

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -457,7 +457,11 @@ const playerFrame = (page) => {
 
   // Push an edited region and wait for the runtime to accept it (a fresh
   // reload-ok marker) and the panel to report live again.
-  const applyHeroRegion = async (src) => {
+  //
+  // `settle: false` returns the instant the reload lands, skipping the panel
+  // wait and the quiet period — the peek checks below need the hold still
+  // running, and settling would spend a third of it.
+  const applyHeroRegion = async (src, { settle = true } = {}) => {
     const reloadsBefore = await heroPlayer.evaluate(
       () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
     );
@@ -468,6 +472,7 @@ const playerFrame = (page) => {
       reloadsBefore,
       { timeout: 8000 }
     );
+    if (!settle) return;
     await page.waitForFunction(() => window.__hero.status().state === "live", null, {
       timeout: 8000,
     });
@@ -740,20 +745,8 @@ const playerFrame = (page) => {
   await sleep(700); // let the trail's presence ramp finish fading out
   const quietHash = await regionHash(heroPlayer);
 
-  // Push an edit and return the moment the runtime accepts it, with the hold
-  // still running: the glimpse is transient, so this deliberately skips
-  // applyHeroRegion's settle sleep.
-  const peekEdit = async (src) => {
-    const before = await heroPlayer.evaluate(
-      () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
-    );
-    await page.evaluate((s) => window.__hero.setRegion(s), src);
-    await heroPlayer.waitForFunction(
-      (b) => window.__scrub.events().filter((event) => event.kind === "reload-ok").length > b,
-      before,
-      { timeout: 8000 }
-    );
-  };
+  // Land an edit with the hold still running.
+  const peekEdit = (src) => applyHeroRegion(src, { settle: false });
   const peekState = () =>
     heroPlayer.evaluate(() => {
       const button = document.getElementById("scrub-extrapolate");
@@ -770,6 +763,8 @@ const playerFrame = (page) => {
 
   const softRegion = region.replace("let jumpVelocity = 13.0", "let jumpVelocity = 9.0");
   await peekEdit(softRegion);
+  const firstPeekAt = Date.now();
+  await sleep(200); // let the presence ramp fade the trail in before sampling
   const peekHash = await regionHash(heroPlayer);
   const duringPeek = await peekState();
   check(
@@ -790,10 +785,12 @@ const playerFrame = (page) => {
   );
 
   // A second edit mid-glimpse EXTENDS the hold rather than letting the first
-  // expire underneath it. "Still peeking afterwards" alone can't tell an
-  // extension from a fresh glimpse that started after the first one lapsed, so
-  // sample continuously across the second edit: the glimpse must never drop.
-  await sleep(250);
+  // expire underneath it. Two things have to be true, and neither alone is
+  // enough: the glimpse must never DROP across the second edit (otherwise it
+  // restarted rather than extended), and it must still be up PAST the first
+  // edit's 1.5s deadline (otherwise the first hold simply hadn't run out yet).
+  // So sample continuously, and hold the sampler open until the first deadline
+  // is provably behind us.
   await heroPlayer.evaluate(() => {
     window.__peekDropped = false;
     window.__peekSampler = window.setInterval(() => {
@@ -802,17 +799,26 @@ const playerFrame = (page) => {
   });
   const stillRegion = region.replace("let jumpVelocity = 13.0", "let jumpVelocity = 8.0");
   await peekEdit(stillRegion);
+  const secondPeekAt = Date.now();
+  // Past the FIRST hold's expiry (and still inside the extended one, which runs
+  // 1.5s from the second edit).
+  await sleep(Math.max(0, firstPeekAt + 1800 - Date.now()));
+  const extended = await peekState();
+  const extendedHash = await regionHash(heroPlayer);
   const dropped = await heroPlayer.evaluate(() => {
     window.clearInterval(window.__peekSampler);
     return window.__peekDropped;
   });
-  await sleep(900); // past the FIRST hold's 1.5s expiry, inside the extended one
-  const extended = await peekState();
-  const extendedHash = await regionHash(heroPlayer);
   check(
     "a second hero edit extends the peek's hold",
-    extended.peeking && extended.pressed && !dropped,
-    JSON.stringify({ ...extended, dropped })
+    extended.peeking &&
+      extended.pressed &&
+      !dropped &&
+      // The sample really was past the first deadline, and not yet past the
+      // second — otherwise the check proved nothing about extension.
+      Date.now() > firstPeekAt + 1500 &&
+      Date.now() < secondPeekAt + 1500,
+    JSON.stringify({ ...extended, dropped, firstPeekAt, secondPeekAt, now: Date.now() })
   );
 
   // Then it retires itself: the trail fades out and the button's glow goes.

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -379,6 +379,16 @@ const playerFrame = (page) => {
     JSON.stringify(bar)
   );
   check("staged hero pulses attention on 🔮", bar.attention, JSON.stringify(bar));
+  // Staging loads the program and replays a script; the peek reports the
+  // VISITOR's edits, so the baseline must arrive without one.
+  check(
+    "hero staging lands without peeking the extrapolation",
+    await heroPlayer.evaluate(
+      () =>
+        !window.__scrub.peeking() &&
+        !document.getElementById("scrub-extrapolate").classList.contains("peeking")
+    )
+  );
 
   // Game input against a paused clock says so instead of doing nothing — but
   // only for keys that would have reached the game. A nudge on the timeline
@@ -712,6 +722,156 @@ const playerFrame = (page) => {
     afterRunReset.paused &&
       afterRunReset.jumps.some((jump) => afterRunReset.frame === Math.max(0, jump - 2)),
     JSON.stringify(afterRunReset)
+  );
+
+  // --- The peek: an edit on a parked timeline glimpses its own future. -------
+  // The discovery path for extrapolation. A visitor who never touches 🔮 edits a
+  // tunable and the future materializes for a beat, then gets out of the way.
+  // Put the demo back in exactly that state: parked, extrapolation OFF.
+  await heroPlayer.evaluate(() => {
+    if (window.__scrub.model().preview.enabled) {
+      document.getElementById("scrub-extrapolate").click();
+    }
+  });
+  await heroPlayer.waitForFunction(
+    () => window.__scrub.paused() && !window.__scrub.model().preview.enabled,
+    { timeout: 8000 }
+  );
+  await sleep(700); // let the trail's presence ramp finish fading out
+  const quietHash = await regionHash(heroPlayer);
+
+  // Push an edit and return the moment the runtime accepts it, with the hold
+  // still running: the glimpse is transient, so this deliberately skips
+  // applyHeroRegion's settle sleep.
+  const peekEdit = async (src) => {
+    const before = await heroPlayer.evaluate(
+      () => window.__scrub.events().filter((event) => event.kind === "reload-ok").length
+    );
+    await page.evaluate((s) => window.__hero.setRegion(s), src);
+    await heroPlayer.waitForFunction(
+      (b) => window.__scrub.events().filter((event) => event.kind === "reload-ok").length > b,
+      before,
+      { timeout: 8000 }
+    );
+  };
+  const peekState = () =>
+    heroPlayer.evaluate(() => {
+      const button = document.getElementById("scrub-extrapolate");
+      return {
+        peeking: window.__scrub.peeking(),
+        pressed: button.classList.contains("peeking"),
+        on: button.classList.contains("on"),
+        ariaPressed: button.getAttribute("aria-pressed"),
+        enabled: window.__scrub.model().preview.enabled,
+        previewFrames: window.__scrub.view().previewFrames,
+        railFuture: document.getElementById("scrub-future").getAttribute("width"),
+      };
+    });
+
+  const softRegion = region.replace("let jumpVelocity = 13.0", "let jumpVelocity = 9.0");
+  await peekEdit(softRegion);
+  const peekHash = await regionHash(heroPlayer);
+  const duringPeek = await peekState();
+  check(
+    "an accepted edit on the parked hero peeks the extrapolation",
+    duringPeek.peeking && duringPeek.pressed && peekHash !== quietHash,
+    JSON.stringify({ ...duringPeek, quietHash, peekHash })
+  );
+  // The glimpse is engine-only by design: the reducer never learns about it, so
+  // every piece of chrome that reads the real setting stays at rest.
+  check(
+    "the peek leaves the timeline chrome quiet",
+    !duringPeek.on &&
+      duringPeek.ariaPressed === "false" &&
+      !duringPeek.enabled &&
+      duringPeek.previewFrames === 0 &&
+      duringPeek.railFuture === "0",
+    JSON.stringify(duringPeek)
+  );
+
+  // A second edit mid-glimpse EXTENDS the hold rather than letting the first
+  // expire underneath it. "Still peeking afterwards" alone can't tell an
+  // extension from a fresh glimpse that started after the first one lapsed, so
+  // sample continuously across the second edit: the glimpse must never drop.
+  await sleep(250);
+  await heroPlayer.evaluate(() => {
+    window.__peekDropped = false;
+    window.__peekSampler = window.setInterval(() => {
+      if (!window.__scrub.peeking()) window.__peekDropped = true;
+    }, 16);
+  });
+  const stillRegion = region.replace("let jumpVelocity = 13.0", "let jumpVelocity = 8.0");
+  await peekEdit(stillRegion);
+  const dropped = await heroPlayer.evaluate(() => {
+    window.clearInterval(window.__peekSampler);
+    return window.__peekDropped;
+  });
+  await sleep(900); // past the FIRST hold's 1.5s expiry, inside the extended one
+  const extended = await peekState();
+  const extendedHash = await regionHash(heroPlayer);
+  check(
+    "a second hero edit extends the peek's hold",
+    extended.peeking && extended.pressed && !dropped,
+    JSON.stringify({ ...extended, dropped })
+  );
+
+  // Then it retires itself: the trail fades out and the button's glow goes.
+  await sleep(1600);
+  const afterHold = await peekState();
+  const retiredHash = await regionHash(heroPlayer);
+  check(
+    "the peek retires its glimpse and its glow after the hold",
+    // Same source as `extendedHash`, so the only difference is the trail.
+    !afterHold.peeking && !afterHold.pressed && !afterHold.enabled && retiredHash !== extendedHash,
+    JSON.stringify({ ...afterHold, extendedHash, retiredHash })
+  );
+
+  // A rejected edit has no new future to show, so it never peeks.
+  await page.evaluate((s) => window.__hero.setRegion(s), `${stillRegion}\n(`);
+  await page.waitForFunction(() => window.__hero.status().state === "error", { timeout: 8000 });
+  await sleep(600);
+  const afterBroken = await peekState();
+  check(
+    "a rejected hero edit does not peek",
+    !afterBroken.peeking && !afterBroken.pressed && !afterBroken.enabled,
+    JSON.stringify(afterBroken)
+  );
+
+  // Reaching for 🔮 mid-glimpse ADOPTS it: the glimpse becomes the real setting
+  // instead of reading as a toggle that turns off what the visitor just saw.
+  await peekEdit(region);
+  const beforeAdopt = await peekState();
+  await heroPlayer.evaluate(() => document.getElementById("scrub-extrapolate").click());
+  const adopted = await peekState();
+  await sleep(1800); // well past the hold the click cancelled
+  const afterAdoptHold = await peekState();
+  check(
+    "clicking 🔮 mid-peek adopts the glimpse as the real setting",
+    beforeAdopt.peeking &&
+      adopted.enabled &&
+      adopted.on &&
+      !adopted.peeking &&
+      afterAdoptHold.enabled &&
+      afterAdoptHold.previewFrames > 0,
+    JSON.stringify({ beforeAdopt, adopted, afterAdoptHold })
+  );
+
+  // Resuming the clock ends a glimpse on the spot: the peek is a parked-timeline
+  // affordance, and a trail over a running sim reads as a rendering glitch.
+  await heroPlayer.evaluate(() => document.getElementById("scrub-extrapolate").click());
+  await heroPlayer.waitForFunction(() => !window.__scrub.model().preview.enabled, {
+    timeout: 3000,
+  });
+  await peekEdit(softRegion);
+  const beforeResume = await peekState();
+  await heroPlayer.evaluate(() => window.__scrub.togglePause());
+  await heroPlayer.waitForFunction(() => !window.__scrub.paused(), { timeout: 8000 });
+  await sleep(200);
+  const afterResume = await peekState();
+  check(
+    "resuming the clock ends the peek immediately",
+    beforeResume.peeking && !afterResume.peeking && !afterResume.pressed && !afterResume.enabled,
+    JSON.stringify({ beforeResume, afterResume })
   );
 
   await page.close();

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -880,6 +880,46 @@ const playerFrame = (page) => {
     JSON.stringify({ beforeResume, afterResume })
   );
 
+  // The peek is HOST-OPT-IN, and off by default. The hero turns it on when it
+  // stages its demo because there the glimpse teaches a first-time visitor what
+  // extrapolation is; every other surface that mounts this same bar — the
+  // browser IDE, `functor run wasm`, an exported bundle — leaves it off, since
+  // 🔮 is a routine tool there and a trail on every save would be noise.
+  //
+  // Withdrawing the opt-in puts this visible mount in exactly the state those
+  // surfaces mount in (`peekOnEdit === false`), so a real accepted edit on a
+  // parked timeline is the honest negative: same bar, same reload, no glimpse.
+  await heroPlayer.evaluate(() => window.__scrub.setPeekOnEdit(false));
+  await heroPlayer.evaluate(() => window.__scrub.togglePause());
+  await heroPlayer.waitForFunction(() => window.__scrub.paused(), { timeout: 8000 });
+  const optedOutBefore = await peekState();
+  await peekEdit(heavyRegion);
+  const optedOut = await peekState();
+  await sleep(300); // a glimpse would be well underway by now
+  const optedOutSettled = await peekState();
+  check(
+    "a default (opted-out) mount does not peek on a paused edit",
+    !optedOutBefore.enabled &&
+      !optedOut.peeking &&
+      !optedOut.pressed &&
+      !optedOutSettled.peeking &&
+      !optedOutSettled.pressed &&
+      !optedOutSettled.enabled &&
+      optedOutSettled.previewFrames === 0,
+    JSON.stringify({ optedOutBefore, optedOut, optedOutSettled })
+  );
+
+  // …and re-arming restores it, so the opt-in is a live switch rather than a
+  // one-way door the hero happens to flip before anything is observable.
+  await heroPlayer.evaluate(() => window.__scrub.setPeekOnEdit(true));
+  await peekEdit(region);
+  const reArmed = await peekState();
+  check(
+    "re-arming the opt-in restores the peek",
+    reArmed.peeking && reArmed.pressed && !reArmed.enabled,
+    JSON.stringify(reArmed)
+  );
+
   await page.close();
 }
 

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -196,25 +196,27 @@ const STYLE = `
   50% { box-shadow: 0 0 0 1px var(--sb-future), 0 0 14px 2px rgba(232, 88, 184, 0.45); }
 }
 /* Peek: while an edit-triggered glimpse of the extrapolation plays, the button
-   presses in and glows brighter than the steady "on" state, easing back over
-   the hold. It is the glimpse's only chrome — it says "the future you just saw
-   lives HERE". Declared after the attention pulse so the press wins if both
-   classes land on the button at once. */
+   presses once and then SHINES for the whole glimpse — it is the glimpse's only
+   chrome, saying "the future you just saw lives HERE". The class is removed when
+   the peek ends, so the infinite shine retires with the trail's fade-out and the
+   two read as one gesture. The filled background is what makes this categorically
+   different from the resting attention ring rather than merely brighter.
+   Declared after the attention pulse so the press wins if both classes land on
+   the button at once. */
 #scrub-extrapolate.peeking {
-  animation: scrub-peek-press 1.5s ease-out;
+  animation: scrub-peek-press 0.3s ease-out, scrub-peek-shine 2s ease-in-out 0.3s infinite;
+  border-color: var(--sb-future);
+  background: rgba(232, 88, 184, 0.22);
+  box-shadow: 0 0 0 2px var(--sb-future), 0 0 18px 3px rgba(232, 88, 184, 0.75);
 }
 @keyframes scrub-peek-press {
   0% { transform: translateY(0); }
-  8% {
-    transform: translateY(1px);
-    border-color: var(--sb-future);
-    box-shadow: 0 0 0 2px var(--sb-future), 0 0 16px rgba(232, 88, 184, 0.85);
-  }
-  55% {
-    border-color: var(--sb-future);
-    box-shadow: 0 0 0 1px var(--sb-future), 0 0 10px rgba(232, 88, 184, 0.5);
-  }
+  35% { transform: translateY(1px); box-shadow: 0 0 0 2px var(--sb-future), 0 0 16px rgba(232, 88, 184, 0.85); }
   100% { transform: none; }
+}
+@keyframes scrub-peek-shine {
+  0%, 100% { box-shadow: 0 0 0 2px var(--sb-future), 0 0 18px 3px rgba(232, 88, 184, 0.75); }
+  50% { box-shadow: 0 0 0 2px var(--sb-future), 0 0 13px 2px rgba(232, 88, 184, 0.55); }
 }
 #scrub-toast {
   /* Docked under the bar's right edge: the frame label sits centered under the
@@ -237,7 +239,9 @@ const STYLE = `
     box-shadow: 0 0 0 2px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.35);
   }
   /* The glimpse still reads through the trail itself; a steady ring marks the
-     button for the duration without the press. */
+     button for the duration without the press or the shine. The filled
+     background carries over from the rule above, so the peek stays
+     categorically distinct from the resting ring here too. */
   #scrub-extrapolate.peeking {
     animation: none;
     border-color: var(--sb-future);
@@ -1112,7 +1116,11 @@ export function mountScrubber({ hidden = false } = {}) {
   //      animation and no timeline state to unwind afterwards.
   // Leaving the peek OUT of the timeline state also keeps it out of the recorded,
   // replayable model: a glimpse is a hint about the UI, never part of the run.
-  const PEEK_HOLD_MS = 1500; // matches the button's press animation
+  // How long the future stays on screen. The button's shine is INFINITE and
+  // retires when the class comes off at the end of the hold, so this duration
+  // alone decides the gesture's length — there is no animation length to keep
+  // it in step with.
+  const PEEK_HOLD_MS = 1500;
   let peekTimer = null;
   const peekActive = () => peekTimer !== null;
   // Retire the glimpse's chrome without touching the engine preview.

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -1123,13 +1123,14 @@ export function mountScrubber({ hidden = false } = {}) {
     pushPreview();
   };
   const startPeek = () => {
-    if (peekActive()) {
-      // Another edit mid-glimpse extends the hold: the future stays on screen
-      // and the press replays, so a run of edits reads as one continuous look.
-      clearTimeout(peekTimer);
-    } else {
-      functor_lang_scrub_set_preview(previewMode);
-    }
+    // Unconditional on purpose: a second edit mid-glimpse extends the hold (the
+    // future stays on screen and the press replays, so a run of edits reads as
+    // one continuous look), and re-asserting the mode also recovers the trail if
+    // something pushed the preview off underneath us. Setting the same mode is
+    // idempotent and does NOT restart the overlay's presence ramp, so extending
+    // never re-fades what is already on screen.
+    clearTimeout(peekTimer);
+    functor_lang_scrub_set_preview(previewMode);
     // The glimpse IS the invitation, delivered. Retire the one-shot attention
     // pulse rather than layering two glows on the same button.
     dismissAttention();
@@ -1140,14 +1141,12 @@ export function mountScrubber({ hidden = false } = {}) {
   };
   extrapolate.addEventListener("click", () => {
     dismissAttention();
-    if (peekActive()) {
-      // Reaching for 🔮 during the glimpse means "keep this" — adopt it as the
-      // real setting instead of reading as a toggle that turns it back off.
-      cancelPeek();
-      dispatch({ type: "preview-changed", preview: { enabled: true } });
-      pushPreview();
-      return;
-    }
+    // Reaching for 🔮 during the glimpse means "keep this", and the ordinary
+    // toggle below already delivers exactly that: a peek only starts while the
+    // real setting is off, so the toggle turns it on and the glimpse becomes
+    // permanent. Retiring the hold first is what makes it stick — otherwise the
+    // pending timer would hand the engine back and fade out what was adopted.
+    cancelPeek();
     dispatch({ type: "preview-changed", preview: { enabled: !state.preview.enabled } });
     pushPreview();
   });
@@ -1323,6 +1322,10 @@ export function mountScrubber({ hidden = false } = {}) {
     // skipping the runtime's ease so a script can capture an exact mid-fade
     // frame; a NEGATIVE value clears the pin and resumes easing.
     setPreview: ({ mode: nextMode, presence: nextPresence, ...preview }) => {
+      // An explicit host push is the real setting; a transient glimpse must not
+      // outlive it. Without this the hold would keep reporting `peeking()` and
+      // holding the glow over a preview this call already changed.
+      cancelPeek();
       if (nextMode !== undefined && Number.isFinite(Number(nextMode))) {
         previewMode = Number(nextMode);
       }
@@ -1419,11 +1422,18 @@ export function mountScrubber({ hidden = false } = {}) {
           // Only an ACCEPTED edit earns a glimpse — a rejected one has no new
           // future to show. Parked-and-off is the whole audience for it: playing
           // already shows the consequence, and enabled is already showing it.
-          if (
-            newReload.kind === "reload-ok" &&
-            state.runtime?.paused &&
-            !state.preview.enabled
-          ) {
+          //
+          // `pausedNow` is this frame's read, NOT `state.runtime.paused`: the
+          // runtime snapshot is dispatched further down, so the reducer still
+          // holds the PREVIOUS frame's pause state here. A resume landing on the
+          // same frame as a reload would otherwise start a glimpse over a
+          // running sim, with no later pause edge to cut it short.
+          //
+          // A `hidden` mount has no bar to press: it is the seam-only mode for
+          // hosts that dock their own chrome (the sandbox), which reads the
+          // reducer the peek deliberately leaves alone. Peeking there would drop
+          // an unexplained trail into the viewport and glow a detached button.
+          if (!hidden && newReload.kind === "reload-ok" && pausedNow && !state.preview.enabled) {
             startPeek();
           }
         }
@@ -1465,6 +1475,11 @@ export function mountScrubber({ hidden = false } = {}) {
     destroy() {
       cancelAnimationFrame(raf);
       clearTimeout(toastTimer);
+      // Tearing down mid-glimpse would otherwise leave the engine preview on
+      // with nothing left to turn it off, and the pending hold would later fire
+      // against a dead mount and push THIS mount's stale state at the engine.
+      // End it now: the trail goes with the bar that explained it.
+      if (peekActive()) endPeek();
       window.removeEventListener("keydown", onPausedGameKey);
       el.remove();
       // The flash overlay lives on the document, not inside the bar, so it has

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -195,6 +195,27 @@ const STYLE = `
   0%, 100% { box-shadow: 0 0 0 1px rgba(232, 88, 184, 0.35), 0 0 0 rgba(232, 88, 184, 0); }
   50% { box-shadow: 0 0 0 1px var(--sb-future), 0 0 14px 2px rgba(232, 88, 184, 0.45); }
 }
+/* Peek: while an edit-triggered glimpse of the extrapolation plays, the button
+   presses in and glows brighter than the steady "on" state, easing back over
+   the hold. It is the glimpse's only chrome — it says "the future you just saw
+   lives HERE". Declared after the attention pulse so the press wins if both
+   classes land on the button at once. */
+#scrub-extrapolate.peeking {
+  animation: scrub-peek-press 1.5s ease-out;
+}
+@keyframes scrub-peek-press {
+  0% { transform: translateY(0); }
+  8% {
+    transform: translateY(1px);
+    border-color: var(--sb-future);
+    box-shadow: 0 0 0 2px var(--sb-future), 0 0 16px rgba(232, 88, 184, 0.85);
+  }
+  55% {
+    border-color: var(--sb-future);
+    box-shadow: 0 0 0 1px var(--sb-future), 0 0 10px rgba(232, 88, 184, 0.5);
+  }
+  100% { transform: none; }
+}
 #scrub-toast {
   /* Docked under the bar's right edge: the frame label sits centered under the
      rail and event details hang below the marker, so this corner is free. */
@@ -214,6 +235,13 @@ const STYLE = `
   #scrub-extrapolate.attention {
     animation: none;
     box-shadow: 0 0 0 2px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.35);
+  }
+  /* The glimpse still reads through the trail itself; a steady ring marks the
+     button for the duration without the press. */
+  #scrub-extrapolate.peeking {
+    animation: none;
+    border-color: var(--sb-future);
+    box-shadow: 0 0 0 2px var(--sb-future);
   }
   #scrub-toast.show { animation: none; }
   /* The marker keeps its final resting look; the reload still reads through
@@ -1061,8 +1089,65 @@ export function mountScrubber({ hidden = false } = {}) {
   reset.addEventListener("click", () => {
     if (resetAction) resetAction();
   });
+  // The peek: a successful edit landing on a PAUSED timeline with extrapolation
+  // off shows its own consequence for a beat — the engine preview fades in, holds,
+  // and fades back out — so a visitor who never touches the bar still discovers
+  // that the future is computable, and is shown where that power lives.
+  //
+  // It drives the ENGINE preview directly and deliberately skips the reducer.
+  // Two reasons, and both are the design:
+  //   1. The chrome must stay quiet. A glimpse is not a mode — the rail's pink
+  //      future segment, the `+frames` label, `.on` and `aria-pressed` all read
+  //      from `state.preview.enabled`, so leaving the reducer alone keeps every
+  //      one of them at rest. Only the button's transient press acknowledges it.
+  //   2. The easing already lives runtime-side. The overlay's presence ramp
+  //      fades the trail in and out on its own, so the glimpse needs no chrome
+  //      animation and no timeline state to unwind afterwards.
+  // Leaving the peek OUT of the timeline state also keeps it out of the recorded,
+  // replayable model: a glimpse is a hint about the UI, never part of the run.
+  const PEEK_HOLD_MS = 1500; // matches the button's press animation
+  let peekTimer = null;
+  const peekActive = () => peekTimer !== null;
+  // Retire the glimpse's chrome without touching the engine preview.
+  const cancelPeek = () => {
+    clearTimeout(peekTimer);
+    peekTimer = null;
+    extrapolate.classList.remove("peeking");
+  };
+  // End the glimpse and hand the engine preview back to the reducer, which is
+  // the only owner of the real setting. Pushing the reducer's truth rather than
+  // a hard "off" matters: if the preview was genuinely enabled mid-glimpse (the
+  // adopt click, or a host driving the seam), the hold must not switch it off.
+  const endPeek = () => {
+    cancelPeek();
+    pushPreview();
+  };
+  const startPeek = () => {
+    if (peekActive()) {
+      // Another edit mid-glimpse extends the hold: the future stays on screen
+      // and the press replays, so a run of edits reads as one continuous look.
+      clearTimeout(peekTimer);
+    } else {
+      functor_lang_scrub_set_preview(previewMode);
+    }
+    // The glimpse IS the invitation, delivered. Retire the one-shot attention
+    // pulse rather than layering two glows on the same button.
+    dismissAttention();
+    extrapolate.classList.remove("peeking");
+    void extrapolate.offsetWidth; // restart the press animation from the top
+    extrapolate.classList.add("peeking");
+    peekTimer = setTimeout(endPeek, PEEK_HOLD_MS);
+  };
   extrapolate.addEventListener("click", () => {
     dismissAttention();
+    if (peekActive()) {
+      // Reaching for 🔮 during the glimpse means "keep this" — adopt it as the
+      // real setting instead of reading as a toggle that turns it back off.
+      cancelPeek();
+      dispatch({ type: "preview-changed", preview: { enabled: true } });
+      pushPreview();
+      return;
+    }
     dispatch({ type: "preview-changed", preview: { enabled: !state.preview.enabled } });
     pushPreview();
   });
@@ -1196,6 +1281,10 @@ export function mountScrubber({ hidden = false } = {}) {
     },
     model: () => state,
     view,
+    // Whether an edit-triggered glimpse of the extrapolation is on screen right
+    // now. It lives outside the timeline state on purpose (see the peek driver),
+    // so this is the only way to observe it.
+    peeking: () => peekActive(),
     events: () => state.events,
     selectEvent: (id) => dispatch({ type: "event-selected", id }),
     // Queue a compact input script against future fixed-step frames. The
@@ -1255,7 +1344,15 @@ export function mountScrubber({ hidden = false } = {}) {
     const pausedNow = functor_lang_scrub_paused();
     if (pausedNow !== wasPaused) {
       wasPaused = pausedNow;
-      if (pausedNow) pausedAt = performance.now();
+      if (pausedNow) {
+        pausedAt = performance.now();
+      } else if (peekActive()) {
+        // Resuming ends a glimpse on the spot. The peek is a parked-timeline
+        // affordance: a trail over a running sim that then vanishes on its own
+        // timer reads as a rendering glitch, and extrapolating a future the
+        // clock is already walking into is the toggle's job, not a hint's.
+        endPeek();
+      }
     }
     const nextDetached = functor_lang_viewer_detached();
     const detachedGeneration = functor_lang_viewer_detached_generation();
@@ -1319,6 +1416,16 @@ export function mountScrubber({ hidden = false } = {}) {
         if (newReload) {
           flashReloadJuice(newReload.kind);
           reglowMarkerCluster(newReload.frame);
+          // Only an ACCEPTED edit earns a glimpse — a rejected one has no new
+          // future to show. Parked-and-off is the whole audience for it: playing
+          // already shows the consequence, and enabled is already showing it.
+          if (
+            newReload.kind === "reload-ok" &&
+            state.runtime?.paused &&
+            !state.preview.enabled
+          ) {
+            startPeek();
+          }
         }
       } catch {
         // A malformed marker payload must not stop the runtime poll loop.

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -502,6 +502,13 @@ export function mountScrubber({ hidden = false } = {}) {
   // The 🔮 attention pulse is a one-shot invitation: once the button has been
   // used (or the host withdraws it), it never pulses again for this mount.
   let attentionDismissed = false;
+  // Edit-triggered peeks are OFF until a host asks for them (see the peek
+  // driver and `setPeekOnEdit`). Default-off is the point: the peek is a
+  // teaching moment for a first-time visitor, and every other surface that
+  // mounts this bar — the browser IDE, `functor run wasm`, an exported
+  // bundle — is a working environment where 🔮 is a routine tool that must
+  // not grab the viewport on every save.
+  let peekOnEdit = false;
   let wasPaused = false;
   let pausedAt = 0;
   let toastTimer = 0;
@@ -1278,6 +1285,21 @@ export function mountScrubber({ hidden = false } = {}) {
       if (attentionDismissed) return;
       extrapolate.classList.add("attention");
     },
+    // Arm (or withdraw) the edit-triggered peek for this mount. OFF by default,
+    // so a surface only glimpses the future if it asked to: the landing hero
+    // turns it on when it stages its demo, because there the glimpse teaches a
+    // first-time visitor what extrapolation is. Working surfaces — the browser
+    // IDE, `functor run wasm`, an exported bundle — leave it off, since there
+    // 🔮 is a routine tool and a trail on every save would be noise.
+    //
+    // It sits here beside `setAttention`/`setReset` rather than in `setPreview`
+    // on purpose: those are host-armed affordances, while `setPreview`'s fields
+    // flow into the reducer, and the peek is deliberately not reducer state.
+    // Withdrawing it mid-glimpse ends the glimpse.
+    setPeekOnEdit: (enabled) => {
+      peekOnEdit = enabled === true;
+      if (!peekOnEdit && peekActive()) endPeek();
+    },
     model: () => state,
     view,
     // Whether an edit-triggered glimpse of the extrapolation is on screen right
@@ -1429,11 +1451,17 @@ export function mountScrubber({ hidden = false } = {}) {
           // same frame as a reload would otherwise start a glimpse over a
           // running sim, with no later pause edge to cut it short.
           //
-          // A `hidden` mount has no bar to press: it is the seam-only mode for
-          // hosts that dock their own chrome (the sandbox), which reads the
-          // reducer the peek deliberately leaves alone. Peeking there would drop
-          // an unexplained trail into the viewport and glow a detached button.
-          if (!hidden && newReload.kind === "reload-ok" && pausedNow && !state.preview.enabled) {
+          // `peekOnEdit` is the real gate: only a host that asked for the
+          // teaching moment gets it. `!hidden` stays as defense in depth — a
+          // seam-only mount has no bar to press, so a glimpse there could only
+          // ever be an unexplained trail and a glow on a detached button.
+          if (
+            peekOnEdit &&
+            !hidden &&
+            newReload.kind === "reload-ok" &&
+            pausedNow &&
+            !state.preview.enabled
+          ) {
             startPeek();
           }
         }

--- a/site/src/hero-app.ts
+++ b/site/src/hero-app.ts
@@ -64,6 +64,8 @@ interface HeroScrubSeam {
   }): void;
   setAttention(attention: { extrapolate?: boolean }): void;
   setReset(handler: (() => void) | null): void;
+  /** Arm the edit-triggered extrapolation peek. Off by default everywhere. */
+  setPeekOnEdit(enabled: boolean): void;
 }
 
 type HeroPlayerWindow = Window & { __scrub?: HeroScrubSeam };
@@ -317,6 +319,12 @@ const seedJumpHistory = async (inputs: ScriptedInput[]) => {
   scrub.setReset(reparkStagedMoment);
   // …and points at 🔮 exactly once, at the moment the demo is ready for it.
   scrub.setAttention({ extrapolate: true });
+  // The hero is the ONE surface that peeks: a visitor here is meeting
+  // extrapolation for the first time, so an edit on the parked timeline should
+  // show them its own future unprompted. Working surfaces (the sandbox, the
+  // browser IDE, `functor run wasm`) leave this off — there 🔮 is a routine
+  // tool and a trail on every save would be noise, not a lesson.
+  scrub.setPeekOnEdit(true);
 };
 
 const maybeStageDemo = () => {


### PR DESCRIPTION
The last piece of the reload-juice arc: **the peek** — an edit-triggered glimpse of the extrapolation preview.

> "Someone trying it paused should get a sense of the extrapolation power right away, with only changing the code."

The peek is the *discovery* mechanism for time-travel extrapolation. A visitor who never touches the scrubber edits a tunable, the future materializes, shows the consequence of their change, points at its own control, and gets out of the way.

**It is the hero's teaching moment by design, and only the hero's.** Dev surfaces where 🔮 is a routine tool — the browser IDE, `functor run wasm`, an exported bundle — don't grab focus on every save. The peek is off by default and armed per mount through the seam; `site/src/hero-app.ts` is the one caller.

![the glimpse mid-fade](https://gist.githubusercontent.com/tommy-xr/9eeafb134017d34e4beade5df485ff48/raw/01-peek-midfade.png)

*Parked at the same frame, `jumpVelocity` edited 13 → 9: the predicted jump arc fades in and the 🔮 glows. Note the rail is unchanged — no pink future segment, no `+frames` label.*

| at rest | during the peek |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/9eeafb134017d34e4beade5df485ff48/raw/00-before.png) | ![peek](https://gist.githubusercontent.com/tommy-xr/9eeafb134017d34e4beade5df485ff48/raw/01-peek-midfade.png) |

![button at rest vs peeking](https://gist.githubusercontent.com/tommy-xr/9eeafb134017d34e4beade5df485ff48/raw/button-compare.png)

*6× zoom on 🔮: flat chip at rest, versus the peek's 2px ring, wide halo, and pink background fill.*

![the glimpse, animated](https://gist.githubusercontent.com/tommy-xr/9eeafb134017d34e4beade5df485ff48/raw/peek.gif)

## Behavior

When a `reload-ok` lands on a mount whose host **armed the peek**, while the timeline is **paused** and the preview is **off**:

1. The **engine** preview turns on directly (`functor_lang_scrub_set_preview(previewMode)`). #632's presence ramp fades the trail in; the chrome stays quiet.
2. The 🔮 button **presses once (0.3s) and then shines** for as long as the future is on screen. The class comes off when the peek ends, so the infinite shine retires with the trail's fade-out and the two read as one gesture. The filled background (`rgba(232, 88, 184, 0.22)`) is what makes the peek *categorically* different from the resting attention ring rather than merely brighter. `prefers-reduced-motion` keeps a static ring and inherits that fill, so the distinction survives without motion.
3. Hold ~1.5s; another accepted edit mid-glimpse **extends** the hold and replays the press.
4. Then the engine preview is handed back to the reducer; presence fades it out, the glow retires.
5. Clicking 🔮 mid-glimpse **adopts** it as the real setting (never toggles off what was just seen).
6. A rejected edit never peeks, and the staging baseline never peeks (the existing seeded/high-water guard).

## Host opt-in

`setPeekOnEdit(enabled)` — a new seam method, **off by default on every mount**. `site/src/hero-app.ts` calls it at staging completion, right beside the `setAttention` pulse it belongs with; nothing else calls it, so the browser IDE (`index-functor-lang.html`, which mounts this bar visibly), `functor run wasm`, and exported bundles stay quiet.

It sits beside `setAttention`/`setReset` rather than becoming a `setPreview` field on purpose: those are host-armed affordances, whereas `setPreview`'s fields flow into the reducer — and the peek is deliberately *not* reducer state. Withdrawing it mid-glimpse ends the glimpse.

The `!hidden` guard from review stays as **defense in depth**: a seam-only mount has no bar to press, so a glimpse there could only ever be an unexplained trail plus a glow on a detached button.

## Coordination with the chrome-polish PR

This PR adds the `.peeking` rules **after** `.attention` in the same stylesheet and changes nothing else there: the resting `.attention` values (halo, duration, ring opacity) and the extrapolate button's `title` attribute are untouched, since the chrome-polish PR in flight off `main` owns both. Expect a trivially resolvable same-file merge — the two changes sit in adjacent blocks.

## Why it bypasses the reducer

Deliberate, and carried in a code comment. The chrome must stay **quiet** — the rail's future segment, the `+frames` label, `.on` and `aria-pressed` all read `state.preview.enabled`, so leaving the reducer alone keeps every one of them at rest. The easing already lives runtime-side in the presence ramp, so the glimpse needs no chrome animation and nothing to unwind. Keeping it out of timeline state also keeps a UI hint out of the recorded, replayable model. `timeline-model.js` is untouched; its 24 `node --test` checks are unchanged and green.

**Answering the open question about the rail:** the pink future rect never appears during a peek. Its width is driven purely by reducer state (`previewVisible = state.preview.enabled`), so engine-preview-on / reducer-off renders no rail future segment and `previewFrames === 0`. The e2e pins this.

## Design questions resolved

- **Unpause mid-glimpse → ends the peek immediately** (diverges from the prototype, which let the timer run out). The peek is a parked-timeline affordance: a transient trail over a running sim that then vanishes on its own timer reads as a rendering glitch, and extrapolating a future the clock is already walking into is the toggle's job. Covered by e2e.
- **Attention pulse → the peek supersedes and permanently dismisses it.** The glimpse *is* the invitation, delivered; stacking two glows on one button is worse than one clear press. This also removes a CSS conflict (both classes set `animation` at equal specificity).
- **Hero status copy → not changed.** `hero-app.ts` is touched only to arm the opt-in (one call + its interface line); no copy changes. *Suggestion for a follow-up:* the hero's "live — click 🔮 to preview the jump" could acknowledge a peek having happened (e.g. "…you just saw it — click 🔮 to keep it"), but that's hero-app copy and belongs in its own change.

## Verification

- `npm run build` green.
- `node e2e/site-sandbox.mjs` — **150/150 checks pass**, including 10 new ones: staging baseline doesn't peek; an accepted parked edit peeks (canvas hash differs + `.peeking`); the chrome stays quiet (`.on` absent, `aria-pressed=false`, reducer disabled, `previewFrames === 0`, rail future width `0`); a second edit extends the hold; the glimpse and glow retire; a rejected edit doesn't peek; clicking mid-peek adopts (and survives past the cancelled hold); resuming ends it immediately; **a default (opted-out) mount does not peek on a paused edit**; and re-arming the opt-in restores it.
- `npx tsc --noEmit -p site` clean (the hero seam interface gained `setPeekOnEdit`).
- `npm run test:scrubber` — 24/24, `timeline-model.js` untouched.
- Visuals captured deterministically via the `__scrub` presence-pin seam (Playwright).

On the opted-out negative: it runs against the **visible hero mount with the opt-in withdrawn**, which is byte-for-byte the state the IDE and exported bundles mount in (`peekOnEdit === false`), driving a real accepted edit on a parked timeline. Driving `index-functor-lang.html` itself would have been the letter of the ask, but its harness (`e2e/functor-lang-preview-reload.mjs`) hardcodes `./target/debug/functor` and so needs a separate debug CLI build; the invariant it would prove — default-off, plus an explicit arm — is what the two new checks pin.

## Review (`/xreview` vs `main`, with media)

Two independent engines (Claude subagent + Codex) plus a dedicated de-dup pass. **Fixed all findings both engines agreed on, plus the worthwhile singles:**

- **[AGREED] High — stale pause state.** The gate read `state.runtime.paused`, the *previous* frame's snapshot (the runtime snapshot dispatches later in the same `update()`). A resume on the same frame as a reload would start a glimpse over a running sim with no later pause edge to end it. Now gates on the fresh `pausedNow`.
- **[AGREED] High — `hidden` mounts.** The sandbox mounts the scrubber hidden and docks its own chrome, which reads the reducer the peek leaves alone; every accepted paused edit there would have dropped an unexplained trail and glowed a detached button. Now gated on `!hidden`.
- **[AGREED] Medium — `destroy()` leaked the hold.** Teardown mid-glimpse left the engine preview on with nothing to turn it off, and the pending timer could push a dead mount's state over a remount.
- **Medium (Codex) — `setPreview` mid-peek desync.** The seam now retires the hold, so `peeking()` can't report a glimpse the host already overwrote.
- **Medium/Low (Claude) — the adopt branch was redundant *and* buggy.** A peek only starts while the real setting is off, so the ordinary toggle already adopts; the special case could also swallow a click and force the preview back on if it became enabled mid-hold. Deleting it is 8 lines smaller and more correct.
- **Low (both) — the extension e2e check could pass vacuously** on a fast reload. It now proves the sample crossed the first hold's deadline and not the second, and keeps a continuity sampler open across the second edit so an extension is distinguishable from a restart.
- **De-dup: `peekEdit` duplicated `applyHeroRegion`.** The helper now takes `{ settle: false }`; `peekEdit` is a one-line alias.

**Dispositioned, not fixed:**

- *Extract a shared `restartClass(node, cls)` helper* (de-dup, marginal — the reviewer explicitly said not to block on it). Declined: the three sites clear different classes, add a computed one, and attach different `animationend` cleanup; the net saving is ~4 lines and each site loses its local explanation.
- *`peek.gif` can't by itself evidence the fade-in/out arc* (a reviewer can only read its first frame). Accepted: the `retiredHash !== extendedHash` e2e check carries the hold-and-retire behavior, and the stills carry the rest.

De-dup coverage: all four strategies ran — S1 names (8 queries / 7175 candidates), S2 clones (252-line report; 10 pairs touch the changed files, none intersecting added lines), S3 index (3590 items), S4 manual read.

Verification was re-run after the fixes: build green, 148/148 e2e, 24/24 units.
