### PR TITLE
fix(e2e): dynamic OS-assigned debug ports — kill the port-collision flake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,14 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      repeats:
+        description: >
+          Run the suite this many times back-to-back (flake stress:
+          `gh workflow run e2e.yml --ref <branch> -f repeats=5`). The suite
+          runs to the first failing iteration.
+        required: false
+        default: "1"
 
 jobs:
   e2e-headless:
@@ -56,5 +64,20 @@ jobs:
         working-directory: tools/functor-sdk
 
       - name: Run headless e2e
-        run: npm run test:e2e:headless
+        # The input goes through env (never interpolated into the script —
+        # dispatch inputs are attacker-controlled text), and is validated so a
+        # bad value fails LOUDLY instead of `seq` erroring inside a command
+        # substitution and the empty loop passing green having run nothing.
+        env:
+          REPEATS: ${{ github.event.inputs.repeats || '1' }}
+        run: |
+          if ! [[ "$REPEATS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "invalid repeats input: $REPEATS" >&2
+            exit 1
+          fi
+          for ((i = 1; i <= REPEATS; i++)); do
+            echo "::group::e2e iteration $i of $REPEATS"
+            npm run test:e2e:headless
+            echo "::endgroup::"
+          done
         working-directory: tools/functor-sdk

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -27,9 +27,16 @@ If 8077 is already taken — a second `functor develop`, or a stale process —
 `develop` logs one line and runs the game **without** a debug server rather than
 failing to start; pass `--debug-port <PORT>` for a second session, or `--no-debug`
 to skip the listener entirely. An explicit `--debug-port` that can't bind is still
-a fatal error (a driver asked for *that* port and is waiting on it). Tooling that
-hard-codes 8077 — the TS SDK's `launch()`, the VS Code inspector's default — should
-therefore be pointed at its own port while a `develop` session is up.
+a fatal error (a driver asked for *that* port and is waiting on it).
+
+`--debug-port 0` binds an **OS-assigned free port**; the `[debug-server]
+listening on http://…` stderr line always reports the ACTUAL bound port, so
+automation parses it instead of assuming the requested one. This is the TS
+SDK `launch()` default — parallel sessions can't collide, and the actual port
+is on `runner.port`. Hard-code a port only when something external must find
+the server at a known address (e.g. `adb forward` on device, or the VS Code
+inspector, whose default is 8077 — point it at its own port while a `develop`
+session is up).
 
 The server binds **localhost by default** (`127.0.0.1:<PORT>`); `--debug-bind 0.0.0.0`
 exposes it to the LAN for remote develop (see `POST /reload-source`) — there is no auth,

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -23,10 +23,17 @@ const MAX_COMMAND_BYTES: usize = 64 * 1024;
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNTIME_REPLY_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Bind `address`, start the transport thread, and return the frame loop's
-/// request receiver. Runtime shells choose their own bind/error policy.
-pub fn spawn(address: impl ToSocketAddrs) -> std::io::Result<mpsc::Receiver<DebugRequest>> {
-    spawn_listener(TcpListener::bind(address)?)
+/// Bind `address`, start the transport thread, and return the actually-bound
+/// address plus the frame loop's request receiver. Port 0 binds an
+/// OS-assigned free port — the returned address carries the real one, which
+/// callers must report (automation reads it to find the server). Runtime
+/// shells choose their own bind/error policy.
+pub fn spawn(
+    address: impl ToSocketAddrs,
+) -> std::io::Result<(std::net::SocketAddr, mpsc::Receiver<DebugRequest>)> {
+    let listener = TcpListener::bind(address)?;
+    let bound = listener.local_addr()?;
+    Ok((bound, spawn_listener(listener)?))
 }
 
 fn spawn_listener(listener: TcpListener) -> std::io::Result<mpsc::Receiver<DebugRequest>> {

--- a/runtime/functor-runtime-desktop/src/debug_server.rs
+++ b/runtime/functor-runtime-desktop/src/debug_server.rs
@@ -14,14 +14,19 @@ pub use functor_runtime_common::debug_protocol::{
 /// There is no authentication, so wide binds are appropriate only on trusted
 /// networks where arbitrary game-code pushes are acceptable.
 ///
+/// Port 0 binds an OS-assigned free port; the "listening" notice below always
+/// reports the ACTUAL bound port, which automation (the functor-sdk harness)
+/// parses to find the server — collision-free parallel sessions by
+/// construction.
+///
 /// A failed bind is fatal for an explicitly requested port (the caller asked
 /// for *that* port and automation is waiting on it). With `optional` — how
 /// `functor develop` asks for its default well-known port — it instead logs
 /// and returns `None`, so a second concurrent session still runs the game.
 pub fn spawn(bind: &str, port: u16, optional: bool) -> Option<Receiver<DebugRequest>> {
     let address = format!("{bind}:{port}");
-    let receiver = match functor_runtime_common::debug_http::spawn((bind, port)) {
-        Ok(receiver) => receiver,
+    let (bound, receiver) = match functor_runtime_common::debug_http::spawn((bind, port)) {
+        Ok(bound_and_receiver) => bound_and_receiver,
         // Only a TAKEN port degrades: any other bind failure (a bad interface,
         // a permission denial) is a misconfiguration the fatal arm should
         // report accurately rather than blame on another session.
@@ -40,7 +45,9 @@ debug server; pass `--debug-port <PORT>` to pick another"
     };
 
     // Stderr, not stdout: `--debug-port` is a common `--json` automation combo,
-    // so this notice must not land in the CLI's ndjson stream.
-    eprintln!("[debug-server] listening on http://{address}");
+    // so this notice must not land in the CLI's ndjson stream. The bound
+    // address (never the requested one) — with port 0 this line is the only
+    // place the real port is reported.
+    eprintln!("[debug-server] listening on http://{bound}");
     Some(receiver)
 }

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -1082,7 +1082,7 @@ pub fn android_main(app: AndroidApp) {
     // browser reach it through `adb forward tcp:8123 tcp:8123` (see README).
     // A bind failure degrades to a standalone boot scene, loudly.
     let debug_rx = match functor_runtime_common::debug_http::spawn(("127.0.0.1", RELOAD_PORT)) {
-        Ok(rx) => {
+        Ok((_bound, rx)) => {
             log::info!("debug endpoint: http://127.0.0.1:{RELOAD_PORT}");
             Some(rx)
         }

--- a/site/serve.mjs
+++ b/site/serve.mjs
@@ -3,6 +3,10 @@
 // WebAssembly.instantiateStreaming requires.
 //
 //   node site/serve.mjs [--port 8123]
+//
+// `--port 0` binds an OS-assigned free port; the "serving" line always
+// reports the ACTUAL port (parse it to find the server) — so scripts can
+// grab a collision-free port instead of hard-coding one.
 
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
@@ -48,6 +52,6 @@ createServer(async (req, res) => {
   }
   res.writeHead(200, { "Content-Type": MIME[extname(file)] ?? "application/octet-stream" });
   createReadStream(file).pipe(res);
-}).listen(port, "127.0.0.1", () => {
-  console.log(`serving site/dist at http://127.0.0.1:${port}`);
+}).listen(port, "127.0.0.1", function () {
+  console.log(`serving site/dist at http://127.0.0.1:${this.address().port}`);
 });

--- a/tools/functor-sdk/README.md
+++ b/tools/functor-sdk/README.md
@@ -131,7 +131,8 @@ no pixels).
 
 ## Multiplayer simulation
 
-Launch N runners on separate debug ports, networked via `Sub.connect`/`Sub.listen`,
+Launch N runners — each gets its own OS-assigned debug port (the `launch()`
+default; read it from `runner.port`) — networked via `Sub.connect`/`Sub.listen`,
 and drive them together — the out-of-process counterpart to the in-process
 browser-hosted multiplayer panes. `waitFor(poll, predicate, opts)` (and the
 `client.waitForState(predicate, opts)` shorthand) polls until an async condition
@@ -145,15 +146,14 @@ Orbs' two roles are inline modules of ONE `game.fun`, so the role is named with
 `entry` (the CLI's `--entry`) rather than inferred from the path.
 
 ```ts
-const launch = (entry: "client" | "server", port: number) =>
+const launch = (entry: "client" | "server") =>
   FunctorRunner.launch({
     gameDir: "examples/orbs",
     functorLangPath: "examples/orbs/game.fun",
     entry,
-    port,
   });
-await using a = await launch("server", 8077);
-await using b = await launch("client", 8078);
+await using a = await launch("server");
+await using b = await launch("client");
 await Promise.all([a.pause(), b.pause()]);
 for (let frame = 0; frame < 600; frame++) {
   await a.keyDown("up");        // per-client input

--- a/tools/functor-sdk/src/index.ts
+++ b/tools/functor-sdk/src/index.ts
@@ -4,6 +4,7 @@ export {
   findRepoRoot,
   formatCrashOutput,
   FunctorRunner,
+  parseListeningPort,
   waitForPort,
 } from "./server.js";
 export type * from "./types.js";

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -89,13 +89,17 @@ export function formatCrashOutput(logLines: string[]): string {
  * ```
  */
 export class FunctorRunner extends FunctorClient implements AsyncDisposable {
-  /** Set if the spawned child emitted an 'error' (e.g. it couldn't be spawned). */
-  private spawnError?: Error;
-
   private constructor(
     http: HttpClient,
+    /** The debug server's actual TCP port (with dynamic allocation — the
+     * default — this is the OS-assigned port parsed from the runtime's own
+     * "listening" line, not the requested one). */
+    public readonly port: number,
     private readonly child: ChildProcess | undefined,
     private readonly logLines: string[],
+    /** Shared with the spawn-time 'error' listener (attached before the
+     * runner exists), so a spawn failure is visible however early it lands. */
+    private readonly spawnErrorRef: { current?: Error },
   ) {
     super(http);
   }
@@ -107,7 +111,9 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
 
   /** Connect to an already-running debug runtime; does not own the process. */
   static async connect(baseUrl = "http://127.0.0.1:8077"): Promise<FunctorRunner> {
-    const runner = new FunctorRunner(new HttpClient(baseUrl), undefined, []);
+    const url = new URL(baseUrl);
+    const port = Number(url.port) || (url.protocol === "https:" ? 443 : 80);
+    const runner = new FunctorRunner(new HttpClient(baseUrl), port, undefined, [], {});
     await runner.state();
     return runner;
   }
@@ -118,7 +124,10 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
    * (`cargo build --bin functor`). Post-E3 there is a single `functor` binary;
    * the game source is the project's `functor.json` entry. */
   static async launch(options: LaunchOptions): Promise<FunctorRunner> {
-    const port = options.port ?? 8077;
+    // Port 0 (the default) = OS-assigned: the runtime binds a free port and
+    // reports it on its "[debug-server] listening" line, which launch parses.
+    // Collision-free under parallel test files / sessions by construction.
+    const port = options.port ?? 0;
     // Resolve the game dir to an absolute path up front, so the spawn cwd and
     // repo-root discovery are consistent regardless of the caller's process cwd.
     const gameDir = isAbsolute(options.gameDir)
@@ -273,59 +282,79 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
       },
     );
 
+    // Resolved with the ACTUAL bound port when the child's own debug server
+    // reports in. Watching the stream (not polling the ring buffer) can't
+    // lose the line, and gating readiness on it means launch never adopts a
+    // FOREIGN process that happens to answer on the requested port.
+    let reportListening: (port: number) => void;
+    const listening = new Promise<number>((r) => {
+      reportListening = r;
+    });
+
     // Decode stdout/stderr line-by-line, holding any trailing partial line (and
     // any split multibyte char) until the rest arrives, so log lines — and the
-    // panic line formatCrashOutput looks for — aren't fragmented across chunks.
-    const decoder = new StringDecoder("utf8");
-    let residual = "";
-    const capture = (chunk: Buffer) => {
-      const lines = (residual + decoder.write(chunk)).split("\n");
-      residual = lines.pop() ?? "";
-      for (const line of lines) {
-        logLines.push(line);
-        if (logLines.length > MAX_LOG_LINES) logLines.shift();
-        if (options.echoLogs) process.stderr.write(`[functor] ${line}\n`);
-      }
+    // listening/panic lines the SDK watches for — aren't fragmented across
+    // chunks. PER STREAM: sharing one decoder/residual would let interleaved
+    // stdout/stderr chunks splice each other's lines (the listening line lands
+    // on stderr while the runtime chats on stdout).
+    const makeCapture = () => {
+      const decoder = new StringDecoder("utf8");
+      let residual = "";
+      return (chunk: Buffer) => {
+        const lines = (residual + decoder.write(chunk)).split("\n");
+        residual = lines.pop() ?? "";
+        for (const line of lines) {
+          logLines.push(line);
+          if (logLines.length > MAX_LOG_LINES) logLines.shift();
+          if (options.echoLogs) process.stderr.write(`[functor] ${line}\n`);
+          const bound = parseListeningPort(line);
+          if (bound !== undefined) reportListening(bound);
+        }
+      };
     };
-    child.stdout?.on("data", capture);
-    child.stderr?.on("data", capture);
+    child.stdout?.on("data", makeCapture());
+    child.stderr?.on("data", makeCapture());
 
-    const runner = new FunctorRunner(
-      new HttpClient(`http://127.0.0.1:${port}`),
-      child,
-      logLines,
-    );
     // A spawn failure (e.g. EACCES, ENOMEM — not caught by the existsSync checks
     // above, which are also TOCTOU) emits 'error' with no other signal; without
     // a listener Node rethrows it as a fatal uncaught exception. Record it so
     // readiness fails fast. ('error' is emitted asynchronously, so attaching
     // here — before the first await — cannot miss it.)
+    const spawnErrorRef: { current?: Error } = {};
     child.once("error", (err) => {
-      runner.spawnError = err;
+      spawnErrorRef.current = err;
     });
 
+    const timeoutMs = options.launchTimeoutMs ?? 60_000;
+    const deadline = Date.now() + timeoutMs;
     try {
-      await runner.waitUntilReady(options.launchTimeoutMs ?? 60_000);
+      const boundPort = await waitForListeningLine(child, spawnErrorRef, listening, deadline);
+      const runner = new FunctorRunner(
+        new HttpClient(`http://127.0.0.1:${boundPort}`),
+        boundPort,
+        child,
+        logLines,
+        spawnErrorRef,
+      );
+      await runner.waitUntilReady(Math.max(1, deadline - Date.now()));
+      return runner;
     } catch (error) {
-      await runner.shutdown();
+      // Covers both phases: runner.shutdown() is shutdownChild(child), so the
+      // pre-runner path needs no separate wrapper.
+      await shutdownChild(child);
       throw new Error(
         `functor failed to start: ${error}\nRecent output:\n${formatCrashOutput(logLines)}`,
       );
     }
-
-    return runner;
   }
 
   private async waitUntilReady(timeoutMs: number): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     for (;;) {
-      if (this.spawnError) {
-        throw this.spawnError;
+      if (this.spawnErrorRef.current) {
+        throw this.spawnErrorRef.current;
       }
-      if (
-        this.child &&
-        (this.child.exitCode !== null || this.child.signalCode !== null)
-      ) {
+      if (this.child && hasExited(this.child)) {
         throw new Error(
           `process exited early (code ${this.child.exitCode}, signal ${this.child.signalCode})`,
         );
@@ -348,30 +377,106 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
   /** Stop the spawned runtime (SIGTERM, escalating to SIGKILL). No-op if this
    * runner connected to an externally-owned process. */
   async shutdown(): Promise<void> {
-    const child = this.child;
-    if (child === undefined || hasExited(child)) {
-      return;
+    if (this.child !== undefined) {
+      await shutdownChild(this.child);
     }
-    await new Promise<void>((settle) => {
-      // Re-check inside the promise: the child may have exited between the guard
-      // above and attaching the listener — otherwise we'd await an 'exit' that
-      // already fired and hang forever (a signal-killed child has exitCode null).
-      if (hasExited(child)) {
-        settle();
-        return;
-      }
-      const killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
-      child.once("exit", () => {
-        clearTimeout(killTimer);
-        settle();
-      });
-      child.kill("SIGTERM");
-    });
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.shutdown();
   }
+}
+
+/** SIGTERM the child, escalating to SIGKILL. Shared by `shutdown()` and the
+ * pre-runner launch failure path (listening never reported). */
+async function shutdownChild(child: ChildProcess): Promise<void> {
+  if (hasExited(child)) {
+    return;
+  }
+  await new Promise<void>((settle) => {
+    // Re-check inside the promise: the child may have exited between the guard
+    // above and attaching the listener — otherwise we'd await an 'exit' that
+    // already fired and hang forever (a signal-killed child has exitCode null).
+    if (hasExited(child)) {
+      settle();
+      return;
+    }
+    const killTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+    child.once("exit", () => {
+      clearTimeout(killTimer);
+      settle();
+    });
+    child.kill("SIGTERM");
+  });
+}
+
+/** The bound port from a runtime `[debug-server] listening on http://…:PORT`
+ * line, or undefined for any other line. Tolerant of IPv6 bracket rendering
+ * and a trailing `\r` (a Windows-piped runtime would leave one after the
+ * `\n` split). */
+export function parseListeningPort(line: string): number | undefined {
+  const bound = line.match(/\[debug-server\] listening on http:\/\/.*:(\d+)\s*$/);
+  return bound ? Number(bound[1]) : undefined;
+}
+
+/** Wait for the child's own `[debug-server] listening on …` line and return
+ * the bound port it reports. This is the only trustworthy source of the port
+ * (with port 0 it's OS-assigned), and requiring OUR child to report it means
+ * a foreign process squatting a requested port can never be silently adopted
+ * as the launched game — the child exits with "Address already in use"
+ * instead, which surfaces here as an early exit. */
+function waitForListeningLine(
+  child: ChildProcess,
+  spawnErrorRef: { current?: Error },
+  listening: Promise<number>,
+  deadline: number,
+): Promise<number> {
+  return new Promise<number>((resolvePort, reject) => {
+    let settled = false;
+    const onExit = () =>
+      fail(
+        new Error(
+          `process exited early (code ${child.exitCode}, signal ${child.signalCode})`,
+        ),
+      );
+    const cleanup = () => {
+      settled = true;
+      clearTimeout(timer);
+      child.removeListener("exit", onExit);
+      child.removeListener("error", fail);
+    };
+    const fail = (error: Error) => {
+      if (settled) return;
+      cleanup();
+      reject(error);
+    };
+    const timer = setTimeout(
+      () =>
+        fail(
+          new Error(
+            "debug server never reported listening (no `[debug-server] listening on …` line)",
+          ),
+        ),
+      Math.max(1, deadline - Date.now()),
+    );
+    // Pre-checks: an 'exit'/'error' that already fired will not fire again
+    // for the listeners below.
+    if (spawnErrorRef.current) {
+      fail(spawnErrorRef.current);
+      return;
+    }
+    if (hasExited(child)) {
+      onExit();
+      return;
+    }
+    child.once("exit", onExit);
+    child.once("error", fail);
+    void listening.then((port) => {
+      if (settled) return;
+      cleanup();
+      resolvePort(port);
+    });
+  });
 }
 
 function runnerExe(): string {

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -222,7 +222,11 @@ export interface LaunchOptions {
   /** Game directory (the runner's cwd, for resolving assets).
    * e.g. an absolute path to `examples/hello`. */
   gameDir: string;
-  /** Debug-runtime HTTP port (default 8077). */
+  /** Debug-runtime HTTP port. Default 0 = OS-assigned: the runtime binds a
+   * free port and reports it on its `[debug-server] listening` line, which
+   * launch parses — read the actual port from `runner.port`. Pass a fixed
+   * port only when something external must find the server at a known
+   * address. */
   port?: number;
   /** Path to the `functor` CLI binary (default `<repoRoot>/target/debug/functor`). */
   runnerBin?: string;

--- a/tools/functor-sdk/test/clock-stepping.e2e.test.ts
+++ b/tools/functor-sdk/test/clock-stepping.e2e.test.ts
@@ -31,7 +31,6 @@ test(
       gameDir,
       repoRoot,
       functorLangPath: join(gameDir, "game.fun"),
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8104),
       headless,
     });
 

--- a/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts
@@ -48,7 +48,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8100),
       headless,
     });
 

--- a/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-effects.e2e.test.ts
@@ -55,7 +55,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8101),
       headless,
     });
 

--- a/tools/functor-sdk/test/functor-lang-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-hot-reload.e2e.test.ts
@@ -44,7 +44,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8093),
       headless,
     });
 

--- a/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-input.e2e.test.ts
@@ -55,7 +55,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8094),
       headless,
     });
     await runner.pause();

--- a/tools/functor-sdk/test/functor-lang-modules-hot-reload.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-modules-hot-reload.e2e.test.ts
@@ -52,7 +52,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath: entryPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8102),
       headless,
     });
 

--- a/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-mouse-button.e2e.test.ts
@@ -67,7 +67,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8096),
       headless,
     });
     await runner.pause();

--- a/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-perf.e2e.test.ts
@@ -123,7 +123,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8102),
       headless,
     });
 

--- a/tools/functor-sdk/test/functor-lang-subscriptions.e2e.test.ts
+++ b/tools/functor-sdk/test/functor-lang-subscriptions.e2e.test.ts
@@ -69,7 +69,6 @@ test(
       gameDir: dir,
       repoRoot,
       functorLangPath,
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8099),
       headless,
     });
 

--- a/tools/functor-sdk/test/held-input.e2e.test.ts
+++ b/tools/functor-sdk/test/held-input.e2e.test.ts
@@ -42,7 +42,6 @@ test(
       gameDir,
       repoRoot,
       functorLangPath: join(gameDir, "game.fun"),
-      port: Number(process.env.FUNCTOR_E2E_PORT ?? 8090),
       headless,
     });
 

--- a/tools/functor-sdk/test/launch-failure.e2e.test.ts
+++ b/tools/functor-sdk/test/launch-failure.e2e.test.ts
@@ -19,7 +19,6 @@ test(
         gameDir: join(repoRoot, "examples", "hello"),
         repoRoot,
         functorLangPath: join(repoRoot, "does", "not", "exist.fun"),
-        port: Number(process.env.FUNCTOR_E2E_PORT ?? 8091),
       }),
       (error: Error) => {
         assert.match(error.message, /functor-lang game source not found/);

--- a/tools/functor-sdk/test/multiplayer.e2e.test.ts
+++ b/tools/functor-sdk/test/multiplayer.e2e.test.ts
@@ -53,19 +53,18 @@ test(
     const repoRoot = findRepoRoot(process.cwd());
     assert.ok(repoRoot, "must run from within the functor workspace");
 
-    // All three debug ports derive from one base so the test is self-consistent
-    // when relocated. (The ws port is fixed at 9101 by the example game.)
-    const base = Number(process.env.FUNCTOR_E2E_PORT ?? 8095);
+    // Debug ports are OS-assigned per launch (the SDK default), so parallel
+    // test files can never collide. (The GAME's ws port is fixed at 9101 by
+    // the example game — only this one test uses it, so it stays.)
     const gameDir = join(repoRoot, "examples", "orbs");
     // Both roles are the SAME file, so the role is named rather than inferred
     // from the path — the CLI's `--entry <name>` against functor.json's roles.
-    const launch = (entry: "client" | "server", port: number) =>
+    const launch = (entry: "client" | "server") =>
       FunctorRunner.launch({
         gameDir,
         repoRoot,
         functorLangPath: join(gameDir, "game.fun"),
         entry,
-        port,
         launchTimeoutMs: 60_000,
         headless,
       });
@@ -73,7 +72,7 @@ test(
     // Server first, and wait for its Sub.listen socket to actually bind before
     // launching clients — the client connects once with no retry, so a client
     // that races ahead of the listener would land in "error" and never converge.
-    await using server = await launch("server", base);
+    await using server = await launch("server");
     await waitForPort("127.0.0.1", 9101, {
       timeoutMs: 60_000,
       description: "orbs server ws listener",
@@ -81,8 +80,8 @@ test(
 
     // The client Joins on connect and streams a Steer every tick from there,
     // so no input injection is needed.
-    await using clientA = await launch("client", base + 1);
-    await using clientB = await launch("client", base + 2);
+    await using clientA = await launch("client");
+    await using clientB = await launch("client");
 
     const waitOpts = { timeoutMs: 90_000, intervalMs: 200 };
 

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import {
   findRepoRoot,
   formatCrashOutput,
+  parseListeningPort,
   FunctorClient,
   HttpClient,
   stepAll,
@@ -383,4 +384,20 @@ test("project load and reload use distinct lifecycle routes", async () => {
     { path: "/load-project", body: files },
     { path: "/reload-project", body: files },
   ]);
+});
+
+test("parseListeningPort reads the runtime's listening line, nothing else", () => {
+  // IPv4, wildcard, IPv6 (SocketAddr renders v6 bracketed), and a trailing
+  // \r (a Windows-piped runtime leaves one after the \n split).
+  assert.equal(parseListeningPort("[debug-server] listening on http://127.0.0.1:60641"), 60641);
+  assert.equal(parseListeningPort("[debug-server] listening on http://0.0.0.0:8077"), 8077);
+  assert.equal(parseListeningPort("[debug-server] listening on http://[::1]:9000"), 9000);
+  assert.equal(parseListeningPort("[debug-server] listening on http://127.0.0.1:8096\r"), 8096);
+  // Non-matches: chatty runtime lines, the bind-failure line, and a port-less URL.
+  assert.equal(parseListeningPort("✓ checked game.fun (+31 modules)"), undefined);
+  assert.equal(
+    parseListeningPort("[debug-server] failed to bind 127.0.0.1:8096: Address already in use"),
+    undefined,
+  );
+  assert.equal(parseListeningPort("[debug-server] listening on http://127.0.0.1"), undefined);
 });


### PR DESCRIPTION
Kills the `e2e-headless` CI flake at its root, per the investigation of runs 30750310856 / 30749724781.

## Root cause

`node --test` runs the SDK e2e **files in parallel**, and two files hard-coded the same debug port: `functor-lang-mouse-button.e2e.test.ts` (8096) vs `multiplayer.e2e.test.ts`'s client A (base 8095 + 1). When CI co-scheduled them, one of two orderings failed — the loser's bind exits 1 (**"process exited early"**, confirmed in the main-run log: `failed to bind 127.0.0.1:8096`), or the loser polls `/state`, the *winner* answers, and the SDK silently adopts a **foreign game** as its client (**"waiting for server to track 2 players"**, 90s). Both were reproduced locally (the pair fails 6/6 when co-run). A second latent collision existed (hot-reload vs perf, both 8102). #636's 20s→90s timeout raise treated this as runner load; it couldn't help.

## Fix: collision-free by construction, not renumbering

- **Runtime**: `debug_http::spawn` returns the bound `SocketAddr`; the desktop debug server prints the **actual** address — so `--debug-port 0` (OS-assigned) works, and the `[debug-server] listening on http://…` line is authoritative. (Documented in `docs/debug-runtime.md`.)
- **SDK**: `launch()` defaults to port 0 and gates readiness on the child's **own** listening line before ever touching `/state` — a foreign process can never be adopted again; a squatted explicit port now fails in ~100ms with the bind error instead of a 90s mystery. Actual port on `runner.port`. Line parsing is per-stream (separate decoders for stdout/stderr so interleaved chunks can't splice the listening line) via an exported, unit-tested `parseListeningPort`.
- **Tests**: every fixed port and `FUNCTOR_E2E_PORT` deleted.
- **`site/serve.mjs`**: `--port 0` binds a free port and reports the real one.
- **CI**: `e2e.yml` gains a validated `workflow_dispatch` `repeats` input — `gh workflow run e2e.yml --ref <branch> -f repeats=5` stress-runs the suite back-to-back on real runners.

Side effect: readiness no longer burns 500ms retry sleeps — the 30-test suite runs in ~3s locally.

## Review (`/xreview`: Claude + Codex + de-dup pass)

- **[AGREED] (Claude High / Codex Medium)** — first draft shared one `StringDecoder`/residual across stdout+stderr; interleaved chunks could splice the listening line into a silent 60s hang → per-stream capture state.
- **Codex Medium** — an invalid `repeats` input made `seq` fail inside command substitution and the empty loop pass green having run nothing; also script-injection surface → input via `env`, validated, arithmetic loop.
- **Claude Medium** — regex missed IPv6/`\r` renderings of the bound addr → loosened, unit-tested.
- **de-dup + Claude (out of scope, tracked)** — `cli/src/commands/mcp.rs` still has its own `free_port`/`reserve_port` machinery with the same TOCTOU + foreign-adoption hazards; now deletable in favor of `--debug-port 0` + line parse. Follow-up issue filed.
- Low fixes applied: `connect()` https port, event-driven wait (no accumulating timers, no duplicated liveness checks), single launch-failure wrapper, SDK README + docs updated.

## Verification

- Local: 3× full headless suite green before review fixes and 3× after (30/30); squatted-port launch fails in 106ms with the bind error; `serve.mjs --port 0` reports its real port; cargo suites green (common 676 + desktop); SDK tsc + unit tests green.
- CI (source of truth): `repeats=5` stress dispatch on this branch — result posted below when it lands.
