### PR TITLE
ci: reliability runs — a label that runs the suites 10x

### DIFF
--- a/.github/workflows/reliability.yml
+++ b/.github/workflows/reliability.yml
@@ -54,6 +54,9 @@ on:
           - e2e-headless
 
 concurrency:
+  # Per-PR for the label path; per-ref for a dispatch. Re-labelling or pushing
+  # supersedes the run in flight instead of stacking a second 10x run on top of
+  # it — at this cost, never pay twice for a superseded answer.
   group: reliability-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -139,10 +142,17 @@ jobs:
       - name: Install wasm-pack
         run: npm install -g wasm-pack
 
+      # DELIBERATE DEVIATION from the mirrored source: `save-if: false`.
+      # rust-cache keys on runner.os + github.job + lockfiles, NOT on matrix.*,
+      # so all N legs would restore the same entry and then race to save it —
+      # burning upload bandwidth and evicting the caches the REAL CI jobs
+      # depend on, out of a shared repo cache budget. The real wasm-smoke.yml /
+      # e2e.yml jobs populate this cache; a reliability run only consumes it.
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: "."
+          save-if: false
 
       - name: Install GL/X11 system libraries
         run: |
@@ -217,6 +227,11 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      # macOS runners are the scarcest and priciest concurrency GitHub gives us.
+      # Without a cap, 10-25 legs claim the whole macOS allowance and stall
+      # every other PR's e2e job behind this opt-in run. Capped, a reliability
+      # run takes longer in wall-clock but stops being a denial of service.
+      max-parallel: 5
       matrix:
         iteration: ${{ fromJSON(needs.gate.outputs.iterations) }}
     steps:
@@ -231,10 +246,13 @@ jobs:
       - name: Install wasm-pack
         run: npm install -g wasm-pack
 
+      # DELIBERATE DEVIATION from the mirrored source — see the note in the
+      # wasm-smoke job above. Restore only; never save from a matrix leg.
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: "."
+          save-if: false
 
       - name: Build web runtime bundle
         run: wasm-pack build --target=web
@@ -259,15 +277,26 @@ jobs:
       - name: Tally pass rates
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_COUNT: ${{ needs.gate.outputs.count }}
+          RUN_WASM: ${{ needs.gate.outputs.run_wasm_smoke }}
+          RUN_E2E: ${{ needs.gate.outputs.run_e2e_headless }}
+          RESULT_WASM: ${{ needs.wasm-smoke.result }}
+          RESULT_E2E: ${{ needs.e2e-headless.result }}
         run: |
           set -euo pipefail
 
           # A matrix's aggregate result cannot distinguish 9/10 from 0/10, so
-          # count this run's own jobs. Matrix job names look like
-          # "wasm-smoke (3)"; the leading token is the suite.
+          # the per-iteration counts come from this run's own jobs. Matrix job
+          # names look like "wasm-smoke (3)".
           gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
             --jq '.jobs[] | [.name, .conclusion] | @tsv' > jobs.tsv
+
+          # Echo the raw tally input: when the counts below disagree with what
+          # the run page shows, this log is what tells you why.
+          echo "--- jobs seen by the tally ---"
+          cat jobs.tsv
+          echo "------------------------------"
 
           {
             echo "## Reliability run"
@@ -278,21 +307,43 @@ jobs:
 
           failed=0
           for suite in wasm-smoke e2e-headless; do
+            case "$suite" in
+              wasm-smoke)   enabled="$RUN_WASM"; aggregate="$RESULT_WASM" ;;
+              e2e-headless) enabled="$RUN_E2E";  aggregate="$RESULT_E2E"  ;;
+              *) echo "unhandled suite ${suite}" >&2; exit 1 ;;
+            esac
+
+            if [ "$enabled" != "true" ]; then
+              echo "| ${suite} | - | - | not selected |" >> "$GITHUB_STEP_SUMMARY"
+              echo "${suite}: not selected"
+              continue
+            fi
+
             total=$(awk -F'\t' -v s="$suite" 'index($1, s " (") == 1' jobs.tsv | wc -l | tr -d ' ')
-            if [ "$total" -eq 0 ]; then continue; fi
             passed=$(awk -F'\t' -v s="$suite" 'index($1, s " (") == 1 && $2 == "success"' jobs.tsv | wc -l | tr -d ' ')
-            if [ "$passed" -eq "$total" ]; then
-              verdict="OK"
-            else
+
+            # Never report a pass we cannot actually account for. If the matrix
+            # did not expand into the expected number of jobs, or the jobs are
+            # not named as assumed, the counts above are meaningless — fail
+            # loudly rather than printing a reassuring 0/0.
+            if [ "$total" -ne "$EXPECTED_COUNT" ]; then
+              verdict="INCOMPLETE — expected ${EXPECTED_COUNT} iterations, accounted for ${total}"
+              failed=1
+            elif [ "$aggregate" != "success" ] || [ "$passed" -ne "$total" ]; then
+              # The aggregate result is the authoritative gate; the counts are
+              # the diagnosis. Disagreement means the tally missed something.
               verdict="FLAKY"
               failed=1
+            else
+              verdict="OK"
             fi
+
             echo "| ${suite} | ${passed} | ${total} | ${verdict} |" >> "$GITHUB_STEP_SUMMARY"
-            echo "${suite}: ${passed}/${total} — ${verdict}"
+            echo "${suite}: ${passed}/${total} — ${verdict} (matrix result: ${aggregate})"
           done
 
           if [ "$failed" -ne 0 ]; then
             echo >> "$GITHUB_STEP_SUMMARY"
-            echo "At least one iteration failed — this is a flake, not a pass." >> "$GITHUB_STEP_SUMMARY"
+            echo "At least one iteration failed or could not be accounted for — this is a flake, not a pass." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi

--- a/.github/workflows/reliability.yml
+++ b/.github/workflows/reliability.yml
@@ -1,0 +1,298 @@
+name: Reliability runs
+
+# Flake hunting: run the browser (wasm-smoke) and native (e2e-headless) suites
+# N times over and report a pass rate, so an intermittent failure shows up as
+# "9/10" instead of as a lucky green tick.
+#
+# OPT-IN, AND ~10x THE COST OF A NORMAL RUN. Two ways to start one:
+#
+#   1. Add the `reliability` label to a pull request. Pushes to an
+#      already-labelled PR re-run it (the `synchronize` path below), so the
+#      label stays meaningful as the branch evolves. Remove the label to stop
+#      paying for it.
+#   2. `workflow_dispatch` — pick the iteration count (default 10, max 25) and
+#      optionally narrow to a single suite.
+#
+# A re-label supersedes the in-flight run (concurrency, cancel-in-progress),
+# so toggling the label doesn't stack runs on top of each other.
+#
+# WHY THE SETUP STEPS ARE DUPLICATED HERE. The `wasm-smoke` job below mirrors
+# `.github/workflows/wasm-smoke.yml` and the `e2e-headless` job mirrors
+# `.github/workflows/e2e.yml`. They are deliberately COPIES rather than a
+# reusable `workflow_call`/composite action: the two source workflows order
+# their steps for fail-fast on different things (wasm-smoke runs `npm ci` +
+# `check:site` BEFORE the expensive Rust/wasm builds; e2e builds the CLI first,
+# then installs SDK deps), and collapsing that into one parameterised action
+# would either lose the fail-fast property or need enough inputs to be worse
+# than the duplication. A reliability workflow also should not be the thing
+# that edits two green, load-bearing CI workflows.
+#
+#   >>> If you change setup steps in wasm-smoke.yml or e2e.yml, change them
+#   >>> here too, or this workflow silently stops reproducing the real job. <<<
+
+on:
+  pull_request:
+    # `labeled` starts a run when the `reliability` label is applied;
+    # `synchronize` re-runs it on every push to a PR that already carries the
+    # label. Both are filtered in the `gate` job below — workflows cannot
+    # filter on a label name at the trigger level.
+    types: [labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "How many times to run each suite (1-25)"
+        required: false
+        default: "10"
+      suite:
+        description: "Which suite to run"
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - wasm-smoke
+          - e2e-headless
+
+concurrency:
+  group: reliability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # The summary job reads this run's own job results to count pass/fail per
+  # iteration (a matrix's aggregate `needs.*.result` cannot tell 9/10 from 0/10).
+  actions: read
+
+jobs:
+  # Decides whether this event should run anything at all, and expands the
+  # iteration count into the JSON list the matrices below consume. GitHub
+  # matrices cannot be sized from an expression directly, so the list is built
+  # here and passed through `fromJSON`.
+  gate:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'reliability') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'reliability'))
+    runs-on: ubuntu-latest
+    outputs:
+      iterations: ${{ steps.plan.outputs.iterations }}
+      count: ${{ steps.plan.outputs.count }}
+      run_wasm_smoke: ${{ steps.plan.outputs.run_wasm_smoke }}
+      run_e2e_headless: ${{ steps.plan.outputs.run_e2e_headless }}
+    steps:
+      - name: Plan the run
+        id: plan
+        env:
+          # The label path is always 10 iterations; only a dispatch can choose.
+          RAW_ITERATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.iterations || '10' }}
+          SUITE: ${{ github.event_name == 'workflow_dispatch' && inputs.suite || 'all' }}
+        run: |
+          set -euo pipefail
+
+          count="${RAW_ITERATIONS}"
+          case "$count" in
+            ''|*[!0-9]*)
+              echo "iterations must be a positive integer, got '${count}'" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$count" -lt 1 ]; then count=1; fi
+          if [ "$count" -gt 25 ]; then count=25; fi
+
+          list="$(seq 1 "$count" | paste -sd, -)"
+          echo "iterations=[${list}]" >> "$GITHUB_OUTPUT"
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+          case "$SUITE" in
+            all)           wasm=true;  e2e=true  ;;
+            wasm-smoke)    wasm=true;  e2e=false ;;
+            e2e-headless)  wasm=false; e2e=true  ;;
+            *) echo "unknown suite '${SUITE}'" >&2; exit 1 ;;
+          esac
+          echo "run_wasm_smoke=${wasm}" >> "$GITHUB_OUTPUT"
+          echo "run_e2e_headless=${e2e}" >> "$GITHUB_OUTPUT"
+
+          echo "Running suite(s) '${SUITE}' x ${count}" >> "$GITHUB_STEP_SUMMARY"
+
+  # === MIRROR OF .github/workflows/wasm-smoke.yml — keep in sync ===
+  wasm-smoke:
+    needs: gate
+    if: needs.gate.outputs.run_wasm_smoke == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        iteration: ${{ fromJSON(needs.gate.outputs.iterations) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        run: npm install -g wasm-pack
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Install GL/X11 system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libx11-dev \
+            libxcursor-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxi-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev \
+            libglfw3 \
+            libglfw3-dev \
+            libasound2-dev \
+            libfontconfig-dev
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Typecheck the site
+        run: npm run check:site
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build web runtime bundle
+        run: wasm-pack build --target=web
+        working-directory: runtime/functor-runtime-web
+
+      - name: Build language analysis wasm
+        run: npm run build:lang-wasm
+
+      - name: Build functor CLI
+        run: cargo build --bin functor
+
+      - name: Run wasm smoke
+        run: npm run test:wasm-smoke
+
+      - name: Run net-coordinator e2e
+        run: npm run test:net-coordinator
+
+      - name: Run sandbox multiplayer e2e
+        run: npm run test:sandbox-mp
+
+      - name: Run wasm remote-asset e2e
+        run: npm run test:wasm-remote-assets
+
+      - name: Run scrubber model tests
+        run: npm run test:scrubber
+
+      - name: Run detached-camera browser test
+        run: npm run test:detached-camera
+
+      - name: Run site sandbox browser tests
+        run: npm run test:site
+
+      - name: Run IDE page browser tests
+        run: npm run test:ide-page
+
+      - name: Run editor keybindings browser tests
+        run: npm run test:editor-keybindings
+
+      - name: Run browser runtime-target tests
+        run: npm run test:runtime-target
+
+  # === MIRROR OF .github/workflows/e2e.yml — keep in sync ===
+  e2e-headless:
+    needs: gate
+    if: needs.gate.outputs.run_e2e_headless == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        iteration: ${{ fromJSON(needs.gate.outputs.iterations) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        run: npm install -g wasm-pack
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Build web runtime bundle
+        run: wasm-pack build --target=web
+        working-directory: runtime/functor-runtime-web
+
+      - name: Build functor CLI
+        run: cargo build --bin functor
+
+      - name: Install SDK dependencies
+        run: npm install
+        working-directory: tools/functor-sdk
+
+      - name: Run headless e2e
+        run: npm run test:e2e:headless
+        working-directory: tools/functor-sdk
+
+  summary:
+    needs: [gate, wasm-smoke, e2e-headless]
+    if: always() && needs.gate.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tally pass rates
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # A matrix's aggregate result cannot distinguish 9/10 from 0/10, so
+          # count this run's own jobs. Matrix job names look like
+          # "wasm-smoke (3)"; the leading token is the suite.
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs?per_page=100" \
+            --jq '.jobs[] | [.name, .conclusion] | @tsv' > jobs.tsv
+
+          {
+            echo "## Reliability run"
+            echo
+            echo "| suite | passed | total | verdict |"
+            echo "| --- | --- | --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          for suite in wasm-smoke e2e-headless; do
+            total=$(awk -F'\t' -v s="$suite" 'index($1, s " (") == 1' jobs.tsv | wc -l | tr -d ' ')
+            if [ "$total" -eq 0 ]; then continue; fi
+            passed=$(awk -F'\t' -v s="$suite" 'index($1, s " (") == 1 && $2 == "success"' jobs.tsv | wc -l | tr -d ' ')
+            if [ "$passed" -eq "$total" ]; then
+              verdict="OK"
+            else
+              verdict="FLAKY"
+              failed=1
+            fi
+            echo "| ${suite} | ${passed} | ${total} | ${verdict} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "${suite}: ${passed}/${total} — ${verdict}"
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo "At least one iteration failed — this is a flake, not a pass." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi


### PR DESCRIPTION
## Motivation

This weekend the e2e suites produced **four distinct flake classes**:

1. a join-order race (fixed, #619)
2. a completion-accept race (fixed, #625)
3. port collisions — the SDK tests overlap 8095-8097 against a hardcoded 8096 *by construction* under concurrent `node --test`; an e2e-headless CI failure came from exactly that overlap
4. fixed-sleep-then-assert settle races — most recently `e2e/detached-camera.mjs:611`, which screenshots, acts, `waitForTimeout(100)`s, then demands **byte-equal** canvas screenshots. It flaked on #644's wasm-smoke run on a loaded runner.

Every one of those was found by accident, from a single red run. A flake that
fails 1-in-10 looks exactly like a pass 90% of the time, so the honest way to
confirm a fix — or to catch a new flake before it lands — is to run the suite
many times and look at the **rate**.

## Usage

**Add the `reliability` label to a PR.** That runs `wasm-smoke` and
`e2e-headless` 10x each and posts a pass-rate table to the run summary:

| suite | passed | total | verdict |
| --- | --- | --- | --- |
| wasm-smoke | 9 | 10 | FLAKY |
| e2e-headless | 10 | 10 | OK |

The check is **red if any single iteration failed** — 9/10 is a flake, not a pass.
Pushing to an already-labelled PR re-runs it; removing the label stops it.

`workflow_dispatch` is the other entry point: 1-25 iterations plus an optional
suite filter. The label path is always 10.

The `reliability` label has been created on the repo (the trigger is inert
without it — GitHub matches the label by name).

## Cost

This is **opt-in and roughly 10x a normal CI run** — that's the whole point, and
it is why it is not on by default. Mitigations in the workflow:

- `concurrency` per-PR with `cancel-in-progress`, so re-labelling or pushing
  supersedes the in-flight run rather than stacking a second 10x run on it.
- `max-parallel: 5` on the macOS matrix — macOS concurrency is the scarcest
  resource we have, and an uncapped 10-25 leg matrix would stall every other
  PR's e2e job behind this one.
- `save-if: false` on `rust-cache` in both jobs: cache keys don't include
  `matrix.*`, so all N legs would restore the same entry and then race to save
  it, evicting the caches the *real* CI jobs depend on. Reliability runs consume
  the cache; they never populate it.

## Why the setup steps are duplicated

The `wasm-smoke` job mirrors `.github/workflows/wasm-smoke.yml` and
`e2e-headless` mirrors `.github/workflows/e2e.yml`, with a loud header comment
tying them together.

I considered extracting a reusable `workflow_call` workflow or a composite
action. The two source workflows deliberately order their steps to fail fast on
different things (wasm-smoke runs `npm ci` + `check:site` *before* the expensive
Rust/wasm builds; e2e builds the CLI first, then installs SDK deps), so a shared
action either loses that property or needs enough inputs to be worse than the
duplication. Weighed against that: a workflow whose entire purpose is CI
reliability should not also be the change that edits two green, load-bearing CI
workflows.

The reviewers pushed back on this (see below) and the counter-proposal —
`workflow_call` added to each existing workflow *independently* — is a good one.
I've left it as a documented follow-up rather than growing this PR's blast
radius; the header comment makes the sync obligation explicit in the meantime.

## Verification

Without merging, this is what could be checked:

- **actionlint 1.7.7 with shellcheck integration** — passes clean.
- **YAML parse** — valid; jobs resolve as `gate`, `wasm-smoke`, `e2e-headless`, `summary`.
- **The gate arithmetic, run locally**: `10 -> 10`, `1 -> 1`, `99 -> 25` (clamped),
  `0 -> 1` (clamped), `abc`/empty -> rejected with a nonzero exit.
- **The summary tally, run locally against synthetic job data** — six cases, all
  correct: 3/3 OK exit 0; 2/3 FLAKY exit 1; **matrix-never-expanded INCOMPLETE
  exit 1**; **job-names-unexpected INCOMPLETE exit 1**; suite-filtered 2/2 exit 0;
  counts-green-but-aggregate-cancelled FLAKY exit 1.

**Event semantics.** `labeled` and `synchronize` both run the workflow **from the
PR's merge ref**, i.e. the version of this file on the *target* branch. So the
label does nothing until this PR merges — **its first real use is on PR B.**

## Review

`/xreview` (Claude subagent + Codex CLI), both engines independently.

**[AGREED] Critical/High — false-green summary.** Both found that the tally
counted job names from the API but never checked it had accounted for the
expected number of jobs: a matrix that never expanded, or jobs named other than
`suite (N)`, yielded 0/0 and a **green** summary — the precise failure this
workflow exists to prevent. **Fixed**: the tally now requires
`total == gate.outputs.count` *and* agreement with the aggregate
`needs.<suite>.result`, reporting `INCOMPLETE` and exiting nonzero otherwise.
Covered by local cases 3, 4 and 6 above.

Also fixed: `reliability` label didn't exist (created); `rust-cache` save
thrash across matrix legs; uncapped macOS matrix; raw tally input now echoed to
the log for diagnosability; concurrency rationale documented.

**Dispositioned, not fixed:** the `workflow_call` refactor (Codex, Low) — a real
improvement, deliberately deferred as above. A CI check asserting the mirrored
steps haven't drifted (Claude, Low) is a sensible follow-up but is more
machinery than the header comment currently justifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
