### PR TITLE
feat(scrubber): quieter flash, button tooltips, and the excerpt teaching comment

### DIFF
--- a/e2e/detached-camera.mjs
+++ b/e2e/detached-camera.mjs
@@ -564,6 +564,10 @@ try {
     // reproduce the untouched authored frame exactly.
     const twoD = Buffer.from(TWO_D_SOURCE).toString("base64url");
     await page.goto(`${BASE}/player.html?src=${twoD}`);
+    // Tooltips are page pixels: a cursor parked on a bar button (left there
+    // by an earlier scenario's click) would leak hover chrome into the
+    // byte-equality captures below. Park it over inert canvas instead.
+    await page.mouse.move(480, 420);
     await page.waitForFunction(() => window.__scrub?.range().length === 2);
     await page.evaluate(() => window.__scrub.togglePause());
     await page.waitForFunction(() => window.__scrub.paused());

--- a/examples/platformer/game.fun
+++ b/examples/platformer/game.fun
@@ -15,7 +15,9 @@
 
 // --- Tunables (tweak these to change whether the jump clears the chasm) ---
 // <editable>
-// Tune the jump — speed, launch, gravity, gap — then click 🔮.
+// Tune the jump, then click 🔮 ("extrapolate") to see the
+// past and future of anything that changes — or just keep
+// tuning while it's on, and watch the future redraw.
 let runSpeed = 8.0        // horizontal speed while held
 let jumpVelocity = 13.0   // upward launch speed
 let gravity = 30.0        // downward acceleration

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -96,8 +96,10 @@ const STYLE = `
   background: rgba(30, 24, 51, 0.97); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
   font: 10px/1.2 var(--sb-font); letter-spacing: 0.02em; white-space: nowrap;
   opacity: 0; visibility: hidden; pointer-events: none;
-  /* The delay lives on the SHOW transition, so the tip fades out immediately
-     on leave rather than waiting out its own dwell. */
+  /* The 0.38s dwell lives on the SHOW transition (below), so a passing cursor
+     never trips a tip, and on leave the opacity fades out at once instead of
+     waiting the dwell out again. Visibility still flips a beat later; the tip
+     is already transparent and pointer-events: none by then. */
   transition: opacity 0.12s ease 0s, visibility 0s linear 0.38s;
 }
 #scrub-main button[data-tip]:hover::after,
@@ -105,9 +107,16 @@ const STYLE = `
   opacity: 1; visibility: visible;
   transition: opacity 0.12s ease 0.38s, visibility 0s linear 0.38s;
 }
-/* The right cluster hangs its tips from the button's right corner — centered,
-   they clip at the iframe edge. Selectors are #scrub-main-qualified so they
-   OUTWEIGH the base rule above; a bare #scrub-camera[data-tip]::after loses. */
+/* Each cluster hangs its tips from the OUTER corner of its button — centered,
+   they overhang the bar and clip at the viewport edge (the landing hero's
+   iframe is ~500px, so both edges are live, not just the right). Selectors are
+   #scrub-main-qualified so they OUTWEIGH the base rule above; a bare
+   #scrub-camera[data-tip]::after loses. */
+#scrub-main #scrub-pause[data-tip]::after,
+#scrub-main #scrub-step[data-tip]::after,
+#scrub-main #scrub-reset[data-tip]::after {
+  left: 0; right: auto; transform: none;
+}
 #scrub-main #scrub-camera[data-tip]::after,
 #scrub-main #scrub-extrapolate[data-tip]::after {
   left: auto; right: 0; transform: none;
@@ -263,10 +272,12 @@ const STYLE = `
   to { opacity: 1; transform: translateY(0); }
 }
 @media (prefers-reduced-motion: reduce) {
-  /* A steady ring carries the same "look here" without motion. */
+  /* A steady ring carries the same "look here" without motion — held at the
+     pulse's own peak, so the reduced-motion rest state is no louder than the
+     animated one, and stays clearly below the peek's filled ring below. */
   #scrub-extrapolate.attention {
     animation: none;
-    box-shadow: 0 0 0 2px var(--sb-future), 0 2px 10px rgba(232, 88, 184, 0.35);
+    box-shadow: 0 0 0 1px rgba(232, 88, 184, 0.3);
   }
   /* The glimpse still reads through the trail itself; a steady ring marks the
      button for the duration without the press or the shine. The filled

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -423,7 +423,7 @@ const HTML = `
          future, so "preview the future" was wrong, and the hero excerpt's
          comment does the teaching. -->
     <button id="scrub-extrapolate" data-tip="Extrapolate"
-      aria-label="Extrapolate the game into the future">🔮</button>
+      aria-label="Extrapolate — see past and future states">🔮</button>
   </div>
   <!-- ▶, not ⏸: the notice only ever shows while paused, and the transport
        button reads ▶ then. It must name the glyph actually on the bar. -->

--- a/runtime/functor-runtime-web/scrubber.js
+++ b/runtime/functor-runtime-web/scrubber.js
@@ -84,6 +84,34 @@ const STYLE = `
 #scrubber button:active {
   transform: translateY(0); box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
+/* Themed tooltips instead of native title= tips: those are slow, unstyled, and
+   never appear on keyboard focus. data-tip carries the label; aria-label keeps
+   the accessible name (which title= was doubling as). */
+#scrub-main button[data-tip] { position: relative; }
+#scrub-main button[data-tip]::after {
+  content: attr(data-tip);
+  position: absolute; z-index: 13; top: calc(100% + 7px); left: 50%;
+  transform: translateX(-50%); padding: 4px 8px;
+  border: 1px solid var(--sb-line); border-radius: 5px; color: var(--sb-text);
+  background: rgba(30, 24, 51, 0.97); box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  font: 10px/1.2 var(--sb-font); letter-spacing: 0.02em; white-space: nowrap;
+  opacity: 0; visibility: hidden; pointer-events: none;
+  /* The delay lives on the SHOW transition, so the tip fades out immediately
+     on leave rather than waiting out its own dwell. */
+  transition: opacity 0.12s ease 0s, visibility 0s linear 0.38s;
+}
+#scrub-main button[data-tip]:hover::after,
+#scrub-main button[data-tip]:focus-visible::after {
+  opacity: 1; visibility: visible;
+  transition: opacity 0.12s ease 0.38s, visibility 0s linear 0.38s;
+}
+/* The right cluster hangs its tips from the button's right corner — centered,
+   they clip at the iframe edge. Selectors are #scrub-main-qualified so they
+   OUTWEIGH the base rule above; a bare #scrub-camera[data-tip]::after loses. */
+#scrub-main #scrub-camera[data-tip]::after,
+#scrub-main #scrub-extrapolate[data-tip]::after {
+  left: auto; right: 0; transform: none;
+}
 #scrub-rail {
   position: relative; flex: 1; min-width: 80px; height: 30px; cursor: ew-resize;
   touch-action: none; user-select: none;
@@ -188,12 +216,14 @@ const STYLE = `
    the demo is staged. A slow breath rather than a blink — it should read as
    "this is the next thing", not as an alarm. Cleared for good on first use. */
 #scrub-extrapolate.attention {
-  border-color: var(--sb-future);
-  animation: scrub-attention 2s ease-in-out infinite;
+  border-color: rgba(232, 88, 184, 0.5);
+  animation: scrub-attention 3.2s ease-in-out infinite;
 }
+/* No outer halo at all: the rest state is presence, not motion — a ring that
+   breathes between two close values. */
 @keyframes scrub-attention {
-  0%, 100% { box-shadow: 0 0 0 1px rgba(232, 88, 184, 0.35), 0 0 0 rgba(232, 88, 184, 0); }
-  50% { box-shadow: 0 0 0 1px var(--sb-future), 0 0 14px 2px rgba(232, 88, 184, 0.45); }
+  0%, 100% { box-shadow: 0 0 0 1px rgba(232, 88, 184, 0.16); }
+  50% { box-shadow: 0 0 0 1px rgba(232, 88, 184, 0.3); }
 }
 /* Peek: while an edit-triggered glimpse of the extrapolation plays, the button
    presses once and then SHINES for the whole glimpse — it is the glimpse's only
@@ -306,20 +336,22 @@ const JUICE_STYLE = `
 .scrub-reload-juice {
   position: fixed; inset: 0; z-index: 9; pointer-events: none; opacity: 0;
 }
-/* Success is deliberately quiet. The star of an accepted edit is the redrawn
-   prediction in the scene, so the vignette only has to say "that landed" and
-   get out of the way — a hairline ring and a faint glow, gone in 0.28s. */
+/* Success is deliberately a whisper. The star of an accepted edit is the
+   redrawn prediction in the scene, so the vignette only has to say "that
+   landed" out of the corner of the eye — a hairline ring and the faintest
+   glow, gone in 0.26s. */
 .scrub-reload-juice.live {
-  animation: scrub-juice-flash 0.28s ease-out;
-  box-shadow: inset 0 0 0 1px rgba(65, 216, 230, 0.5),
-    inset 0 0 44px 8px rgba(65, 216, 230, 0.16);
+  animation: scrub-juice-flash 0.26s ease-out;
+  box-shadow: inset 0 0 0 1px rgba(65, 216, 230, 0.22),
+    inset 0 0 30px 5px rgba(65, 216, 230, 0.07);
 }
-/* A rejection shouts, and lingers a beat longer: nothing else on the page says
-   the edit was refused, so this is the one the reader must not miss. */
+/* A rejection is the one that must not be missed — nothing else on the page
+   says the edit was refused — so it reads clearly and lingers a beat longer.
+   Clearly, not a klaxon: enough red to catch the eye without flooding it. */
 .scrub-reload-juice.rejected {
-  animation: scrub-juice-flash 0.45s ease-out;
-  box-shadow: inset 0 0 0 2px rgba(255, 107, 125, 0.9),
-    inset 0 0 60px 12px rgba(255, 107, 125, 0.4);
+  animation: scrub-juice-flash 0.42s ease-out;
+  box-shadow: inset 0 0 0 2px rgba(255, 107, 125, 0.55),
+    inset 0 0 46px 8px rgba(255, 107, 125, 0.22);
 }
 @keyframes scrub-juice-flash {
   0% { opacity: 0; }
@@ -336,9 +368,11 @@ const JUICE_STYLE = `
 
 const HTML = `
   <div id="scrub-main">
-    <button id="scrub-pause" title="Pause / resume">⏸</button>
-    <button id="scrub-step" title="Step one frame forward">⏭</button>
-    <button id="scrub-reset" title="Reset the demo" hidden>↺</button>
+    <button id="scrub-pause" data-tip="Pause" aria-label="Pause">⏸</button>
+    <button id="scrub-step" data-tip="Step one frame"
+      aria-label="Step one frame forward">⏭</button>
+    <button id="scrub-reset" data-tip="Reset the demo"
+      aria-label="Reset the demo" hidden>↺</button>
     <span id="scrub-rail" aria-label="Time-travel timeline" title="Drag to seek">
     <svg id="scrub-timeline" viewBox="0 0 1000 30" preserveAspectRatio="none"
       role="group" aria-label="Timeline event markers">
@@ -372,8 +406,13 @@ const HTML = `
     </span>
     <!-- Left of the rail = transport (⏸ ⏭/↺); right of it = ways to LOOK at
          the frame the transport landed on (📷 the scene, 🔮 its future). -->
-    <button id="scrub-camera" title="Open the debug camera" hidden>📷</button>
-    <button id="scrub-extrapolate" title="Extrapolate the game into the future">🔮</button>
+    <button id="scrub-camera" data-tip="Debug camera"
+      aria-label="Open the debug camera" hidden>📷</button>
+    <!-- The tip is deliberately JUST the name: 🔮 shows the past AND the
+         future, so "preview the future" was wrong, and the hero excerpt's
+         comment does the teaching. -->
+    <button id="scrub-extrapolate" data-tip="Extrapolate"
+      aria-label="Extrapolate the game into the future">🔮</button>
   </div>
   <!-- ▶, not ⏸: the notice only ever shows while paused, and the transport
        button reads ▶ then. It must name the glyph actually on the bar. -->
@@ -876,14 +915,20 @@ export function mountScrubber({ hidden = false } = {}) {
       (state.preview.enabled ? ` <span class="fut">+${current.previewFrames}</span>` : "") +
       ` / ${Math.round(current.viewport.hi)}`;
     pause.textContent = current.paused ? "▶" : "⏸";
-    pause.setAttribute("aria-label", current.paused ? "Resume" : "Pause");
+    pause.dataset.tip = current.paused ? "Play" : "Pause";
+    pause.setAttribute("aria-label", current.paused ? "Play" : "Pause");
     camera.hidden = false;
     camera.disabled = pendingPointerLock || pendingDetachedGeneration !== null;
     camera.textContent = detachedActive ? "🔗" : "📷";
-    camera.title = detachedActive
-      ? "Exit the debug camera"
-      : "Debug camera — FPS in 3D, pan/zoom in 2D";
-    camera.setAttribute("aria-label", camera.title);
+    // The tip is the short name (it hangs under a right-edge button); the
+    // accessible name keeps the longer teaching string title= used to carry.
+    camera.dataset.tip = detachedActive ? "Exit debug camera" : "Debug camera";
+    camera.setAttribute(
+      "aria-label",
+      detachedActive
+        ? "Exit the debug camera"
+        : "Debug camera — FPS in 3D, pan/zoom in 2D",
+    );
     camera.setAttribute("aria-pressed", String(detachedActive));
     camera.classList.toggle("on", detachedActive);
     el.classList.toggle("debug-active", detachedActive);

--- a/site/styles.css
+++ b/site/styles.css
@@ -310,10 +310,10 @@ a:hover {
   border-top: 1px solid var(--line);
   /* Tall enough for the whole excerpt — the four tunables and their lead
      comment up top, the world composition below — with no line clipped. The
-     budget is 14 code lines at the shared 11.5px/1.65 editor type; adding a
+     budget is 16 code lines at the shared 11.5px/1.65 editor type; adding a
      line to the <editable> region means growing this too (the e2e asserts
      nothing clips). */
-  height: 304px;
+  height: 342px;
   overflow: hidden;
   background: #161226;
   display: flex;


### PR DESCRIPTION
Three chrome adjustments to the time-travel bar, plus the teaching comment on the landing hero's excerpt. **Every value here was live-tuned and approved by the maintainer on a running preview** — they are applied exactly as given, not re-derived.

## 1. The reload flash whispers

`.scrub-reload-juice.live` drops to a 1px ring at alpha 0.22 with a 30px glow at 0.07, over 0.26s. Success should be noticed out of the corner of the eye — the star of an accepted edit is the redrawn prediction in the scene, not the vignette.

`.rejected` stays the one you must not miss (nothing else on the page says the edit was refused) but is no longer a klaxon: 0.55/0.22 over 0.42s instead of 0.9/0.4.

## 2. Themed button tooltips replace `title=`

Native `title` tips are slow, unstyled, and — the real reason — **never appear on keyboard focus**. The five transport buttons now carry `data-tip` rendered through a themed `::after`, shown on `:hover` *and* `:focus-visible` after a 0.38s dwell. `aria-label` keeps the accessible name that `title` was doubling as, so accessible-name queries are unaffected.

The dwell rides the *show* transition, so a cursor passing over the bar never trips a tip, while leaving fades one out at once.

**🔮's tip is deliberately just "Extrapolate."** It shows the past *and* the future, so "preview the future" was simply wrong; the hero excerpt below does the teaching instead.

Each cluster hangs its tip from its own **outer** corner. Centered, tips overhang the bar and clip at the iframe edge — and at the landing hero's ~500px frame *both* edges are live. The overrides are `#scrub-main`-qualified so they outweigh the base rule; a bare `#scrub-extrapolate[data-tip]::after` loses on specificity (that exact bug shipped in the prototype, so it's pinned by a measured check, not by eye).

![extrapolate tooltip](https://gist.githubusercontent.com/tommy-xr/c93ebee068d27d6e74e61a5a2ab1d890/raw/tip-extrapolate.png)
![pause tooltip](https://gist.githubusercontent.com/tommy-xr/c93ebee068d27d6e74e61a5a2ab1d890/raw/tip-pause.png)

## 3. The resting attention pulse quiets down

`#scrub-extrapolate.attention` loses its outer halo entirely and breathes between alpha 0.16 and 0.3 over 3.2s. The rest state is presence, not motion.

**This is load-bearing for #638's peek**, which merged just under this branch: the bright treatment belongs to the *active* peek (filled background, 2px ring, 18px halo), and a quiet rest state is what makes that contrast read. The two rules are adjacent and coexist unchanged — all 10 peek e2e checks pass here.

## 4. The hero excerpt teaches what 🔮 does

The one-line lead comment becomes three, naming the thing plainly: past **and** future, live while you keep tuning. `site/styles.css` grows `.hero-editor` 304px → 342px for the two extra lines — its own comment already required that ("adding a line to the `<editable>` region means growing this too"), and the site e2e asserts nothing clips.

Before / after:

![before](https://gist.githubusercontent.com/tommy-xr/c93ebee068d27d6e74e61a5a2ab1d890/raw/hero-desktop-before.png)
![after](https://gist.githubusercontent.com/tommy-xr/c93ebee068d27d6e74e61a5a2ab1d890/raw/hero-excerpt.png)

Mobile (390px) clips trailing comments in both before and after — pre-existing, unchanged.

The flash intensities are the one thing a still can't show; they were live-tuned by the maintainer on a running preview rather than captured here.

## Verification

- `npm run build` — green (rebuilt after the rebase onto #638, and again after the review fixes; `scrubber.js` is `include_bytes!`-embedded in the CLI).
- `npm run test:scrubber` — 24/24.
- `node e2e/site-sandbox.mjs` — **152 checks, 0 failures**, including all 10 of #638's peek checks.
- Playwright against the built site — 16 checks: every visible transport tip inside **both** iframe edges (⏸ `[9.0, 51.9]`, ↺ `[39.4, 144.5]`, 📷 `[350.3, 443.0]`, 🔮 `[396.6, 483.0]` in a 492px frame); keyboard focus shows a tip; the pause tip flips Play/Pause with state; the excerpt shows all three comment lines with `scrollWidth == clientWidth`. A **negative control** confirms the check is real: forcing the centered rule puts 🔮's tip at 554px in a 492px frame.
- No test, e2e, or site source selected those buttons by `title` — all scrubber selectors are ID-based, so nothing needed updating.

## Review (`/xreview`, two engines + a de-dup pass)

**Fixed:**
- **High** (Claude, measured) — the *left* cluster clipped off the **left** edge at the hero's width (⏸ at −4.1px; both ⏸ and ⏭ at phone widths). The mirror of the bug the override fixed on the right. Now anchored left, and pinned by the both-edges check above.
- **Low [AGREED — both engines, same proposed value]** — under `prefers-reduced-motion` the resting ring kept the old 2px + halo, making the no-motion path *louder* than the quieted animated one, and competitive with the peek. Now holds at the pulse's own peak (1px @ 0.3).
- **Low** — the leave-transition comment overclaimed; `visibility` does lag the opacity fade. Comment corrected rather than the maintainer-approved CSS.

**Dispositioned, not changed:**
- **Low** (Codex) — 🔮's `aria-label` still says "into the future", which is the same inaccuracy the tip text was changed to avoid. **Flagging for the maintainer**: the string is maintainer-approved, so I did not unilaterally rewrite an accessible name. Worth a follow-up.
- **Low** — `#scrub-rail` keeps its native `title="Drag to seek"`, so hovering across the bar alternates themed → native → themed. Out of scope by instruction (the rail's title was explicitly to be left alone).
- **Low** — pause's `aria-label` is now "Play" where the sandbox's separate mp bar says "Resume". The label was specified; the two are different components.
- **Low** — `test:scrubber` covers the pure timeline reducer, not this DOM/CSS. True; that's why the Playwright checks above exist.
- **Medium** (de-dup) — the tooltip re-declares the floating-panel recipe that `#scrub-event-detail` and `#scrub-toast` already use, with small drift (radius 5 vs 6, bg .97 vs .98). Extracting a shared rule would mean re-tuning three widgets' approved values; declined for a scoped chrome change, worth its own pass.
- `site/src/mp-panes.ts` keeps native `title=` on its parallel transport. Its styles live in the host page while `scrubber.js` injects into the game iframe — there is no cross-document CSS seam, and inventing one here would outweigh the change. Noted as follow-up.

De-dup coverage: S1-names (2 queries / 7228 candidates), S2-clones (whole-repo, zero rows touching the changed files), S3-index (2997 items + targeted greps), S4-read over the full diff.
