### PR TITLE
feat(site): set the editor codelenses into the surface

### DIFF
--- a/site/src/lang-intel.ts
+++ b/site/src/lang-intel.ts
@@ -1384,13 +1384,22 @@ const intelTheme = EditorView.theme({
   ".cm-expect-error": { border: "1.5px solid #e05561" },
   ".cm-expect-running": { border: "1.5px dashed #d8a657" },
   ".cm-expect-unrunnable": { border: "1.5px solid rgba(233, 230, 242, 0.35)" },
-  // Codelenses: a dimmed signature line above the def.
+  // Codelenses: a dimmed signature line above the def, set INTO the surface —
+  // a darker cut of the editor's own violet with a crisp dark top lip, a soft
+  // shadow falling from it, and a faint catch-light on the bottom edge, so the
+  // strip reads as a recessed channel separate from the code. Box-shadow only:
+  // the row keeps exactly its unstyled height (no reflow vs. a plain line).
   ".cm-lens": {
     fontFamily: mono,
     fontSize: "0.82em",
     color: "#6c6685",
     fontStyle: "italic",
     lineHeight: "1.5",
+    background: "rgba(8, 5, 18, 0.45)",
+    boxShadow:
+      "inset 0 1px 0 rgba(0, 0, 0, 0.55), " +
+      "inset 0 4px 5px -3px rgba(0, 0, 0, 0.5), " +
+      "inset 0 -1px 0 rgba(233, 230, 242, 0.05)",
   },
   // Autocomplete popup: the same calm dark panel as the hover tooltip.
   ".cm-tooltip.cm-tooltip-autocomplete": {


### PR DESCRIPTION
The editor's signature codelenses floated flat in the code — on dense stretches (e.g. three consecutive consts in the Neon grid example) they were easy to misread as source lines. This sets them **into** the surface: a darker cut of the editor's own violet (`rgba(8,5,18,.45)` under `#161226`), a crisp dark top lip, a soft shadow falling from it, and a faint catch-light on the bottom edge (theme text at 5%), so each lens reads as a recessed channel separate from the code.

Chosen from four candidate treatments compared live on the Neon grid example (flat / soft trough / crisp deboss / **lip + glow**); the shadows keep to the calm-theme palette rather than gray-black.

**No reflow:** the treatment is background + `box-shadow` only — lens rows keep exactly their previous height, so buffer metrics and the (recently fixed, #641) lens stability during transient errors are untouched.

## Before → after

![before/after](https://gist.githubusercontent.com/tommy-xr/cd761608eb74796ccf4e367c6b0c012d/raw/lens-inset-beforeafter.png)

![toggle](https://gist.githubusercontent.com/tommy-xr/cd761608eb74796ccf4e367c6b0c012d/raw/lens-inset-toggle.gif)

<sub>Same viewport, alternating before/after. Captured headlessly from the built site (Playwright, `?example=hero`).</sub>

## Verification

- `tsc -p site --noEmit` clean.
- Built the site and screenshotted the served sandbox: computed style on `.cm-lens` confirms the fill + three inset shadows; the captures above are from the real built page, not injected CSS.
- Single-property theme change (one `.cm-lens` rule in `intelTheme`), no behavior touched — review skipped as trivial per project guidelines.
