### PR TITLE
docs(site): the manual teaches module roles for same-file multiplayer

### DIFF
--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -273,26 +273,27 @@ let draw = (model, tts: float) =>
           <p>
             A multiplayer game is two <strong>roles</strong> over one world. Functor lets both
             roles live in a single file: <code>functor.json</code> declares
-            <code>entries</code> instead of one <code>entry</code>, and each role names a binding
-            <strong>prefix</strong>. The runner then resolves the canonical contract through that
-            prefix as camelCase — the <code>client</code> role reads
-            <code>clientInit</code> / <code>clientTick</code> / <code>clientDraw</code>, the
-            <code>server</code> role reads <code>serverInit</code> / <code>serverTick</code> /
-            <code>serverDraw</code> — so one edit hot-reloads both roles atomically.
+            <code>entries</code> instead of one <code>entry</code>, and each role names an inline
+            <strong><code>module</code></strong> block in that file. The block's members
+            <em>are</em> that role's contract — the <code>client</code> role reads
+            <code>Client.init</code> / <code>Client.tick</code> / <code>Client.draw</code>, the
+            <code>server</code> role reads <code>Server.init</code> / <code>Server.tick</code> /
+            <code>Server.draw</code>.
           </p>
           <pre class="shell"># functor.json
 {
   "language": "functor-lang",
   "entries": {
-    "client": { "file": "game.fun", "prefix": "client" },
-    "server": { "file": "game.fun", "prefix": "server" }
+    "client": { "file": "game.fun", "module": "Client" },
+    "server": { "file": "game.fun", "module": "Server" }
   }
 }</pre>
           <p>
-            Everything above the role sections is <em>shared</em>: the protocol type both roles
-            agree on, and the authoritative rules written as pure functions. That sharing is the
-            point — one declaration of the protocol, so a typo on either side is a check-time
-            error.
+            Everything above the two blocks is <em>shared</em>: the protocol type both roles agree
+            on, and the authoritative rules written as pure functions. That sharing is the point —
+            one declaration of the protocol, so a typo on either side is a check-time error. And
+            because it is one buffer, one save hot-reloads both roles atomically; delete a block a
+            role names and the reload fails loudly, keeping the old program running.
           </p>
           <p class="docs-callout">
             <strong>This step is the role structure, not the wire.</strong> To keep it runnable in
@@ -308,7 +309,7 @@ let draw = (model, tts: float) =>
 type Ship = { pid: float, x: float, dx: float }
 type Wire = | Steer(dx: float)
 
-// ===== SERVER — pure functions over the world =====
+// ===== THE WORLD — the authoritative rules, as pure functions =====
 let world0: List&lt;Ship> = [
   { pid: 0.0, x: -4.0, dx: 0.0 },
   { pid: 1.0, x: 4.0, dx: 0.0 }]
@@ -337,49 +338,72 @@ let render = (myPid: float, ships: List&lt;Ship>) =>
       Sprite.circle(if s.pid == myPid then mine() else theirs(), 1.0)
         |> Sprite.move(s.x, 0.0))))
 
-// ===== CLIENT ROLE — clientInit / clientTick / clientDraw =====
-let clientInit = { myPid: 0.0, botPid: 1.0, ships: world0, dx: 0.0 }
+// ===== CLIENT ROLE — Client.init / Client.tick / Client.draw =====
+module Client {
+  type Model = { myPid: float, botPid: float, ships: List&lt;Ship>, dx: float }
 
-let clientSampledInput = (m, snapshot: Input.snapshot) =>
-  let held = (k: Key.t) => snapshot.heldKeys |> List.any((key) => key == k) in
-  { m with dx: (if held(Key.D) then 1.0 else 0.0) - (if held(Key.A) then 1.0 else 0.0) }
+  let init: Model = { myPid: 0.0, botPid: 1.0, ships: world0, dx: 0.0 }
 
-let clientTick = (m, dt: float, tts: float) =>
-  { m with ships:
-      m.ships
-        |> recv(m.myPid, Steer(m.dx))
-        |> recv(m.botPid, Steer(botDx(m.botPid, tts)))
-        |> step(dt) }
+  let sampledInput = (m: Model, snapshot: Input.snapshot) =>
+    let held = (k: Key.t) => snapshot.heldKeys |> List.any((key) => key == k) in
+    { m with dx: (if held(Key.D) then 1.0 else 0.0) - (if held(Key.A) then 1.0 else 0.0) }
 
-let clientDraw = (m, tts: float) => render(m.myPid, m.ships)
+  let tick = (m: Model, dt: float, tts: float) =>
+    { m with ships:
+        m.ships
+          |> recv(m.myPid, Steer(m.dx))
+          |> recv(m.botPid, Steer(botDx(m.botPid, tts)))
+          |> step(dt) }
 
-// ===== SERVER ROLE — serverInit / serverTick / serverDraw =====
-let serverInit = clientInit
+  let draw = (m: Model, tts: float) => render(m.myPid, m.ships)
+}
 
-let serverTick = (m, dt: float, tts: float) =>
-  { m with ships:
-      m.ships
-        |> recv(m.myPid, Steer(botDx(m.myPid, tts)))
-        |> recv(m.botPid, Steer(botDx(m.botPid, tts)))
-        |> step(dt) }
+// ===== SERVER ROLE — Server.init / Server.tick / Server.draw =====
+module Server {
+  type Model = { ships: List&lt;Ship> }
 
-let serverDraw = clientDraw</pre>
+  let init: Model = { ships: world0 }
+
+  let tick = (m: Model, dt: float, tts: float) =>
+    { m with ships:
+        m.ships
+          |> recv(0.0, Steer(botDx(0.0, tts)))
+          |> recv(1.0, Steer(botDx(1.0, tts)))
+          |> step(dt) }
+
+  // The authority holds no seat of its own, so nothing renders as "mine".
+  let draw = (m: Model, tts: float) => render(0.0 - 1.0, m.ships)
+}</pre>
+          <p>
+            Two rules to know when a role moves into a block. A block's own names
+            <em>shadow</em> the file's, so <code>module Client { let init = init }</code> is
+            self-referential rather than an alias — give shared values names the contract never
+            uses (<code>world0</code>, <code>render</code>) and let each block call those. And a
+            module name occupies its file's <em>type</em> namespace too, so
+            <code>module Client</code> may not sit beside a top-level <code>type Client</code>;
+            the role's model type goes inside the block, as <code>Client.Model</code>.
+          </p>
           <p>
             <code>--entry</code> picks the role, and <code>build</code> validates
-            <em>every</em> declared role's contract under its own prefixed names:
+            <em>every</em> declared role's contract under its own block:
           </p>
           <pre class="shell">functor -d . build                      # checks both roles
 functor -d . run native --entry client  # you steer, with A and D
 functor -d . run native --entry server  # the same world, seen from the authority</pre>
+          <p>
+            A role is not native-only. <code>run wasm</code> and <code>build wasm</code> bake it
+            into the served page's boot config — the web player also takes
+            <code>?module=Server</code> directly — and <code>run vr</code> declares the role in
+            every push to the headset.
+          </p>
           <p class="docs-callout">
             This is the one step with no <strong>▶ try it</strong> button — that path pastes a
-            program in and boots it against the <em>unprefixed</em> contract, which a
-            prefixed role by definition doesn't answer. The sandbox can still play a declared
-            role when it knows it up front:
-            <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see the
-            one-file, two-role shape at full size in its preferred form — each role an inline
-            <code>module Client</code> / <code>module Server</code> block instead of a prefix,
-            over a real wire, with an authoritative claim-resolution rule.
+            program in and boots the file's bare <code>init</code> / <code>tick</code> /
+            <code>draw</code>, which a role living in a block by definition doesn't answer. The
+            sandbox can play a declared role when it knows it up front:
+            <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see these same
+            two blocks at full size — over a real wire, with an authoritative claim-resolution
+            rule.
           </p>
         </section>
 

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -372,7 +372,7 @@ module Server {
           |> step(dt) }
 
   // The authority holds no seat of its own, so nothing renders as "mine".
-  let draw = (m: Model, tts: float) => render(0.0 - 1.0, m.ships)
+  let draw = (m: Model, tts: float) => render(-1.0, m.ships)
 }</pre>
           <p>
             Two rules to know when a role moves into a block. A block's own names
@@ -392,8 +392,8 @@ functor -d . run native --entry client  # you steer, with A and D
 functor -d . run native --entry server  # the same world, seen from the authority</pre>
           <p>
             A role is not native-only. <code>run wasm</code> and <code>build wasm</code> bake it
-            into the served page's boot config — the web player also takes
-            <code>?module=Server</code> directly — and <code>run vr</code> declares the role in
+            into the served or exported page's boot config, this site's player takes
+            <code>?module=Server</code> on its URL, and <code>run vr</code> declares the role in
             every push to the headset.
           </p>
           <p class="docs-callout">
@@ -401,9 +401,9 @@ functor -d . run native --entry server  # the same world, seen from the authorit
             program in and boots the file's bare <code>init</code> / <code>tick</code> /
             <code>draw</code>, which a role living in a block by definition doesn't answer. The
             sandbox can play a declared role when it knows it up front:
-            <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see these same
-            two blocks at full size — over a real wire, with an authoritative claim-resolution
-            rule.
+            <a href="../sandbox.html?example=orbs">open Orbs in the sandbox</a> to see the same
+            two-block shape at full size — over a real wire, with an authoritative
+            claim-resolution rule.
           </p>
         </section>
 
@@ -556,7 +556,9 @@ let area = (s: Shape): float =>
           <p>
             Constructors resolve <em>bare</em> and live in the value namespace
             (<code>Shape.Circle</code> does <strong>not</strong> work), so constructor names must
-            be unique across all variant types in the file. Variants from a <em>module</em> are the
+            be unique across all variant types in the module — a file, or an inline
+            <code>module</code> block, each of which is its own namespace. Variants from a
+            <em>module</em> are the
             other way around — <code>Option.Some</code>, never bare <code>Some</code> (see
             <a href="../docs/#api-option">Option and Result</a>). Unapplied constructors are
             first-class: <code>xs |> List.map(Circle)</code>. When the scrutinee's type is known,

--- a/site/src/docs.ts
+++ b/site/src/docs.ts
@@ -11,6 +11,7 @@ const KEYWORDS = new Set([
   "type",
   "match",
   "with",
+  "module",
   "mut",
   "in",
   "if",

--- a/site/src/functor-lang.ts
+++ b/site/src/functor-lang.ts
@@ -12,6 +12,7 @@ const KEYWORDS = new Set([
   "type",
   "match",
   "with",
+  "module",
   "mut",
   "in",
   "if",


### PR DESCRIPTION
The manual's tutorial **step 6 — "Multiplayer: two roles in one file"** still taught same-file
multiplayer through the **prefix** form (`clientInit`/`serverTick`, `"prefix": "client"` in
`functor.json`, and a "boots against the *unprefixed* contract" callout). Nothing in the repo uses
the prefix form for a real role anymore — `examples/orbs`, the canonical same-file reference, is
two inline `module` blocks. This rewrites the step to teach the **module** form.

## What changed

- **`module Client { … }` / `module Server { … }` blocks**, with the protocol type, the world step
  and the renderer shared bare above them — the shape `examples/orbs` really has, at tutorial size
  (~45 lines, no networking; orbs is *not* pasted in).
- **`functor.json`** now declares `{"client": {"file": "game.fun", "module": "Client"}, "server":
  {"file": "game.fun", "module": "Server"}}` — byte-identical to `examples/orbs/functor.json`.
- **The role runs on every shell.** A new sentence covers `--entry server` natively, the served or
  exported wasm page's boot config (and `?module=Server` on this site's player), and `run vr`
  declaring the role in each device push. No protocol deep-dive.
- **Hot reload kept and sharpened**: one buffer, one save reloads both roles atomically; deleting a
  block a role names fails loudly and keeps the old program running. (Verified — see below.)
- **One short aside on the two migration traps** from the `functor-lang` skill: a block's own names
  shadow the file's (so `module Client { let init = init }` is self-referential, not an alias), and
  `module Client` may not sit beside a top-level `type Client`, so the role's model type goes inside
  the block as `Client.Model`. Two sentences, not a wall.
- The **▶ try it** callout now explains the real reason the step has no run button: that path boots
  the file's *bare* `init`/`tick`/`draw`, which a role living in a block doesn't answer.

**The prefix form is dropped from the tutorial entirely** rather than kept as an aside. The manual
is a learning path, and a transitional form is a second thing to learn for a shape no sample uses;
readers migrating an existing project are served by the reference docs. **No prefix support was
removed from any code or test** — `site/player.html`, `site/src/examples.ts` and the CLI still accept
`?prefix=` / `"prefix"`, and deprecating it is a separate arc.

## Also stale, fixed here

- **`module` was not a syntax-highlighting keyword** (`site/src/docs.ts`, `site/src/functor-lang.ts`
  — both carry a "keep the two in sync" comment). The step's defining keyword rendered as plain body
  text while every neighbouring `let`/`type`/`match` was coloured. Flagged by **both** review engines.
- **The ctor-uniqueness sentence in "The language"** said constructor names must be unique "across
  all variant types in the file". With inline modules taught one section up that is no longer the
  whole rule — uniqueness is **per module**, which is exactly why orbs' two blocks may each declare
  their own. Now: "…in the module — a file, or an inline `module` block, each of which is its own
  namespace."

Nothing else in `site/manual/` (it is a single page, no siblings) or on any other site page carried
stale prefix-form or "native-only module roles" language.

## Verification

**Every code snippet in the step was executed.** The tutorial's Functor Lang block was extracted
from the built HTML programmatically and diffed byte-for-byte against a scratch project (that parity
check was re-run after the review fixes), then:

```
functor -d <scratch> build     →  ✓ checked game.fun  (both roles)
functor -d <scratch> test      →  ✓ (no expects)
functor -d <scratch> run native --entry client --capture-frame …  →  ✓ renders
functor -d <scratch> run native --entry server --capture-frame …  →  ✓ renders
```

The `functor.json` in that scratch project is the snippet from the page verbatim. The "delete a
block and it fails loudly" claim was verified by deleting `module Server` and re-running `build`:

```
error: functor.json entry `server`: game.fun has no inline `module Server { … }` for this
       entry role — it declares: Client
```

Also green: `npm run check:site`, `npm run test:site` (ALL CHECKS PASSED), `npm run site:build` at
both base and change.

## Before / after

Built at the base ref and at the change (`npm run site:build`), served, captured headlessly with
Playwright chromium at 2× DPR. Stills only — nothing animated changed.

**Desktop (1280px)**

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/0345521cce4118f756314d0825307173/raw/before-desktop.png" width="420"> | <img src="https://gist.githubusercontent.com/tommy-xr/0345521cce4118f756314d0825307173/raw/after-desktop.png" width="420"> |

**Mobile (420px)**

| before | after |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/0345521cce4118f756314d0825307173/raw/before-mobile.png" width="260"> | <img src="https://gist.githubusercontent.com/tommy-xr/0345521cce4118f756314d0825307173/raw/after-mobile.png" width="260"> |

Layout is unchanged — same callout/`pre` components, the step just grows. Horizontal clipping of long
code lines at 420px is pre-existing behaviour for every snippet on the page and is no worse here
(the base shot clips at the same column).

## Review (`/xreview`, with `--media` on the after-stills)

Two engines plus a dedicated de-dup pass. **No Critical or High findings from either engine.**

- **[AGREED] Medium — `module` unhighlighted.** Both engines flagged it from the screenshots.
  **Fixed** (added to both keyword sets).
- **Medium — "the web player also takes `?module=Server` directly" was wrong for `run wasm`.**
  That page bakes `__FUNCTOR_LANG_ENTRY_MODULE__` and reads no role query; only *this site's* player
  accepts `?module=`. **Fixed** — the sentence now attributes it to this site's player, and says
  "served or exported page's boot config".
- **Low — `render(0.0 - 1.0, …)` read as a workaround** for something that is not a restriction.
  **Fixed** → `render(-1.0, …)`, re-verified with `functor build` and a headless capture.
- **Low — "these same two blocks at full size" overclaimed** about orbs. **Fixed** → "the same
  two-block shape at full size".
- **Low — the pre-existing ctor-uniqueness sentence now contradicts the step.** **Fixed** (above).
- **Low — the vr clause omits that a module role needs a tool APK speaking debug protocol v9+.**
  **Won't fix, deliberate**: the brief asked for one sentence on the shells without a protocol
  deep-dive, and `run vr` refuses an older APK rather than mis-booting, so the omission cannot
  mislead a reader into a silent wrong-role run.
- **Low — "A role is not native-only" answers an unasked question.** **Won't fix**: the shells
  sentence is explicitly part of this change's brief.
- De-dup pass: **"No actionable duplication."** The snippet shares no code with
  `examples/orbs/game.fun` (only the shape, which is the lesson), and the module-roles prose has no
  other *rendered* home to link to — `SKILL.md` and `docs/functor-lang.md` are not published by
  `site/build.mjs`. Coverage: S1-names ran (no signal — HTML-only diff), S2-clones ran (256 pairs
  repo-wide, zero touching `site/manual/`), S3-index and S4-read ran, none unavailable.

All verification above was re-run after the fixes.

## Follow-ups (not in this PR)

- `open`, `expect` and `unit` are still missing from both syntax-highlighting keyword sets — the same
  gap `module` had, worth one sweep.
- The two syntax highlighters (`site/src/docs.ts` and `site/src/functor-lang.ts`) duplicate their
  keyword set behind a "keep in sync" comment; a shared constant would make drift impossible.
