### PR TITLE
fix(site): the server pane keeps its role prefix

### DIFF
--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -454,18 +454,18 @@ const loadExample = async (id: string) => {
     // only the entry, the file ORDER, and the role prefix differ.
     const serverParams = new URLSearchParams(params);
     serverParams.set("game", serverFile);
-    // …except the role PREFIX, which is the one param the server owns: a
-    // same-file sample (orbs) has both roles in one entry, so the server pane
-    // differs from the client pane only by the prefix it resolves through, and
-    // inheriting the client's would boot the wrong contract.
-    serverParams.delete("prefix");
-    if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     serverParams.delete("file");
-    // The client's ROLE must not leak into the server pane — neither form.
-    // A same-file sample states the server's own inline module; absent, the
-    // server file's plain top-level contract is the role.
-    serverParams.delete("module");
+    // …except the ROLE, which is the one thing the server owns, in either of
+    // its two forms: a same-file sample (orbs) has both roles in one entry, so
+    // the server pane differs from the client pane only by the role it
+    // resolves through, and inheriting the client's would boot the wrong
+    // contract. Drop BOTH forms first, then apply the server's own — absent,
+    // the server file's plain top-level contract is the role. (Clearing has to
+    // come before setting: deleting after a set is what silently boots the
+    // server pane as a second client.)
     serverParams.delete("prefix");
+    serverParams.delete("module");
+    if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
     if (example?.server?.module) serverParams.set("module", example.server.module);
     for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
       serverParams.append("file", file);


### PR DESCRIPTION
**Live regression on main, currently deployed**: #623's server-pane cleanup appended `serverParams.delete("prefix")` *after* the line that sets the server role's prefix, so the clear runs last and wins. Orbs' "server" pane therefore boots the unprefixed (client) contract — `Sub.connect` instead of `Sub.listen` — and the sandbox session is three clients dialling an authority that never exists: no connections, no traffic, silently.

Main's CI could not see it: the orbs role assertions live in the in-flight wire-log branch (#622's sandbox proof was a scratch script), and mp — the only other multiplayer sample — declares its server as a separate file with no role param, so it was immune. Found by re-verifying the wire-log branch after rebase, where the new orbs checks went from green to zero-traffic.

**Fix**: clear both role forms (`prefix`, `module`) *first*, then apply whichever the server declares — with a comment stating why the order matters.

**Verification**: `tsc -p site --noEmit` clean; site built; Playwright probe on this branch confirms the server pane's iframe src carries `prefix=server` again. Full e2e evidence on the wire-log branch (which carries this same commit): all 6 previously-failing orbs checks green, 12 decoded wire-log rows, `replay=133` parked dots — plus `npm run test:site` 140 PASS and `net-coordinator` 15/15.

The wire-log PR will rebase over this once merged (it currently carries the identical commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)