### PR TITLE
feat(site): the wire log — traffic per scrubber

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -122,6 +122,37 @@ const installProbe = (page) =>
           (conn) => `${conn.hidden ? "hidden" : conn.dataset.linked}:${conn.title.slice(0, 20)}`
         ),
       pill: () => document.getElementById("status").textContent.trim(),
+      /** The chrono rail's own label — reference-clock frames, the axis the
+       * packet log is keyed to. */
+      railFrame: () => document.getElementById("mp-frame").textContent.trim(),
+      /** The pinned wire log: what it says it is showing, and what it shows. */
+      wireLog: () => {
+        const panel = document.querySelector(".mp-wirelog");
+        const selected = document.querySelectorAll(".mp-wire.selected").length;
+        if (!panel || panel.hidden) return { pinned: false, rows: [], selected };
+        const box = panel.getBoundingClientRect();
+        return {
+          pinned: true,
+          selected,
+          link: panel.querySelector(".mp-wl-link").textContent.trim(),
+          footer: panel.querySelector(".mp-wl-ft").textContent.trim(),
+          tethered: !document.querySelector(".mp-tether").hasAttribute("visibility"),
+          box: {
+            x: Math.round(box.x),
+            y: Math.round(box.y),
+            w: Math.round(box.width),
+            h: Math.round(box.height),
+          },
+          rows: [...panel.querySelectorAll(".mp-wl")].map((row) => ({
+            frame: Number((row.querySelector(".f").textContent.match(/-?\d+/) ?? [NaN])[0]),
+            dir: row.querySelector(".d").textContent.trim(),
+            payload: row.querySelector(".payload").textContent.trim(),
+            bytes: row.querySelector(".n").textContent.trim(),
+            at: row.classList.contains("at"),
+          })),
+        };
+      },
+      clickEdge: (index) => document.querySelectorAll(".mp-edge-chip")[index].click(),
       pauseAll: () => document.getElementById("mp-pause").click(),
       layout: () => ({
         view: document.querySelector(".mp-grid").dataset.view,
@@ -1077,6 +1108,43 @@ try {
       .catch(() => false);
     check(flowed, "orbs' authority traffic reaches the wires live");
 
+    // --- the pinned wire log: click a link, read its traffic as VALUES -------
+    await page.evaluate(() => window.__mpProbe.clickEdge(0));
+    await sleep(400);
+    const pinned = await page.evaluate(() => window.__mpProbe.wireLog());
+    const boxes = await page.evaluate(() => window.__mpProbe.boxes());
+    check(
+      pinned.pinned && pinned.link === "c1 ↔ srv" && pinned.selected === 1 && pinned.tethered,
+      "clicking a link pins its wire log, tethered, with that wire selected",
+      JSON.stringify({ link: pinned.link, selected: pinned.selected, tether: pinned.tethered })
+    );
+    // orbs' protocol is a typed ADT, so the rows must read as its constructors —
+    // the whole point of decoding rather than showing bytes.
+    const decoded = pinned.rows.filter((row) => /Snapshot|Steer|Welcome|Join|Claim/.test(row.payload));
+    check(
+      pinned.rows.length > 0 && decoded.length > 0,
+      "the rows are decoded Wire values, not bytes",
+      `${pinned.rows.length} rows; e.g. "${pinned.rows.at(-1)?.payload ?? ""}"`
+    );
+    check(
+      pinned.rows.some((row) => row.dir === "c1→srv") &&
+        pinned.rows.some((row) => row.dir === "srv→c1"),
+      "both directions are interleaved in one list",
+      pinned.rows.map((row) => row.dir).join(" ")
+    );
+    // The panel parks in a free quadrant: it may not cover the hub it describes.
+    // The overlap arithmetic is written out here rather than imported: this is
+    // the check ON the production placement, so it must not share its maths.
+    const hub = boxes[2];
+    const overlaps = (a, b) =>
+      Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x)) *
+      Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+    check(
+      overlaps(pinned.box, hub) === 0,
+      "the panel never covers the hub",
+      `${JSON.stringify(pinned.box)} vs hub ${JSON.stringify([hub.x, hub.y, hub.w, hub.h])}`
+    );
+
     await page.evaluate(() => window.__mpProbe.pauseAll());
     await sleep(600);
     await page.focus("#mp-playhead");
@@ -1092,6 +1160,37 @@ try {
       `replay=${head.replay} live=${head.live} at #f ${head.label}`
     );
 
+    // SCRUB-LOCKED: parked, the panel's viewport sits at the playhead and marks
+    // the nearest row — the rail and the log are one instrument.
+    const parkedLog = await page.evaluate(() => window.__mpProbe.wireLog());
+    const playhead = Number(head.label.match(/-?\d+/)?.[0] ?? NaN);
+    const marked = parkedLog.rows.find((row) => row.at);
+    check(
+      !!marked && Math.abs(marked.frame - playhead) <= 60,
+      "parked, the log marks the row nearest the playhead",
+      `playhead #f ${playhead}; marked ${JSON.stringify(marked ?? null)}`
+    );
+
+    // Resuming FROM THE HEAD hands the wires back to the live feed, and the
+    // replayed dots go with the mode rather than lingering as traffic that is
+    // not happening. (From the head deliberately: resuming from a rewound frame
+    // is a live session again, but the panes' connections do not survive the
+    // rewind — a coordinator-barrier problem, not this view's.)
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    const resumed = await page
+      .waitForFunction(() => window.__mpProbe.network().live > 0, null, { timeout: 15000 })
+      .then(() => page.evaluate(() => window.__mpProbe.network()))
+      .catch(() => page.evaluate(() => window.__mpProbe.network()));
+    check(
+      resumed.live > 0 && resumed.replay === 0,
+      "resuming returns the wires to the live feed",
+      `live=${resumed.live} replay=${resumed.replay}`
+    );
+
+    // Park again and scrub to the very start of the recording.
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(600);
+    await page.focus("#mp-playhead");
     await page.keyboard.press("Home");
     await sleep(400);
     const start = await page.evaluate(() => ({
@@ -1108,17 +1207,34 @@ try {
       `${start.dots} dots (${start.replay} replay, ${start.live} live) at #f ${start.label}`
     );
 
-    // Resuming hands the wires back to the live feed — and the replayed dots go
-    // with the mode, rather than lingering as traffic that is not happening.
-    await page.evaluate(() => window.__mpProbe.pauseAll());
-    const resumed = await page
-      .waitForFunction(() => window.__mpProbe.network().live > 0, null, { timeout: 15000 })
-      .then(() => page.evaluate(() => window.__mpProbe.network()))
-      .catch(() => page.evaluate(() => window.__mpProbe.network()));
+    // Scrubbing sweeps the rows with the dots: the window at the start of the
+    // recording is not the window at the head.
+    const startLog = await page.evaluate(() => window.__mpProbe.wireLog());
     check(
-      resumed.live > 0 && resumed.replay === 0,
-      "resuming returns the wires to the live feed",
-      `live=${resumed.live} replay=${resumed.replay}`
+      startLog.pinned &&
+        (startLog.rows.length === 0 ||
+          startLog.rows.at(-1).frame < (parkedLog.rows.at(-1)?.frame ?? Infinity)),
+      "scrubbing back sweeps the log's viewport with the playhead",
+      `head ended at #f ${parkedLog.rows.at(-1)?.frame}, start ends at #f ${startLog.rows.at(-1)?.frame}`
+    );
+
+    // Escape clears the pin (the last layer in the cascade — no popover is open
+    // and no event is selected here), and another link re-pins in place.
+    await page.keyboard.press("Escape");
+    await sleep(200);
+    const cleared = await page.evaluate(() => window.__mpProbe.wireLog());
+    check(
+      !cleared.pinned && cleared.selected === 0,
+      "esc clears the pinned panel and deselects the wire",
+      JSON.stringify(cleared)
+    );
+    await page.evaluate(() => window.__mpProbe.clickEdge(1));
+    await sleep(300);
+    const repinned = await page.evaluate(() => window.__mpProbe.wireLog());
+    check(
+      repinned.pinned && repinned.link === "c2 ↔ srv" && repinned.selected === 1,
+      "clicking another link re-pins the panel to it",
+      `${repinned.link} — ${repinned.selected} selected`
     );
     await page.close();
   }

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -141,6 +141,8 @@ const installProbe = (page) =>
             c.textContent.trim()
           ),
           dots: document.querySelectorAll(".mp-packet").length,
+          replay: document.querySelectorAll(".mp-packet.replay").length,
+          live: document.querySelectorAll(".mp-packet:not(.replay)").length,
           up: document.querySelectorAll(".mp-packet.up").length,
           down: document.querySelectorAll(".mp-packet.down").length,
           // The legend + demoted pane readouts now live on the status bar's
@@ -1044,6 +1046,80 @@ try {
         (line.includes("[functor-lang]") && line.includes("error"))
     );
     check(errors.length === 0, "no orbs pane reported a runtime error", errors.slice(0, 3).join(" | "));
+    await page.close();
+  }
+
+  // --- 4g. Parked, the wires replay the LOG at the playhead. ------------------
+  // Traffic is keyed to the timeline (Packet.frame, the reference clock), so a
+  // parked session does not show a frozen live feed — it shows the packets that
+  // actually crossed around the frame the rail is parked at. Two assertions
+  // make that real: at the HEAD there is replayed traffic and no live dot at
+  // all, and at the very start of the recording — before the connect handshake
+  // — there is nothing on the wires, because nothing had been sent yet.
+  //
+  // The session is parked as soon as it is linked, which freezes the recorded
+  // window at its first ~900 frames: `Home` therefore still lands on the boot
+  // frames, whatever else this suite does afterwards.
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`${BASE}/sandbox.html?example=orbs#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    await page.click("#mp-view-network");
+    await settle(page);
+    // The server broadcasts a snapshot per tick, so traffic appears as soon as
+    // the panes are linked — no input needed to provoke it.
+    const flowed = await page
+      .waitForFunction(() => window.__mpProbe.network().down > 0, null, { timeout: 25000 })
+      .then(() => true)
+      .catch(() => false);
+    check(flowed, "orbs' authority traffic reaches the wires live");
+
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(600);
+    await page.focus("#mp-playhead");
+    await page.keyboard.press("End");
+    await sleep(400);
+    const head = await page.evaluate(() => ({
+      ...window.__mpProbe.network(),
+      label: window.__mpProbe.railFrame(),
+    }));
+    check(
+      head.replay > 0 && head.live === 0,
+      "parked at the head, every dot on the wires comes from the packet log",
+      `replay=${head.replay} live=${head.live} at #f ${head.label}`
+    );
+
+    await page.keyboard.press("Home");
+    await sleep(400);
+    const start = await page.evaluate(() => ({
+      ...window.__mpProbe.network(),
+      label: window.__mpProbe.railFrame(),
+    }));
+    // The recording may begin BEFORE the connect handshake (slow boot: the
+    // wires are empty here) or right on top of it (fast boot: the handshake
+    // packets replay). The invariant is the same either way: parked at the
+    // start, everything on the wires is replayed history — nothing is live.
+    check(
+      start.live === 0 && (start.dots === 0 || start.replay === start.dots),
+      "parked at the recording's start, only replayed history is on the wires",
+      `${start.dots} dots (${start.replay} replay, ${start.live} live) at #f ${start.label}`
+    );
+
+    // Resuming hands the wires back to the live feed — and the replayed dots go
+    // with the mode, rather than lingering as traffic that is not happening.
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    const resumed = await page
+      .waitForFunction(() => window.__mpProbe.network().live > 0, null, { timeout: 15000 })
+      .then(() => page.evaluate(() => window.__mpProbe.network()))
+      .catch(() => page.evaluate(() => window.__mpProbe.network()));
+    check(
+      resumed.live > 0 && resumed.replay === 0,
+      "resuming returns the wires to the live feed",
+      `live=${resumed.live} replay=${resumed.replay}`
+    );
     await page.close();
   }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:wasm-remote-assets": "node e2e/remote-assets.mjs",
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",
+    "test:wire-value": "node --test site/src/wire-value.test.ts",
     "test:vscode-e2e": "playwright test -c tools/functor-lang-vscode/tests-integration/playwright.config.mjs",
     "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -53,6 +53,19 @@ const FLIGHT_MS = 600;
 const MAX_DOTS = 260;
 
 /**
+ * How wide a window of the packet log the REPLAY renders, in reference-clock
+ * frames.
+ *
+ * The live feed keeps `FLIGHT_MS` of traffic in the air at once; parking the
+ * session must show the same picture at the same density, so the window is that
+ * flight time expressed in frames (600ms at the timeline's 60fps). A packet
+ * routed AT the playhead is at the start of its flight and one a full window
+ * back is arriving — so scrubbing sweeps the traffic along the wires exactly as
+ * running it would, in either direction.
+ */
+const REPLAY_WINDOW_FRAMES = 36;
+
+/**
  * Payload bytes at which a dot reaches its largest size, per direction.
  *
  * INTENT is a keypress-sized message, so it saturates early and its range is
@@ -94,6 +107,13 @@ export interface NetworkGraphOptions {
   net: NetCoordinator;
   clients: () => NetworkNode[];
   server: () => NetworkNode | null;
+  /**
+   * The session clock, in reference-clock frames (mp-panes owns it). While
+   * `parked` — paused, or mid-scrub — the graph stops animating the live feed
+   * and REPLAYS the log around `frame` instead: the traffic belongs to the
+   * timeline, so the rail decides which packets are on the wires.
+   */
+  clock: () => { parked: boolean; frame: number | null };
 }
 
 export interface NetworkGraph {
@@ -126,7 +146,11 @@ interface Dot {
   el: SVGElement;
   edge: Edge;
   dir: Direction;
+  /** When the dot was spawned, on the host clock — the LIVE feed's animation. */
   start: number;
+  /** Fixed position along the wire (0..1), for a REPLAYED dot: a parked session
+   * has no host-clock flight, its position is decided by the playhead. */
+  held: number | null;
 }
 
 interface Point {
@@ -146,6 +170,7 @@ export function initNetworkGraph({
   net,
   clients,
   server,
+  clock,
 }: NetworkGraphOptions): NetworkGraph {
   const layer = document.createElement("div");
   layer.className = "mp-net-layer";
@@ -169,6 +194,13 @@ export function initNetworkGraph({
    * listener only buffers — every DOM write happens in `step`. */
   let inbox: Packet[] = [];
   let active = false;
+  /** Which feed the dots on screen came from. A mode change clears them: a live
+   * dot mid-flight and a replayed one mean different things, and letting the
+   * two coexist would show traffic at the playhead that never crossed there. */
+  let replaying = false;
+  /** The frame the replay is currently drawn for, so a held playhead rebuilds
+   * nothing. `null` = nothing drawn yet. */
+  let replayFrame: number | null = null;
 
   const addEdge = (node: NetworkNode): Edge => {
     const path = document.createElementNS(SVG_NS, "path");
@@ -305,7 +337,13 @@ export function initNetworkGraph({
     }
   };
 
-  const spawn = (edge: Edge, dir: Direction, bytes: number, now: number) => {
+  const spawn = (
+    edge: Edge,
+    dir: Direction,
+    bytes: number,
+    now: number,
+    held: number | null = null
+  ) => {
     // Both directions are circles; size scales MILDLY with the bytes the dot
     // carries, over a range that differs by direction (FULL_BYTES). The
     // client's own ink rides on `color` for intent; authority takes the
@@ -315,13 +353,52 @@ export function initNetworkGraph({
     const el = document.createElementNS(SVG_NS, "circle");
     el.setAttribute("r", (dir === "up" ? 2.6 + weight * 2 : 2 + weight * 0.8).toFixed(2));
     if (dir === "up") el.style.color = edge.node.color;
-    el.setAttribute("class", `mp-packet ${dir}`);
+    // `replay` is the same shape and the same ink — it is the same traffic, read
+    // from the log instead of from the live feed. The class exists so the
+    // provenance is assertable (and stylable) rather than inferred.
+    el.setAttribute("class", `mp-packet ${dir}${held === null ? "" : " replay"}`);
     if (dots.length >= MAX_DOTS) {
       const oldest = dots.shift();
       oldest?.el.remove();
     }
     packets.appendChild(el);
-    dots.push({ el, edge, dir, start: now });
+    dots.push({ el, edge, dir, start: now, held });
+  };
+
+  /**
+   * Draw the log's window at `frame`: one dot per edge per direction per frame
+   * of recorded traffic, held at the position that frame's age gives it.
+   *
+   * The same batching rule the live feed uses (Addendum 5a.5), applied to the
+   * record rather than to the moment — so a parked frame and the live frame it
+   * was show the same picture.
+   */
+  const renderReplay = (frame: number, now: number) => {
+    clearDots();
+    replayFrame = frame;
+    if (reduceMotion.matches) return;
+    const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number; age: number }>();
+    // Newest first: the log is chronological, and the window is at its end
+    // whenever the session is live-parked, so walking back leaves early.
+    const log = net.packets();
+    for (let i = log.length - 1; i >= 0; i--) {
+      const packet = log[i];
+      if (packet.frame === null) continue;
+      const age = frame - packet.frame;
+      if (age < 0) continue;
+      if (age >= REPLAY_WINDOW_FRAMES) break;
+      if (packet.kind !== "message") continue;
+      const dir: Direction = packet.from === "server" ? "down" : "up";
+      const edge = edges.get(dir === "up" ? packet.from : packet.to);
+      if (!edge) continue;
+      const key = `${edge.node.id}|${dir}|${packet.frame}`;
+      const carried = batched.get(key);
+      if (carried) carried.bytes += packet.size;
+      else batched.set(key, { edge, dir, bytes: packet.size, age });
+    }
+    for (const { edge, dir, bytes, age } of batched.values()) {
+      spawn(edge, dir, bytes, now, age / REPLAY_WINDOW_FRAMES);
+    }
   };
 
   const step = () => {
@@ -329,41 +406,58 @@ export function initNetworkGraph({
     const now = performance.now();
     const seen = inbox;
     inbox = [];
+    // PARKED: the traffic belongs to the timeline, so the rail decides what is
+    // on the wires — the live feed is dropped (`seen` is discarded above) and
+    // the window around the playhead is drawn from the coordinator's log
+    // instead. Live/unparked keeps the per-frame batched feed below.
+    const { parked, frame } = clock();
+    const replay = parked && frame !== null;
+    if (replay !== replaying) {
+      replaying = replay;
+      clearDots();
+      replayFrame = null;
+    }
+    // A held playhead rebuilds nothing; the advance pass below still runs, so a
+    // relayout re-places the held dots on the wires' new geometry.
+    if (replay && frame !== replayFrame) renderReplay(frame, now);
     // BATCHED PER FRAME (Addendum 5a.5, retiring the old time sampling): one
     // dot per edge per direction per frame that carried traffic, sized by the
     // bytes that frame carried. A 60Hz session broadcasts a snapshot per client
     // per frame, so a dot per packet is a swarm and a time sample is a lie
     // about the rate; a dot per frame is exactly what the wire did, at the rate
-    // the screen can show. (Traffic keyed to the TIMELINE — replaying the
-    // scrubbed window's packets — arrives with the wire-log PR.)
-    const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number }>();
-    for (const packet of seen) {
-      // Lifecycle events (connected/disconnected) are not traffic — the pane
-      // headers already say who is linked. Dots are payload.
-      if (packet.kind !== "message") continue;
-      const dir: Direction = packet.from === "server" ? "down" : "up";
-      const edge = edges.get(dir === "up" ? packet.from : packet.to);
-      if (!edge) continue;
-      edge.count += 1;
-      // Reduced motion: no flying dots at all. The edge keeps a static packet
-      // COUNT badge instead, so the traffic is still legible without animation.
-      if (reduceMotion.matches) continue;
-      const key = `${edge.node.id}|${dir}`;
-      const carried = batched.get(key);
-      if (carried) carried.bytes += packet.size;
-      else batched.set(key, { edge, dir, bytes: packet.size });
+    // the screen can show.
+    if (!replay) {
+      const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number }>();
+      for (const packet of seen) {
+        // Lifecycle events (connected/disconnected) are not traffic — the pane
+        // headers already say who is linked. Dots are payload.
+        if (packet.kind !== "message") continue;
+        const dir: Direction = packet.from === "server" ? "down" : "up";
+        const edge = edges.get(dir === "up" ? packet.from : packet.to);
+        if (!edge) continue;
+        edge.count += 1;
+        // Reduced motion: no flying dots at all. The edge keeps a static packet
+        // COUNT badge instead, so the traffic is still legible without animation.
+        if (reduceMotion.matches) continue;
+        const key = `${edge.node.id}|${dir}`;
+        const carried = batched.get(key);
+        if (carried) carried.bytes += packet.size;
+        else batched.set(key, { edge, dir, bytes: packet.size });
+      }
+      for (const { edge, dir, bytes } of batched.values()) spawn(edge, dir, bytes, now);
+      // The preference can flip while the view is open; whatever is still in the
+      // air stops immediately rather than finishing its flight.
+      if (reduceMotion.matches && dots.length > 0) clearDots();
     }
-    for (const { edge, dir, bytes } of batched.values()) spawn(edge, dir, bytes, now);
-    // The preference can flip while the view is open; whatever is still in the
-    // air stops immediately rather than finishing its flight.
-    if (reduceMotion.matches && dots.length > 0) clearDots();
     // Read every position first, then write every transform: `getPointAtLength`
     // flushes pending layout, so interleaving it with the transform writes
     // would flush once PER DOT.
     const moved: { el: SVGElement; point: DOMPoint }[] = [];
     for (let i = dots.length - 1; i >= 0; i--) {
       const dot = dots[i];
-      const t = (now - dot.start) / FLIGHT_MS;
+      // A replayed dot is HELD where the playhead put it; a live one flies on
+      // the host clock. Both then travel the same wire the same way.
+      const t = dot.held ?? (now - dot.start) / FLIGHT_MS;
       if (t >= 1 || dot.edge.length === 0) {
         dot.el.remove();
         dots.splice(i, 1);
@@ -383,6 +477,9 @@ export function initNetworkGraph({
     for (const dot of dots) dot.el.remove();
     dots.length = 0;
     inbox = [];
+    // Nothing is drawn, so no frame is drawn FOR: the next parked step rebuilds
+    // (renderReplay re-stamps this immediately after clearing).
+    replayFrame = null;
   };
 
   const setActive = (on: boolean) => {

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -17,9 +17,13 @@
 //      range, so the per-frame snapshot stream never dominates the picture.
 //   2. PACE is a measurement. See FLIGHT_MS.
 //
-// The wire log (click an edge → a pinned, scrub-locked panel) is the NEXT PR.
+// The third rule is the WIRE LOG: clicking an edge pins a panel, tethered to
+// that wire with a dashed leader, showing that link's traffic as DECODED VALUES
+// (`Steer {turn:1}`) rather than as bytes — and locked to the chrono rail, so
+// scrubbing sweeps the rows the same way it sweeps the dots.
 
 import type { NetCoordinator, Packet } from "./net-coordinator.js";
+import { decodeWire, fullWire } from "./wire-value.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -58,12 +62,40 @@ const MAX_DOTS = 260;
  *
  * The live feed keeps `FLIGHT_MS` of traffic in the air at once; parking the
  * session must show the same picture at the same density, so the window is that
- * flight time expressed in frames (600ms at the timeline's 60fps). A packet
- * routed AT the playhead is at the start of its flight and one a full window
+ * flight time expressed in frames (the timeline's fixed 60fps), DERIVED rather
+ * than written down so the two cannot drift apart. A packet routed AT the
+ * playhead is at the start of its flight and one a full window
  * back is arriving — so scrubbing sweeps the traffic along the wires exactly as
  * running it would, in either direction.
  */
-const REPLAY_WINDOW_FRAMES = 36;
+const REPLAY_WINDOW_FRAMES = Math.round((FLIGHT_MS / 1000) * 60);
+
+/**
+ * Rows in the pinned wire log's viewport.
+ *
+ * Not a scroll buffer: the panel is a WINDOW onto the log at the playhead, and
+ * the rail is how you move it. A dozen rows is what a 16:9 stage has room for
+ * beside the cards without the panel becoming a second layout.
+ */
+const WIRE_LOG_ROWS = 12;
+
+/** Rows of context kept AFTER the playhead's row, so the parked frame does not
+ * sit on the panel's last line with nothing following it. */
+const WIRE_LOG_LEAD = 3;
+
+/** The panel's margin from the stage's edge when it parks in a free quadrant. */
+const PANEL_MARGIN = 10;
+
+/**
+ * How often the LIVE tail repaints its rows, in ms.
+ *
+ * A tail that turns over sixty times a second is not a log, it is a blur — and
+ * each repaint decodes a dozen payloads and rebuilds the rows, on a page that
+ * is already running three games. Ten a second reads as live and costs a sixth
+ * as much. Parked, there is no throttle at all: the panel must answer the rail
+ * on the frame the playhead moves.
+ */
+const LIVE_ROW_MS = 100;
 
 /**
  * Payload bytes at which a dot reaches its largest size, per direction.
@@ -127,6 +159,8 @@ export interface NetworkGraph {
   /** Zero the per-edge packet totals — a new program is a new session, and the
    * reduced-motion badge must not carry the previous example's traffic. */
   resetCounts(): void;
+  /** Pin the wire log to a link (a client pane id), or clear it with null. */
+  selectEdge(id: string | null): void;
   destroy(): void;
 }
 
@@ -135,11 +169,17 @@ type Direction = "up" | "down";
 interface Edge {
   node: NetworkNode;
   path: SVGPathElement;
-  chip: HTMLElement;
+  /** The same curve, drawn invisibly and fat: a 1.4px wire is not a click
+   * target, and widening the visible one would make every wire shout. */
+  hit: SVGPathElement;
+  chip: HTMLButtonElement;
   chipLabel: HTMLElement;
   chipCount: HTMLElement;
   length: number;
   count: number;
+  /** The curve's midpoint, in layer coordinates — where the chip sits, and
+   * where the pinned panel's tether attaches. */
+  mid: Point;
 }
 
 interface Dot {
@@ -157,6 +197,11 @@ interface Point {
   x: number;
   y: number;
 }
+
+/** A measured box in the WIRE LAYER's coordinates — what every geometry in this
+ * module is expressed in (the layer shares the stage's box). */
+const toLocal = (box: DOMRect, origin: DOMRect): DOMRect =>
+  new DOMRect(box.left - origin.left, box.top - origin.top, box.width, box.height);
 
 /** A cubic's point at t = 0.5 — where the edge chip sits. */
 const midpoint = (p0: Point, c0: Point, c1: Point, p1: Point): Point => ({
@@ -184,8 +229,34 @@ export function initNetworkGraph({
   svg.setAttribute("aria-hidden", "true");
   const wires = document.createElementNS(SVG_NS, "g");
   const packets = document.createElementNS(SVG_NS, "g");
-  svg.append(wires, packets);
+  // The pinned panel's leader line. Last, so it draws over the wires it points
+  // at rather than under them.
+  const tether = document.createElementNS(SVG_NS, "g");
+  tether.setAttribute("class", "mp-tether");
+  const tetherLine = document.createElementNS(SVG_NS, "path");
+  const tetherNub = document.createElementNS(SVG_NS, "circle");
+  tetherNub.setAttribute("r", "3");
+  tether.append(tetherLine, tetherNub);
+  svg.append(wires, packets, tether);
   layer.appendChild(svg);
+
+  // The pinned wire log. It rides the CHIPS layer, which sits after the grid in
+  // the DOM: a panel of text under a pane card is a panel you cannot read.
+  const panel = document.createElement("aside");
+  panel.className = "mp-wirelog";
+  panel.hidden = true;
+  panel.innerHTML = `
+    <header class="mp-wl-hd">
+      <b class="mp-wl-link"></b>
+      <span class="mp-wl-what">wire log</span>
+      <button type="button" class="mp-wl-x" title="Clear the pinned wire log">esc to clear ✕</button>
+    </header>
+    <div class="mp-wl-rows" role="log" aria-label="Wire log"></div>
+    <footer class="mp-wl-ft"></footer>`;
+  chips.appendChild(panel);
+  const panelLink = panel.querySelector(".mp-wl-link") as HTMLElement;
+  const panelRows = panel.querySelector(".mp-wl-rows") as HTMLElement;
+  const panelFoot = panel.querySelector(".mp-wl-ft") as HTMLElement;
 
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   const edges = new Map<string, Edge>();
@@ -201,6 +272,12 @@ export function initNetworkGraph({
   /** The frame the replay is currently drawn for, so a held playhead rebuilds
    * nothing. `null` = nothing drawn yet. */
   let replayFrame: number | null = null;
+  /** The link whose wire log is pinned (a client pane id), or null. */
+  let selected: string | null = null;
+  /** What the panel's rows currently say, so a steady session rewrites nothing. */
+  let rowKey = "";
+  /** When the rows last repainted — the live tail's throttle (LIVE_ROW_MS). */
+  let lastRowPaint = 0;
 
   const addEdge = (node: NetworkNode): Edge => {
     const path = document.createElementNS(SVG_NS, "path");
@@ -208,19 +285,28 @@ export function initNetworkGraph({
     // The player color rides on `color`, so the wire's stroke and the dot's
     // fill and glow can all be one `currentColor` in the stylesheet.
     path.style.color = node.color;
-    wires.appendChild(path);
-    const chip = document.createElement("span");
+    const hit = document.createElementNS(SVG_NS, "path");
+    hit.setAttribute("class", "mp-wire-hit");
+    hit.addEventListener("click", () => selectEdge(node.id === selected ? null : node.id));
+    wires.append(path, hit);
+    // A real button: the chip is the wire's label AND its accessible click
+    // target — the SVG curve is reachable by pointer only.
+    const chip = document.createElement("button");
+    chip.type = "button";
     chip.className = "mp-edge-chip";
     chip.innerHTML = `<b></b><i></i>`;
+    chip.addEventListener("click", () => selectEdge(node.id === selected ? null : node.id));
     chips.appendChild(chip);
     const edge: Edge = {
       node,
       path,
+      hit,
       chip,
       chipLabel: chip.querySelector("b")!,
       chipCount: chip.querySelector("i")!,
       length: 0,
       count: 0,
+      mid: { x: 0, y: 0 },
     };
     edges.set(node.id, edge);
     return edge;
@@ -228,8 +314,12 @@ export function initNetworkGraph({
 
   const dropEdge = (edge: Edge, id: string) => {
     edge.path.remove();
+    edge.hit.remove();
     edge.chip.remove();
     edges.delete(id);
+    // A link that is gone cannot stay pinned — its rows would freeze on a
+    // client that is no longer in the session.
+    if (selected === id) selectEdge(null);
     for (let i = dots.length - 1; i >= 0; i--) {
       if (dots[i].edge === edge) {
         dots[i].el.remove();
@@ -254,14 +344,14 @@ export function initNetworkGraph({
     if (origin.width === 0 || origin.height === 0) return;
     svg.setAttribute("viewBox", `0 0 ${origin.width} ${origin.height}`);
     const boxOf = (node: NetworkNode) => {
-      const box = node.shell.getBoundingClientRect();
+      const box = toLocal(node.shell.getBoundingClientRect(), origin);
       return {
-        left: box.left - origin.left,
-        top: box.top - origin.top,
+        left: box.left,
+        top: box.top,
         width: box.width,
         height: box.height,
-        cx: box.left - origin.left + box.width / 2,
-        cy: box.top - origin.top + box.height / 2,
+        cx: box.left + box.width / 2,
+        cy: box.top + box.height / 2,
       };
     };
     const hubBox = boxOf(hub);
@@ -303,11 +393,12 @@ export function initNetworkGraph({
       const edge = edges.get(node.id) ?? addEdge(node);
       edge.node = node;
       edge.path.style.color = node.color;
-      edge.path.setAttribute(
-        "d",
-        `M${from.x},${from.y} C${c0.x},${c0.y} ${c1.x},${c1.y} ${to.x},${to.y}`
-      );
+      edge.hit.style.color = node.color;
+      const d = `M${from.x},${from.y} C${c0.x},${c0.y} ${c1.x},${c1.y} ${to.x},${to.y}`;
+      edge.path.setAttribute("d", d);
+      edge.hit.setAttribute("d", d);
       const mid = midpoint(from, c0, c1, to);
+      edge.mid = mid;
       edge.chip.style.left = `${mid.x}px`;
       edge.chip.style.top = `${mid.y}px`;
       written.push(edge);
@@ -316,6 +407,7 @@ export function initNetworkGraph({
     // with the `d` writes above would flush per edge instead of once.
     for (const edge of written) edge.length = edge.path.getTotalLength();
     paintChips();
+    placePanel();
   };
 
   // Every write is change-guarded, so this is a couple of string compares per
@@ -330,12 +422,275 @@ export function initNetworkGraph({
         // measurement the coordinator cannot make yet.
         edge.chip.title =
           `${label} — this client's configured link profile. Impairment is ` +
-          `recorded, not applied yet, so every packet crosses at the same pace.`;
+          `recorded, not applied yet, so every packet crosses at the same pace. ` +
+          `Click to pin this link's wire log.`;
       }
       const count = `${edge.count} pkt`;
       if (edge.chipCount.textContent !== count) edge.chipCount.textContent = count;
     }
   };
+
+  // ---------------------------------------------------------- the wire log
+  // Clicking a wire pins this panel to it (design addendum 5, rule 3): that
+  // link's traffic, both directions interleaved by frame, as the VALUES the
+  // game sent. It is a panel rather than a hover tooltip precisely because it
+  // has to stay readable while the other hand is scrubbing.
+
+  /** `client 2` → `c2`, `server` → `srv`: a direction column has to fit. */
+  const shortName = (id: string): string =>
+    id === "server" ? "srv" : id.startsWith("client ") ? `c${id.slice(7)}` : id;
+
+  /**
+   * Is this packet traffic on the pinned link?
+   *
+   * A link is a PANE PAIR, not a connection id: a game that opened two
+   * connections to the same authority would interleave both here. Nothing in
+   * the samples does, and the pane pair is what the wire on screen represents.
+   */
+  const onLink = (packet: Packet, id: string): boolean =>
+    packet.kind === "message" &&
+    ((packet.from === id && packet.to === "server") ||
+      (packet.from === "server" && packet.to === id));
+
+  /**
+   * The first index in the log whose frame is after `at` — the playhead's place
+   * in the record, by binary search.
+   *
+   * The log is sorted by frame because the reference clock only ever advances;
+   * an unframed packet (the boot handshake, routed before the reference pane
+   * had recorded a frame) sorts before everything, which is also where it
+   * belongs on the timeline.
+   */
+  const indexAfter = (log: readonly Packet[], at: number): number => {
+    let lo = 0;
+    let hi = log.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if ((log[mid].frame ?? -Infinity) <= at) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  };
+
+  const selectEdge = (id: string | null) => {
+    if (id !== null && !edges.has(id)) return;
+    if (selected === id) return;
+    selected = id;
+    rowKey = "";
+    for (const [edgeId, edge] of edges) {
+      const on = edgeId === id;
+      edge.path.classList.toggle("selected", on);
+      // The fat hit path doubles as the selection HALO — see the stylesheet.
+      edge.hit.classList.toggle("selected", on);
+      edge.chip.classList.toggle("selected", on);
+      edge.chip.setAttribute("aria-pressed", String(on));
+    }
+    renderPanel();
+    // A new link is a new tether and a new free quadrant to find, even when the
+    // row count happens to match (which is what renderPanel re-places on).
+    placePanel();
+  };
+
+  /**
+   * The panel's viewport onto the log: this link's message traffic, oldest
+   * first, both directions in one list (which is what "interleaved by frame"
+   * means when the log is already in routing order), plus which row the
+   * playhead is on.
+   *
+   * SCRUB-LOCKED: parked, the window ends a few rows PAST the playhead's row so
+   * the parked frame is not the last line on the panel; live, it tails the
+   * newest traffic. One time axis, two representations (design §5).
+   *
+   * Costs a screenful, not a session: the log is ordered by frame (the
+   * reference clock only advances), so the playhead's position is found by
+   * BINARY SEARCH and the walk starts there. A linear scan from the end would
+   * traverse all ten thousand packets every time the rail is parked in the
+   * past — exactly the state this feature exists for.
+   */
+  const viewportRows = (
+    id: string,
+    at: number | null
+  ): { rows: Packet[]; highlight: number } => {
+    const log = net.packets();
+    const before: Packet[] = [];
+    const after: Packet[] = [];
+    // The lead rows first, walking FORWARD from the playhead: the ones nearest
+    // it, not the newest in the session.
+    const pivot = at === null ? log.length : indexAfter(log, at);
+    for (let i = pivot; i < log.length && after.length < WIRE_LOG_LEAD; i++) {
+      if (onLink(log[i], id)) after.push(log[i]);
+    }
+    for (let i = pivot - 1; i >= 0 && before.length < WIRE_LOG_ROWS; i--) {
+      if (onLink(log[i], id)) before.push(log[i]);
+    }
+    before.reverse();
+    const rows = before.slice(Math.max(0, before.length - (WIRE_LOG_ROWS - after.length)));
+    const highlight = at === null || rows.length === 0 ? -1 : rows.length - 1;
+    rows.push(...after);
+    return { rows, highlight };
+  };
+
+  const renderPanel = () => {
+    if (!selected || !active) {
+      panel.hidden = true;
+      tether.setAttribute("visibility", "hidden");
+      return;
+    }
+    const edge = edges.get(selected);
+    if (!edge) return;
+    const { parked, frame } = clock();
+    // LIVE the rows are a tail, and a tail that turns over sixty times a second
+    // is not readable — so it repaints at a rate a reader can follow, and the
+    // work (decode + rebuild) happens at that rate too. PARKED there is no
+    // throttle: the panel must answer the rail immediately.
+    const now = performance.now();
+    if (!parked && now - lastRowPaint < LIVE_ROW_MS) return;
+    const { rows: shown, highlight } = viewportRows(
+      selected,
+      parked && frame !== null ? frame : null
+    );
+    const key =
+      `${selected}|${highlight}|` +
+      // `at` disambiguates two packets that share a frame, a direction and a
+      // size — a fixed-width intent (`Steer {turn:0}` vs `{turn:1}`) otherwise
+      // hashes the same and the rows would go stale.
+      shown.map((packet) => `${packet.frame}:${packet.from}:${packet.size}:${packet.at}`).join(",");
+    if (key === rowKey) return;
+    const rowCount = panelRows.childElementCount;
+    lastRowPaint = now;
+    rowKey = key;
+
+    panel.hidden = false;
+    panelLink.textContent = `${shortName(selected)} ↔ srv`;
+    panel.style.setProperty("--pc", edge.node.color);
+    let anyPlain = false;
+    panelRows.replaceChildren(
+      ...shown.map((packet, index) => {
+        const up = packet.from !== "server";
+        const decoded = decodeWire(packet.text);
+        if (!decoded.typed) anyPlain = true;
+        const row = document.createElement("div");
+        row.className = `mp-wl${index === highlight ? " at" : ""}`;
+        // The full rendering is built ON HOVER, once: rendering every row's
+        // whole payload unelided (a world snapshot, per row, per repaint) to
+        // fill a tooltip nobody has asked for yet is the most expensive thing
+        // this panel could do.
+        row.addEventListener(
+          "mouseenter",
+          () => {
+            row.title = fullWire(packet.text);
+          },
+          { once: true }
+        );
+        const frameCell = document.createElement("span");
+        frameCell.className = "f";
+        frameCell.textContent = `#f ${packet.frame ?? "—"}`;
+        const dirCell = document.createElement("span");
+        dirCell.className = `d ${up ? "up" : "dn"}`;
+        dirCell.textContent = up
+          ? `${shortName(packet.from)}→srv`
+          : `srv→${shortName(packet.to)}`;
+        // textContent, never innerHTML: this is a running game's own data.
+        const payload = document.createElement("span");
+        payload.className = "payload";
+        if (decoded.head) {
+          const ctor = document.createElement("b");
+          ctor.textContent = decoded.head;
+          const args = document.createElement("em");
+          args.textContent = decoded.body;
+          payload.append(ctor, args);
+        } else {
+          payload.textContent = decoded.body;
+        }
+        const bytes = document.createElement("span");
+        bytes.className = "n";
+        bytes.textContent = `${packet.size} B`;
+        row.append(frameCell, dirCell, payload, bytes);
+        return row;
+      })
+    );
+    if (shown.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "mp-wl-empty";
+      empty.textContent = parked
+        ? "nothing had crossed this link yet at this frame"
+        : "no traffic on this link yet";
+      panelRows.appendChild(empty);
+    }
+    panelFoot.textContent = anyPlain
+      ? "Effect.send text — shown exactly as sent"
+      : "Effect.sendMsg — decoded as values, never bytes";
+    // Only a change in the panel's SIZE can move it, and only the row count
+    // changes that. Re-placing on every repaint would mean five forced layouts
+    // per repaint (the panel's box, the cards' boxes, the wire's bbox) directly
+    // after writing the rows — the read-after-write flush this file avoids
+    // everywhere else.
+    if (panelRows.childElementCount !== rowCount) placePanel();
+  };
+
+  /** Overlap area of two boxes, in px². Zero when they miss each other. */
+  const overlap = (a: DOMRect, b: DOMRect): number =>
+    Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left)) *
+    Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
+
+  /**
+   * Park the panel in the free quadrant, and run its tether to the wire.
+   *
+   * MEASURED, not placed: the stage's layout changes with the client count and
+   * the window size, so the panel scores the four corners against what is
+   * actually on the stage — every pane card, plus the selected wire's own
+   * bounding box — and takes the one that covers the least. Distance to the
+   * wire breaks ties, so among clear corners it sits near what it describes.
+   */
+  const placePanel = () => {
+    if (!selected || panel.hidden) {
+      tether.setAttribute("visibility", "hidden");
+      return;
+    }
+    const edge = edges.get(selected);
+    if (!edge) return;
+    const origin = layer.getBoundingClientRect();
+    if (origin.width === 0 || origin.height === 0) return;
+    const size = panel.getBoundingClientRect();
+    const hub = server();
+    const obstacles = [...clients(), ...(hub ? [hub] : [])].map((node) =>
+      toLocal(node.shell.getBoundingClientRect(), origin)
+    );
+    const bbox = edge.path.getBBox();
+    obstacles.push(new DOMRect(bbox.x, bbox.y, bbox.width, bbox.height));
+    const maxX = Math.max(PANEL_MARGIN, origin.width - size.width - PANEL_MARGIN);
+    const maxY = Math.max(PANEL_MARGIN, origin.height - size.height - PANEL_MARGIN);
+    let best: { x: number; y: number; score: number } | null = null;
+    for (const x of [PANEL_MARGIN, maxX]) {
+      for (const y of [PANEL_MARGIN, maxY]) {
+        const box = new DOMRect(x, y, size.width, size.height);
+        const covered = obstacles.reduce((total, other) => total + overlap(box, other), 0);
+        const reach = Math.hypot(x + size.width / 2 - edge.mid.x, y + size.height / 2 - edge.mid.y);
+        // Area dominates: being clear of the cards and the wire is the rule,
+        // being near the wire is only the tie-break.
+        const score = covered * 1000 + reach;
+        if (!best || score < best.score) best = { x, y, score };
+      }
+    }
+    if (!best) return;
+    panel.style.left = `${best.x}px`;
+    panel.style.top = `${best.y}px`;
+    // The tether lands on the panel's nearest edge, so it never crosses the
+    // panel to reach it.
+    const anchor = {
+      x: Math.max(best.x, Math.min(edge.mid.x, best.x + size.width)),
+      y: Math.max(best.y, Math.min(edge.mid.y, best.y + size.height)),
+    };
+    tether.removeAttribute("visibility");
+    tether.style.color = edge.node.color;
+    tetherLine.setAttribute("d", `M${edge.mid.x},${edge.mid.y} L${anchor.x},${anchor.y}`);
+    tetherNub.setAttribute("cx", String(edge.mid.x));
+    tetherNub.setAttribute("cy", String(edge.mid.y));
+  };
+
+  (panel.querySelector(".mp-wl-x") as HTMLButtonElement).addEventListener("click", () =>
+    selectEdge(null)
+  );
 
   const spawn = (
     edge: Edge,
@@ -366,6 +721,21 @@ export function initNetworkGraph({
   };
 
   /**
+   * Which wire a packet travelled, and which way — the one rule the live feed
+   * and the replay share, so the two can never disagree about what a packet is.
+   *
+   * Null for a packet that is not traffic (the connected/disconnected lifecycle
+   * events — the pane headers already say who is linked; dots are payload) or
+   * whose wire is not on the stage.
+   */
+  const linkOf = (packet: Packet): { edge: Edge; dir: Direction } | null => {
+    if (packet.kind !== "message") return null;
+    const dir: Direction = packet.from === "server" ? "down" : "up";
+    const edge = edges.get(dir === "up" ? packet.from : packet.to);
+    return edge ? { edge, dir } : null;
+  };
+
+  /**
    * Draw the log's window at `frame`: one dot per edge per direction per frame
    * of recorded traffic, held at the position that frame's age gives it.
    *
@@ -378,23 +748,20 @@ export function initNetworkGraph({
     replayFrame = frame;
     if (reduceMotion.matches) return;
     const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number; age: number }>();
-    // Newest first: the log is chronological, and the window is at its end
-    // whenever the session is live-parked, so walking back leaves early.
+    // Straight to the playhead by binary search, then back one window — the
+    // walk costs the window, never the session (same rule as viewportRows).
     const log = net.packets();
-    for (let i = log.length - 1; i >= 0; i--) {
+    for (let i = indexAfter(log, frame) - 1; i >= 0; i--) {
       const packet = log[i];
-      if (packet.frame === null) continue;
+      if (packet.frame === null) break;
       const age = frame - packet.frame;
-      if (age < 0) continue;
       if (age >= REPLAY_WINDOW_FRAMES) break;
-      if (packet.kind !== "message") continue;
-      const dir: Direction = packet.from === "server" ? "down" : "up";
-      const edge = edges.get(dir === "up" ? packet.from : packet.to);
-      if (!edge) continue;
-      const key = `${edge.node.id}|${dir}|${packet.frame}`;
+      const link = linkOf(packet);
+      if (!link) continue;
+      const key = `${link.edge.node.id}|${link.dir}|${packet.frame}`;
       const carried = batched.get(key);
       if (carried) carried.bytes += packet.size;
-      else batched.set(key, { edge, dir, bytes: packet.size, age });
+      else batched.set(key, { edge: link.edge, dir: link.dir, bytes: packet.size, age });
     }
     for (const { edge, dir, bytes, age } of batched.values()) {
       spawn(edge, dir, bytes, now, age / REPLAY_WINDOW_FRAMES);
@@ -429,12 +796,9 @@ export function initNetworkGraph({
     if (!replay) {
       const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number }>();
       for (const packet of seen) {
-        // Lifecycle events (connected/disconnected) are not traffic — the pane
-        // headers already say who is linked. Dots are payload.
-        if (packet.kind !== "message") continue;
-        const dir: Direction = packet.from === "server" ? "down" : "up";
-        const edge = edges.get(dir === "up" ? packet.from : packet.to);
-        if (!edge) continue;
+        const link = linkOf(packet);
+        if (!link) continue;
+        const { edge, dir } = link;
         edge.count += 1;
         // Reduced motion: no flying dots at all. The edge keeps a static packet
         // COUNT badge instead, so the traffic is still legible without animation.
@@ -471,6 +835,9 @@ export function initNetworkGraph({
       el.setAttribute("transform", `translate(${point.x.toFixed(2)},${point.y.toFixed(2)})`);
     }
     paintChips();
+    // The pinned log follows the same clock the dots do — live it tails, parked
+    // it sits at the playhead. Both are change-guarded (`rowKey`).
+    renderPanel();
   };
 
   const clearDots = () => {
@@ -485,8 +852,12 @@ export function initNetworkGraph({
   const setActive = (on: boolean) => {
     if (on === active) return;
     active = on;
-    if (!on) clearDots();
-    else relayout();
+    if (!on) {
+      clearDots();
+      // The pin belongs to the view: leaving it and coming back should show the
+      // topology, not a panel pinned to whatever was interesting minutes ago.
+      selectEdge(null);
+    } else relayout();
   };
 
   const unsubscribe = net.onPacket((packet) => {
@@ -510,7 +881,10 @@ export function initNetworkGraph({
     resetCounts() {
       for (const edge of edges.values()) edge.count = 0;
       paintChips();
+      // A new program is a new protocol: the pinned rows are the old one's.
+      selectEdge(null);
     },
+    selectEdge,
     destroy() {
       observer.disconnect();
       unsubscribe();

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -425,7 +425,18 @@ export function initMultiplayerPanes({
   // it owns every pane — including pane 1, the page's own #player — so no pane
   // can be created outside its view. It is inert for a game that declares no
   // `Sub.connect`/`Sub.listen`: those panes never post a command.
-  const net = new NetCoordinator();
+  //
+  // It is handed the session's REFERENCE CLOCK so every routed packet lands on
+  // the axis the chrono rail labels (see the frame-offset block below, which
+  // owns the definition). Passed as a getter because the panes it measures do
+  // not exist yet at this line — and because the reference pane can change
+  // (a server pane mounting, a client count going to zero and back).
+  const net = new NetCoordinator({
+    referenceFrame: () => {
+      const reference = referencePane();
+      return reference ? headOf(reference) : null;
+    },
+  });
 
   const panes: Pane[] = [];
 
@@ -447,12 +458,20 @@ export function initMultiplayerPanes({
     color: pane.color,
     linkLabel: () => `${pane.link.name} · ${pane.link.ms}ms`,
   });
+  // Where the SESSION is parked, in reference-clock frames — the one number the
+  // rail's label already shows, published for the views that have to agree with
+  // it. `parked` is the chrono state (paused or mid-scrub), which is what turns
+  // the network view from a live feed into a replay of the log at `frame`.
+  // Written once per frame by `paint`, read by the graph on the same rAF.
+  let sessionClock: { parked: boolean; frame: number | null } = { parked: false, frame: null };
+
   const graph = initNetworkGraph({
     stage,
     grid,
     net,
     clients: () => panes.map(asNode),
     server: () => (serverPane ? asNode(serverPane.pane) : null),
+    clock: () => sessionClock,
   });
 
   const makePane = (role: PaneRole, index: number, iframe: HTMLIFrameElement): Pane => {
@@ -1449,6 +1468,12 @@ export function initMultiplayerPanes({
     const inReference = (frame: number) => Math.max(0, Math.round(frame - clockShift));
     if (!primary?.detached()) debugDrawer.hidden = true;
     chrono.classList.toggle("dormant", !current);
+    // Publish the session clock before anything else reads it this frame (the
+    // graph steps after `paint`). A bar with no seam yet is not parked — it has
+    // no time at all, and claiming "parked at nothing" would blank the live feed.
+    sessionClock = current
+      ? { parked: current.paused, frame: inReference(current.selectedFrame) }
+      : { parked: false, frame: null };
     if (primary && current) {
       const span = Math.max(current.viewport.hi - current.viewport.lo, 1);
       const played = $("mp-played");

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -103,6 +103,10 @@ interface TimelineView {
   previewFrames: number;
   previewClippedFrames: number;
   selectedFrame: number;
+  /** The event marker the timeline has selected, if any (timeline-model.js) —
+   * what makes Escape's cascade able to tell "an event is selected" from "the
+   * wire log is pinned". */
+  selectedEventId: number | null;
   paused: boolean;
   eventMarkers: {
     id: number;
@@ -431,12 +435,9 @@ export function initMultiplayerPanes({
   // owns the definition). Passed as a getter because the panes it measures do
   // not exist yet at this line — and because the reference pane can change
   // (a server pane mounting, a client count going to zero and back).
-  const net = new NetCoordinator({
-    referenceFrame: () => {
-      const reference = referencePane();
-      return reference ? headOf(reference) : null;
-    },
-  });
+  // Measured once per frame by `measureClocks` (see the frame-offset block).
+  let referenceFrame: number | null = null;
+  const net = new NetCoordinator({ referenceFrame: () => referenceFrame });
 
   const panes: Pane[] = [];
 
@@ -742,9 +743,24 @@ export function initMultiplayerPanes({
   // input lands (coordinator arc, input inversion).
   function pickerKeys(event: KeyboardEvent) {
     const target = event.target as HTMLElement;
+    // Escape dismisses ONE layer at a time, outermost first: a transient
+    // popover, then the timeline's selected event, then the pinned wire log.
+    // That order is "most recently opened, most easily reopened" — a link menu
+    // is a click away, an event marker is a click away, and the wire log is the
+    // thing you were reading, so it should not vanish because a menu happened to
+    // be open. Each press does exactly one thing, so nothing is dismissed
+    // invisibly.
     if (event.key === "Escape") {
-      closePopovers();
-      primarySeam()?.selectEvent(null);
+      if (document.querySelector(".mp-link-menu:not([hidden])")) {
+        closePopovers();
+        return;
+      }
+      const seam = primarySeam();
+      if (seam?.view()?.selectedEventId != null) {
+        seam.selectEvent(null);
+        return;
+      }
+      graph.selectEdge(null);
       return;
     }
     if (target.closest?.(".cm-editor") || /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return;
@@ -1151,6 +1167,11 @@ export function initMultiplayerPanes({
   const measureClocks = () => {
     const reference = referencePane();
     const referenceHead = reference ? headOf(reference) : null;
+    // Published for the coordinator, which stamps every packet with it. Read
+    // ONCE per frame here rather than per packet: `headOf` crosses the iframe
+    // boundary into a pane's wasm, and a busy session routes dozens of packets
+    // between two frames — all of which belong to this same instant anyway.
+    referenceFrame = referenceHead;
     if (!reference || referenceHead === null) return;
     offsets.set(reference, 0);
     const live = allPanes();
@@ -1736,8 +1757,11 @@ export function initMultiplayerPanes({
       } else {
         mountServer(serverSrc);
       }
-      // A different program is a different session: the per-link packet totals
-      // the reduced-motion badge shows start over with it.
+      // A different program is a different session: the packet log, and the
+      // per-link totals the reduced-motion badge shows, start over with it —
+      // the new panes count frames from zero, so the old rows would otherwise
+      // land under the new session's playhead.
+      net.clearLog();
       graph.resetCounts();
       updateChrome();
       paintAggregate();

--- a/site/src/net-coordinator.ts
+++ b/site/src/net-coordinator.ts
@@ -32,12 +32,13 @@
 // loss, partitions — is deliberately absent, and so is the step barrier: a
 // routed packet is delivered on the host's NEXT rAF, not on the receiving
 // pane's next fixed step. Impairment and the barrier are later PRs; when the
-// barrier lands, `flush()` becomes step-time delivery and `Packet.tick` stops
-// being null.
+// barrier lands, `flush()` becomes step-time delivery and a packet's frame
+// stops being a measurement and becomes the step it was scheduled in.
 //
-// The packet log records from day one even though nothing renders it yet: the
-// coordinator is the only place that sees every packet, so it owns the log the
-// later packet-log rail reads.
+// The packet log is the record every traffic view reads. Each row is keyed to
+// the REFERENCE CLOCK (`Packet.frame`) so traffic lives on the same axis the
+// chrono rail draws — scrubbing back replays the window's packets instead of
+// only ever showing the live present.
 
 /** The commands a pane's runtime emits (`functor_runtime_common::net::ConnCommand`,
  * serialized by serde's default externally-tagged representation). */
@@ -60,11 +61,25 @@ type DeliveredEvent =
 
 /** One routed packet, as the packet-log rail and the network view read it. */
 export interface Packet {
-  /** The step it belongs to — always null until the barrier lands (see above). */
-  tick: number | null;
+  /**
+   * The REFERENCE-CLOCK frame the packet was routed in — the session's own time
+   * axis, the one the chrono rail labels (mp-panes' `referenceFrame`). This is
+   * what makes traffic scrubbable: park the rail at frame N and the view can
+   * replay exactly the packets that crossed around N.
+   *
+   * MEASURED, not scheduled: there is no step barrier yet, so this is the
+   * reference pane's live head at route time, ±a frame. When the barrier lands
+   * it becomes the step the packet is delivered in, by construction.
+   *
+   * `null` when there is no reference clock to key against — a host that passed
+   * no `referenceFrame`, or a session whose reference pane has not recorded a
+   * frame yet (a packet from the boot handshake).
+   */
+  frame: number | null;
   /** When the coordinator routed it (`performance.now()`). Host-clock time, not
-   * game time: until the barrier lands a packet has no step to belong to, and
-   * the network view still has to place it on a wall-clock timeline. */
+   * game time: the wall-clock sibling of `frame`, kept because a live view
+   * animates on the host's clock while `frame` places the packet in the
+   * session's. */
   at: number;
   /** Pane id the packet originated from. */
   from: string;
@@ -134,6 +149,20 @@ interface PendingConnect {
   since: number;
 }
 
+export interface NetCoordinatorOptions {
+  /**
+   * The session's REFERENCE CLOCK, as a frame number — what every routed packet
+   * is keyed to (`Packet.frame`).
+   *
+   * A getter rather than a pushed value: the coordinator is constructed before
+   * any pane exists, and the clock is a live measurement of whichever pane is
+   * currently the reference (the server pane, or client 1 without one). The
+   * host owns that definition — the coordinator only asks, per packet, what
+   * time it is. `null` while nothing has recorded a frame yet.
+   */
+  referenceFrame?: () => number | null;
+}
+
 export class NetCoordinator {
   private readonly panes = new Map<string, Pane>();
   /** authority -> the listening side (pane + its listen key). */
@@ -148,7 +177,10 @@ export class NetCoordinator {
   private raf = 0;
   private readonly abort = new AbortController();
 
-  constructor() {
+  private readonly options: NetCoordinatorOptions;
+
+  constructor(options: NetCoordinatorOptions = {}) {
+    this.options = options;
     window.addEventListener("message", (event) => this.onMessage(event), {
       signal: this.abort.signal,
     });
@@ -391,7 +423,7 @@ export class NetCoordinator {
     if (!pane) return;
     pane.outbox.push(event);
     const packet: Packet = {
-      tick: null,
+      frame: this.options.referenceFrame?.() ?? null,
       at: performance.now(),
       from,
       to: to.pane,

--- a/site/src/net-coordinator.ts
+++ b/site/src/net-coordinator.ts
@@ -89,12 +89,32 @@ export interface Packet {
   kind: DeliveredEvent["kind"];
   /** Payload bytes for a message; 0 for the lifecycle kinds. */
   size: number;
+  /**
+   * The message's wire TEXT, exactly as the receiving runtime sees it — kept so
+   * a reader can decode it into the value the game actually sent (wire-value.ts)
+   * rather than showing bytes. Undefined for the lifecycle kinds.
+   *
+   * It costs nothing to route (the coordinator already decodes the payload for
+   * delivery, so this is the same string) and it is what bounds the log's
+   * memory: the cap is a packet count, so a chatty snapshot protocol holds
+   * roughly `PACKET_LOG_CAP × payload` bytes of text. Decoding is deliberately
+   * NOT done here — only the handful of rows a panel shows are ever parsed.
+   */
+  text?: string;
 }
 
 /** Newest entries win: an hour-long session must not grow without bound. The
  * trim runs in blocks so it is not an O(n) memmove per packet at the cap. */
 const PACKET_LOG_CAP = 10_000;
 const PACKET_LOG_SLACK = 1_000;
+
+/**
+ * …and a second bound, on the payload TEXT the log retains: a count alone is
+ * not a memory bound, because a game chooses how big a message is. 8 MB holds
+ * the whole 10k-packet cap for an ordinary protocol (orbs' snapshots are ~800
+ * bytes) and sheds oldest-first for a chatty one.
+ */
+const PACKET_LOG_BYTES = 8 << 20;
 
 /**
  * How long a `Connect` with no listener waits for its server pane before it
@@ -172,6 +192,8 @@ export class NetCoordinator {
   private readonly conns = new Map<number, Conn>();
   private readonly pending: PendingConnect[] = [];
   private readonly log: Packet[] = [];
+  /** Payload text the log is holding, in characters (see PACKET_LOG_BYTES). */
+  private logBytes = 0;
   private readonly watchers = new Set<(packet: Packet) => void>();
   private nextConn = 1;
   private raf = 0;
@@ -238,6 +260,18 @@ export class NetCoordinator {
   /** Every packet routed so far, oldest first (capped at the last 10k). */
   packets(): readonly Packet[] {
     return this.log;
+  }
+
+  /**
+   * Forget every routed packet. A new PROGRAM is a new session: its panes
+   * restart their clocks from zero, so the previous program's rows would
+   * otherwise share frame numbers with the new one's and reappear under the
+   * playhead as traffic that never happened (and, on a quiet link, as another
+   * protocol's decoded messages).
+   */
+  clearLog(): void {
+    this.log.length = 0;
+    this.logBytes = 0;
   }
 
   /**
@@ -430,10 +464,20 @@ export class NetCoordinator {
       conn: event.conn,
       kind: event.kind,
       size,
+      ...(event.kind === "message" ? { text: event.text } : {}),
     };
     this.log.push(packet);
+    this.logBytes += packet.text?.length ?? 0;
     if (this.log.length > PACKET_LOG_CAP + PACKET_LOG_SLACK) {
-      this.log.splice(0, this.log.length - PACKET_LOG_CAP);
+      for (const dropped of this.log.splice(0, this.log.length - PACKET_LOG_CAP)) {
+        this.logBytes -= dropped.text?.length ?? 0;
+      }
+    }
+    // The byte bound sheds one packet at a time: it only bites for a protocol
+    // whose messages are large, and there the newest few are what a reader is
+    // looking at anyway.
+    while (this.logBytes > PACKET_LOG_BYTES && this.log.length > 1) {
+      this.logBytes -= this.log.shift()?.text?.length ?? 0;
     }
     for (const watcher of this.watchers) watcher(packet);
   }

--- a/site/src/wire-value.test.ts
+++ b/site/src/wire-value.test.ts
@@ -1,0 +1,75 @@
+// The wire decoder's contract, headless: it decodes what `Effect.sendMsg`
+// actually puts on the wire, and it NEVER throws on anything else.
+//
+// The second half is the point. This runs inside the host page's rAF loop on
+// text a game chose, so a frame that threw would stop the chrono bar — the
+// hostile cases below are the regression guard for that.
+//
+//   node --test site/src/wire-value.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { decodeWire, fullWire } from "./wire-value.ts";
+
+const framed = (value: unknown) => `fun:${JSON.stringify(value)}`;
+
+test("decodes a typed variant into constructor and arguments", () => {
+  const row = decodeWire(
+    framed({
+      Variant: [
+        "Steer",
+        [{ Record: [["turn", { Number: 1 }], ["thrust", { Bool: true }]] }],
+      ],
+    })
+  );
+  assert.equal(row.typed, true);
+  assert.equal(row.head, "Steer");
+  assert.equal(row.body, "{turn:1, thrust:true}");
+});
+
+test("elides deep and wide values, and keeps the full rendering for the tooltip", () => {
+  const orb = { Record: [["id", { Number: 3 }]] };
+  const row = decodeWire(framed({ Variant: ["Snapshot", [{ List: [orb, orb, orb, orb, orb] }]] }));
+  assert.equal(row.head, "Snapshot");
+  assert.match(row.body, /…5/);
+  assert.match(fullWire(framed({ Variant: ["Snapshot", [{ List: [orb, orb, orb, orb, orb] }]] })), /id:3/);
+});
+
+test("plain Effect.send text passes through, marked untyped", () => {
+  const row = decodeWire("hello");
+  assert.deepEqual(row, { head: "", body: "hello", typed: false });
+  assert.equal(fullWire("hello"), "hello");
+});
+
+test("never throws on hostile or skewed frames", () => {
+  const hostile = [
+    undefined,
+    "",
+    "fun:",
+    "fun:{}",
+    "fun:null",
+    "fun:7",
+    "fun:[1,2,3]",
+    "fun:{not json",
+    framed({ Variant: [] }),
+    framed({ Variant: ["X", "not an array"] }),
+    framed({ Variant: [7, [{ Number: 1 }]] }),
+    framed({ List: [null, undefined, { Nope: 1 }] }),
+    framed({ Record: [null, ["ok"]] }),
+    framed({ Map: [[null, null]] }),
+    framed({ Number: "not a number" }),
+  ];
+  for (const wire of hostile) {
+    const row = decodeWire(wire as string | undefined);
+    assert.equal(typeof row.body, "string", `body for ${String(wire)}`);
+    assert.equal(typeof fullWire(wire as string | undefined), "string", `full for ${String(wire)}`);
+  }
+});
+
+test("caps the tooltip's rendering rather than carrying a whole payload", () => {
+  const long = { Text: "x".repeat(50_000) };
+  const wire = framed({ Variant: ["Chat", [long]] });
+  const row = decodeWire(wire);
+  const full = fullWire(wire);
+  assert.ok(full.length <= 2001, `full was ${full.length}`);
+  assert.ok(row.body.length < 120, `body was ${row.body.length}`);
+});

--- a/site/src/wire-value.ts
+++ b/site/src/wire-value.ts
@@ -1,0 +1,204 @@
+// Decoding a packet's wire TEXT back into the value the game actually sent —
+// what makes the wire log readable as `Steer {turn:1, thrust:true}` instead of
+// as a byte count (design addendum 5, rule 3: "rows are decoded ADT values,
+// never hex").
+//
+// WHAT IS ACTUALLY ON THE WIRE. `Effect.sendMsg(conn, msg)` frames its payload
+// as a control-character prefix — U+0001 then `fun:`, never produced by
+// ordinary game text — followed by the payload as JSON
+// (functor_runtime_common::functor_lang_prelude, `TYPED_MSG_PREFIX` /
+// `encode_typed_msg`). The JSON is serde's default representation of
+// `EffectValue`, the plain-data subset of a Functor Lang value: externally
+// tagged, so a variant is `{"Variant":["Steer",[…args…]]}`, a record is
+// `{"Record":[["turn",{"Number":1}]]}`, and so on. Plain `Effect.send(conn,
+// text)` carries the text unframed, and the runtime passes it through
+// untouched — so a connection can carry both, and this module reports which.
+//
+// Pure and DOM-free on purpose: this is the part worth reasoning about, and it
+// is the part a reader will not want to open a browser to check.
+
+/** The serde shape of `functor_runtime_common::functor_lang_prelude::EffectValue`. */
+export type WireValue =
+  | { Number: number }
+  | { Bool: boolean }
+  | { Text: string }
+  | { List: WireValue[] }
+  | { Map: [WireKey, WireValue][] }
+  | { Tuple: WireValue[] }
+  | { Record: [string, WireValue][] }
+  | { Variant: [string, WireValue[]] };
+
+type WireKey = { Bool: boolean } | { Number: number } | { Text: string };
+
+/** The framing `Effect.sendMsg` puts in front of a typed payload
+ * (`TYPED_MSG_PREFIX` on the Rust side). */
+const TYPED_MSG_PREFIX = "\u0001fun:";
+
+/**
+ * How deep a rendered value goes before it collapses to `{…}` / `[…]`.
+ *
+ * A wire log row is one line in a pinned panel, and the reader is scanning for
+ * WHICH message this is, not auditing its contents — the constructor plus a
+ * glance at the top fields answers that. The unelided rendering is always one
+ * hover away (`fullWire`).
+ *
+ * The elision RULES are this module's own, matching the approved mockup's
+ * `Move {dx:1}` rather than the Rust `Value::preview`'s spacier
+ * `Move({ dx: 1 })` (functor-lang/src/value.rs): a wire row is a dense column
+ * beside a game, not an editor inlay. The budgets are borrowed from it.
+ */
+const MAX_DEPTH = 2;
+
+/** Items shown before a list/record elides the rest. */
+const MAX_ITEMS = 4;
+
+/** Characters of a string shown in a row before it elides (the Rust preview's
+ * `MAX_PREVIEW_STRING`, functor-lang/src/value.rs — same job, same budget). */
+const MAX_STRING = 40;
+
+/**
+ * Characters of the UNELIDED rendering kept for the row's tooltip.
+ *
+ * The payload is a running game's own data and can be any size; a title
+ * attribute is not the place to put a megabyte of it.
+ */
+const MAX_FULL = 2000;
+
+/** One decoded row, split into the two things a row shows. */
+export interface DecodedWire {
+  /** The constructor name — `Steer`, `Snapshot` — or "" for a payload that is
+   * not a variant (plain text, a bare record). */
+  head: string;
+  /** The arguments, compact and depth-capped. */
+  body: string;
+  /** False for a plain `Effect.send` text payload, or a frame that would not
+   * parse — the row then shows the raw text and says so. */
+  typed: boolean;
+}
+
+/** A number as a game author wrote it: whole numbers without their `.0`, and
+ * five significant digits otherwise — the precision the editor's inline values
+ * and the Rust `Value::preview` already use, so one value reads the same
+ * wherever the tooling shows it. */
+const num = (n: number): string =>
+  typeof n !== "number" || Number.isInteger(n) ? String(n) : String(Number(n.toPrecision(5)));
+
+const str = (value: string, full: boolean): string =>
+  JSON.stringify(full || value.length <= MAX_STRING ? value : `${value.slice(0, MAX_STRING)}…`);
+
+const keyOf = (key: WireKey): string => {
+  if (typeof key !== "object" || key === null) return String(key);
+  if ("Text" in key) return key.Text;
+  if ("Number" in key) return num(key.Number);
+  return String(key.Bool);
+};
+
+/**
+ * Render a value. `full` drops every limit — that is the tooltip's text.
+ *
+ * TOTAL by construction: the input is untrusted (a game can `Effect.send` any
+ * text at all, including a hand-written `fun:` frame), so anything that
+ * is not a value this understands renders as its own JSON rather than throwing.
+ * A decoder that can throw would take the host's rAF loop down with it.
+ */
+const render = (value: WireValue, depth: number, full: boolean): string => {
+  // `JSON.stringify` answers `undefined` for `undefined` — the one input that
+  // would put the string "undefined" (or worse, nothing) in a row.
+  const asJson = (other: unknown) => JSON.stringify(other) ?? String(other);
+  if (typeof value !== "object" || value === null) return asJson(value);
+  const deep = !full && depth >= MAX_DEPTH;
+  const take = <T,>(items: T[]) => (full ? items : items.slice(0, MAX_ITEMS));
+  const more = (items: unknown[], mark: string) =>
+    !full && items.length > MAX_ITEMS ? [mark] : [];
+  if ("Number" in value) return num(value.Number);
+  if ("Bool" in value) return String(value.Bool);
+  if ("Text" in value) return str(value.Text, full);
+  if ("List" in value && Array.isArray(value.List)) {
+    if (deep) return value.List.length ? `[…${value.List.length}]` : "[]";
+    const shown = take(value.List).map((item) => render(item, depth + 1, full));
+    return `[${[...shown, ...more(value.List, `…${value.List.length}`)].join(", ")}]`;
+  }
+  if ("Tuple" in value && Array.isArray(value.Tuple)) {
+    return `(${value.Tuple.map((item) => render(item, depth + 1, full)).join(", ")})`;
+  }
+  if ("Record" in value && Array.isArray(value.Record)) {
+    if (deep) return "{…}";
+    const shown = take(value.Record).map(
+      (entry) => `${entry?.[0]}:${render(entry?.[1], depth + 1, full)}`
+    );
+    return `{${[...shown, ...more(value.Record, "…")].join(", ")}}`;
+  }
+  if ("Map" in value && Array.isArray(value.Map)) {
+    if (deep) return "{…}";
+    const shown = take(value.Map).map(
+      (entry) => `${keyOf(entry?.[0])}→${render(entry?.[1], depth + 1, full)}`
+    );
+    return `{${[...shown, ...more(value.Map, "…")].join(", ")}}`;
+  }
+  if ("Variant" in value && Array.isArray(value.Variant)) {
+    const [ctor, args] = value.Variant;
+    const label = typeof ctor === "string" ? ctor : asJson(ctor);
+    if (!Array.isArray(args) || args.length === 0) return label;
+    // A one-record argument is the common shape (`Steer(intent)`), and it reads
+    // better braced than parenthesized — the mockup's `Move {dx:1}`.
+    if (args.length === 1 && args[0] && "Record" in args[0]) {
+      return `${label} ${render(args[0], depth, full)}`;
+    }
+    return `${label}(${args.map((arg) => render(arg, depth + 1, full)).join(", ")})`;
+  }
+  // Not a value this understands: show it as the JSON it is, rather than
+  // pretending — and rather than throwing.
+  return asJson(value);
+};
+
+/**
+ * The typed payload inside a wire text, or null for plain `Effect.send` text
+ * (and for a frame that does not parse — version skew, or a game that wrote the
+ * prefix itself).
+ */
+const parseWire = (raw: string): WireValue | null => {
+  if (!raw.startsWith(TYPED_MSG_PREFIX)) return null;
+  try {
+    const value = JSON.parse(raw.slice(TYPED_MSG_PREFIX.length)) as WireValue;
+    return typeof value === "object" && value !== null ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Decode a packet's wire text into the row a wire log shows.
+ *
+ * Never throws, and that is load-bearing rather than defensive: this runs
+ * inside the host's rAF loop, on text a game chose, so a single hostile or
+ * skewed frame that threw would stop the whole chrono bar. Anything that is not
+ * a typed payload is shown as the text it is, marked untyped.
+ */
+export function decodeWire(wire: string | undefined): DecodedWire {
+  const raw = wire ?? "";
+  const value = parseWire(raw);
+  if (!value) return { head: "", body: raw, typed: false };
+  const compact = render(value, 0, false);
+  if ("Variant" in value && Array.isArray(value.Variant) && typeof value.Variant[0] === "string") {
+    const ctor = value.Variant[0];
+    // `render` already puts the constructor at the front; the row prints the
+    // head itself, so the body is only what follows it.
+    return { head: ctor, body: compact.slice(ctor.length).trim(), typed: true };
+  }
+  return { head: "", body: compact, typed: true };
+}
+
+/**
+ * The same payload with every elision dropped — the row's tooltip.
+ *
+ * Separate from `decodeWire`, and deliberately: rendering a whole world
+ * snapshot per row is far more expensive than the one-line form, and the panel
+ * repaints its rows continuously while only ever showing one tooltip. Capped
+ * all the same — a title attribute is not the place for a megabyte of payload.
+ */
+export function fullWire(wire: string | undefined): string {
+  const raw = wire ?? "";
+  const value = parseWire(raw);
+  const rendered = value ? render(value, 0, true) : raw;
+  return rendered.length <= MAX_FULL ? rendered : `${rendered.slice(0, MAX_FULL)}…`;
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -3579,6 +3579,204 @@ a:hover {
   }
 }
 
+/* ---- the pinned wire log (Addendum 5, rule 3) ----
+
+   Clicking a wire pins that link's traffic beside it. The panel takes the
+   SELECTED CLIENT'S ink (--pc, set inline by mp-network.ts) for its frame, its
+   header and its intent rows, so "which link am I reading" is answered by color
+   before any text is parsed — the same rule the dots follow. */
+
+/* The click target: the visible wire is 1.4px, which is not something to aim
+   at. A transparent stroke ten times that width takes the clicks, and only it
+   takes them — the layer itself stays click-through. */
+.mp-wire-hit {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 18;
+  pointer-events: stroke;
+  cursor: pointer;
+}
+
+/* The selected wire steps forward, but the WIRE must not thicken much: its
+   packets ride the same currentColor, so a bright fat stroke swallows exactly
+   the traffic you pinned it to read (it did — the first attempt added a
+   drop-shadow glow and the dots vanished into it). Instead the line goes to
+   full ink at a hair more weight, and the depth comes from a soft halo BEHIND
+   the dots — the hit path, already the right shape and already there. */
+.mp-wire.selected {
+  opacity: 1;
+  stroke-width: 1.8;
+}
+
+.mp-wire-hit.selected {
+  stroke: currentColor;
+  opacity: 0.13;
+}
+
+.mp-edge-chip {
+  cursor: pointer;
+}
+
+.mp-edge-chip.selected {
+  border-color: color-mix(in srgb, currentColor 45%, var(--line));
+  color: var(--text);
+}
+
+.mp-edge-chip:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
+
+/* The leader line, dashed so it reads as an annotation rather than as another
+   wire, with a nub where it grips the edge. */
+.mp-tether path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1;
+  stroke-dasharray: 3 4;
+  opacity: 0.5;
+}
+
+.mp-tether circle {
+  fill: var(--bg);
+  stroke: currentColor;
+  stroke-width: 1.4;
+}
+
+.mp-wirelog {
+  --pc: var(--cyan);
+  position: absolute;
+  width: 330px;
+  max-width: calc(100% - 20px);
+  pointer-events: auto;
+  background: rgba(17, 13, 32, 0.97);
+  border: 1px solid color-mix(in srgb, var(--pc) 42%, var(--line));
+  border-radius: 5px;
+  box-shadow:
+    0 0 24px color-mix(in srgb, var(--pc) 14%, transparent),
+    0 18px 40px rgba(0, 0, 0, 0.6);
+}
+
+.mp-wirelog[hidden] {
+  display: none;
+}
+
+.mp-wl-hd {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  font: 10px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  background: color-mix(in srgb, var(--pc) 7%, transparent);
+  border-bottom: 1px solid var(--line);
+  border-radius: 4px 4px 0 0;
+}
+
+.mp-wl-hd b {
+  font-weight: 500;
+  color: var(--pc);
+}
+
+.mp-wl-x {
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.mp-wl-x:hover {
+  color: var(--text);
+}
+
+.mp-wl-rows {
+  padding: 5px 0;
+}
+
+/* Four columns, fixed where the content is fixed-width (frame, direction,
+   bytes) so the payload — the only column whose width is a judgement call —
+   gets everything left over. */
+.mp-wl {
+  display: grid;
+  grid-template-columns: 54px 62px 1fr 46px;
+  gap: 8px;
+  padding: 3px 10px;
+  font: 10.5px/1.5 var(--font-mono);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  border-left: 2px solid transparent;
+}
+
+.mp-wl:hover {
+  background: color-mix(in srgb, var(--pc) 6%, transparent);
+}
+
+/* The row at the playhead. This is the panel's one loud moment, and it earns
+   it: it is what makes the log and the rail visibly the same instrument. */
+.mp-wl.at {
+  border-left-color: var(--pc);
+  background: color-mix(in srgb, var(--pc) 14%, transparent);
+}
+
+.mp-wl .f {
+  color: var(--text-dim);
+}
+
+/* Direction takes the ink of whoever SENT it: the client's own color going up,
+   the authority's slate coming down. */
+.mp-wl .d.up {
+  color: var(--pc);
+}
+
+.mp-wl .d.dn {
+  color: var(--scrub-server);
+}
+
+.mp-wl .payload {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* Constructor first and lit, arguments after and quiet — the row is scanned for
+   WHICH message this is. */
+.mp-wl .payload b {
+  font-weight: 500;
+}
+
+.mp-wl .payload em {
+  font-style: normal;
+  color: var(--text-dim);
+  margin-left: 5px;
+}
+
+.mp-wl .n {
+  text-align: right;
+  color: var(--text-dim);
+}
+
+.mp-wl-empty {
+  margin: 0;
+  padding: 6px 12px;
+  font: 10px/1.5 var(--font-mono);
+  color: var(--text-dim);
+}
+
+.mp-wl-ft {
+  padding: 5px 10px;
+  border-top: 1px solid var(--line);
+  font: 9.5px/1.4 var(--font-mono);
+  color: var(--text-dim);
+}
+
 /* ---- the network status strip (Addendum 5a.3) ----
 
    The legend, and the readouts the pane headers drop when they clip to

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -58,5 +58,10 @@
   // `.tsx` joins the checked set alongside `.ts` — the React islands in
   // src/components/ are checked directly, not merely transitively via their
   // importer.
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  // `*.test.ts` is the one exception: those run under NODE (`node --test`, type
+  // stripping), so they import `node:test` and a `./x.ts` specifier — neither of
+  // which exists in the browser world this config describes. They cover pure,
+  // DOM-free modules, which is why they can run there at all.
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
![wire log scrub replay](https://gist.githubusercontent.com/tommy-xr/5d4859c7c57d564f16b45ac220605c89/raw/wirelog2-scrub.gif)

<sub>Scrub the rail, watch the wires replay: parked dots ARE the packets from that frame, and the pinned log's rows follow the playhead — orbs' own protocol, decoded as values.</sub>

![pinned wire log, live](https://gist.githubusercontent.com/tommy-xr/5d4859c7c57d564f16b45ac220605c89/raw/wirelog-pinned-live.png)

<sub>Live: clicking a link pins its wire log — both directions interleaved by frame, rows decoded as `Steer {…}` / `Snapshot (…)`, never bytes.</sub>

![parked, replayed from the log](https://gist.githubusercontent.com/tommy-xr/5d4859c7c57d564f16b45ac220605c89/raw/wirelog-parked-replay.png)

<sub>Parked at the head: every dot on the wires comes from the packet log, and the row nearest the playhead is marked.</sub>

<details>
<summary>More media</summary>

![mid-scrub still](https://gist.githubusercontent.com/tommy-xr/5d4859c7c57d564f16b45ac220605c89/raw/wirelog2-scrub-still.png)

<sub>Mid-scrub at `#f 319 / 389` — the panel's viewport has swept with the playhead (rows now around #f 317) while replayed dots ride both wires.</sub>

Captured headlessly from `site/dist` (Playwright, `sandbox.html?example=orbs#clients=2`, network view) by driving the same parking/seek seam `e2e/sandbox-mp.mjs` §4g asserts on: pin the edge chip, pause, `End`, rewind two seconds, then 24 × 5-frame `ArrowRight` steps. Every captured frame reported `live=0` with replay dots present, and 24 distinct marked rows across the sweep.

</details>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

**The wire log — traffic per scrubber** (design doc Addendum 5 rule 3 + 5a item 5, Bryan's ask). Two commits:

**1. Packets live on the timeline.** Every routed packet is stamped with the **reference-clock frame** at route time (the same axis the chrono rail's `#f` label shows — the coordinator takes a `referenceFrame()` getter from mp-panes' continuous offset measurement, cached once per frame). And the network view's dots now have two honest modes: **live** (per-frame batching, as before) and **parked** — dots render *from the log*, sweeping the playhead's window as you scrub. Scrub the rail, watch the wires replay. A parked dot IS the packet from that frame; the last "is that dot real?" question is gone.

**2. The pinned wire log.** Click a wire → the mockup's panel, real: filtered to that link, both directions interleaved by frame, rows like `#f 227  c1→srv  Steer {turn:0, thrust:false, claim:false}  116 B` — **decoded values, never bytes**. Scrub-locked: parked at frame N shows the rows around N with the nearest highlighted; scrubbing sweeps them; live tails the newest at 10 Hz. `esc` clears (after popovers), another wire re-pins, the selected wire halos *behind* its packets. Placement is measured, not fixed: the panel scores the stage's corners against every card and the wire's bbox, and the dashed tether anchors to the edge facing the wire.

**The decode discovery:** `Effect.sendMsg` frames payloads as `U+0001 fun:` + serde's externally-tagged JSON of the value; plain `Effect.send` text crosses unframed; one connection can carry both. `site/src/wire-value.ts` decodes both **totally** — it runs in the host rAF loop on game-chosen text, so it must never throw, and its hostile-input unit suite (`npm run test:wire-value`) found three real throws during development. Render budgets align with the runtime's own `Value::preview`.

**Cross-engine review (Claude + Codex + dup pass), all findings dispositioned.** Fixed, [AGREED]: the decoder-can-throw class (→ total decoder + tests); null-frame packets sorting as future rows; unbounded retained payload text (log now bounded by bytes and count). Fixed, single-engine: log cleared on program change; panel work throttled (10 Hz tail, hover-built tooltips, placement only on change); binary-search log walks when parked; aria firehose silenced; per-packet reference-clock reads hoisted. Dispositioned with rationale in-diff: the compact render style (the approved mockup's), corner-scoring placement, the e2e's deliberately independent overlap math.

**Verification (re-run at the post-#626/#635 rebase):** `tsc` strict clean; wasm pkg + site rebuilt from scratch; `npm run test:wire-value` 5/5; `npm run test:site` 135/135; `e2e/sandbox-mp.mjs` all green (+8 new wire-log/replay checks: log-sourced dots when parked and zero live-feed dots, none before the session, panel rows decode orbs' constructors, rows follow a seek, esc clears, re-pin); `e2e/net-coordinator.mjs` 15/15.

Next: remove `examples/mp` (orbs becomes the sole multiplayer sample; both e2e suites and the SDK e2e re-point to orbs) → impairment, where these log rows gain sent-vs-delivered frames and the link chips become measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
