### PR TITLE
fix: lambda-param hover types; keep codelenses through transient parse errors

### DIFF
--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1597,6 +1597,45 @@ for (const example of examples) {
       `lenses=${lenses}, defs=${topDefs}`
     );
 
+    // A transient parse error (the mid-typing state) must KEEP the lenses —
+    // dropping the block widgets would reflow the whole buffer on every
+    // broken keystroke. The wasm signals "didn't run" with null lenses; the
+    // decoration field holds the previous set (mapped through the edits)
+    // while diagnostics refresh. TYPE the breakage — an incremental edit,
+    // the case the keep-stale rule exists for (setSource is a wholesale
+    // replace, which legitimately rebuilds from scratch).
+    // A zero-width load diagnostic renders as a lint POINT, not a range.
+    const lintMarks = () =>
+      page.locator(".cm-lintRange-error, .cm-lintPoint-error").count();
+    await page.click(".cm-content");
+    await page.keyboard.press("Control+End");
+    await page.keyboard.press("Meta+ArrowDown"); // mac's cursorDocEnd
+    // No brackets — autoclose would pair them into a VALID empty record.
+    await page.keyboard.type("let broken =");
+    const marked = await poll(lintMarks, (n) => n > 0);
+    check("broken edit: the parse error is marked", marked > 0, `count=${marked}`);
+    // The decoration rebuild is rAF-deferred after the lint pass; let it land
+    // before counting, or the count could pass vacuously (the old empty-array
+    // behavior also still shows lenses at the instant the marks render).
+    await page.evaluate(
+      () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+    );
+    const held = await page.locator(".cm-lens").count();
+    check(
+      "broken edit: codelenses survive the transient parse error",
+      held >= topDefs,
+      `lenses=${held}, defs=${topDefs}`
+    );
+    // Restore the clean buffer so the hover check below sees the same doc,
+    // and wait out the fresh boot the restore triggers — the section's final
+    // "keeps the sandbox live" check must not race it.
+    await page.evaluate((s) => window.__sandbox.setSource(s), INTEL_SRC);
+    await poll(lintMarks, (n) => n === 0);
+    await poll(() => page.locator(".cm-lens").count(), (n) => n >= topDefs);
+    await page.waitForFunction(() => window.__sandbox.status().state === "live", {
+      timeout: 30000,
+    });
+
     // Hover a REAL code token (skip the lens/inlay widget text) and rest the
     // mouse over it — a jiggle would keep resetting the hover timer.
     const coord = await page.evaluate(() => {

--- a/functor-lang/src/hover.rs
+++ b/functor-lang/src/hover.rs
@@ -6,9 +6,9 @@
 //! The answer is the **innermost** expression (or lambda parameter, or
 //! top-level definition name) whose span contains the offset, rendered as
 //! `name : Type` for named things and bare `Type` otherwise. Types come from
-//! the checker's per-expression table ([`crate::types::ExprTypes`]) — in
-//! unannotated code they are honestly `Unknown` (the language is gradually
-//! typed; see [`crate::types`]).
+//! the checker's per-expression and per-binding tables
+//! ([`crate::types::ExprTypes`]) — where inference has nothing (the language
+//! is gradually typed; see [`crate::types`]) they are honestly `unknown`.
 
 use crate::ast::TypeName;
 use crate::ir::{Expr, ExprKind, Module, Pattern, PatternKind};
@@ -87,11 +87,15 @@ fn visit(expr: &Expr, types: &ExprTypes, consider: &mut impl FnMut(Span, String)
         ExprKind::Lambda { params, body, .. } => {
             consider(expr.span, ty.to_string());
             for param in params.iter() {
-                let shown = param
-                    .ty
-                    .as_ref()
-                    .map(type_name_text)
-                    .unwrap_or_else(|| "Unknown".to_string());
+                // Inferred type first — but an Unknown entry (e.g. an
+                // annotation that didn't resolve) defers to the user's own
+                // spelling, which is what they need to see to fix it.
+                let shown = types
+                    .binding(param.binding)
+                    .filter(|t| **t != Type::Unknown)
+                    .map(Type::to_string)
+                    .or_else(|| param.ty.as_ref().map(type_name_text))
+                    .unwrap_or_else(|| Type::Unknown.to_string());
                 consider(param.span, format!("{} : {shown}", param.name));
             }
             visit(body, types, consider);
@@ -279,9 +283,27 @@ mod tests {
     }
 
     #[test]
-    fn unannotated_code_hovers_as_unknown() {
+    fn unannotated_param_hovers_with_the_inferred_type() {
+        // A polymorphic param renders its inferred type var, matching the
+        // codelens (`f : ('a) => 'a`) and inlay hints.
         let text = hover_at("let f = (x) => x", "x)").unwrap();
-        assert_eq!(text, "x : Unknown");
+        assert_eq!(text, "x : 'a");
+    }
+
+    #[test]
+    fn unannotated_params_hover_with_types_inferred_from_use() {
+        let src = "let dot = (t, ix, iz) => t * 2.0 + ix + iz";
+        assert_eq!(hover_at(src, "t,").unwrap(), "t : float");
+        assert_eq!(hover_at(src, "ix,").unwrap(), "ix : float");
+        assert_eq!(hover_at(src, "iz)").unwrap(), "iz : float");
+    }
+
+    #[test]
+    fn unresolvable_annotation_hovers_with_the_users_spelling() {
+        // A mistyped/unimported type name checks as Unknown, but hover must
+        // show what the user wrote — that's what they need to see to fix it.
+        let text = hover_at("let f = (p: Bogus) => 1.0", "p:").unwrap();
+        assert_eq!(text, "p : Bogus");
     }
 
     #[test]

--- a/site/src/lang-intel.ts
+++ b/site/src/lang-intel.ts
@@ -78,11 +78,17 @@ interface AnalyzeDiagnostic {
   severity: "error";
 }
 
-/** The parsed `analyze` / `analyze_project` payload; all three are present. */
+/**
+ * The parsed `analyze` / `analyze_project` payload; all three keys are
+ * present. `inlays`/`lenses` are NULL (together) when the check pass didn't
+ * run — a parse/link failure mid-typing — meaning "keep the previous set";
+ * an empty array is authoritative (clears them). Diagnostics are always
+ * fresh.
+ */
 interface AnalyzeResult {
   diagnostics: AnalyzeDiagnostic[];
-  inlays: { pos: number; label: string }[];
-  lenses: { from: number; text: string }[];
+  inlays: { pos: number; label: string }[] | null;
+  lenses: { from: number; text: string }[] | null;
 }
 
 /** The parsed `hover` payload (the empty string means "nothing to show"). */
@@ -212,6 +218,9 @@ export const analyzeCached = (docString: string): AnalyzeResult | null => {
       args ? analyzeProjectFn!(args.filesJson, args.active) : analyzeFn(docString)
     );
   } catch {
+    // A genuine wasm trap / malformed JSON — the analyzer itself is broken,
+    // not the buffer. The empty (authoritative) result, NOT the null keep-
+    // stale one: null here would pin the last decorations forever.
     result = { diagnostics: [], inlays: [], lenses: [] };
   }
   lastKey = key;
@@ -500,16 +509,21 @@ class LensWidget extends WidgetType {
 const buildDecorations = (state: EditorState): DecorationSet | null => {
   const result = peekCached(state.doc.toString());
   if (!result) return null;
+  // Null inlays/lenses = the pass didn't run (a transient parse error while
+  // typing): keep the previous set, mapped through the edits. Dropping the
+  // block-widget lenses here would reflow the whole buffer on every broken
+  // keystroke. Diagnostics still refresh — only the decorations hold.
+  if (result.inlays == null || result.lenses == null) return null;
   const doc = state.doc;
   const len = doc.length;
   const ranges: Range<Decoration>[] = [];
-  for (const it of result.inlays || []) {
+  for (const it of result.inlays) {
     const pos = Math.max(0, Math.min(it.pos | 0, len));
     ranges.push(
       Decoration.widget({ widget: new InlayWidget(String(it.label ?? "")), side: 1 }).range(pos)
     );
   }
-  for (const it of result.lenses || []) {
+  for (const it of result.lenses) {
     const from = Math.max(0, Math.min(it.from | 0, len));
     const line = doc.lineAt(from);
     ranges.push(

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -26,6 +26,7 @@ import {
   analyzeCached,
   completeAt,
   resetIntel,
+  refreshIntel,
   onDiagnostics,
   wireLiveTrace,
   currentLiveHints,
@@ -330,6 +331,10 @@ const setDoc = (
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
   programmaticEdit = false;
+  // …and drop the outgoing program's decorations (the IDE's setDoc does the
+  // same): if the incoming source doesn't analyze cleanly, the keep-stale
+  // lens rule would otherwise pin the old program's lenses to the new buffer.
+  refreshIntel(view);
   runtimeTarget.projectChanged({ fresh: true });
 };
 

--- a/tools/functor-lang-wasm/src/lib.rs
+++ b/tools/functor-lang-wasm/src/lib.rs
@@ -52,7 +52,10 @@ const USER_FILE: &str = "game.fun";
 ///
 /// `from`/`to`/`pos` are whole-document UTF-16 offsets.
 /// A load-level failure (parse/link error) comes back as a single diagnostic —
-/// never an exception. Prelude spans are filtered out.
+/// never an exception — with `"inlays": null, "lenses": null` meaning "the
+/// pass didn't run; keep the previous set" (the mid-typing state must not
+/// reflow the buffer by dropping every lens). An EMPTY `inlays`/`lenses`
+/// array is authoritative (clears them). Prelude spans are filtered out.
 #[wasm_bindgen]
 pub fn functor_lang_analyze(src: &str) -> String {
     analyze_json(src)
@@ -440,8 +443,8 @@ fn load_error_json(active: &Path, active_src: &str, err: project::ProjectError) 
     };
     json!({
         "diagnostics": [{ "from": at, "to": at, "message": message, "severity": "error" }],
-        "inlays": [],
-        "lenses": [],
+        "inlays": Value::Null,
+        "lenses": Value::Null,
     })
     .to_string()
 }
@@ -554,13 +557,27 @@ mod tests {
     }
 
     // A parse failure comes back as a single diagnostic (never an exception),
-    // at the reported point.
+    // at the reported point — with NULL inlays/lenses ("the pass didn't run;
+    // keep the previous set"), so a transient mid-typing error doesn't drop
+    // every lens and reflow the buffer.
     #[test]
-    fn parse_error_is_a_single_diagnostic() {
+    fn parse_error_is_a_single_diagnostic_with_null_lenses() {
         let out = parse(&analyze_json("let init = {\n"));
         let diags = out["diagnostics"].as_array().unwrap();
         assert_eq!(diags.len(), 1, "{out}");
         assert_eq!(diags[0]["severity"], "error");
+        assert!(out["inlays"].is_null(), "{out}");
+        assert!(out["lenses"].is_null(), "{out}");
+    }
+
+    // A VALID program with nothing to report answers with EMPTY arrays — the
+    // authoritative "there are no lenses" (clears them), distinct from null.
+    #[test]
+    fn valid_lens_free_program_reports_empty_arrays() {
+        let out = parse(&analyze_json("type Tag = | A | B\n"));
+        assert_eq!(out["diagnostics"].as_array().unwrap().len(), 0, "{out}");
+        assert_eq!(out["lenses"].as_array().unwrap().len(), 0, "{out}");
+        assert_eq!(out["inlays"].as_array().unwrap().len(), 0, "{out}");
     }
 
     // Non-ASCII before an error proves the UTF-8 byte offset is converted to a


### PR DESCRIPTION
Two language-server fixes for the editors (site sandbox/IDE + VS Code via the LSP).

## 1. `fix(lang)`: hover on unannotated lambda params showed `Unknown`

Hovering `t`/`ix`/`iz` in `let dot = (t, ix, iz) => …` (the Neon grid example) showed `t : Unknown`, while the codelens correctly showed `dot : (float, float, float) => Scene.t`. The checker records correct inferred param types in its per-binding table — codelens and inlay hints read it; hover's `Lambda` arm rendered only the source annotation with a literal `"Unknown"` fallback (`hover.rs`), inconsistent even with pattern-variable hover in the same file.

Hover now reads the binding table first, deferring to the user's annotation when the recorded type is `Unknown` — a mistyped/unimported type name keeps the user's spelling (`p : Bogus`, not `p : unknown`), which is what they need to see to fix it. One fix covers both editors: the LSP and the site wasm share `hover_text`.

## 2. `fix(site)`: codelenses no longer vanish (and reflow the buffer) while typing

A transiently unparsable buffer made the analyze pass return **empty** lens/inlay arrays, dropping every codelens block widget — a vertical reflow of the whole buffer, twice per broken keystroke. Only the **parse/link** path did this (type errors already kept lenses), and it's CodeMirror/site-specific: VS Code's codelens UI keeps stale lenses natively (Monaco isn't used anywhere in the repo).

This takes the keep-previous-lenses approach (VS Code's own behavior), with the "couldn't analyze" signal made explicit rather than inferred:

- **wasm**: a load failure answers `"inlays": null, "lenses": null` — "the pass didn't run; keep the previous set" — mirroring the existing `rows: null` convention of `expects_project`. Empty arrays remain the authoritative clear; unknown-active/malformed-payload paths keep them. Diagnostics stay fresh.
- **client**: a null payload is treated like a stale cache — the decoration `StateField` keeps the previous set, mapped through edits so lenses stay glued to their lines while the squiggle/Problems panel update immediately.
- **sandbox `setDoc`**: wholesale replaces (example switch, `#src=` load) now clear decorations via `refreshIntel`, matching the IDE — without it, wholesale-loading a broken program could pin the outgoing program's lens to the new buffer.

## Review (`/xreview`: Claude + Codex + de-dup pass)

- **High (Claude)** — first-draft hover fix lost the user's spelling for unresolvable annotations → fixed (`.filter(Unknown)` + test).
- **[AGREED] Medium (Claude + Codex)** — sandbox wholesale replace could strand stale lenses → fixed (`refreshIntel` in `setDoc`).
- **Medium (Claude)** — JS `catch` returning null would pin decorations forever on a genuine wasm trap; null at unknown-active/malformed sites was scope creep → both reverted to authoritative-empty; null is load-failure-only.
- **Medium ×2 (Claude)** — e2e assertion could pass vacuously (rAF-deferred rebuild) and the restore raced the section's final live check → double-rAF wait + explicit live wait.
- **Low** — dead `|| []` fallbacks dropped; `"Unknown"` literal aligned with `Type::Unknown`'s lowercase display (also flagged by the de-dup pass).
- Dispositioned, not changed: e2e `lintMarks` vs section-11's `lintCount` (block-scoped per page section; hoisting would churn an unrelated section). LSP-side last-good lens cache for VS Code's milder flicker: deliberate follow-up, low value under VS Code's native smoothing.
- De-dup coverage: S1-names (8 queries / 7144 candidates), S2-clones (251 pairs, 12 touching changed files, all pre-existing), S3-index, S4-read — no actionable duplication; the null convention is deliberate reuse of the `expects_project` pattern.

## Verification

- `cargo test -p functor-lang` (140) and `-p functor-lang-wasm` (23) pass, incl. new tests: neon-grid-shaped param hovers, polymorphic `x : 'a`, `p : Bogus` spelling, null-on-parse-error vs empty-on-valid payloads.
- `tsc -p site --noEmit` clean; full site e2e passed with the new checks ("codelenses survive the transient parse error", typed via real keyboard — `setSource` is a whole-doc replace that maps block widgets destructively).
- Post-review-fix e2e re-run: the suite flakes machine-wide in the chrono-bar section under load (a fully **clean tree** fails identically at `site-sandbox.mjs:960`), so the review-touched section was re-validated in isolation: all five checks pass (parse error marked → lenses survive → clean restore rebuilds → live).

## Visuals

Captured headlessly with Playwright against the built site — `main` (before) and this branch (after), same program, same typing sequence, 1280x800.

### 1. Codelens flicker — typing a transiently broken edit

**Before** (`main`): every `.cm-lens` signature line disappears while the buffer is unparsable, reflowing the whole document, then reappears on fix.

![codelens flicker - before](https://gist.githubusercontent.com/tommy-xr/2eecbd89a336591925ee9020a26950ef/raw/lens-before.gif)

**After** (this branch): the lenses stay put through the broken state; only the error mark updates.

![codelens flicker - after](https://gist.githubusercontent.com/tommy-xr/2eecbd89a336591925ee9020a26950ef/raw/lens-after.gif)

The discriminating instant — the editor while `let broken =` sits in the buffer (one lint mark on each side):

| before — `.cm-lens` count **0** | after — `.cm-lens` count **4** |
| --- | --- |
| ![before, broken state](https://gist.githubusercontent.com/tommy-xr/2eecbd89a336591925ee9020a26950ef/raw/lens-before-broken.png) | ![after, broken state](https://gist.githubusercontent.com/tommy-xr/2eecbd89a336591925ee9020a26950ef/raw/lens-after-broken.png) |

<sub>Same 4-def program. The before side drops all four lens rows (and the inlay hints) while broken, pulling every line up — that vertical shift is the flicker.</sub>

### 2. Hover on an unannotated lambda param

Hovering `t` in `let dot = (t, ix, iz) => ...` (the Neon grid example):

![lambda-param hover - before/after](https://gist.githubusercontent.com/tommy-xr/2eecbd89a336591925ee9020a26950ef/raw/hover-beforeafter.png)

<sub>Tooltip text read straight from the DOM: before `t : Unknown`, after `t : float`.</sub>

