### PR TITLE
refactor(examples): orbs adopts module Client/Server over the real transport

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -239,9 +239,15 @@ error listing the blocks the file does declare). The transitional form names
 a binding **prefix** — `"server": { "file": "game.fun", "prefix": "server" }`
 — resolving every canonical entry binding through the prefix as camelCase
 (`serverInit`/`serverTick`/…). A role declares at most one of the two.
-`examples/orbs` is the same-file reference: its `client` role is the file's
-plain top-level contract and its `server` role is the `server` PREFIX — the
-form its sandbox server pane shipped with. **Both forms run on native and
+The two multiplayer samples are the deliberate pair of shapes:
+`examples/orbs` is the SAME-FILE reference — one `game.fun` whose `client`
+and `server` roles are BOTH inline modules of it (`module Client { … }` /
+`module Server { … }`), with the protocol, the world step and the renderer
+shared bare above them, so one buffer hot-reloads both roles atomically (its
+sandbox client and server panes boot the same source at `?module=Client` /
+`?module=Server`). `examples/mp` is the roles-as-FILES reference — the shape
+to reach for once roles outgrow one buffer or want independent deploy units.
+**Both forms run on native and
 wasm**: `run wasm`/`build wasm` bake the
 role into the served/exported page's boot config (`window.__functorLangEntryModule`
 / `…EntryPrefix`; the site player takes `?module=<Ident>` or `?prefix=<ident>`,
@@ -447,6 +453,17 @@ let tick = (m, dt, tts) => Server.step(Server.Spawn(1.0), m)
   `"server": { "file": "game.fun", "module": "Server" }` resolves
   `Server.init`/`Server.tick`/… (see `entries` above). Such a role runs on
   native and wasm; only vr still refuses it.
+- **The shadowing trap when a role moves into a block.** A block's own names
+  shadow the file's, so `module Client { let init = init }` is
+  **self-referential**, not an alias of a top-level `init` — you get
+  `error: global Client.init used before its definition`, and the same goes
+  for any `tick`/`draw`/`update` the file also defines at top level. Give
+  shared values names the contract does not use (`initialGame`, `board`) and
+  let each block reference those. The same rule holds for TYPES: a
+  `module Client` may not sit next to a top-level `type Client` (a module
+  name occupies its file's value and type namespaces — that is a collision
+  load error, not shadowing), so move the role's model type INTO the block
+  (`Client.Model`).
 - **Hot reload**: canonical names are the rebind identity, so an inline
   module's closures rebind normally — but MOVING a def into (or out of) a
   module renames it (`step` → `Server.step`), which the rebinder treats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,22 +248,17 @@ error listing the file's blocks). The transitional form names a binding **prefix
 `"server": {"file": "game.fun", "prefix": "server"}` — resolving every canonical entry
 binding through the prefix as camelCase (`serverInit`/`serverTick`/…); a role declares at
 most one of the two. `build` validates every declared role's contract with its resolved
-<<<<<<< HEAD
-names. Module roles are native-only for now (`run wasm`/`build wasm`/`run vr` refuse
-them, so a role that must also run in the browser stays on the prefix form);
-prefixed roles also run on wasm (`run wasm`/`build wasm` bake the prefix into the
-page's boot config; the site player takes `?prefix=<ident>`) — vr loads the unprefixed
-contract only. `examples/orbs` is the same-file reference: its `client` role is the
-file's plain top-level contract and its `server` role is the `server` PREFIX — the form
-that also runs in the browser, which the sandbox's server pane needs.
-=======
 names. Both forms run on native and wasm — `run wasm`/`build wasm` bake the role into the
 served/exported page's boot config, and the site player takes `?module=<Ident>` or
 `?prefix=<ident>`. Only `run vr` refuses a role (the device push path boots the APK's
-embedded producer with the unprefixed contract). `examples/orbs` is the same-file
-reference: its `client` role is the file's plain top-level contract and its `server` role
-is a `module Server { … }` block.
->>>>>>> 8333093 (feat(web): module entry roles on the embedded producer)
+embedded producer with the unprefixed contract). The two multiplayer samples are the
+deliberate pair of shapes: **`examples/orbs`** is the SAME-FILE reference — one `game.fun`
+whose `client` and `server` roles are both inline modules of it (`module Client { … }` /
+`module Server { … }`, with the protocol, the world step and the renderer shared bare above
+them), so one buffer hot-reloads both roles atomically and the sandbox runs the two panes
+off the same source; **`examples/mp`** is the roles-as-FILES reference (`client.fun` +
+`server.fun` over a shared `protocol.fun`) — the shape to reach for once roles outgrow one
+buffer or want independent deploy units.
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/docs/functor-lang.md
+++ b/docs/functor-lang.md
@@ -707,11 +707,9 @@ snapshots — no GPU, fully agent-verifiable.
       naming the role, the file, and the blocks it does declare — re-resolved
       on every hot reload, so deleting the block fails loudly and keeps the
       old program instead of reporting every binding missing. Module roles
-      landed native-only here; Part 9 lifted that to wasm. `examples/orbs`
-      is the same-file reference: its `client` role is the file's plain
-      top-level contract (so the sandbox and the docs teach the same
-      `init`/`tick`/`draw`) and its `server` role stays on the PREFIX form,
-      the one its sandbox server pane shipped with. *Verify:* config-shape tests
+      landed native-only here; Part 9 lifted that to wasm, and Part 10 moved
+      `examples/orbs` — the same-file reference — onto blocks for BOTH of its
+      roles. *Verify:* config-shape tests
       (module form, module+prefix refusal, non-string/non-Capitalized names,
       unknown keys), contract tests naming `Server.tick`, an unknown-block
       error test, a desktop load + hot-reload test for a module role, the
@@ -736,6 +734,30 @@ snapshots — no GPU, fully agent-verifiable.
       block lists the file's blocks), CLI tests for the lifted guards and the
       page's baked boot config, and a headless `run wasm` browser smoke of a
       `module Server` role.
+      **Part 10 — the samples adopt the two canonical shapes — done:**
+      `examples/orbs` is now fully symmetric — its functor.json maps BOTH
+      roles to blocks of the one `game.fun`
+      (`{"client": {"file": "game.fun", "module": "Client"},
+      "server": {"file": "game.fun", "module": "Server"}}`), with the
+      protocol, the world step and the renderer shared bare above them.
+      Nothing at the file's top level answers a plain entry any more, and the
+      sandbox plays both ends of it over the REAL transport: the client panes
+      boot `?module=Client`, the authority pane `?module=Server`, one buffer,
+      one atomic hot reload. `examples/mp` is deliberately NOT migrated — it
+      is the roles-as-FILES shape (`client.fun` + `server.fun` over a shared
+      `protocol.fun`), the one to reach for once roles outgrow a buffer or
+      want independent deploy units. Two traps the migration documents at the
+      trap (SKILL.md's inline-module section): a block's own `init` shadows
+      the file's, so `let init = init` inside the block is self-referential
+      rather than an alias, and a `module Client` may not sit beside a
+      top-level `type Client` — the role's model type moves into the block
+      (`Client.Model`). With orbs migrated, **no role anywhere in the repo
+      uses the `prefix` form** — the precondition for deprecating it.
+      *Verify:* per-role native captures byte-identical to the pre-migration
+      project at the same fixed time, `test`/`build`/`build wasm` on the
+      project (the exported page carries `__functorLangEntryModule`), and the
+      sandbox e2e pinning the module-form panes plus live packet flow between
+      the client panes and the authority.
 - [x] **Language: string interpolation** (done 2026-07-23). An explicit
       F#-style `$"score: {score}"` literal accepts full Functor expressions
       in each `{…}` hole and evaluates them left-to-right. String values

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -1028,15 +1028,20 @@ try {
       "both orbs clients were seated by the authority (a pid off the wire)",
       String(models.c1).slice(0, 120)
     );
+    // A SEAT, not just a pilot: the world's pilots carry a `pid` too, so only
+    // the cid→pid pairing proves the authority bound each connection.
     check(
       typeof models.server === "string" &&
-        (models.server.match(/cid: /g) ?? []).length === 2 &&
-        (models.server.match(/pid: /g) ?? []).length >= 2,
+        (models.server.match(/cid: \d+, pid: \d+/g) ?? []).length === 2,
       "the authority holds a seat for each client pane",
       String(models.server).slice(0, 160)
     );
+    // A boot failure can surface as an uncaught exception rather than a
+    // `[functor-lang]` line, so the pageerror relay counts too.
     const errors = consoleLog.filter(
-      (line) => line.includes("[functor-lang]") && line.includes("error")
+      (line) =>
+        line.startsWith("pageerror:") ||
+        (line.includes("[functor-lang]") && line.includes("error"))
     );
     check(errors.length === 0, "no orbs pane reported a runtime error", errors.slice(0, 3).join(" | "));
     await page.close();

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -21,7 +21,10 @@
 //   6. switching to a single-role example removes the server pane again;
 //   7. every pane CARD letterboxes to a 16:9 body inside its cell in the grid
 //      and network views, the "+" seat is last in reading order, and the
-//      network wires anchor to the cards rather than to the cells.
+//      network wires anchor to the cards rather than to the cells;
+//   8. ORBS — the same-file sample — boots every pane of the ONE file at its
+//      own inline module (`?module=Client` / `?module=Server`), and its real
+//      wire carries packets both ways between the blocks.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -109,6 +112,9 @@ const installProbe = (page) =>
     window.__mpProbe = {
       roles: () => shells().map((s) => s.role),
       headers: () => shells().map((s) => s.header),
+      // Each pane's player URL — the seam a same-file sample's ROLE travels
+      // through (`?module=Client` / `?module=Server`).
+      srcs: () => shells().map((s) => s.frame.getAttribute("src")),
       // The link indicator, read as STATE rather than as prose: the dot is what
       // survives when a thumbnail header clips the word off (see headerParts).
       links: () =>
@@ -926,6 +932,113 @@ try {
       "the late client and the server still correspond after the seek",
       `offset was ${offset}, now ${after[1] - after[2]}`
     );
+    await page.close();
+  }
+
+  // --- 4f. Orbs: both roles are MODULES of one file, over the real wire. ------
+  // examples/mp puts its roles in separate FILES; orbs puts them in one buffer
+  // as `module Client` / `module Server`, so the ROLE — not the file — is what
+  // distinguishes the panes. That makes this the only section where booting
+  // the wrong param is silent-ish rather than a 404: a pane that lost its
+  // `?module=` would boot the file's (nonexistent) plain top-level contract, so
+  // reaching `live` at all is already an assertion, and the packet flow below
+  // proves the two blocks are really talking to each other.
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    const consoleLog = [];
+    page.on("console", (m) => consoleLog.push(m.text()));
+    page.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+    await page.goto(`${BASE}/sandbox.html?example=orbs#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    check(
+      roles.join(", ") === "client 1, client 2, server",
+      "orbs mounts two client panes and an authority pane",
+      roles.join(", ")
+    );
+    const srcs = await page.evaluate(() => window.__mpProbe.srcs());
+    const params = srcs.map((src) => new URLSearchParams(src.split("?")[1]));
+    check(
+      params.length === 3 &&
+        params.every((p) => !p.has("prefix")) &&
+        params[0].get("module") === "Client" &&
+        params[1].get("module") === "Client" &&
+        params[2].get("module") === "Server",
+      "every orbs pane boots its role as a MODULE — clients Client, authority Server",
+      params.map((p) => `${p.get("game")}?module=${p.get("module")}`).join(" | ")
+    );
+    // One file, one project: the panes differ ONLY by the role they resolve.
+    check(
+      params.every((p) => p.get("game") === params[0].get("game")),
+      "all three panes boot the same file",
+      params.map((p) => p.get("game")).join(" | ")
+    );
+
+    const pill = await page
+      .waitForFunction(() => window.__mpProbe.pill().includes("2+1 running"), null, {
+        timeout: 20000,
+      })
+      .then(() => page.evaluate(() => window.__mpProbe.pill()))
+      .catch(() => page.evaluate(() => window.__mpProbe.pill()));
+    check(pill.includes("2+1 running"), "the orbs pill counts clients and authority apart", pill);
+
+    // THE TRANSPORT. Orbs speaks a real wire: each client dials the authority
+    // (`Sub.connect`), the authority listens (`Sub.listen`) and answers a
+    // Welcome, then snapshots stream back every tick. Packets on the hub's
+    // wires — both directions — are that traffic, sampled live.
+    await page.click("#mp-view-network");
+    await sleep(600);
+    const graph = await page.evaluate(() => window.__mpProbe.network());
+    check(
+      graph.wires === 2 && graph.drawn === 2,
+      "the hub view wires each orbs client to the authority",
+      `${graph.wires} wires`
+    );
+    let flight = graph;
+    let flowing = false;
+    for (let i = 0; i < 40 && !flowing; i++) {
+      await sleep(150);
+      flight = await page.evaluate(() => window.__mpProbe.network());
+      flowing = flight.up > 0 && flight.down > 0;
+    }
+    check(
+      flowing,
+      "orbs packets fly both ways — Steer up, Snapshot down",
+      `up=${flight.up} down=${flight.down}`
+    );
+
+    // …and the traffic MEANS something: the authority seated both connections
+    // and each client is flying a pid the server handed it (init's -1).
+    await page.click("#mp-view-tiled");
+    await sleep(2500);
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(1500);
+    const models = await page.evaluate(() => ({
+      c1: window.__mpProbe.model("client 1"),
+      c2: window.__mpProbe.model("client 2"),
+      server: window.__mpProbe.model("server"),
+    }));
+    const seated = (model) =>
+      typeof model === "string" && /myPid: (?!-1)\d/.test(model) && model.includes("ships: [");
+    check(
+      seated(models.c1) && seated(models.c2),
+      "both orbs clients were seated by the authority (a pid off the wire)",
+      String(models.c1).slice(0, 120)
+    );
+    check(
+      typeof models.server === "string" &&
+        (models.server.match(/cid: /g) ?? []).length === 2 &&
+        (models.server.match(/pid: /g) ?? []).length >= 2,
+      "the authority holds a seat for each client pane",
+      String(models.server).slice(0, 160)
+    );
+    const errors = consoleLog.filter(
+      (line) => line.includes("[functor-lang]") && line.includes("error")
+    );
+    check(errors.length === 0, "no orbs pane reported a runtime error", errors.slice(0, 3).join(" | "));
     await page.close();
   }
 

--- a/examples/orbs/functor.json
+++ b/examples/orbs/functor.json
@@ -1,7 +1,7 @@
 {
   "language": "functor-lang",
   "entries": {
-    "client": "game.fun",
-    "server": { "file": "game.fun", "prefix": "server" }
+    "client": { "file": "game.fun", "module": "Client" },
+    "server": { "file": "game.fun", "module": "Server" }
   }
 }

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -6,6 +6,12 @@
 // claim it: it takes your color, and your score is the orbs you own. A full
 // board deals a fresh round. The server owns the world; a client sends what
 // it is doing and draws the snapshots it gets back.
+//
+// BOTH roles are inline modules of this ONE file — `module Client` at the
+// bottom and `module Server` under it, each block's members ARE that role's
+// contract (`Client.init`/`Client.tick`/…). functor.json maps the roles to
+// them; everything above the blocks is shared by both. One buffer, one atomic
+// hot reload, and the protocol declared exactly once.
 
 // ==========================  PROTOCOL  ================================
 // What both roles agree on — exactly what `Effect.sendMsg` carries (no string
@@ -61,10 +67,10 @@ let claimRange = 1.8
 let overOrb = (ship: Ship, o: Orb): bool =>
   dist2(ship.x, ship.y, o.x, o.y) < claimRange * claimRange
 
-// ===========================  SERVER  =================================
+// ========================  THE WORLD (shared)  ========================
 // PURE functions over the protocol types: `join` seats a pilot, `recv` folds
 // one arriving message in, `step` advances a tick and settles claims. The
-// role that puts them behind a socket is at the bottom of the file.
+// role that puts them behind a socket is `module Server` at the bottom.
 
 let turnSpeed = 3.2       // radians/second
 let moveSpeed = 9.0       // units/second while thrusting
@@ -156,11 +162,9 @@ let step = (dt: float, w: World): World =>
 let scoreOf = (pid: float, orbs: List<Orb>): float =>
   orbs |> List.filter((o) => o.owner == pid) |> List.length
 
-// ===========================  CLIENT  =================================
-// The `client` role is this file's ordinary top-level contract
-// (init/subscriptions/update/sampledInput/tick/draw). It holds NO authority:
-// it dials the server, says what it is doing, and draws the last Snapshot it
-// was sent. Your pid arrives in the Welcome — identity comes from the server.
+// =====================  PRESENTATION (shared)  ========================
+// Both roles draw the same board from the same two lists — the client from
+// the last Snapshot it was sent, the authority from the world it owns.
 
 // Palette: zero-arg functions, not top-level values — the sandbox's lang-intel
 // evaluates this module under the plain prelude, where Color.* doesn't exist.
@@ -173,55 +177,6 @@ let bg = () => Color.rgb(0.02, 0.025, 0.06)
 // Color carries IDENTITY, not "me": a pid looks the same in every pane.
 let inkFor = (pid: float) => if Math.mod(pid, 2.0) == 0.0 then cyan() else pink()
 
-type Client = { conn: Option.t<float>, myPid: float,
-                ships: List<Ship>, orbs: List<Orb>, intent: Intent }
-
-let init: Client = { conn: Option.None, myPid: 0.0 - 1.0,
-                     ships: [], orbs: [], intent: coast }
-
-// Declaring the connection in `subscriptions` keeps the socket open.
-let subscriptions = (m: Client) => Sub.connect(serverUrl, toMsg)
-
-let update = (m: Client, msg: Msg) =>
-  match msg with
-  | Opened(id) => ({ m with conn: Option.Some(id) }, Effect.sendMsg(id, Join))
-  | Packet(_, wire) =>
-      (match wire with
-       | Welcome(pid) => { m with myPid: pid }
-       | Snapshot(ships, orbs) => { m with ships: ships, orbs: orbs }
-       | _ => m)          // Join/Steer/Claim are client -> server only
-  | Closed(_) => { m with conn: Option.None, ships: [], orbs: [] }
-  | Noise(_) => m       // a hiccup is not a disconnect: keep playing
-
-// Held LEVELS, read once per tick — exactly what the Steer forwards.
-let sampledInput = (m: Client, snap: Input.snapshot) =>
-  let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
-  { m with intent: {
-      turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
-          - (if held(Key.Right) || held(Key.D) then 1.0 else 0.0),
-      thrust: held(Key.Up) || held(Key.W),
-      claim: held(Key.Space) } }
-
-// One burst per tick — and nothing at all before the server has seated us.
-// `Steer` reports the input we are holding right now; a `Claim` rides along
-// only when the last Snapshot we were sent puts us over a free orb. Both are
-// PROPOSALS — neither is a fact until the server re-checks it.
-let tick = (m: Client, dt: float, tts: float) =>
-  match m.conn with
-  | Option.None => m
-  | Option.Some(id) =>
-    (match m.ships |> List.find((s) => s.pid == m.myPid) with
-     | Option.None => m
-     | Option.Some(s) =>
-       let claim =
-         if not m.intent.claim then []
-         else (match m.orbs |> List.find((o) => o.owner < 0.0 && overOrb(s, o)) with
-               | Option.Some(o) => [Claim(o.id)]
-               | Option.None => []) in
-       (m, Effect.batch([Steer(m.intent), ..claim]
-                          |> List.map((w) => Effect.sendMsg(id, w)))))
-
-// ---------- rendering ----------
 // Unclaimed orbs glow dim white; a claimed orb burns its owner's color.
 let orbSprite = (o: Orb) =>
   let claimed = o.owner >= 0.0 in
@@ -267,61 +222,120 @@ let board = (me: float, alone: string, ships: List<Ship>, orbs: List<Orb>) =>
         |> List.append([hud(alone, ships, orbs)])))
     |> Frame.withClearColor(bg())
 
-let draw = (m: Client, tts: float) =>
-  board(m.myPid, "waiting for the server...", m.ships, m.orbs)
+// ===========================  CLIENT  =================================
+// The `client` role: functor.json maps it to { "file": "game.fun",
+// "module": "Client" }, so this block's members ARE the contract —
+// Client.init/Client.tick/Client.draw/… It holds NO authority: it dials the
+// server, says what it is doing, and draws the last Snapshot it was sent.
+// Your pid arrives in the Welcome — identity comes from the server.
 
-// ========================  SERVER ROLE  ===============================
-// The same file is ALSO the `server` entry: functor.json maps the role to
-// { "file": "game.fun", "prefix": "server" }, so the runner resolves this
-// section's bindings as the contract — serverInit/serverTick/serverDraw/…
+module Client {
+  type Model = { conn: Option.t<float>, myPid: float,
+                 ships: List<Ship>, orbs: List<Orb>, intent: Intent }
+
+  let init: Model = { conn: Option.None, myPid: 0.0 - 1.0,
+                      ships: [], orbs: [], intent: coast }
+
+  // Declaring the connection in `subscriptions` keeps the socket open.
+  let subscriptions = (m: Model) => Sub.connect(serverUrl, toMsg)
+
+  let update = (m: Model, msg: Msg) =>
+    match msg with
+    | Opened(id) => ({ m with conn: Option.Some(id) }, Effect.sendMsg(id, Join))
+    | Packet(_, wire) =>
+        (match wire with
+         | Welcome(pid) => { m with myPid: pid }
+         | Snapshot(ships, orbs) => { m with ships: ships, orbs: orbs }
+         | _ => m)          // Join/Steer/Claim are client -> server only
+    | Closed(_) => { m with conn: Option.None, ships: [], orbs: [] }
+    | Noise(_) => m       // a hiccup is not a disconnect: keep playing
+
+  // Held LEVELS, read once per tick — exactly what the Steer forwards.
+  let sampledInput = (m: Model, snap: Input.snapshot) =>
+    let held = (k: Key.t) => snap.heldKeys |> List.any((h) => h == k) in
+    { m with intent: {
+        turn: (if held(Key.Left) || held(Key.A) then 1.0 else 0.0)
+            - (if held(Key.Right) || held(Key.D) then 1.0 else 0.0),
+        thrust: held(Key.Up) || held(Key.W),
+        claim: held(Key.Space) } }
+
+  // One burst per tick — and nothing at all before the server has seated us.
+  // `Steer` reports the input we are holding right now; a `Claim` rides along
+  // only when the last Snapshot we were sent puts us over a free orb. Both are
+  // PROPOSALS — neither is a fact until the server re-checks it.
+  let tick = (m: Model, dt: float, tts: float) =>
+    match m.conn with
+    | Option.None => m
+    | Option.Some(id) =>
+      (match m.ships |> List.find((s) => s.pid == m.myPid) with
+       | Option.None => m
+       | Option.Some(s) =>
+         let claim =
+           if not m.intent.claim then []
+           else (match m.orbs |> List.find((o) => o.owner < 0.0 && overOrb(s, o)) with
+                 | Option.Some(o) => [Claim(o.id)]
+                 | Option.None => []) in
+         (m, Effect.batch([Steer(m.intent), ..claim]
+                            |> List.map((w) => Effect.sendMsg(id, w)))))
+
+  let draw = (m: Model, tts: float) =>
+    board(m.myPid, "waiting for the server...", m.ships, m.orbs)
+}
+
+// ===========================  SERVER  =================================
+// The `server` role, the same file's other block: functor.json maps it to
+// { "file": "game.fun", "module": "Server" }, so the runner resolves
+// Server.init/Server.tick/Server.draw/… as the contract
 // (functor -d examples/orbs run native --entry server). One buffer, both
 // roles, one hot reload.
 
-type Seat = { cid: float, pid: float }   // connection -> the pilot it steers
+module Server {
+  type Seat = { cid: float, pid: float }   // connection -> the pilot it steers
 
-// An empty arena: every pilot arrives over a wire, so the board starts with
-// five unclaimed orbs and nobody in it.
-let serverInit = { world: newWorld(), seats: [] }
+  // An empty arena: every pilot arrives over a wire, so the board starts with
+  // five unclaimed orbs and nobody in it.
+  let init = { world: newWorld(), seats: [] }
 
-// Declaring the listener in `subscriptions` keeps the server bound.
-let serverSubscriptions = (m) => Sub.listen(bind, toMsg)
+  // Declaring the listener in `subscriptions` keeps the server bound.
+  let subscriptions = (m) => Sub.listen(bind, toMsg)
 
-let seatPid = (cid: float, m): Option.t<float> =>
-  m.seats |> List.find((s) => s.cid == cid) |> Option.map((s) => s.pid)
+  let seatPid = (cid: float, m): Option.t<float> =>
+    m.seats |> List.find((s) => s.cid == cid) |> Option.map((s) => s.pid)
 
-let serverUpdate = (m, msg: Msg) =>
-  match msg with
-  | Opened(_) => m        // a socket, not yet a pilot: the Join seats it
-  | Packet(cid, wire) =>
-      (match wire with
-       // The handshake: seat a pilot for this connection, answer its identity.
-       // A re-Join is answered from the seat it already has — one connection
-       // is one pilot, however many times it asks.
-       | Join =>
-         (match seatPid(cid, m) with
-          | Option.Some(pid) => (m, Effect.sendMsg(cid, Welcome(pid)))
-          | Option.None =>
-            let (w, pid) = join(m.world) in
-            ({ m with world: w, seats: [{ cid: cid, pid: pid }, ..m.seats] },
-             Effect.sendMsg(cid, Welcome(pid))))
-       // Everything else is keyed by the connection, never by the wire value.
-       | _ =>
-         (match seatPid(cid, m) with
-          | Option.Some(pid) => { m with world: m.world |> recv(pid, wire) }
-          | Option.None => m))
-  | Noise(_) => m
-  | Closed(cid) =>
-      (match seatPid(cid, m) with
-       | Option.Some(pid) => { m with world: m.world |> leave(pid),
-                               seats: m.seats |> List.filter((s) => not s.cid == cid) }
-       | Option.None => m)
+  let update = (m, msg: Msg) =>
+    match msg with
+    | Opened(_) => m        // a socket, not yet a pilot: the Join seats it
+    | Packet(cid, wire) =>
+        (match wire with
+         // The handshake: seat a pilot for this connection, answer its identity.
+         // A re-Join is answered from the seat it already has — one connection
+         // is one pilot, however many times it asks.
+         | Join =>
+           (match seatPid(cid, m) with
+            | Option.Some(pid) => (m, Effect.sendMsg(cid, Welcome(pid)))
+            | Option.None =>
+              let (w, pid) = join(m.world) in
+              ({ m with world: w, seats: [{ cid: cid, pid: pid }, ..m.seats] },
+               Effect.sendMsg(cid, Welcome(pid))))
+         // Everything else is keyed by the connection, never by the wire value.
+         | _ =>
+           (match seatPid(cid, m) with
+            | Option.Some(pid) => { m with world: m.world |> recv(pid, wire) }
+            | Option.None => m))
+    | Noise(_) => m
+    | Closed(cid) =>
+        (match seatPid(cid, m) with
+         | Option.Some(pid) => { m with world: m.world |> leave(pid),
+                                 seats: m.seats |> List.filter((s) => not s.cid == cid) }
+         | Option.None => m)
 
-let serverTick = (m, dt: float, tts: float) =>
-  let stepped = m.world |> step(dt) in
-  let snap = Snapshot(stepped.pilots |> List.map((p) => p.ship), stepped.orbs) in
-  ({ m with world: stepped },
-   Effect.batch(m.seats |> List.map((s) => Effect.sendMsg(s.cid, snap))))
+  let tick = (m, dt: float, tts: float) =>
+    let stepped = m.world |> step(dt) in
+    let snap = Snapshot(stepped.pilots |> List.map((p) => p.ship), stepped.orbs) in
+    ({ m with world: stepped },
+     Effect.batch(m.seats |> List.map((s) => Effect.sendMsg(s.cid, snap))))
 
-let serverDraw = (m, tts: float) =>   // the authority holds no seat of its own
-  board(0.0 - 1.0, "waiting for a pilot...",
-        m.world.pilots |> List.map((p) => p.ship), m.world.orbs)
+  let draw = (m, tts: float) =>   // the authority holds no seat of its own
+    board(0.0 - 1.0, "waiting for a pilot...",
+          m.world.pilots |> List.map((p) => p.ship), m.world.orbs)
+}

--- a/examples/orbs/game.fun
+++ b/examples/orbs/game.fun
@@ -7,8 +7,8 @@
 // board deals a fresh round. The server owns the world; a client sends what
 // it is doing and draws the snapshots it gets back.
 //
-// BOTH roles are inline modules of this ONE file — `module Client` at the
-// bottom and `module Server` under it, each block's members ARE that role's
+// BOTH roles are inline modules of this ONE file — `module Client` near the
+// end and `module Server` after it; each block's members ARE that role's
 // contract (`Client.init`/`Client.tick`/…). functor.json maps the roles to
 // them; everything above the blocks is shared by both. One buffer, one atomic
 // hot reload, and the protocol declared exactly once.

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -374,10 +374,12 @@ functor -d . run native --entry server  # the same world, seen from the authorit
           <p class="docs-callout">
             This is the one step with no <strong>▶ try it</strong> button — that path pastes a
             program in and boots it against the <em>unprefixed</em> contract, which a
-            prefixed role by definition doesn't answer. The sandbox can still play a prefixed
-            role when it knows the prefix up front:
+            prefixed role by definition doesn't answer. The sandbox can still play a declared
+            role when it knows it up front:
             <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see this same
-            one-file, two-role shape at full size, with an authoritative claim-resolution rule.
+            one-file, two-role shape at full size — both roles as inline
+            <code>module Client</code> / <code>module Server</code> blocks, over a real wire,
+            with an authoritative claim-resolution rule.
           </p>
         </section>
 

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -376,10 +376,10 @@ functor -d . run native --entry server  # the same world, seen from the authorit
             program in and boots it against the <em>unprefixed</em> contract, which a
             prefixed role by definition doesn't answer. The sandbox can still play a declared
             role when it knows it up front:
-            <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see this same
-            one-file, two-role shape at full size — both roles as inline
-            <code>module Client</code> / <code>module Server</code> blocks, over a real wire,
-            with an authoritative claim-resolution rule.
+            <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see the
+            one-file, two-role shape at full size in its preferred form — each role an inline
+            <code>module Client</code> / <code>module Server</code> block instead of a prefix,
+            over a real wire, with an authoritative claim-resolution rule.
           </p>
         </section>
 

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -70,10 +70,10 @@ export interface Example {
    * example's own entry, which is copied and listed already.
    *
    * The server pane derives its params from the client's, so the server
-   * ROLE must be stated here rather than inherited: `prefix` when the role
-   * resolves prefixed bindings in a shared file (orbs: `serverInit`/…,
-   * carried as `?prefix=`), or `module` when it is an inline entry module
-   * (`{ "file": …, "module": "Server" }`, carried as `?module=`). At most
+   * ROLE must be stated here rather than inherited: `module` when it is an
+   * inline entry module in a shared file (orbs: `{ "file": …, "module":
+   * "Server" }`, carried as `?module=`), or `prefix` for the transitional
+   * prefixed-binding form (`serverInit`/…, carried as `?prefix=`). At most
    * one of the two.
    */
   server?: { file: string; module?: string; prefix?: string };
@@ -151,18 +151,20 @@ export const EXAMPLES: Example[] = [
   // Named `bounce` (not `physics`): the flat copy makes `file = module`, and a
   // module literally named `Physics` collides with the builtin/prelude namespace.
   { id: "bounce", label: "Physics", source: "examples/physics/game.fun" },
-  // The minimal multiplayer-mechanics sample in ONE module (banner sections:
-  // PROTOCOL / SERVER / CLIENT / SERVER ROLE), so the wire ADT and the
-  // authoritative claim resolution are right there in the editable buffer.
+  // The minimal multiplayer-mechanics sample in ONE file (banner sections:
+  // PROTOCOL / THE WORLD / PRESENTATION / CLIENT / SERVER — the last two the
+  // roles' own `module` blocks), so the wire ADT and the authoritative claim
+  // resolution are right there in the editable buffer.
   {
     id: "orbs",
     label: "Orbs (multiplayer)",
     source: "examples/orbs/game.fun",
     multiplayer: true,
-    // Both roles are in the ONE editable buffer: the sandbox plays the
-    // `client` role (the file's ordinary top-level contract, so no `prefix`),
-    // and the server pane re-enters the same file through the `server` prefix.
-    server: { file: exampleEntryPath("orbs"), prefix: "server" },
+    // Both roles are inline MODULES of the ONE editable buffer: the sandbox
+    // plays `module Client` (`?module=Client`), and the server pane re-enters
+    // the same file at `module Server` (`?module=Server`).
+    module: "Client",
+    server: { file: exampleEntryPath("orbs"), module: "Server" },
   },
   // The client/server sample: two ROLES over a shared typed protocol, run
   // end-to-end in the pane grid — the client panes and a server pane, wired to

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -435,12 +435,12 @@ const loadExample = async (id: string) => {
     params.set("cursor", cursorPolicy);
   }
   for (const file of files) params.append("file", file);
-  // A same-file-entries sample plays its declared role: the player boots the
-  // prefixed contract (e.g. orbs' clientInit/clientTick/…).
-  if (example?.prefix) params.set("prefix", example.prefix);
-  // …or, in the preferred same-file form, the role's inline module (the
-  // player takes one of the two).
+  // A same-file-entries sample plays its declared role: in the preferred form
+  // the role's inline module (e.g. orbs' Client.init/Client.tick/…)…
   if (example?.module) params.set("module", example.module);
+  // …or the transitional prefixed contract (clientInit/clientTick/…); the
+  // player takes one of the two.
+  if (example?.prefix) params.set("prefix", example.prefix);
   frame.src = `player.html?${params}`;
   // A sample with a SERVER role (examples.ts `server`) also boots a server
   // pane: the SAME file list re-entered at the server file. `?file=` is the
@@ -450,23 +450,19 @@ const loadExample = async (id: string) => {
   let serverSrc: string | null = null;
   if (serverFile) {
     // Derived from the client's params, so every project setting the sample
-    // declares (prefix, cursor, mouseCapture) reaches the server pane too —
-    // only the entry, the file ORDER, and the role prefix differ.
+    // declares (cursor, mouseCapture) reaches the server pane too — only the
+    // entry, the file ORDER, and the ROLE differ.
     const serverParams = new URLSearchParams(params);
     serverParams.set("game", serverFile);
-    // …except the role PREFIX, which is the one param the server owns: a
-    // same-file sample (orbs) has both roles in one entry, so the server pane
-    // differs from the client pane only by the prefix it resolves through, and
-    // inheriting the client's would boot the wrong contract.
-    serverParams.delete("prefix");
-    if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     serverParams.delete("file");
-    // The client's ROLE must not leak into the server pane — neither form.
-    // A same-file sample states the server's own inline module; absent, the
-    // server file's plain top-level contract is the role.
+    // The client's ROLE must not leak into the server pane — neither form, so
+    // both are dropped before the server's own is applied. A same-file sample
+    // (orbs) has both roles in the one entry and differs only here; absent a
+    // declared role, the server file's plain top-level contract is the role.
     serverParams.delete("module");
     serverParams.delete("prefix");
     if (example?.server?.module) serverParams.set("module", example.server.module);
+    if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);
     }


### PR DESCRIPTION
Redo of the closed **#627** on top of the merged **#623** (module roles on the
embedded/wasm producer, now in `main` as a7ce3d1). #627 was superseded when
**#622** rewrote `examples/orbs/game.fun` to speak the real transport and
reverted #601's `module Server` back to the PREFIX form, because the sandbox's
server pane runs in the browser and module roles were native-only at the time.
#623 removed that constraint, so the migration lands fresh against the
transport version — **including the server pane, which #627 could not take.**

## The migration

**`examples/orbs` is now fully symmetric.** Both roles are inline modules of the
one `game.fun`:

```json
{ "entries": {
    "client": { "file": "game.fun", "module": "Client" },
    "server": { "file": "game.fun", "module": "Server" }
} }
```

Nothing at the file's top level answers a plain entry any more. The protocol
ADT, the pure world step (`join`/`recv`/`step`/`resolveOrb`), the palette and the
shared renderer (`orbSprite`/`shipSprite`/`hud`/`board`) stay bare above the two
blocks; `module Client { … }` and `module Server { … }` hold only their own
contract. The diff is mechanical — every moved body is character-for-character
what it was (both reviewers verified this independently); the only renames are
the two the language forces (below).

`site/src/examples.ts` declares `module: "Client"` and
`server: { file: …, module: "Server" }`, so the sandbox's client panes boot
`?module=Client` and the authority pane `?module=Server` — the same buffer, one
atomic hot reload, two roles.

## The two traps, documented at the trap

SKILL.md's inline-module section now carries both, next to the role contract
rather than only in a PR body:

1. **A block's own `init` shadows the file's**, so `let init = init` inside
   `module Client` is *self-referential* (`error: global Client.init used before
   its definition`), not an alias. Shared values keep names the contract does not
   use.
2. **A `module Client` may not sit beside a top-level `type Client`** — a module
   name occupies its file's value AND type namespaces, so that is a *collision
   load error*, not shadowing. The client's model type moved into the block as
   `Client.Model`.

## Two bugs fixed on the way

- **`site/src/sandbox.tsx` dropped the server pane's role.** #623's review fix
  added a second `serverParams.delete("prefix")` *after* the server's own prefix
  was applied, so on `main` the orbs authority pane booted with **no role at
  all** — i.e. the file's plain top-level contract, which was the CLIENT. That is
  the "before" capture below: all three panes read *"waiting for the server…"*
  (the client's own `alone` string, rendered by the pane labelled SERVER) with
  zero packets. The two deletes are now one delete-both-then-apply-own block, so
  the transitional prefix form works again too.
- **`CLAUDE.md` had committed merge-conflict markers** (`<<<<<<< HEAD` /
  `>>>>>>> 8333093`) in the `entries` paragraph, merged with #623. Resolved here
  (keeping the #623 side) because this PR rewrites that paragraph anyway —
  flagging it so nobody assumes `main` was clean.

## Docs

The skill's `entries` paragraph, CLAUDE.md's, and a new **Part 10** in
`docs/functor-lang.md` all position the two multiplayer samples as the deliberate
pair: **`examples/orbs`** = the SAME-FILE shape (both roles as blocks of one
buffer), **`examples/mp`** = the roles-as-FILES shape (`client.fun` + `server.fun`
over a shared `protocol.fun`) — **deliberately not migrated**, and untouched here.
`site/manual/index.html`'s orbs callout no longer calls the sample a prefixed
role.

## Prefix-deprecation precondition

**After this PR nothing in the repo uses the prefix form for a real role.**
`grep -rn '"prefix"' --include=functor.json` is empty across `examples/` and
`e2e/fixtures/`; the form survives only in its own CLI/site tests and in the
manual's step-6 tutorial program, which still teaches `"prefix": "client"` /
`"prefix": "server"` end to end. That tutorial is the one substantive consumer a
deprecation has to migrate (it is a rendered docs surface, so it wants its own
before/after screenshots) — deliberately NOT deprecated here.

## Verification

- **Native parity — byte-identical, per role.** Same binary, a pristine copy of
  the pre-migration project vs. the migrated one,
  `--capture-frame --capture-time 3 --fixed-time 3`, both roles:
  `client` → `b320a84e…` on both sides, `server` → `5cb97213…` on both sides.
  Re-taken on the final tree after the review fixes.
- `functor -d examples/orbs test` ✓ · `build` ✓ (both roles' contracts) ·
  `build wasm` ✓ — the exported page's boot config carries
  `__functorLangEntryModule = "Client"` with an empty prefix.
- **`npm run test:sandbox-mp` — ALL CHECKS PASSED**, including the new section 4f
  (committed): every orbs pane boots the same file, the clients at
  `?module=Client` and the authority at `?module=Server` with **no** prefix
  anywhere; the hub wires both clients; **packets fly both ways** (`up=50
  down=50`); both clients hold a pid the authority handed them (init's is `-1`);
  the authority holds a `cid: N, pid: M` seat per pane; no pane errored. A pane
  that lost its `?module=` would boot a contract this file no longer has, so
  reaching `live` is itself an assertion.
- `npm run test:site` — **ALL CHECKS PASSED** (the per-example smoke is derived
  from the live picker, so `orbs` is in it). `npm run check:site` clean.
- `cargo test --no-fail-fast -p functor-cli -p functor_runtime_common
  -p functor-runtime-desktop` — green except the one known-broken-on-main
  failure, `scrubber_only_captures_primary_pointer_drags` (open as **#635**);
  confirmed it is that test and only that test.
- No perf run: nothing here touches a per-frame hot path (an example's `.fun`, its
  site metadata, an e2e, and docs).

## Captures

**The sandbox, before → after** (orbs, 2 clients, NETWORK view). Before is
`origin/main`; after is this branch. Note the causal honesty: the before/after
difference is produced by the **`sandbox.tsx` delete-ordering fix** — the module
migration is what the panes now boot *through*, not what unbroke them. The
parity hashes above are the evidence that the migration itself changed nothing.

| before (`main`) | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/f05cb6b81189d0303eb3cceb515b5153/raw/before-orbs-network.png" width="470"> | <img src="https://gist.githubusercontent.com/tommy-xr/f05cb6b81189d0303eb3cceb515b5153/raw/after-orbs-network.png" width="470"> |
| all three panes at *"waiting for the server…"*, zero packet dots | clients seated `P0`/`P1`, the authority mirroring the same world, dots flowing both ways |

**Native parity** (byte-identical to the pre-migration project at the same fixed
time — these ARE the base captures, hash for hash):

| `--entry client` | `--entry server` |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/f05cb6b81189d0303eb3cceb515b5153/raw/final-new-client.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/f05cb6b81189d0303eb3cceb515b5153/raw/final-new-server.png" width="420"> |

**The manual's callout** (the one rendered docs surface this touches), before →
after: [before](https://gist.githubusercontent.com/tommy-xr/f05cb6b81189d0303eb3cceb515b5153/raw/before-manual.png) ·
[after](https://gist.githubusercontent.com/tommy-xr/f05cb6b81189d0303eb3cceb515b5153/raw/after-manual.png).

## xreview dispositions

Three reviewers over `origin/main...HEAD`: a Claude subagent, the Codex CLI (both
also given the before/after images), and the de-duplication pass. **Neither engine
raised a Critical or High finding**; Codex returned *"No findings. The scoped
changes appear correct and appropriately limited."*

| # | Finding | Engine | Disposition |
| --- | --- | --- | --- |
| 1 | **Medium** — the manual's step 6 still teaches the PREFIX form, and the edited callout said orbs shows "this same shape", which is now false | Claude | **Fixed** (the callout says orbs shows the shape *in its preferred form*, each role a block instead of a prefix). Migrating step 6's tutorial program itself is the prefix-deprecation work, filed above, not smuggled in here. |
| 2 | **Medium** — the before/after screenshots demonstrate the `sandbox.tsx` fix, not a benefit of module roles; the body should say so | Claude | **Fixed in this body** — stated explicitly under Captures. |
| 3 | **Medium (process)** — `site/manual/index.html` is a rendered surface edited without before/after captures | Claude | **Fixed.** Both captured and linked above. |
| 4 | **Low** — the seat assertion's `pid: ` count was near-vacuous (the world's pilots carry `pid` too, so it passes with zero seats) | Claude | **Fixed.** It now counts `cid: N, pid: M` pairs — the seat binding itself. |
| 5 | **Low** — the section's console-error filter misses a boot failure surfaced as an uncaught exception, since `pageerror:` lines carry no `[functor-lang]` | Claude | **Fixed.** The filter takes `pageerror:` lines too. |
| 6 | **Low** — `game.fun`'s header said `module Client` is "at the bottom and `module Server` under it" | Claude | **Fixed** ("near the end … after it"). |
| 7 | **Low** — the `srcs` assertion checks sandbox.tsx's own URL construction, not that the runtime honored `?module=` | Claude | **Won't fix (by design).** The comment says so, and the live/packet/model checks below it are the runtime proof; `e2e/module-role-wasm.mjs` covers the runtime resolution at its own layer. |
| 8 | **Low (dup, `extract` [S2-clones, S4-read])** ×3 — the new e2e section repeats section 4a/4d's pill wait, paused-model read, and packet-poll loops | de-dup | **Won't fix.** Every section in this file is deliberately self-contained (its own page, its own probe, its own timings); hoisting three helpers would rewrite two heavily-asserted unrelated sections for no behavior change. Worth a dedicated cleanup pass, not this diff. |
| 9 | **Low (dup, `diverged` [S4-read])** — the "two canonical shapes" paragraph now exists in CLAUDE.md, SKILL.md and Part 10 | de-dup | **Won't fix.** CLAUDE.md↔SKILL.md sync is mandated by CLAUDE.md itself; `docs/functor-lang.md` is a roadmap LOG whose parts are written once and kept as history. |

Both engines independently confirmed the substance: the moved bodies are
identical to `origin/main`'s modulo the two forced renames, nothing inside either
block shadows or fails to resolve (`Server.tick` reaches the top-level `step`,
`Client.tick` the top-level `overOrb`, both `draw`s the shared `board`),
`Server.init`'s initializer demands only pure top-level defs, and the sandbox
param derivation is now correct for both role forms. The de-dup pass cleared the
`.fun` move outright ("no binding exists twice") and found no prior art for
`__mpProbe.srcs()`.

> **Coverage:** all four strategies ran; none unavailable. S1-names = 18-line
> report, 3 queries over 7167 candidates. S2-clones = 254-line report, filtered to
> 5 pairs touching the changed files, 4 within the new region. S3-index =
> 3576-line index, grepped for role/entry/prefix/module/iframe-src/serverParams.
> S4-read = full diff, 9 files, plus the surrounding e2e sections read in source.

Re-validated after the fixes: orbs `test`/`build`, `check:site`, the parity
captures re-taken on the final tree (same two hashes), and
`npm run test:sandbox-mp` **ALL CHECKS PASSED**.
