### PR TITLE
feat(mcp): multiplayer ergonomics — step_all, model_revision, pending_net

### DIFF
--- a/cli/src/commands/functor_lang_project.rs
+++ b/cli/src/commands/functor_lang_project.rs
@@ -498,6 +498,7 @@ impl FunctorLangProject {
             .saturating_sub(1);
         emit(Event::FunctorLangLoaded {
             entry: self.entry.clone(),
+            role: self.role.clone(),
             sibling_count,
         });
         Ok(project)

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -169,6 +169,15 @@ struct Session {
     /// Never read — its `Drop` is the whole point.
     #[allow(dead_code)]
     scratch: Option<ScratchDir>,
+    /// The `functor.json` this session BOOTED with, verbatim — the launch
+    /// directory's, or the inline file set's. `GET /project` reports modules,
+    /// not project metadata, so this is the only place a launched session's
+    /// manifest survives, and `save_project` writes it rather than
+    /// reconstructing one (a multi-entry project reconstructed as
+    /// `{"entry": "game.fun"}` builds green and fails at run). `None` for an
+    /// ATTACHED session: the manifest of a runtime someone else started is not
+    /// knowable over the wire.
+    manifest: Option<String>,
 }
 
 /// The await-safe part of a registry session.
@@ -409,6 +418,7 @@ impl Registry {
         port: Option<u16>,
         child: Option<Child>,
         scratch: Option<ScratchDir>,
+        manifest: Option<String>,
     ) -> String {
         // A launched child is a process this server just created, so it starts
         // a fresh exact-URL lifecycle even if an old attached runtime used the
@@ -442,7 +452,7 @@ impl Registry {
                 },
             )
         });
-        self.insert_with_gate(url, port, child, scratch, operation_gate, quarantined)
+        self.insert_with_gate(url, port, child, scratch, manifest, operation_gate, quarantined)
     }
 
     fn insert_with_gate(
@@ -451,6 +461,7 @@ impl Registry {
         port: Option<u16>,
         child: Option<Child>,
         scratch: Option<ScratchDir>,
+        manifest: Option<String>,
         operation_gate: Arc<tokio::sync::Mutex<()>>,
         quarantined: Arc<AtomicBool>,
     ) -> String {
@@ -470,6 +481,7 @@ impl Registry {
                 port,
                 child,
                 scratch,
+                manifest,
             },
         );
         id
@@ -610,6 +622,11 @@ stop an owned session, or restart both an attached runtime and this MCP server, 
         self.sessions.keys().cloned().collect()
     }
 
+    /// The `functor.json` this session booted with, if this server launched it.
+    fn manifest(&self, id: &str) -> Option<String> {
+        self.sessions.get(id).and_then(|s| s.manifest.clone())
+    }
+
     fn remove(&mut self, id: &str) -> Result<Session, String> {
         match self.sessions.remove(id) {
             Some(session) => {
@@ -739,6 +756,8 @@ stop it if owned, or restart both the attached runtime and this MCP server",
                 None,
                 None,
                 None,
+                // Attached: the runtime's manifest is not on this wire.
+                None,
                 self.operation_gate.clone(),
                 self.quarantined.clone(),
             ))
@@ -807,12 +826,20 @@ pub struct LaunchArgs {
     /// just wrote. A `functor.json` pair is honored; without one the server
     /// synthesizes a single-entry manifest. Give this OR `dir`.
     pub files: Option<Vec<(String, String)>>,
-    /// Named entry, for a project whose functor.json declares `entries`.
+    /// Named entry, for a project whose functor.json declares `entries` — the
+    /// ROLE this session runs (`"server"`, `"client"`). Defaults to `client`,
+    /// or the sole entry. Launch one session per role to simulate a
+    /// multiplayer game.
     pub entry: Option<String>,
     /// `"hidden"` (default) renders into an invisible window — `capture_frame`
     /// works. `"headless"` creates no GL context at all — no display or GPU
     /// needed, but `capture_frame` then fails.
     pub mode: Option<String>,
+    /// Include the runtime's full endpoint index in the response (default
+    /// false). The response always carries `protocol_version`, which is the
+    /// part a caller acts on; the index is the same ~2 KB on every launch, and
+    /// `GET /` on the session's url serves it at any time.
+    pub discovery: Option<bool>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -848,6 +875,19 @@ pub struct StepArgs {
     /// Delta time for each step, in seconds (default 0.016).
     pub dts: Option<f64>,
     /// How many steps to queue (default 1, maximum 10,000).
+    pub frames: Option<u32>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct StepAllArgs {
+    /// The sessions to step, in the order they must step — producer first,
+    /// then the authority, then any observer. The order is the caller's
+    /// declaration and this tool preserves it exactly.
+    pub sessions: Vec<String>,
+    /// Delta time for each step, in seconds (default 0.016). Every session
+    /// steps by the same amount, which is what keeps them in lockstep.
+    pub dts: Option<f64>,
+    /// How many steps each session runs per round (default 1, maximum 10,000).
     pub frames: Option<u32>,
 }
 
@@ -1056,6 +1096,13 @@ files writes the inline project to a scratch directory this server owns",
                 )
             }
         };
+        // Remember the manifest this session boots with, BEFORE the game runs:
+        // `GET /project` reports modules, not project metadata, so this is the
+        // only copy `save_project` can write back. Both arms above leave a
+        // `functor.json` in `dir` (the inline path synthesizes one), and an
+        // unreadable manifest is not this tool's error to raise — the launch
+        // below fails on it with the runtime's own message.
+        let manifest = std::fs::read_to_string(dir.join("functor.json")).ok();
         let port = resolve!(self
             .sessions
             .lock()
@@ -1120,19 +1167,27 @@ files writes the inline project to a scratch directory this server owns",
             Some(port),
             Some(child),
             scratch,
+            manifest,
         );
-        ok_text(
-            serde_json::json!({
-                "session": id,
-                "url": url,
-                "port": port,
-                "mode": mode,
-                "owned": true,
-                "dir": absolute(&dir),
-                "discovery": discovery,
-            })
-            .to_string(),
-        )
+        let mut response = serde_json::json!({
+            "session": id,
+            "url": url,
+            "port": port,
+            "mode": mode,
+            "owned": true,
+            "dir": absolute(&dir),
+            "protocol_version": discovery.get("protocol_version").cloned().unwrap_or(Value::Null),
+            "endpoints": "GET / on this url, or launch_game { discovery: true }",
+        });
+        // The endpoint index is ~2 KB of text that says the same thing on every
+        // launch, and a client launching three roles paid for it three times.
+        // The version is the part a caller acts on; the index stays one
+        // argument away (and `connect_game`, where the runtime is a stranger,
+        // still returns it unconditionally).
+        if args.discovery.unwrap_or(false) {
+            response["discovery"] = discovery;
+        }
+        ok_text(response.to_string())
     }
 
     /// Attach to a debug server this process does NOT own — a runtime someone
@@ -1494,6 +1549,85 @@ MCP server before reconnecting or reusing that runtime URL.",
         ok_text(state.to_string())
     }
 
+    /// Step several sessions ONE ROUND, strictly sequentially, in the order
+    /// given — the multiplayer lockstep primitive. Each session's steps fully
+    /// land (`pending_steps` back to 0) before the next session starts, and
+    /// the result carries every session's post-step state summary.
+    ///
+    /// The order is the contract: **step producer → authority → observer**.
+    /// A client's input has to reach the authority before the authority steps,
+    /// and the authority's broadcast has to exist before an observer steps, or
+    /// each round lands work an arbitrary number of rounds late. Stepping the
+    /// same group CONCURRENTLY is not reproducible: whether a packet arrives
+    /// before or after its receiver's step is a race, so two identical runs
+    /// disagree. Pause every session first — this steps the clock, it does not
+    /// pin it.
+    ///
+    /// Sessions are resolved and checked for duplicates before anything steps,
+    /// so a typo cannot leave the group half-advanced. A failure partway
+    /// through still means the earlier sessions advanced: like the SDK's
+    /// `stepAll`, there is no rollback, so treat it as terminal for the run.
+    #[tool]
+    async fn step_all(
+        &self,
+        Parameters(args): Parameters<StepAllArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let frames = args.frames.unwrap_or(1);
+        if !(1..=MAX_STEP_FRAMES).contains(&frames) {
+            return tool_error(format!(
+                "step_all frames must be between 1 and {MAX_STEP_FRAMES}; got {frames}"
+            ));
+        }
+        let dts = args.dts.unwrap_or(0.016);
+        if !dts.is_finite() || dts <= 0.0 {
+            return tool_error(format!(
+                "step_all dts must be a finite positive number; got {dts}"
+            ));
+        }
+        if args.sessions.is_empty() {
+            return tool_error(
+                "step_all needs at least one session id, in the order they must step \
+(producer → authority → observer)",
+            );
+        }
+        // Resolve everything up front: a group half-stepped because the third
+        // id was a typo is a desynced simulation with no way back.
+        let mut targets = Vec::with_capacity(args.sessions.len());
+        for (index, session) in args.sessions.iter().enumerate() {
+            if args.sessions[..index].contains(session) {
+                return tool_error(format!(
+                    "step_all lists session {session:?} more than once — a session that must \
+step twice per round is two rounds, not one list"
+                ));
+            }
+            targets.push((session.clone(), resolve!(self.target(session))));
+        }
+
+        let mut stepped = Vec::with_capacity(targets.len());
+        for (session, target) in targets {
+            // One gate at a time, in order: holding all of them would deadlock
+            // against any other caller holding one of ours.
+            let _operation = resolve!(self.acquire_operation(&target, &context).await);
+            let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
+            let state = match self.advance(&target, dts, frames, operation_deadline).await {
+                Ok(state) => state,
+                Err(message) => {
+                    return tool_error(format!(
+                        "step_all stopped at session {session:?}: {message}\n\nSessions before it \
+in the list have already advanced; the group is no longer in lockstep."
+                    ))
+                }
+            };
+            let mut summary = summarize_state(&state);
+            summary["session"] = Value::String(session);
+            stepped.push(summary);
+        }
+        ok_text(
+            serde_json::json!({ "dts": dts, "frames": frames, "sessions": stepped }).to_string(),
+        )
+    }
+
     /// Un-pin the clock: the game follows wall-clock time again, and window
     /// input reaches it once more.
     #[tool]
@@ -1600,10 +1734,12 @@ or \"fps\" (a first-person WASD + mouse-look scene)"
     /// authored over the wire gets a durable home. The sources come from the
     /// RUNTIME (`GET /project`), so they are what it is actually running,
     /// including every `reload_source`/`reload_project` edit that never
-    /// touched a file. A single-entry `functor.json` is synthesized when the
-    /// directory has none (a project's own manifest is never rewritten, and a
-    /// multi-entry one is not reconstructed). A directory that already holds a
-    /// project is REFUSED unless `overwrite` is true.
+    /// touched a file. The `functor.json` the session BOOTED with is written
+    /// alongside them, so a multi-entry (multiplayer) project keeps its roles;
+    /// a directory's own manifest is never rewritten, and an ATTACHED session,
+    /// whose manifest is not knowable over the wire, gets a synthesized
+    /// single-entry one. A directory that already holds a project is REFUSED
+    /// unless `overwrite` is true.
     #[tool]
     async fn save_project(
         &self,
@@ -1628,10 +1764,16 @@ rebuild that runtime from this version of Functor."
         };
         let files: Vec<(String, String)> = resolve!(serde_json::from_str(&body)
             .map_err(|error| format!("GET /project did not return [path, source] pairs: {error}")));
+        let manifest = self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .manifest(&args.session);
         let dir = std::path::PathBuf::from(&args.dir);
         let written = resolve!(save_project_to(
             &dir,
             &files,
+            manifest.as_deref(),
             args.overwrite.unwrap_or(false)
         ));
         ok_text(
@@ -3132,6 +3274,10 @@ fn summarize_state(state: &Value) -> Value {
         "frame": state.get("frame").cloned().unwrap_or(Value::Null),
         "tts": state.get("tts").cloned().unwrap_or(Value::Null),
         "pending_steps": state.get("pending_steps").cloned().unwrap_or(Value::Null),
+        // The networked facts (protocol v10): `frame` alone cannot say whether
+        // anything landed on a session a peer can write to.
+        "model_revision": state.get("model_revision").cloned().unwrap_or(Value::Null),
+        "pending_net": state.get("pending_net").cloned().unwrap_or(Value::Null),
         "held_keys": state.pointer("/input/held_keys").cloned().unwrap_or(Value::Null),
         "model_bytes": json_encoded_len(state.get("model").unwrap_or(&Value::Null)).unwrap_or(0),
     })
@@ -3753,6 +3899,33 @@ fn existing_project_files(dir: &std::path::Path) -> Vec<String> {
     found
 }
 
+/// The `.fun` files a `functor.json` DECLARES: its `entry`, or every `entries`
+/// value (the plain `"client.fun"` form and the same-file `{ "file": … }` one).
+/// `None` means the text is not a manifest object at all.
+///
+/// Used to check that a remembered manifest still describes the file set being
+/// saved — an unknown/extra key is not this function's business, since the
+/// manifest is written verbatim and the loader owns its own validation.
+fn manifest_entry_files(manifest: &str) -> Option<Vec<String>> {
+    let json: serde_json::Value = serde_json::from_str(manifest).ok()?;
+    let object = json.as_object()?;
+    let declared = match (object.get("entry"), object.get("entries")) {
+        (Some(entry), _) => vec![entry.as_str()?.to_string()],
+        (None, Some(serde_json::Value::Object(entries))) => entries
+            .values()
+            .map(|value| match value {
+                serde_json::Value::String(file) => Some(file.clone()),
+                serde_json::Value::Object(role) => {
+                    Some(role.get("file")?.as_str()?.to_string())
+                }
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?,
+        _ => return None,
+    };
+    Some(declared)
+}
+
 /// Persist a session's sources into `dir`, returning what was written.
 ///
 /// A directory that already holds a project is refused unless `overwrite` —
@@ -3761,9 +3934,18 @@ fn existing_project_files(dir: &std::path::Path) -> Vec<String> {
 /// `overwrite`, modules this session does NOT have are removed as well:
 /// `file = module`, so a leftover sibling would still load and the saved copy
 /// would not be the program that ran.
+///
+/// `manifest` is the `functor.json` the session BOOTED with, when this server
+/// launched it. It is written verbatim rather than reconstructed: a multiplayer
+/// project's `entries` map cannot be recovered from `GET /project` (which
+/// reports modules, not project metadata), and reconstructing it as
+/// `{"entry": "game.fun"}` produces a directory that builds green and then runs
+/// the wrong role — the failure this argument exists to prevent. A manifest
+/// that no longer describes the file set is REFUSED rather than adjusted.
 fn save_project_to(
     dir: &std::path::Path,
     files: &[(String, String)],
+    manifest: Option<&str>,
     overwrite: bool,
 ) -> Result<Vec<String>, String> {
     let entry = entry_of(files)?.to_string();
@@ -3783,7 +3965,33 @@ overwrite: true to replace it",
     if !files.iter().any(|(path, _)| path == "functor.json")
         && !existing.iter().any(|name| name == "functor.json")
     {
-        files.push(("functor.json".to_string(), synthesized_manifest(&entry)));
+        let manifest = match manifest {
+            // The session's own manifest: roles, cursor policy, and every other
+            // project-level setting survive the save exactly as launched.
+            Some(manifest) => {
+                if let Some(declared) = manifest_entry_files(manifest) {
+                    let missing: Vec<&str> = declared
+                        .iter()
+                        .map(String::as_str)
+                        .filter(|file| !files.iter().any(|(path, _)| path == file))
+                        .collect();
+                    if !missing.is_empty() {
+                        return Err(format!(
+                            "the session's functor.json declares {} but the running program \
+no longer has {} — saving would write a manifest that builds and then fails at run. Save the \
+sources to a directory that already holds the right functor.json instead.",
+                            declared.join(", "),
+                            missing.join(", ")
+                        ));
+                    }
+                }
+                manifest.to_string()
+            }
+            // An ATTACHED session: nothing on the wire reports the manifest, so
+            // the single-entry one is the only honest guess.
+            None => synthesized_manifest(&entry),
+        };
+        files.push(("functor.json".to_string(), manifest));
     }
     write_project_files(dir, &files)?;
     for stale in existing
@@ -4459,8 +4667,8 @@ mod tests {
         .await;
         {
             let mut registry = server.sessions.lock().unwrap();
-            registry.insert(url.clone(), None, None, None);
-            registry.insert(url.clone(), None, None, None);
+            registry.insert(url.clone(), None, None, None, None);
+            registry.insert(url.clone(), None, None, None, None);
         }
         let target = server.target("s1").unwrap();
 
@@ -4900,6 +5108,7 @@ mod tests {
                 ("game.fun".into(), "let init = 1".into()),
                 ("util.fun".into(), "let k = 2".into()),
             ],
+            None,
             false,
         )
         .unwrap();
@@ -4909,6 +5118,73 @@ mod tests {
             std::fs::read_to_string(dir.join("game.fun")).unwrap(),
             "let init = 1"
         );
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.join("functor.json")).unwrap())
+                .unwrap();
+        assert_eq!(manifest["entry"], "game.fun");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A MULTI-ENTRY project must survive the round trip. `GET /project`
+    /// reports modules, not project metadata, so a reconstructed manifest
+    /// would say `{"entry": "game.fun"}` — a directory that builds green and
+    /// then runs the client when asked for the server. The session's own
+    /// manifest is written verbatim instead, roles and all.
+    #[test]
+    fn saving_preserves_the_multi_entry_manifest_the_session_booted_with() {
+        let dir = std::env::temp_dir().join(format!("functor-mcp-save-mp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let booted = "{\n  \"language\": \"functor-lang\",\n  \"entries\": {\n    \
+\"client\": { \"file\": \"game.fun\", \"module\": \"Client\" },\n    \
+\"server\": { \"file\": \"game.fun\", \"module\": \"Server\" }\n  }\n}\n";
+
+        super::save_project_to(
+            &dir,
+            &[("game.fun".into(), "let x = 1".into())],
+            Some(booted),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join("functor.json")).unwrap(),
+            booted,
+            "the manifest is written verbatim, not reconstructed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A manifest that no longer describes the file set is REFUSED, not
+    /// quietly adjusted: writing it would produce exactly the failure the
+    /// preservation exists to prevent, one step later.
+    #[test]
+    fn saving_refuses_a_manifest_that_names_a_module_the_session_no_longer_has() {
+        let dir = std::env::temp_dir().join(format!("functor-mcp-save-gone-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let error = super::save_project_to(
+            &dir,
+            &[("game.fun".into(), "let x = 1".into())],
+            Some("{\"language\":\"functor-lang\",\"entries\":{\"client\":\"client.fun\"}}"),
+            false,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("client.fun"), "{error}");
+        assert!(!dir.join("functor.json").exists(), "nothing was written");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An ATTACHED session's manifest is not knowable over the wire, so the
+    /// synthesized single-entry one remains the honest answer there.
+    #[test]
+    fn saving_an_attached_session_still_synthesizes_a_single_entry_manifest() {
+        let dir = std::env::temp_dir().join(format!("functor-mcp-save-att-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        super::save_project_to(&dir, &[("game.fun".into(), "let x = 1".into())], None, false)
+            .unwrap();
+
         let manifest: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(dir.join("functor.json")).unwrap())
                 .unwrap();
@@ -4929,12 +5205,14 @@ mod tests {
                 ("game.fun".into(), "let init = 1".into()),
                 ("util.fun".into(), "let k = 2".into()),
             ],
+            None,
             false,
         )
         .unwrap();
         std::fs::write(dir.join("functor.json"), "{\"entry\":\"game.fun\"}").unwrap();
 
-        super::save_project_to(&dir, &[("game.fun".into(), "let init = 2".into())], true).unwrap();
+        super::save_project_to(&dir, &[("game.fun".into(), "let init = 2".into())], None, true)
+            .unwrap();
 
         assert_eq!(
             std::fs::read_to_string(dir.join("game.fun")).unwrap(),
@@ -4965,7 +5243,7 @@ mod tests {
         std::fs::write(dir.join("game.fun"), "someone else's game").unwrap();
 
         let error =
-            super::save_project_to(&dir, &[("game.fun".into(), "let init = 1".into())], false)
+            super::save_project_to(&dir, &[("game.fun".into(), "let init = 1".into())], None, false)
                 .unwrap_err();
 
         assert!(error.contains("already holds a project"), "{error}");
@@ -4981,9 +5259,9 @@ mod tests {
     #[test]
     fn ids_are_short_sequential_and_resolve_to_their_url() {
         let mut registry = Registry::default();
-        let first = registry.insert("http://127.0.0.1:1".into(), None, None, None);
-        let alias = registry.insert("http://127.0.0.1:1".into(), None, None, None);
-        let second = registry.insert("http://127.0.0.1:2".into(), None, None, None);
+        let first = registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
+        let alias = registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
+        let second = registry.insert("http://127.0.0.1:2".into(), None, None, None, None);
 
         assert_eq!(first, "s1");
         assert_eq!(alias, "s2");
@@ -5032,7 +5310,7 @@ mod tests {
     #[tokio::test]
     async fn cancellation_wins_while_a_mutating_request_waits_for_the_gate() {
         let mut registry = Registry::default();
-        registry.insert("http://127.0.0.1:1".into(), None, None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
         let target = registry.target("s1").unwrap();
         let held = target.operation_gate.clone().lock_owned().await;
         let (cancel, cancelled) = tokio::sync::oneshot::channel::<()>();
@@ -5077,8 +5355,8 @@ mod tests {
     #[tokio::test]
     async fn stop_closing_rejects_queued_clones_but_not_an_alias_id() {
         let mut registry = Registry::default();
-        registry.insert("http://127.0.0.1:1".into(), None, None, None);
-        registry.insert("http://127.0.0.1:1".into(), None, None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
         let queued = registry.target("s1").unwrap();
         let held = queued.operation_gate.clone().lock_owned().await;
         let waiter =
@@ -5108,8 +5386,8 @@ mod tests {
         let server = FunctorMcp::new();
         {
             let mut registry = server.sessions.lock().unwrap();
-            registry.insert("http://127.0.0.1:1".into(), None, None, None);
-            registry.insert("http://127.0.0.1:1".into(), None, None, None);
+            registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
+            registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
             registry.sessions.get_mut("s1").unwrap().owned = true;
         }
         let reservation = server.reserve_connect("http://127.0.0.1:1");
@@ -5164,8 +5442,8 @@ mod tests {
         let empty = registry.url("s1").unwrap_err();
         assert!(empty.contains("no sessions yet"), "{empty}");
 
-        registry.insert("http://127.0.0.1:1".into(), None, None, None);
-        registry.insert("http://127.0.0.1:2".into(), None, None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
+        registry.insert("http://127.0.0.1:2".into(), None, None, None, None);
         let unknown = registry.url("s9").unwrap_err();
         assert!(unknown.contains("s1, s2"), "{unknown}");
     }
@@ -5181,7 +5459,7 @@ mod tests {
         let other = registry.reserve_port().unwrap();
         assert_ne!(port, other);
 
-        registry.insert("http://127.0.0.1:1".into(), Some(port), None, None);
+        registry.insert("http://127.0.0.1:1".into(), Some(port), None, None, None);
         registry.remove("s1").unwrap();
         assert!(!registry.reserved.contains(&port));
     }
@@ -5189,13 +5467,13 @@ mod tests {
     #[test]
     fn removing_a_session_forgets_it_and_does_not_reuse_its_id() {
         let mut registry = Registry::default();
-        registry.insert("http://127.0.0.1:1".into(), None, None, None);
+        registry.insert("http://127.0.0.1:1".into(), None, None, None, None);
         let removed = registry.remove("s1").unwrap();
 
         assert_eq!(removed.url, "http://127.0.0.1:1");
         assert!(registry.url("s1").is_err());
         assert_eq!(
-            registry.insert("http://127.0.0.1:3".into(), None, None, None),
+            registry.insert("http://127.0.0.1:3".into(), None, None, None, None),
             "s2"
         );
         let Err(message) = registry.remove("s1") else {

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -1177,7 +1177,6 @@ files writes the inline project to a scratch directory this server owns",
             "owned": true,
             "dir": absolute(&dir),
             "protocol_version": discovery.get("protocol_version").cloned().unwrap_or(Value::Null),
-            "endpoints": "GET / on this url, or launch_game { discovery: true }",
         });
         // The endpoint index is ~2 KB of text that says the same thing on every
         // launch, and a client launching three roles paid for it three times.
@@ -1530,18 +1529,7 @@ MCP server before reconnecting or reusing that runtime URL.",
         Parameters(args): Parameters<StepArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let frames = args.frames.unwrap_or(1);
-        if !(1..=MAX_STEP_FRAMES).contains(&frames) {
-            return tool_error(format!(
-                "step frames must be between 1 and {MAX_STEP_FRAMES}; got {frames}"
-            ));
-        }
-        let dts = args.dts.unwrap_or(0.016);
-        if !dts.is_finite() || dts <= 0.0 {
-            return tool_error(format!(
-                "step dts must be a finite positive number; got {dts}"
-            ));
-        }
+        let (dts, frames) = resolve!(step_args("step", args.dts, args.frames));
         let target = resolve!(self.target(&args.session));
         let _operation = resolve!(self.acquire_operation(&target, &context).await);
         let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
@@ -1551,40 +1539,39 @@ MCP server before reconnecting or reusing that runtime URL.",
 
     /// Step several sessions ONE ROUND, strictly sequentially, in the order
     /// given — the multiplayer lockstep primitive. Each session's steps fully
-    /// land (`pending_steps` back to 0) before the next session starts, and
-    /// the result carries every session's post-step state summary.
+    /// land (`pending_steps` back to 0) before the next session starts; a
+    /// session's already-received network events are drained (`pending_net`
+    /// back to 0) before IT steps; and the result carries every session's
+    /// post-step state summary, in the order given.
     ///
     /// The order is the contract: **step producer → authority → observer**.
     /// A client's input has to reach the authority before the authority steps,
     /// and the authority's broadcast has to exist before an observer steps, or
     /// each round lands work an arbitrary number of rounds late. Stepping the
     /// same group CONCURRENTLY is not reproducible: whether a packet arrives
-    /// before or after its receiver's step is a race, so two identical runs
-    /// disagree. Pause every session first — this steps the clock, it does not
-    /// pin it.
+    /// before or after its receiver's step is then a race, so two identical
+    /// runs disagree. Pause every session first — this steps the clock, it
+    /// does not pin it.
     ///
-    /// Sessions are resolved and checked for duplicates before anything steps,
-    /// so a typo cannot leave the group half-advanced. A failure partway
-    /// through still means the earlier sessions advanced: like the SDK's
-    /// `stepAll`, there is no rollback, so treat it as terminal for the run.
+    /// What it does NOT promise: a packet still ON THE WIRE is invisible to
+    /// every process, so this orders the stepping and drains what has already
+    /// arrived — it is not a transport barrier. A game whose correctness
+    /// depends on delivery within one round needs its own convergence check
+    /// (poll `get_state` for the game-level fact) between rounds.
+    ///
+    /// Sessions are resolved and checked for duplicates — by runtime URL, so
+    /// two ids aliasing one game are refused — before anything steps, so a
+    /// typo cannot leave the group half-advanced. A failure partway through
+    /// still means the earlier sessions advanced: like the SDK's `stepAll`,
+    /// there is no rollback, so treat it as terminal for the run. The whole
+    /// call shares ONE 120-second wall-clock deadline.
     #[tool]
     async fn step_all(
         &self,
         Parameters(args): Parameters<StepAllArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let frames = args.frames.unwrap_or(1);
-        if !(1..=MAX_STEP_FRAMES).contains(&frames) {
-            return tool_error(format!(
-                "step_all frames must be between 1 and {MAX_STEP_FRAMES}; got {frames}"
-            ));
-        }
-        let dts = args.dts.unwrap_or(0.016);
-        if !dts.is_finite() || dts <= 0.0 {
-            return tool_error(format!(
-                "step_all dts must be a finite positive number; got {dts}"
-            ));
-        }
+        let (dts, frames) = resolve!(step_args("step_all", args.dts, args.frames));
         if args.sessions.is_empty() {
             return tool_error(
                 "step_all needs at least one session id, in the order they must step \
@@ -1592,32 +1579,51 @@ MCP server before reconnecting or reusing that runtime URL.",
             );
         }
         // Resolve everything up front: a group half-stepped because the third
-        // id was a typo is a desynced simulation with no way back.
-        let mut targets = Vec::with_capacity(args.sessions.len());
-        for (index, session) in args.sessions.iter().enumerate() {
-            if args.sessions[..index].contains(session) {
+        // id was a typo is a desynced simulation with no way back. Duplicates
+        // are rejected by URL rather than by id, because two ids can alias one
+        // runtime — and stepping that game twice is exactly what this prevents.
+        let mut targets: Vec<(String, SessionTarget)> = Vec::with_capacity(args.sessions.len());
+        for session in &args.sessions {
+            let target = resolve!(self.target(session));
+            if let Some((other, _)) = targets.iter().find(|(_, seen)| seen.url == target.url) {
                 return tool_error(format!(
-                    "step_all lists session {session:?} more than once — a session that must \
-step twice per round is two rounds, not one list"
+                    "step_all lists {other:?} and {session:?}, which are the same runtime ({}) — \
+a session that must step twice per round is two rounds, not one list",
+                    target.url
                 ));
             }
-            targets.push((session.clone(), resolve!(self.target(session))));
+            targets.push((session.clone(), target));
         }
 
-        let mut stepped = Vec::with_capacity(targets.len());
+        // ONE deadline for the call, not one per session: N sessions must not
+        // multiply how long a single tool call can block.
+        let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
+        let mut stepped: Vec<Value> = Vec::with_capacity(targets.len());
         for (session, target) in targets {
-            // One gate at a time, in order: holding all of them would deadlock
-            // against any other caller holding one of ours.
-            let _operation = resolve!(self.acquire_operation(&target, &context).await);
-            let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
-            let state = match self.advance(&target, dts, frames, operation_deadline).await {
-                Ok(state) => state,
-                Err(message) => {
-                    return tool_error(format!(
+            let desync = |message: String| {
+                if stepped.is_empty() {
+                    format!("step_all stopped at session {session:?}: {message}")
+                } else {
+                    format!(
                         "step_all stopped at session {session:?}: {message}\n\nSessions before it \
 in the list have already advanced; the group is no longer in lockstep."
-                    ))
+                    )
                 }
+            };
+            // One gate at a time, in order: holding all of them would deadlock
+            // against any other caller holding one of ours.
+            let _operation = match self.acquire_operation(&target, &context).await {
+                Ok(operation) => operation,
+                Err(message) => return tool_error(desync(message)),
+            };
+            // Drain what this session has ALREADY received before it steps, so
+            // the round folds it in rather than carrying it to the next one.
+            if let Err(message) = self.settle_net(&target, operation_deadline).await {
+                return tool_error(desync(message));
+            }
+            let state = match self.advance(&target, dts, frames, operation_deadline).await {
+                Ok(state) => state,
+                Err(message) => return tool_error(desync(message)),
             };
             let mut summary = summarize_state(&state);
             summary["session"] = Value::String(session);
@@ -2039,6 +2045,39 @@ impl FunctorMcp {
                     STEP_STALL_TIMEOUT.as_secs()
                 );
                 return Err(self.abort_advance(target, error).await);
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Wait until the session has delivered every inbound network event it has
+    /// already received (`pending_net` back to 0), so the next step folds them
+    /// in rather than carrying them into the following round.
+    ///
+    /// This is a DRAIN, not a transport barrier: a packet still on the wire is
+    /// invisible to every process, so quiescence here means "nothing already
+    /// received is unprocessed", not "nothing is coming". A pre-v10 runtime
+    /// reports no `pending_net` at all, which reads as 0 and makes this a
+    /// no-op — the honest degrade, since such a runtime cannot answer.
+    async fn settle_net(
+        &self,
+        target: &SessionTarget,
+        operation_deadline: Instant,
+    ) -> Result<(), String> {
+        let deadline = Instant::now() + STEP_STALL_TIMEOUT;
+        loop {
+            ensure_operation_active(target, operation_deadline)?;
+            let state = self.state(&target.url).await?;
+            if state["pending_net"].as_u64().unwrap_or(0) == 0 {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "inbound network events stopped draining ({} still queued after {}s) — the \
+game loop may be stuck",
+                    state["pending_net"],
+                    STEP_STALL_TIMEOUT.as_secs()
+                ));
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
@@ -3269,6 +3308,24 @@ fn track_input_command(
     Ok(())
 }
 
+/// Validate the `dts` / `frames` a step tool was given, defaulted. One copy for
+/// `step` and `step_all` so the two cannot drift on what they accept.
+fn step_args(tool: &str, dts: Option<f64>, frames: Option<u32>) -> Result<(f64, u32), String> {
+    let frames = frames.unwrap_or(1);
+    if !(1..=MAX_STEP_FRAMES).contains(&frames) {
+        return Err(format!(
+            "{tool} frames must be between 1 and {MAX_STEP_FRAMES}; got {frames}"
+        ));
+    }
+    let dts = dts.unwrap_or(0.016);
+    if !dts.is_finite() || dts <= 0.0 {
+        return Err(format!(
+            "{tool} dts must be a finite positive number; got {dts}"
+        ));
+    }
+    Ok((dts, frames))
+}
+
 fn summarize_state(state: &Value) -> Value {
     serde_json::json!({
         "frame": state.get("frame").cloned().unwrap_or(Value::Null),
@@ -3899,31 +3956,58 @@ fn existing_project_files(dir: &std::path::Path) -> Vec<String> {
     found
 }
 
-/// The `.fun` files a `functor.json` DECLARES: its `entry`, or every `entries`
-/// value (the plain `"client.fun"` form and the same-file `{ "file": … }` one).
-/// `None` means the text is not a manifest object at all.
+/// What a `functor.json` DECLARES, as sorted `(role, file)` pairs: the single
+/// `entry` form as one nameless role, and every `entries` value (both the plain
+/// `"client.fun"` form and the same-file `{ "file": …, "module": … }` one).
+/// `None` means the text is not a manifest this can reason about.
 ///
-/// Used to check that a remembered manifest still describes the file set being
-/// saved — an unknown/extra key is not this function's business, since the
-/// manifest is written verbatim and the loader owns its own validation.
-fn manifest_entry_files(manifest: &str) -> Option<Vec<String>> {
+/// The ROLE names matter as much as the files: a same-file multiplayer project
+/// declares `client` and `server` against ONE `game.fun`, so comparing files
+/// alone cannot tell it apart from a single-entry project on the same file —
+/// which is exactly the corruption this exists to catch. An unknown/extra key
+/// is not this function's business: the manifest is written verbatim and the
+/// loader owns its own validation.
+fn manifest_entries(manifest: &str) -> Option<Vec<(String, String)>> {
     let json: serde_json::Value = serde_json::from_str(manifest).ok()?;
     let object = json.as_object()?;
-    let declared = match (object.get("entry"), object.get("entries")) {
-        (Some(entry), _) => vec![entry.as_str()?.to_string()],
+    let mut declared = match (object.get("entry"), object.get("entries")) {
+        // Both is what the loader calls Conflicting — not a manifest to reason
+        // about. Reading it as "entry wins" would validate against a shape the
+        // project could never boot.
+        (Some(_), Some(_)) => return None,
+        (Some(entry), None) => vec![(String::new(), entry.as_str()?.to_string())],
         (None, Some(serde_json::Value::Object(entries))) => entries
-            .values()
-            .map(|value| match value {
-                serde_json::Value::String(file) => Some(file.clone()),
-                serde_json::Value::Object(role) => {
-                    Some(role.get("file")?.as_str()?.to_string())
-                }
-                _ => None,
+            .iter()
+            .map(|(role, value)| {
+                let file = match value {
+                    serde_json::Value::String(file) => file.clone(),
+                    serde_json::Value::Object(object) => object.get("file")?.as_str()?.to_string(),
+                    _ => return None,
+                };
+                Some((role.clone(), file))
             })
             .collect::<Option<Vec<_>>>()?,
         _ => return None,
     };
+    // A set: `entries` is a map, so its declaration order is not part of what
+    // the manifest means.
+    declared.sort();
     Some(declared)
+}
+
+/// Name declared entries the way both teaching errors below do.
+fn render_entries(entries: &[(String, String)]) -> String {
+    entries
+        .iter()
+        .map(|(role, file)| {
+            if role.is_empty() {
+                file.clone()
+            } else {
+                format!("{role} → {file}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Persist a session's sources into `dir`, returning what was written.
@@ -3959,6 +4043,28 @@ overwrite: true to replace it",
         ));
     }
     let mut files = files.to_vec();
+    // Overwriting a directory that keeps its OWN manifest is the other way to
+    // end up with a project that builds and runs the wrong role: the sources
+    // become this session's, the manifest stays whoever's it was. Refuse when
+    // the two disagree about the entries rather than write the mismatch.
+    if let (Some(booted), true) = (
+        manifest,
+        existing.iter().any(|name| name == "functor.json"),
+    ) {
+        let there = std::fs::read_to_string(dir.join("functor.json")).unwrap_or_default();
+        if let (Some(mine), Some(theirs)) = (manifest_entries(booted), manifest_entries(&there)) {
+            if mine != theirs {
+                return Err(format!(
+                    "{} already holds a functor.json declaring {}, but this session runs {} — \
+saving would leave that manifest in place over these sources, which builds and then runs the \
+wrong entry. Save to a directory with no functor.json, or fix that one first.",
+                    dir.display(),
+                    render_entries(&theirs),
+                    render_entries(&mine)
+                ));
+            }
+        }
+    }
     // The manifest is not part of what the runtime reports, so write one for a
     // project that has none — and never rewrite the one already there, which
     // may declare named entries this session's sources cannot describe.
@@ -3969,18 +4075,19 @@ overwrite: true to replace it",
             // The session's own manifest: roles, cursor policy, and every other
             // project-level setting survive the save exactly as launched.
             Some(manifest) => {
-                if let Some(declared) = manifest_entry_files(manifest) {
-                    let missing: Vec<&str> = declared
+                if let Some(declared) = manifest_entries(manifest) {
+                    let mut missing: Vec<&str> = declared
                         .iter()
-                        .map(String::as_str)
+                        .map(|(_, file)| file.as_str())
                         .filter(|file| !files.iter().any(|(path, _)| path == file))
                         .collect();
+                    missing.dedup();
                     if !missing.is_empty() {
                         return Err(format!(
                             "the session's functor.json declares {} but the running program \
 no longer has {} — saving would write a manifest that builds and then fails at run. Save the \
 sources to a directory that already holds the right functor.json instead.",
-                            declared.join(", "),
+                            render_entries(&declared),
                             missing.join(", ")
                         ));
                     }
@@ -5172,6 +5279,49 @@ mod tests {
 
         assert!(error.contains("client.fun"), "{error}");
         assert!(!dir.join("functor.json").exists(), "nothing was written");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The other way to end up running the wrong role: `overwrite` a directory
+    /// that keeps its OWN manifest. The sources become this session's, the
+    /// manifest stays whoever's it was — so a disagreement is refused, not
+    /// written.
+    #[test]
+    fn overwriting_refuses_a_directory_whose_manifest_declares_other_entries() {
+        let dir = std::env::temp_dir().join(format!("functor-mcp-save-clash-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("functor.json"), "{\"entry\":\"game.fun\"}").unwrap();
+        std::fs::write(dir.join("game.fun"), "someone else's game").unwrap();
+
+        let error = super::save_project_to(
+            &dir,
+            &[("game.fun".into(), "let x = 1".into())],
+            Some("{\"language\":\"functor-lang\",\"entries\":{\"client\":{\"file\":\"game.fun\",\"module\":\"Client\"},\"server\":{\"file\":\"game.fun\",\"module\":\"Server\"}}}"),
+            true,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("wrong entry"), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("game.fun")).unwrap(),
+            "someone else's game",
+            "nothing was written"
+        );
+
+        // The same directory, same declared entries: saving over it is fine.
+        std::fs::write(dir.join("functor.json"), "{\"entry\":\"game.fun\"}").unwrap();
+        super::save_project_to(
+            &dir,
+            &[("game.fun".into(), "let x = 1".into())],
+            Some("{\"language\":\"functor-lang\",\"entry\":\"game.fun\"}"),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("game.fun")).unwrap(),
+            "let x = 1"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -71,8 +71,15 @@ pub enum Event {
     },
     /// A command ended (also the exit-code carrier for machine consumers).
     CommandFinished { ok: bool, duration_ms: u64 },
-    /// A `build` typecheck passed (`entry` plus `sibling_count` sibling modules).
-    FunctorLangLoaded { entry: String, sibling_count: usize },
+    /// A `build` typecheck passed (`entry` plus `sibling_count` sibling
+    /// modules). `role` names the `entries` key that was checked, and is empty
+    /// for a single-`entry` project: roles of a multiplayer project commonly
+    /// share ONE file, so the entry path alone cannot say which one ran.
+    FunctorLangLoaded {
+        entry: String,
+        role: String,
+        sibling_count: usize,
+    },
     /// An Functor Lang check / load error, positioned in its file. `source_line` is the
     /// raw offending line (no caret baked in) so the human renderer can draw a
     /// rustc-style caret under `col`; machine consumers get the same structured
@@ -290,6 +297,7 @@ impl PlainRenderer {
             }
             Event::FunctorLangLoaded {
                 entry,
+                role,
                 sibling_count,
             } => {
                 let siblings = match sibling_count {
@@ -297,10 +305,19 @@ impl PlainRenderer {
                     1 => " (+1 module)".to_string(),
                     n => format!(" (+{n} modules)"),
                 };
+                // Two roles of a multiplayer project usually share one file, so
+                // naming the file alone leaves "which role did I just check?"
+                // unanswered — the exact question `--entry` was asked.
+                let role = if role.is_empty() {
+                    String::new()
+                } else {
+                    format!(" as {role}")
+                };
                 vec![format!(
-                    "{} checked {}{}",
+                    "{} checked {}{}{}",
                     g_ok().green(),
                     entry,
+                    role,
                     siblings.dimmed()
                 )]
             }

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -107,7 +107,7 @@ screenshot run has no reason to grab your mouse.
 | Method & path | Purpose |
 | --- | --- |
 | `POST /capture` | PNG (`image/png`) of the next rendered frame |
-| `GET /state` | runtime state JSON: `frame`, `tts`, combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (keyboard/mouse held + pressed/released sets and optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
+| `GET /state` | runtime state JSON: `frame`, `tts`, `model_revision` + `pending_net` (protocol v10 — see below), combined/legacy `viewport`, `views` (`main` on desktop; `left` + `right` on Quest), `input` (keyboard/mouse held + pressed/released sets and optional typed device domains), `model` (structured JSON — see below), `model_debug` (Rust `Debug` text) |
 | `GET /scene` | current frame as JSON: `camera` + `scene` + `lights` |
 | `GET /trace` | paused-inspector trace: the last real frame's entry-point invocations plus a synthesized `draw` pass, replayed while paused. Each site (binders AND variable reads, `site`) carries the full `value`, a depth-limited `preview`, and `kind` (primitive/composite — the editor's inline-vs-hover policy); `{ "paused": false, "invocations": [] }` while playing. Paused docs also carry `coverage` (per-file span starts with the frame OFFSETS they executed on, over a ±120-frame journal ring — positive offsets appear when scrubbed behind the live head) and `runnable` (the static could-run set) — the recency gutter's data |
 | `POST /input` | inject input (see below) |
@@ -151,6 +151,36 @@ the sigils as a strong convention rather than a proof):
 It is a one-way observation format (there is deliberately no parser back),
 and it is `null` for producers without a structured model (e.g. `--replay`,
 whose `model_debug` still describes the replay position).
+
+### `model_revision` and `pending_net` in `GET /state` (protocol v10)
+
+**Pause freezes the CLOCK, not the network.** `POST /time {"type":"set"}` stops
+time advancing; it does not stop the shell's sockets. A paused session keeps
+accepting inbound messages and keeps folding them through `update`, so its
+model changes while `frame` and `tts` stand perfectly still.
+
+That makes **`frame` not a version label for a networked model** — a driver
+that snapshots the model, waits, and compares `frame` to decide whether
+anything happened will conclude "nothing did" while the authority has quietly
+seated three players. `model_revision` is the label to use instead:
+
+- **`model_revision`** counts how many times the model has been REPLACED by
+  game logic since the program loaded — every entry point's return and every
+  effect or network fold, counted at the producer's single model assignment.
+  Monotone, never reset (a hot reload *rebinds* the model rather than replacing
+  it, and does not count). Compare it against a previous read to answer "did
+  anything land", whether or not the clock moved.
+- **`pending_net`** is how many inbound network events the shell has accepted
+  from its transport but not yet delivered to the game — connection events and
+  completed HTTP responses. **Poll until it is 0 to know a session is
+  quiescent** before snapshotting a baseline. It cannot see a packet still on
+  the wire between two processes, so it is a lower bound on outstanding
+  network work: it proves nothing already received is unprocessed, not that
+  nothing is coming.
+
+Both are additive, so a pre-v10 runtime simply omits them and they read `0`.
+A client that WAITS on either must gate on `GET /`'s `protocol_version` first —
+a constant zero from an old runtime is indistinguishable from real quiescence.
 
 ### `POST /input`
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -167,9 +167,12 @@ seated three players. `model_revision` is the label to use instead:
 - **`model_revision`** counts how many times the model has been REPLACED by
   game logic since the program loaded — every entry point's return and every
   effect or network fold, counted at the producer's single model assignment.
-  Monotone, never reset (a hot reload *rebinds* the model rather than replacing
-  it, and does not count). Compare it against a previous read to answer "did
-  anything land", whether or not the clock moved.
+  Monotone, never reset. Compare it against a previous read to answer "did
+  anything land", whether or not the clock moved. Replacing the model from
+  *outside* the game does not count — a hot reload (which rebinds it),
+  `/load-project`, `/rewind`, a timeline seek — because those are operations
+  the driver itself just performed and each answers with fresh state to
+  re-baseline from.
 - **`pending_net`** is how many inbound network events the shell has accepted
   from its transport but not yet delivered to the game — connection events and
   completed HTTP responses. **Poll until it is 0 to know a session is

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -383,25 +383,42 @@ step_all { "sessions": ["s2", "s1", "s3"] }      // one lockstep round
 
 **The ordering law: step producer → authority → observer.** `step_all` steps the
 sessions strictly sequentially in the order given — each session's steps land
-fully (`pending_steps` back to 0) before the next session starts — and returns
-every session's post-step summary in that order. The order is the semantics, not
-a convenience: a client's input has to reach the authority *before* the
-authority steps, and the authority's broadcast has to exist *before* an observer
-steps, or every round lands its work an arbitrary number of rounds late.
-**Concurrent stepping is not reproducible**: whether a packet arrives before or
-after its receiver's step is a race, so two identical runs disagree. Sessions
-are resolved and de-duplicated before anything steps, so a typo cannot leave the
-group half-advanced — but a failure *partway through* means earlier sessions
-already advanced, with no rollback.
+fully (`pending_steps` back to 0) before the next session starts, and each
+session's already-received network events are drained (`pending_net` back to 0)
+before *it* steps — and returns every session's post-step summary in that order.
+The order is the semantics, not a convenience: a client's input has to reach the
+authority *before* the authority steps, and the authority's broadcast has to
+exist *before* an observer steps, or every round lands its work an arbitrary
+number of rounds late. **Concurrent stepping is not reproducible**: whether a
+packet arrives before or after its receiver's step is a race, so two identical
+runs disagree. Sessions are resolved and de-duplicated — by runtime URL, so two
+ids aliasing one game are refused — before anything steps, so a typo cannot
+leave the group half-advanced; a failure *partway through* means earlier
+sessions already advanced, with no rollback. The whole call shares one
+120-second deadline.
+
+**What it does not promise.** `step_all` orders the *stepping* and drains what
+has already arrived. It is **not a transport barrier**: a packet still on the
+wire between two processes is invisible to every process (which is exactly what
+`pending_net` says it cannot see), so nothing here can force delivery to happen
+within a given round. A game whose correctness depends on that needs its own
+convergence check between rounds — poll `get_state` for the game-level fact
+("the authority has seated both clients", "the observer's world matches"), the
+same way you would wait for any distributed condition.
 
 **Pause freezes the CLOCK, not the network.** A paused role keeps accepting
 inbound messages and folding them through `update`, so its model changes while
 `frame` and `tts` stand still. Two consequences for a driver:
 
 - `frame` is **not** a version label for a networked model. `model_revision`
-  is: it counts every replacement of the model, whatever caused it, so
-  comparing it against an earlier read answers "did anything land" even with
-  the clock stopped.
+  is: it counts every replacement of the model **by game logic** — a tick, an
+  injected input, an effect fold, a network delivery — so comparing it against
+  an earlier read answers "did anything land" even with the clock stopped.
+  (Operations that replace the model *from outside* the game — a hot reload, a
+  `load_project`, a `rewind` — deliberately do not count. Those are things the
+  driver itself just did, and each returns fresh state to re-baseline from; a
+  counter that also moved for them would not distinguish "the network changed
+  my model" from "I rewound it".)
 - Before snapshotting a baseline, wait for **`pending_net` to reach 0** on
   every role. That is the shell's inbound queue depth; zero means nothing
   already received is still unprocessed. (It cannot see a packet still on the

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -93,7 +93,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 
 | Tool | What it does |
 | --- | --- |
-| `launch_game` | Spawn a game as a child on a free port and return its session id. The project comes from `dir` **or** from `files` — the whole project inline (see below). `mode` is `hidden` (default) or `headless`. |
+| `launch_game` | Spawn a game as a child on a free port and return its session id. The project comes from `dir` **or** from `files` — the whole project inline (see below). `entry` names the ROLE, for a project whose `functor.json` declares `entries` (`"server"`, `"client"`; default `client`, or the sole entry) — one session per role. `mode` is `hidden` (default) or `headless`. The response carries `protocol_version`; pass `discovery: true` for the full endpoint index. |
 | `connect_game` | Attach to a runtime this server does **not** own (a human's `functor develop` on port 8077, someone else's `--debug-port`, or an adb-forwarded Quest). |
 | `list_sessions` | Every session: id, url, owned/attached, and whether it currently answers. |
 | `stop_game` | Kill a launched game and close its exact-URL aliases/pending connects; merely forget one attached id. |
@@ -102,7 +102,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 
 | Tool | What it does |
 | --- | --- |
-| `get_state` | `frame`, `tts`, `pending_steps`, viewports, sampled `input`, and the model — the structured JSON view (the default read; `model_debug` is the Debug text). |
+| `get_state` | `frame`, `tts`, `pending_steps`, `model_revision`, `pending_net`, viewports, sampled `input`, and the model — the structured JSON view (the default read; `model_debug` is the Debug text). |
 | `get_scene` | The camera, scene graph, and lights `draw` produced. Pure data, so it works headlessly. |
 | `get_trace` | The paused inspector trace: every entry point's binder and variable values for the last real frame. Pause first. |
 | `capture_frame` | A PNG of the next rendered frame, returned as an MCP image block. |
@@ -113,6 +113,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 | --- | --- |
 | `pause` | Pin the clock (defaults to the current `tts`), so nothing advances on its own. |
 | `step` | Run 1–10,000 `frames` of finite positive `dts` each, **wait for them to land**, and return the fresh state. |
+| `step_all` | Step several sessions one round, strictly sequentially, in the order given — the multiplayer lockstep primitive. See [Running a multiplayer session](#running-a-multiplayer-session). |
 | `resume` | Follow wall-clock time again. |
 | `send_input` | Inject one `POST /input` command verbatim — key, mouse move/wheel/button, `ui_event`, or an `xr` sample. |
 | `rewind` | Restore model + physics to a recorded frame (it pins the clock first, as `/rewind` requires). |
@@ -124,7 +125,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 | Tool | What it does |
 | --- | --- |
 | `init_game` | Scaffold a starter project on disk — the same `functor.json` + `game.fun` `functor init` writes. `template` is `"3d"` (default) or `"fps"`. Never overwrites; its `dir` goes straight into `launch_game`. |
-| `save_project` | Write a session's **current** source to a directory. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. Refuses a directory that already holds a project unless `overwrite`. |
+| `save_project` | Write a session's **current** source to a directory, with the `functor.json` it booted with — so a multi-entry (multiplayer) project keeps its roles. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. Refuses a directory that already holds a project unless `overwrite`. |
 
 **Learning the language and the API.** Two session-free tools, and they are
 different halves: `language_guide` is the LANGUAGE (how to write `.fun` at all),
@@ -173,6 +174,10 @@ deterministic rather than racy:
   half-landed batch. A batch (`frames > 1`) runs up to 8 ticks per rendered
   frame, so it has proportionally fewer input/network/render points — step one
   at a time when the game must see input or I/O between steps.
+- **Order is the semantics for a networked group.** `step_all` steps sessions
+  sequentially in the order given — producer → authority → observer — because
+  stepping them concurrently makes packet arrival a race. See
+  [Running a multiplayer session](#running-a-multiplayer-session).
 - **Input is level state.** A key, a held mouse button, and an injected XR sample
   stay in force across steps until released or replaced. That is how a paused
   session is scripted: press, step a few frames, release.
@@ -323,10 +328,17 @@ A directory that already holds a project (a `functor.json` or any `.fun` /
 a matching name is no evidence that it is the same project. Pass
 `overwrite: true` to replace it; that also **deletes modules the session does
 not have**, since `file = module` means a leftover sibling would still load and
-the saved copy would not be the program that ran. A `functor.json` is
-synthesized only when the directory has none — an existing manifest is never
-rewritten, and a multi-entry one is not reconstructed (`/project` reports
-modules, not project metadata).
+the saved copy would not be the program that ran.
+
+The `functor.json` is written only when the directory has none — an existing
+manifest is never rewritten — and it is the one the session **booted with**,
+verbatim. `/project` reports modules, not project metadata, so a manifest
+cannot be reconstructed from it: a multi-entry (multiplayer) project would come
+back as `{"entry": "game.fun"}`, a directory that builds green and then runs the
+wrong role. A remembered manifest that no longer describes the file set (a
+module the session dropped) is REFUSED rather than adjusted. An ATTACHED
+session is the one case with no answer — nothing on the wire reports a
+runtime's manifest — so it still gets a synthesized single-entry one.
 
 The other direction is `init_game`, which scaffolds the ordinary starter on
 disk — `init_game { "dir": "./my-game" }` then
@@ -349,6 +361,66 @@ stop_game  { "session": "s1" }
 Nothing advanced between the click and the step, and `step` returned only once
 the step had actually run — so `model.count` is the click's effect, not a
 sample of a still-moving game.
+
+## Running a multiplayer session
+
+A multi-entry project (`functor.json` with `entries`, like `examples/orbs`) is
+one directory holding several ROLES — often, as in orbs, several inline
+`module` blocks of one file. Each role is its own runtime, so it is its own
+session: launch one per role and name it with `entry`, since the path cannot
+say which role a shared file is being run as.
+
+```jsonc
+launch_game { "dir": "examples/orbs", "entry": "server", "mode": "headless" }  // → s1
+launch_game { "dir": "examples/orbs", "entry": "client", "mode": "headless" }  // → s2
+launch_game { "dir": "examples/orbs", "entry": "client", "mode": "headless" }  // → s3
+
+pause    { "session": "s2" }                     // pin every role's clock
+pause    { "session": "s1" }
+pause    { "session": "s3" }
+step_all { "sessions": ["s2", "s1", "s3"] }      // one lockstep round
+```
+
+**The ordering law: step producer → authority → observer.** `step_all` steps the
+sessions strictly sequentially in the order given — each session's steps land
+fully (`pending_steps` back to 0) before the next session starts — and returns
+every session's post-step summary in that order. The order is the semantics, not
+a convenience: a client's input has to reach the authority *before* the
+authority steps, and the authority's broadcast has to exist *before* an observer
+steps, or every round lands its work an arbitrary number of rounds late.
+**Concurrent stepping is not reproducible**: whether a packet arrives before or
+after its receiver's step is a race, so two identical runs disagree. Sessions
+are resolved and de-duplicated before anything steps, so a typo cannot leave the
+group half-advanced — but a failure *partway through* means earlier sessions
+already advanced, with no rollback.
+
+**Pause freezes the CLOCK, not the network.** A paused role keeps accepting
+inbound messages and folding them through `update`, so its model changes while
+`frame` and `tts` stand still. Two consequences for a driver:
+
+- `frame` is **not** a version label for a networked model. `model_revision`
+  is: it counts every replacement of the model, whatever caused it, so
+  comparing it against an earlier read answers "did anything land" even with
+  the clock stopped.
+- Before snapshotting a baseline, wait for **`pending_net` to reach 0** on
+  every role. That is the shell's inbound queue depth; zero means nothing
+  already received is still unprocessed. (It cannot see a packet still on the
+  wire, so it is a lower bound — pair it with a game-level condition, e.g.
+  "the server seated both clients".)
+
+Both fields need debug protocol v10 (`docs/debug-runtime.md`).
+
+**Hot-reload keeps connections.** Reloading the authority with `reload_source`
+or `reload_project` preserves the live model *and* the live sockets — connections
+are owned by the shell, which does not reload — so clients stay joined across an
+edit to the server's rules.
+
+Launch the authority first and let its listener bind before a client dials —
+an orbs client connects once and does not retry.
+
+`e2e/mcp-step-all.mjs` is the end-to-end proof: it runs the three roles of
+`examples/orbs` twice from scratch and asserts the ordered lockstep produces
+the identical world trace both times.
 
 ## Debugging a human's live session
 
@@ -401,6 +473,8 @@ tracking every frame).
 - [`docs/debug-runtime.md`](debug-runtime.md) — the HTTP surface these tools wrap,
   with the exact request/response shapes.
 - `e2e/mcp-server.mjs` — the end-to-end proof, speaking raw JSON-RPC to the server.
+- `e2e/mcp-step-all.mjs` — the multiplayer proof: three roles of
+  `examples/orbs`, stepped in order, run twice, asserted identical.
 - `.claude/skills/functor-lang/SKILL.md` — the language guide `language_guide`
   serves, and the file to edit when the language changes.
 - [`docs/functor-lang.md`](functor-lang.md) — the language roadmap behind it.

--- a/e2e/mcp-rpc.mjs
+++ b/e2e/mcp-rpc.mjs
@@ -1,0 +1,112 @@
+// The MCP e2e harnesses' shared JSON-RPC client.
+//
+// `functor mcp` speaks line-delimited JSON-RPC 2.0 on stdio and the harnesses
+// speak it RAW — no MCP client library — so what they assert is exactly what a
+// coding agent's client would see. That is worth exactly one copy: this module
+// is it, imported by `mcp-server.mjs` and `mcp-step-all.mjs`.
+//
+// Plain ESM with node builtins only, like every other file in `e2e/`.
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const ROOT = fileURLToPath(new URL("..", import.meta.url));
+export const BIN = process.env.FUNCTOR_BIN ?? `${ROOT}target/debug/functor`;
+
+/** A line-delimited JSON-RPC client over a child's stdio. */
+export class Rpc {
+  constructor(proc) {
+    this.proc = proc;
+    this.pending = new Map();
+    this.nextId = 1;
+    this.buffer = "";
+    this.stderr = "";
+    proc.stdout.setEncoding("utf8");
+    proc.stdout.on("data", (chunk) => this.#onData(chunk));
+    proc.stderr.on("data", (chunk) => (this.stderr += chunk));
+  }
+
+  #onData(chunk) {
+    this.buffer += chunk;
+    let index;
+    while ((index = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, index).trim();
+      this.buffer = this.buffer.slice(index + 1);
+      if (!line) continue;
+      const message = JSON.parse(line);
+      const waiter = this.pending.get(message.id);
+      if (waiter) {
+        this.pending.delete(message.id);
+        clearTimeout(waiter.timer);
+        message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
+      }
+    }
+  }
+
+  notify(method, params) {
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  beginRequest(method, params) {
+    const id = this.nextId++;
+    const result = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`));
+      }, 60000);
+      this.pending.set(id, { resolve, reject, timer });
+    });
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+    return { id, result };
+  }
+
+  request(method, params) {
+    return this.beginRequest(method, params).result;
+  }
+
+  cancelRequest(id, reason) {
+    this.notify("notifications/cancelled", { requestId: id, reason });
+    // MCP deliberately sends no response for a cancelled request. Settle the
+    // local waiter while the state assertion below proves the server did not
+    // execute the queued mutation after dropping that response.
+    const waiter = this.pending.get(id);
+    if (waiter) {
+      this.pending.delete(id);
+      clearTimeout(waiter.timer);
+      waiter.resolve({ cancelled: true });
+    }
+  }
+
+  /** Call a tool and return its single text content block, parsed if it is JSON. */
+  async call(name, args = {}) {
+    const result = await this.request("tools/call", { name, arguments: args });
+    const text = result.content.map((block) => block.text ?? "").join("");
+    if (result.isError) throw new Error(`${name} failed: ${text}`);
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+}
+
+export const failures = [];
+export const check = (ok, what) => {
+  console.log(`  ${ok ? "✓" : "✗"} ${what}`);
+  if (!ok) failures.push(what);
+};
+
+
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Spawn `functor mcp`, complete the MCP handshake, and return `{ proc, rpc }`. */
+export async function startMcp(clientName) {
+  const proc = spawn(BIN, ["mcp"], { cwd: ROOT, stdio: ["pipe", "pipe", "pipe"] });
+  const rpc = new Rpc(proc);
+  await rpc.request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: clientName, version: "0" },
+  });
+  rpc.notify("notifications/initialized", {});
+  return { proc, rpc };
+}

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -55,6 +55,7 @@ const EXPECTED_TOOLS = [
   "send_input",
   "pause",
   "step",
+  "step_all",
   "resume",
   "rewind",
   "reload_source",
@@ -226,7 +227,11 @@ try {
   const launched = await rpc.call("launch_game", { dir: "examples/counter", mode: "headless" });
   session = launched.session;
   check(/^s\d+$/.test(session), `launch_game returned a session id (${session})`);
-  check(launched.discovery?.service === "functor debug runtime", "the child answered the debug-runtime discovery endpoint");
+  check(
+    typeof launched.protocol_version === "number",
+    `the child answered discovery, reporting protocol v${launched.protocol_version}`,
+  );
+  check(launched.discovery === undefined, "the ~2 KB endpoint index is not repeated on every launch (pass discovery: true for it)");
   check(launched.owned === true, "the session is owned (this server spawned it)");
 
   const listed = await rpc.call("list_sessions");
@@ -899,7 +904,7 @@ let draw = (m: Model, tts) =>
   check(scaffoldResult.files.includes("game.fun"), `init_game wrote ${scaffoldResult.files} into ${scaffoldResult.dir}`);
 
   const scaffolded = await rpc.call("launch_game", { dir: scaffold, mode: "headless" });
-  check(scaffolded.discovery?.service === "functor debug runtime", "the scaffolded project boots");
+  check(typeof scaffolded.protocol_version === "number", "the scaffolded project boots");
   await rpc.call("stop_game", { session: scaffolded.session });
 
   let reinit = null;

--- a/e2e/mcp-server.mjs
+++ b/e2e/mcp-server.mjs
@@ -37,10 +37,9 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
-const BIN = process.env.FUNCTOR_BIN ?? `${ROOT}target/debug/functor`;
+// The raw JSON-RPC client is shared with e2e/mcp-step-all.mjs.
+import { BIN, check, failures, Rpc, ROOT } from "./mcp-rpc.mjs";
 
 /** Every tool the server must advertise (docs/mcp.md). */
 const EXPECTED_TOOLS = [
@@ -66,89 +65,6 @@ const EXPECTED_TOOLS = [
   "init_game",
   "save_project",
 ];
-
-/** A line-delimited JSON-RPC client over a child's stdio. */
-class Rpc {
-  constructor(proc) {
-    this.proc = proc;
-    this.pending = new Map();
-    this.nextId = 1;
-    this.buffer = "";
-    this.stderr = "";
-    proc.stdout.setEncoding("utf8");
-    proc.stdout.on("data", (chunk) => this.#onData(chunk));
-    proc.stderr.on("data", (chunk) => (this.stderr += chunk));
-  }
-
-  #onData(chunk) {
-    this.buffer += chunk;
-    let index;
-    while ((index = this.buffer.indexOf("\n")) >= 0) {
-      const line = this.buffer.slice(0, index).trim();
-      this.buffer = this.buffer.slice(index + 1);
-      if (!line) continue;
-      const message = JSON.parse(line);
-      const waiter = this.pending.get(message.id);
-      if (waiter) {
-        this.pending.delete(message.id);
-        clearTimeout(waiter.timer);
-        message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
-      }
-    }
-  }
-
-  notify(method, params) {
-    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
-  }
-
-  beginRequest(method, params) {
-    const id = this.nextId++;
-    const result = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`));
-      }, 60000);
-      this.pending.set(id, { resolve, reject, timer });
-    });
-    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
-    return { id, result };
-  }
-
-  request(method, params) {
-    return this.beginRequest(method, params).result;
-  }
-
-  cancelRequest(id, reason) {
-    this.notify("notifications/cancelled", { requestId: id, reason });
-    // MCP deliberately sends no response for a cancelled request. Settle the
-    // local waiter while the state assertion below proves the server did not
-    // execute the queued mutation after dropping that response.
-    const waiter = this.pending.get(id);
-    if (waiter) {
-      this.pending.delete(id);
-      clearTimeout(waiter.timer);
-      waiter.resolve({ cancelled: true });
-    }
-  }
-
-  /** Call a tool and return its single text content block, parsed if it is JSON. */
-  async call(name, args = {}) {
-    const result = await this.request("tools/call", { name, arguments: args });
-    const text = result.content.map((block) => block.text ?? "").join("");
-    if (result.isError) throw new Error(`${name} failed: ${text}`);
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-}
-
-const failures = [];
-const check = (ok, what) => {
-  console.log(`  ${ok ? "✓" : "✗"} ${what}`);
-  if (!ok) failures.push(what);
-};
 
 const proc = spawn(BIN, ["mcp"], { cwd: ROOT, stdio: ["pipe", "pipe", "pipe"] });
 const rpc = new Rpc(proc);

--- a/e2e/mcp-step-all.mjs
+++ b/e2e/mcp-step-all.mjs
@@ -1,0 +1,336 @@
+// `functor mcp` E2E: the MULTIPLAYER surface — ordered stepping, quiescence,
+// and a multi-entry project that survives `save_project`.
+//
+// It runs `examples/orbs` for real: one authoritative `server` role plus two
+// `client` roles — three separate runtimes talking over a localhost socket.
+// Both roles are inline modules of ONE file, so each is named with `entry`
+// rather than inferred from a path, which is also the shape that made
+// `save_project` corrupt the manifest.
+// What it proves (docs/mcp.md, "Running a multiplayer session"):
+//
+//   1. `step_all` steps a group STRICTLY SEQUENTIALLY in the caller's declared
+//      order — producer → authority → observer — and returns each session's
+//      post-step summary in that order, each with its steps fully landed.
+//   2. That ordering is REPRODUCIBLE: the whole run is performed twice, from
+//      scratch, and the authority's per-round world trace must be identical.
+//      (Stepping the same group concurrently is a race between a packet and
+//      its receiver's step, which is why the tool has an order at all.)
+//   3. `pending_net` is the quiescence signal a baseline needs, and
+//      `model_revision` moves on network folds that no clock step caused —
+//      pause freezes the clock, not the network.
+//   4. `save_project` preserves a multi-entry `functor.json`. Reconstructing
+//      one loses the roles: the saved directory builds green and then runs the
+//      wrong entry.
+//
+// Run manually (needs the CLI built; the wasm bundle is not required):
+//
+//   cargo build -p functor-cli --no-default-features
+//   node e2e/mcp-step-all.mjs
+//
+// Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BIN = process.env.FUNCTOR_BIN ?? `${ROOT}target/debug/functor`;
+const DIR = "examples/orbs";
+/** The ws port `examples/orbs` binds (`let bind = "127.0.0.1:9101"`). */
+const WS_PORT = 9101;
+/** Lockstep rounds per run. Enough to see the world move, short enough to run twice. */
+const ROUNDS = 12;
+const DTS = 0.016;
+
+/** A line-delimited JSON-RPC client over a child's stdio. */
+class Rpc {
+  constructor(proc) {
+    this.proc = proc;
+    this.pending = new Map();
+    this.nextId = 1;
+    this.buffer = "";
+    this.stderr = "";
+    proc.stdout.setEncoding("utf8");
+    proc.stdout.on("data", (chunk) => this.#onData(chunk));
+    proc.stderr.on("data", (chunk) => (this.stderr += chunk));
+  }
+
+  #onData(chunk) {
+    this.buffer += chunk;
+    let index;
+    while ((index = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, index).trim();
+      this.buffer = this.buffer.slice(index + 1);
+      if (!line) continue;
+      const message = JSON.parse(line);
+      const waiter = this.pending.get(message.id);
+      if (waiter) {
+        this.pending.delete(message.id);
+        clearTimeout(waiter.timer);
+        message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
+      }
+    }
+  }
+
+  notify(method, params) {
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    const result = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`));
+      }, 60000);
+      this.pending.set(id, { resolve, reject, timer });
+    });
+    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+    return result;
+  }
+
+  async call(name, args = {}) {
+    const result = await this.request("tools/call", { name, arguments: args });
+    const text = result.content.map((block) => block.text ?? "").join("");
+    if (result.isError) throw new Error(`${name} failed: ${text}`);
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+}
+
+const failures = [];
+const check = (ok, what) => {
+  console.log(`  ${ok ? "✓" : "✗"} ${what}`);
+  if (!ok) failures.push(what);
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Poll `get_state` until `predicate` holds, or fail loudly with the last state. */
+async function waitForState(rpc, session, predicate, what, timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  for (;;) {
+    last = await rpc.call("get_state", { session });
+    if (predicate(last)) return last;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${what}; last state: ${JSON.stringify(last.model)}`);
+    }
+    await sleep(100);
+  }
+}
+
+/** Wait until something is listening on a localhost TCP port.
+ *
+ * An orbs client dials ONCE with no retry, so a client launched before the
+ * server's `Sub.listen` has bound lands in "error" and never converges. The
+ * SDK's own multiplayer test gates on the same port for the same reason. */
+async function waitForPort(port, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const open = await new Promise((resolve) => {
+      const socket = connect({ host: "127.0.0.1", port });
+      socket.once("connect", () => (socket.destroy(), resolve(true)));
+      socket.once("error", () => (socket.destroy(), resolve(false)));
+    });
+    if (open) return;
+    if (Date.now() > deadline) throw new Error(`nothing listening on 127.0.0.1:${port}`);
+    await sleep(100);
+  }
+}
+
+/** The authority's ships: `world.pilots` is a list of `{ ship, intent }`. */
+const shipsOf = (state) => state.model.world.pilots.map((p) => p.ship);
+
+/** Every ship's position keyed by pid, the baseline a trace is measured from. */
+const positionsOf = (ships) => new Map(ships.map((s) => [s.pid, { x: s.x, y: s.y }]));
+
+/** The authority's world as a comparable string: each ship's DISPLACEMENT
+ * from the paused baseline, in pid order.
+ *
+ * Displacement rather than absolute position, because the absolute one is not
+ * a property of the stepping at all: it depends on how many wall-clock frames
+ * ran between launch and pause, which no driver controls. What the ordering
+ * law claims — and what this compares — is that N ordered rounds move the
+ * world by exactly the same amount every time. */
+const traceOf = (ships, base) =>
+  [...ships]
+    .sort((a, b) => a.pid - b.pid)
+    .map((s) => {
+      const from = base.get(s.pid);
+      if (!from) return `${s.pid}@unseated-at-baseline`;
+      return `${s.pid}@${(s.x - from.x).toFixed(6)},${(s.y - from.y).toFixed(6)}`;
+    })
+    .join(" ");
+
+/** One complete multiplayer run: launch, settle, pause, step in lockstep. */
+async function lockstepRun(rpc, label) {
+  // Server FIRST, and only launch a client once its listener is really bound:
+  // an orbs client dials once and never retries.
+  const server = (await rpc.call("launch_game", { dir: DIR, entry: "server", mode: "headless" })).session;
+  await waitForPort(WS_PORT);
+
+  // One client at a time, each seated before the next launches, so the pids
+  // the server hands out are the launch order rather than a race — the trace
+  // below is per-pid, and "which client is P0" must not vary between runs.
+  const c1 = (await rpc.call("launch_game", { dir: DIR, entry: "client", mode: "headless" })).session;
+  await waitForState(rpc, c1, (s) => s.model.myPid === 0, "client 1 to be seated as P0");
+  const c2 = (await rpc.call("launch_game", { dir: DIR, entry: "client", mode: "headless" })).session;
+  await waitForState(rpc, c2, (s) => s.model.myPid === 1, "client 2 to be seated as P1");
+
+  // Both clients drawing the server's world: the handshake is over and this is
+  // a three-party session rather than a race we got lucky in.
+  for (const [name, session] of [["1", c1], ["2", c2]]) {
+    await waitForState(rpc, session, (s) => s.model.ships.length === 2, `client ${name} to see both ships`);
+  }
+
+  // Nothing in orbs moves on its own — a pilot moves while THRUST is held. Hold
+  // it on client 1 (level state, so it stays held across every step below) and
+  // wait for the authority to have that intent, which is the game-level
+  // convergence check `step_all` deliberately does not pretend to provide.
+  await rpc.call("send_input", { session: c1, command: { type: "key", key: "w", down: true } });
+  const seated = await waitForState(
+    rpc,
+    server,
+    (s) => s.model.world.pilots.length === 2
+      && s.model.world.pilots.some((p) => p.ship.pid === 0 && p.intent.thrust === true),
+    "the server to seat both pilots and see P0 thrusting",
+  );
+
+  for (const session of [c1, server, c2]) await rpc.call("pause", { session });
+  // Quiescence: pausing pinned the CLOCK, not the sockets. `pending_net` is
+  // what says nothing already received is still unprocessed — without it a
+  // baseline can be snapshotted mid-delivery.
+  const quiescent = {};
+  for (const session of [c1, server, c2]) {
+    quiescent[session] = await waitForState(
+      rpc,
+      session,
+      (s) => s.pending_net === 0,
+      `session ${session} to go quiescent`,
+    );
+  }
+
+  const base = await rpc.call("get_state", { session: server });
+  const baseline = positionsOf(shipsOf(base));
+  const trace = [];
+  let firstResponse = null;
+  for (let round = 0; round < ROUNDS; round += 1) {
+    // The ordering law: producer → authority → observer.
+    const stepped = await rpc.call("step_all", { sessions: [c1, server, c2], dts: DTS });
+    firstResponse ??= stepped;
+    trace.push(traceOf(shipsOf(await rpc.call("get_state", { session: server })), baseline));
+  }
+
+  const final = await rpc.call("get_state", { session: server });
+  await rpc.call("send_input", { session: c1, command: { type: "key", key: "w", down: false } });
+  for (const session of [c1, c2, server]) await rpc.call("stop_game", { session }).catch(() => {});
+
+  return {
+    label,
+    sessions: [c1, server, c2],
+    seatedAt: seated.frame,
+    quiescent,
+    baseRevision: base.model_revision,
+    finalRevision: final.model_revision,
+    firstResponse,
+    trace,
+  };
+}
+
+const proc = spawn(BIN, ["mcp"], { cwd: ROOT, stdio: ["pipe", "pipe", "pipe"] });
+const rpc = new Rpc(proc);
+
+try {
+  await rpc.request("initialize", {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "functor-e2e-step-all", version: "0" },
+  });
+  rpc.notify("notifications/initialized", {});
+
+  console.log("▸ step_all validates the group before anything steps");
+  let empty = null;
+  try {
+    await rpc.call("step_all", { sessions: [] });
+  } catch (error) {
+    empty = error.message;
+  }
+  check(empty !== null && /producer/.test(empty), "an empty session list is a teaching error naming the order");
+
+  console.log("\n▸ run 1: three roles of examples/orbs, stepped in order");
+  const first = await lockstepRun(rpc, "run-1");
+  check(
+    first.firstResponse.sessions.map((s) => s.session).join(",") === first.sessions.join(","),
+    `step_all reports the sessions in the caller's order (${first.firstResponse.sessions.map((s) => s.session)})`,
+  );
+  check(
+    first.firstResponse.sessions.every((s) => s.pending_steps === 0),
+    "every session's steps had fully landed before step_all returned",
+  );
+  check(
+    first.firstResponse.sessions.every((s) => typeof s.model_revision === "number"),
+    "each summary carries the networked model_revision",
+  );
+  check(
+    first.finalRevision > first.baseRevision,
+    `the authority's model_revision advanced over the run (${first.baseRevision} → ${first.finalRevision})`,
+  );
+  check(new Set(first.trace).size > 1, "the world actually moved (the trace is not a constant)");
+
+  // The port must be free again before the second server binds.
+  await sleep(2000);
+
+  console.log("\n▸ run 2: the same run, from scratch");
+  const second = await lockstepRun(rpc, "run-2");
+  const same = first.trace.join(" | ") === second.trace.join(" | ");
+  check(same, "ORDERED stepping is exactly reproducible: both runs produced the same world trace");
+  if (!same) {
+    console.log(`    run-1: ${first.trace.join(" | ")}`);
+    console.log(`    run-2: ${second.trace.join(" | ")}`);
+  }
+
+  console.log("\n▸ save_project keeps a multi-entry project multi-entry");
+  // orbs is the SAME-FILE role shape: two inline modules of one `game.fun`, so
+  // the file set alone cannot say whether this is one role or two. That is
+  // exactly the manifest a reconstructed `{"entry":"game.fun"}` destroys.
+  const files = [
+    ["game.fun", readFileSync(join(ROOT, DIR, "game.fun"), "utf8")],
+    ["functor.json", readFileSync(join(ROOT, DIR, "functor.json"), "utf8")],
+  ];
+
+  const inline = await rpc.call("launch_game", { files, entry: "server", mode: "headless" });
+  const state = await rpc.call("get_state", { session: inline.session });
+  check(state.model.world !== undefined, "the inline multi-entry project booted the SERVER role");
+
+  const saveDir = mkdtempSync(join(tmpdir(), "functor-mcp-mp-save-"));
+  const saved = await rpc.call("save_project", { session: inline.session, dir: saveDir, overwrite: true });
+  check(saved.files.includes("functor.json"), `save_project wrote ${saved.files}`);
+  const manifest = JSON.parse(readFileSync(join(saveDir, "functor.json"), "utf8"));
+  check(
+    manifest.entries !== undefined && manifest.entries.server !== undefined,
+    `the saved manifest still declares the ROLES (${JSON.stringify(manifest)})`,
+  );
+  check(manifest.entry === undefined, "it was not reconstructed as a single-entry project");
+  await rpc.call("stop_game", { session: inline.session });
+
+  console.log("\n▸ launch_game's response is the version, not the whole index");
+  check(typeof inline.protocol_version === "number", `launch_game returns protocol_version ${inline.protocol_version}`);
+  check(inline.discovery === undefined, "the endpoint index is not repeated on every launch");
+  const verbose = await rpc.call("launch_game", { dir: "examples/counter", mode: "headless", discovery: true });
+  check(verbose.discovery?.service === "functor debug runtime", "discovery: true still returns the full index");
+  await rpc.call("stop_game", { session: verbose.session });
+} catch (error) {
+  failures.push(String(error?.stack ?? error));
+  console.error(error);
+} finally {
+  proc.stdin.end();
+}
+
+console.log(failures.length === 0 ? "\nAll multiplayer MCP checks passed." : `\n${failures.length} failure(s):`);
+for (const failure of failures) console.log(`  - ${failure}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/e2e/mcp-step-all.mjs
+++ b/e2e/mcp-step-all.mjs
@@ -28,87 +28,20 @@
 //   node e2e/mcp-step-all.mjs
 //
 // Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
-import { spawn } from "node:child_process";
 import { connect } from "node:net";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
-const BIN = process.env.FUNCTOR_BIN ?? `${ROOT}target/debug/functor`;
+// The raw JSON-RPC client is shared with e2e/mcp-server.mjs.
+import { check, failures, ROOT, sleep, startMcp } from "./mcp-rpc.mjs";
+
 const DIR = "examples/orbs";
 /** The ws port `examples/orbs` binds (`let bind = "127.0.0.1:9101"`). */
 const WS_PORT = 9101;
 /** Lockstep rounds per run. Enough to see the world move, short enough to run twice. */
 const ROUNDS = 12;
 const DTS = 0.016;
-
-/** A line-delimited JSON-RPC client over a child's stdio. */
-class Rpc {
-  constructor(proc) {
-    this.proc = proc;
-    this.pending = new Map();
-    this.nextId = 1;
-    this.buffer = "";
-    this.stderr = "";
-    proc.stdout.setEncoding("utf8");
-    proc.stdout.on("data", (chunk) => this.#onData(chunk));
-    proc.stderr.on("data", (chunk) => (this.stderr += chunk));
-  }
-
-  #onData(chunk) {
-    this.buffer += chunk;
-    let index;
-    while ((index = this.buffer.indexOf("\n")) >= 0) {
-      const line = this.buffer.slice(0, index).trim();
-      this.buffer = this.buffer.slice(index + 1);
-      if (!line) continue;
-      const message = JSON.parse(line);
-      const waiter = this.pending.get(message.id);
-      if (waiter) {
-        this.pending.delete(message.id);
-        clearTimeout(waiter.timer);
-        message.error ? waiter.reject(new Error(JSON.stringify(message.error))) : waiter.resolve(message.result);
-      }
-    }
-  }
-
-  notify(method, params) {
-    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
-  }
-
-  request(method, params) {
-    const id = this.nextId++;
-    const result = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`${method} timed out\nstderr:\n${this.stderr}`));
-      }, 60000);
-      this.pending.set(id, { resolve, reject, timer });
-    });
-    this.proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
-    return result;
-  }
-
-  async call(name, args = {}) {
-    const result = await this.request("tools/call", { name, arguments: args });
-    const text = result.content.map((block) => block.text ?? "").join("");
-    if (result.isError) throw new Error(`${name} failed: ${text}`);
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-}
-
-const failures = [];
-const check = (ok, what) => {
-  console.log(`  ${ok ? "✓" : "✗"} ${what}`);
-  if (!ok) failures.push(what);
-};
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /** Poll `get_state` until `predicate` holds, or fail loudly with the last state. */
 async function waitForState(rpc, session, predicate, what, timeoutMs = 20000) {
@@ -242,17 +175,9 @@ async function lockstepRun(rpc, label) {
   };
 }
 
-const proc = spawn(BIN, ["mcp"], { cwd: ROOT, stdio: ["pipe", "pipe", "pipe"] });
-const rpc = new Rpc(proc);
+const { proc, rpc } = await startMcp("functor-e2e-step-all");
 
 try {
-  await rpc.request("initialize", {
-    protocolVersion: "2025-06-18",
-    capabilities: {},
-    clientInfo: { name: "functor-e2e-step-all", version: "0" },
-  });
-  rpc.notify("notifications/initialized", {});
-
   console.log("▸ step_all validates the group before anything steps");
   let empty = null;
   try {
@@ -261,6 +186,14 @@ try {
     empty = error.message;
   }
   check(empty !== null && /producer/.test(empty), "an empty session list is a teaching error naming the order");
+
+  let unknown = null;
+  try {
+    await rpc.call("step_all", { sessions: ["s99"] });
+  } catch (error) {
+    unknown = error.message;
+  }
+  check(unknown !== null && !/already advanced/.test(unknown), "an unresolvable session fails before anything steps");
 
   console.log("\n▸ run 1: three roles of examples/orbs, stepped in order");
   const first = await lockstepRun(rpc, "run-1");
@@ -288,7 +221,11 @@ try {
   console.log("\n▸ run 2: the same run, from scratch");
   const second = await lockstepRun(rpc, "run-2");
   const same = first.trace.join(" | ") === second.trace.join(" | ");
-  check(same, "ORDERED stepping is exactly reproducible: both runs produced the same world trace");
+  // Reproducibility here is EVIDENCE, not a proof: ordering removes the
+  // stepping race, but nothing can fence a packet still on the wire (see
+  // docs/mcp.md, "What it does not promise"). This is the regression guard for
+  // the ordering — a concurrent stepAll fails it.
+  check(same, "the ordered lockstep reproduced the identical world trace across two fresh runs");
   if (!same) {
     console.log(`    run-1: ${first.trace.join(" | ")}`);
     console.log(`    run-2: ${second.trace.join(" | ")}`);

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:runtime-target": "node e2e/runtime-target.mjs",
     "test:xr-injection": "cargo build -p functor-cli --no-default-features && node e2e/xr-pose-injection.mjs",
     "test:mcp": "cargo build -p functor-cli --no-default-features && node e2e/mcp-server.mjs",
+    "test:mcp-step-all": "cargo build -p functor-cli --no-default-features && node e2e/mcp-step-all.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:detached-camera": "node site/demos/detached-camera.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -242,8 +242,14 @@ pub struct RuntimeState {
     /// pausing pins the CLOCK, not the transport, so a paused session keeps
     /// folding inbound messages through `update` while `frame` stands still.
     /// A driver that wants "did anything land since my snapshot" compares this.
-    /// A hot reload REBINDS the model rather than replacing it and does not
-    /// count. `default` because a pre-v10 runtime omits it.
+    ///
+    /// It counts replacements BY GAME LOGIC. Replacing the model from OUTSIDE
+    /// the game deliberately does not count: a hot reload (which rebinds it),
+    /// a whole-project load, a `/rewind` or a timeline seek. Those are things
+    /// the driver itself just performed, and each hands back fresh state to
+    /// re-baseline from — a counter that moved for them too could not tell
+    /// "the network changed my model" from "I rewound it". `default` because a
+    /// pre-v10 runtime omits it.
     #[serde(default)]
     pub model_revision: u64,
     /// Inbound network events the shell has accepted from its transport and

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -53,7 +53,16 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// contract (so `functor run vr` refuses to push a role to one), and a v9
 /// runtime treats a push with no role query as "the role already in force
 /// stands".
-pub const DEBUG_PROTOCOL_VERSION: u32 = 9;
+///
+/// 10 added `model_revision` and `pending_net` to `GET /state`, the two facts
+/// a driver of a NETWORKED session cannot derive from `frame`: pausing freezes
+/// the clock, not the transport, so a paused game's model still changes as
+/// inbound messages fold through `update`. `model_revision` counts model
+/// replacements and `pending_net` reports the shell's undelivered inbound
+/// events. Additive — a pre-v10 runtime simply omits both, which deserializes
+/// as `0`; a client that waits on either must gate on the version rather than
+/// read a constant zero as "quiescent".
+pub const DEBUG_PROTOCOL_VERSION: u32 = 10;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -107,7 +116,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), model_revision (model replacements so far — the version label for a networked model, since pause freezes the clock and not the network), pending_net (inbound network events accepted but not yet delivered to the game), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -224,6 +233,28 @@ pub struct RuntimeState {
     /// every requested step has been simulated, which is how a harness knows a
     /// batched advance has fully landed without guessing a frame target.
     pub pending_steps: u32,
+    /// How many times the game's model has been REPLACED by game logic since
+    /// the program loaded — every `tick`/`input`/`update` return and every
+    /// effect or network fold, counted at the producer's single model
+    /// assignment.
+    ///
+    /// This is the version label for a networked model, and `frame` is not:
+    /// pausing pins the CLOCK, not the transport, so a paused session keeps
+    /// folding inbound messages through `update` while `frame` stands still.
+    /// A driver that wants "did anything land since my snapshot" compares this.
+    /// A hot reload REBINDS the model rather than replacing it and does not
+    /// count. `default` because a pre-v10 runtime omits it.
+    #[serde(default)]
+    pub model_revision: u64,
+    /// Inbound network events the shell has accepted from its transport and
+    /// not yet delivered into the game
+    /// ([`crate::net::inbound_pending`]) — connection events and completed
+    /// HTTP responses. Zero is the quiescence signal a harness waits on before
+    /// snapshotting a baseline; it cannot see a packet still on the wire, so it
+    /// is a lower bound on outstanding network work. `default` because a
+    /// pre-v10 runtime omits it.
+    #[serde(default)]
+    pub pending_net: u64,
     pub viewport: RuntimeViewport,
     pub views: Vec<RuntimeView>,
     /// The structured JSON view of the model
@@ -609,6 +640,8 @@ mod tests {
             frame: 42,
             tts: 1.5,
             pending_steps: 3,
+            model_revision: 17,
+            pending_net: 2,
             viewport: RuntimeViewport::new(1920, 1080),
             views: vec![RuntimeView::new("main", 1920, 1080)],
             model: json!({ "label": "hello" }),
@@ -634,6 +667,8 @@ mod tests {
                 "frame": 42,
                 "tts": 1.5,
                 "pending_steps": 3,
+                "model_revision": 17,
+                "pending_net": 2,
                 "viewport": { "width": 1920, "height": 1080 },
                 "views": [{
                     "name": "main",
@@ -858,6 +893,27 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 9);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 10);
+    }
+
+    /// The v10 fields are ADDITIVE: a pre-v10 payload (which carries neither)
+    /// still deserializes, reading `0` for both. That is exactly why a client
+    /// waiting on either must gate on `protocol_version` first — a constant
+    /// zero from an old runtime is indistinguishable from real quiescence.
+    #[test]
+    fn a_pre_v10_state_payload_still_decodes_with_zeroed_v10_fields() {
+        let state: RuntimeState = serde_json::from_value(json!({
+            "frame": 7,
+            "tts": 0.5,
+            "pending_steps": 0,
+            "viewport": { "width": 8, "height": 8 },
+            "views": [],
+            "model": null,
+            "model_debug": "",
+            "input": serde_json::to_value(InputSnapshot::default()).unwrap(),
+        }))
+        .expect("a pre-v10 /state payload decodes");
+        assert_eq!(state.model_revision, 0);
+        assert_eq!(state.pending_net, 0);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -103,6 +103,11 @@ pub struct FunctorLangEmbeddedGame {
     module: functor_lang::ir::Module,
     session: Session,
     model: Value,
+    /// How many times [`Self::model`] has been replaced by game logic — the
+    /// debug protocol's `model_revision`. Counted by `FrameCtx::absorb`, and
+    /// deliberately NOT reset by a hot reload (which rebinds the model rather
+    /// than replacing it), so it stays monotone for the life of the process.
+    model_revision: u64,
     has_input: bool,
     has_sampled_input: bool,
     /// The shell samples physical state before a fixed simulation step. Hold
@@ -345,6 +350,7 @@ impl FunctorLangEmbeddedGame {
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
+            model_revision: 0,
             has_input: loaded.has_input,
             has_sampled_input: loaded.has_sampled_input,
             pending_sampled_input: None,
@@ -569,6 +575,7 @@ impl FunctorLangEmbeddedGame {
             session: &self.session,
             names: &self.names,
             model: &mut self.model,
+            model_revision: &mut self.model_revision,
             physics_rt: &mut self.physics_rt,
             physics_frame: &mut self.physics_frame,
             recorder: &mut self.recorder,
@@ -1084,6 +1091,10 @@ AudioScene.empty), got {}",
 
     fn state_json(&self) -> serde_json::Value {
         crate::functor_lang_prelude::value_to_json(&self.model)
+    }
+
+    fn model_revision(&self) -> u64 {
+        self.model_revision
     }
 
     /// The paused-inspector trace (visual-debugger PR2b), same contract and

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -9828,6 +9828,8 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
             frame: 1,
             tts: 0.0,
             pending_steps: 0,
+            model_revision: 0,
+            pending_net: 0,
             viewport: crate::debug_protocol::RuntimeViewport::new(1, 1),
             views: vec![],
             model: value_to_json(&value),

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -717,6 +717,11 @@ pub struct FrameCtx<'a> {
     /// canonical lookup and error message in the frame body goes through it.
     pub names: &'a EntryNames,
     pub model: &'a mut Value,
+    /// How many times `model` has been replaced (see [`FrameCtx::absorb`], the
+    /// producer's single model assignment). The debug protocol reports it as
+    /// `model_revision`: the version label for a model a NETWORK can change
+    /// while the clock is paused and `frame` stands still.
+    pub model_revision: &'a mut u64,
     pub physics_rt: &'a mut SteppedPhysics,
     /// The physics world's current fixed frame (what the coupled scene
     /// recorder stores per rendered frame).
@@ -1200,9 +1205,15 @@ impl FrameCtx<'_> {
     /// adopt the model, and drain the effects to a fixed point through `update`
     /// (docs/functor-lang.md B6). Every producer path that runs game code funnels through
     /// here, so effects work uniformly from tick, input, mouse, and messages.
+    ///
+    /// It is therefore also the producer's single model ASSIGNMENT, and where
+    /// `model_revision` is counted: every replacement, whatever ran the game
+    /// code — a stepped `tick`, an injected input, or an inbound network
+    /// message folding through `update` while the clock is paused.
     pub fn absorb(&mut self, returned: Value) {
         let (model, effects) = split_model_effect(returned);
         *self.model = model;
+        *self.model_revision = self.model_revision.saturating_add(1);
         // Effects are commands, not data — one stored in the model would make
         // the pair sniff ambiguous on a later return (see `split_model_effect`).
         if contains_effect(self.model) {
@@ -1849,10 +1860,12 @@ fn forward_step_scene_with_error(
 
     let result = {
         let mut clock = clock;
+        let mut model_revision = 0u64;
         let mut ctx = FrameCtx {
             session,
             names,
             model: &mut model,
+            model_revision: &mut model_revision,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
             recorder: &mut dry_recorder,
@@ -2713,10 +2726,12 @@ mod tests {
             },
             silent_emit,
         );
+        let mut model_revision = 0u64;
         let mut ctx = FrameCtx {
             session,
             names: &EntryNames::UNPREFIXED,
             model,
+            model_revision: &mut model_revision,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
             recorder: &mut recorder,
@@ -2879,10 +2894,12 @@ mod tests {
             },
             silent_emit,
         );
+        let mut model_revision = 0u64;
         let mut ctx = FrameCtx {
             session,
             names: &EntryNames::UNPREFIXED,
             model,
+            model_revision: &mut model_revision,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
             recorder: &mut recorder,
@@ -2940,10 +2957,12 @@ mod tests {
             },
             silent_emit,
         );
+        let mut model_revision = 0u64;
         let mut ctx = FrameCtx {
             session,
             names: &EntryNames::UNPREFIXED,
             model,
+            model_revision: &mut model_revision,
             physics_rt: &mut physics_rt,
             physics_frame: &mut physics_frame,
             recorder: &mut recorder,
@@ -3148,6 +3167,7 @@ mod tests {
     struct PhysicsHarness {
         session: Session,
         model: Value,
+        model_revision: u64,
         physics_rt: SteppedPhysics,
         physics_frame: u64,
         recorder: SceneRecorder,
@@ -3175,6 +3195,7 @@ mod tests {
             PhysicsHarness {
                 session,
                 model,
+                model_revision: 0,
                 physics_rt: SteppedPhysics::new(),
                 physics_frame: 0,
                 recorder: SceneRecorder::new(),
@@ -3202,6 +3223,7 @@ mod tests {
                 session: &self.session,
                 names: &EntryNames::UNPREFIXED,
                 model: &mut self.model,
+                model_revision: &mut self.model_revision,
                 physics_rt: &mut self.physics_rt,
                 physics_frame: &mut self.physics_frame,
                 recorder: &mut self.recorder,

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1206,10 +1206,12 @@ impl FrameCtx<'_> {
     /// (docs/functor-lang.md B6). Every producer path that runs game code funnels through
     /// here, so effects work uniformly from tick, input, mouse, and messages.
     ///
-    /// It is therefore also the producer's single model ASSIGNMENT, and where
-    /// `model_revision` is counted: every replacement, whatever ran the game
-    /// code — a stepped `tick`, an injected input, or an inbound network
-    /// message folding through `update` while the clock is paused.
+    /// It is therefore also the producer's single model ASSIGNMENT BY GAME
+    /// LOGIC, and where `model_revision` is counted: a stepped `tick`, an
+    /// injected input, or an inbound network message folding through `update`
+    /// while the clock is paused. The producers' own replacements (reload,
+    /// project load, timeline seek) go around it and deliberately do not
+    /// count — see [`crate::protocol::GameProducer::model_revision`].
     pub fn absorb(&mut self, returned: Value) {
         let (model, effects) = split_model_effect(returned);
         *self.model = model;

--- a/runtime/functor-runtime-common/src/net/mod.rs
+++ b/runtime/functor-runtime-common/src/net/mod.rs
@@ -22,6 +22,66 @@ pub use inbox::*;
 pub use registry::*;
 pub use virtual_net::*;
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Inbound network events a shell has accepted from its transport but has not
+/// yet delivered into the game — the debug protocol's `pending_net`.
+///
+/// The shells receive connection events and completed HTTP responses on
+/// background threads/tasks and hand them to the game once per rendered frame
+/// (`deliver_net_ws`). The channel in between has no observable depth, so the
+/// gauge is kept here instead: a shell counts an event UP before it queues it
+/// and DOWN as it delivers it, which makes the gauge err high for an instant
+/// rather than reporting quiescence while an event is in flight.
+///
+/// It is a lower bound on outstanding network work — a packet still on the
+/// wire between two processes is invisible to every process — but it is the
+/// fact a driver needs before snapshotting a baseline: nothing already
+/// received is still unprocessed.
+static INBOUND_PENDING: AtomicU64 = AtomicU64::new(0);
+
+/// Shell: one inbound event is being queued for the game.
+pub fn note_inbound_queued() {
+    INBOUND_PENDING.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Shell: one queued inbound event has been delivered (or could not be
+/// queued at all). Saturating, so a miscounted shell cannot wrap the gauge.
+pub fn note_inbound_delivered() {
+    let _ = INBOUND_PENDING.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |pending| {
+        Some(pending.saturating_sub(1))
+    });
+}
+
+/// The current inbound queue depth, for `GET /state`'s `pending_net`.
+pub fn inbound_pending() -> u64 {
+    INBOUND_PENDING.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod inbound_gauge_tests {
+    use super::*;
+
+    /// The gauge tracks queued-minus-delivered, and a delivery a shell reports
+    /// without a matching queue SATURATES rather than wrapping — a miscount
+    /// must not turn `pending_net` into 18 quintillion, which a harness would
+    /// read as "never quiescent" forever.
+    #[test]
+    fn the_inbound_gauge_counts_up_and_saturates_down() {
+        let base = inbound_pending();
+        note_inbound_queued();
+        note_inbound_queued();
+        assert_eq!(inbound_pending(), base + 2);
+        note_inbound_delivered();
+        note_inbound_delivered();
+        assert_eq!(inbound_pending(), base);
+        if base == 0 {
+            note_inbound_delivered();
+            assert_eq!(inbound_pending(), 0);
+        }
+    }
+}
+
 /// Stable identifier for one connection, assigned by the runtime and reported to
 /// the game via [`NetEvent::Connected`]. It is plain data: the game stores it in
 /// its model and names it when sending (so outbound `Effect`s stay plain data and

--- a/runtime/functor-runtime-common/src/net/mod.rs
+++ b/runtime/functor-runtime-common/src/net/mod.rs
@@ -53,6 +53,17 @@ pub fn note_inbound_delivered() {
     });
 }
 
+/// Hand one inbound event to the shell's frame loop over `tx`, counting it in
+/// the gauge — the ONE way a shell should queue inbound work, so a transport
+/// added later cannot forget to count. A send that fails (the loop is gone)
+/// counts straight back down, since nothing will ever deliver it.
+pub fn send_inbound<T>(tx: &std::sync::mpsc::Sender<T>, event: T) {
+    note_inbound_queued();
+    if tx.send(event).is_err() {
+        note_inbound_delivered();
+    }
+}
+
 /// The current inbound queue depth, for `GET /state`'s `pending_net`.
 pub fn inbound_pending() -> u64 {
     INBOUND_PENDING.load(Ordering::Relaxed)

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -412,7 +412,10 @@ pub trait GameProducer {
     ///
     /// It exists because `frame` is not a version label for a NETWORKED
     /// model: pausing pins the clock, not the transport, so inbound messages
-    /// keep folding through `update` while `frame` stands still. The default,
+    /// keep folding through `update` while `frame` stands still. It counts
+    /// replacements by GAME LOGIC only — a reload, a project load, and a
+    /// timeline rewind replace the model without counting, because the driver
+    /// performing one already knows it did. The default,
     /// `0`, is the honest answer for a producer whose model never changes
     /// under it (the replay producer replays recorded frames).
     fn model_revision(&self) -> u64 {

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -405,6 +405,20 @@ pub trait GameProducer {
         serde_json::Value::Null
     }
 
+    /// How many times the live model has been REPLACED since the program
+    /// loaded (the debug server's `GET /state` `model_revision`, protocol
+    /// v10) — every entry point's return and every effect or network fold,
+    /// counted at the producer's single model assignment.
+    ///
+    /// It exists because `frame` is not a version label for a NETWORKED
+    /// model: pausing pins the clock, not the transport, so inbound messages
+    /// keep folding through `update` while `frame` stands still. The default,
+    /// `0`, is the honest answer for a producer whose model never changes
+    /// under it (the replay producer replays recorded frames).
+    fn model_revision(&self) -> u64 {
+        0
+    }
+
     /// The paused-inspector trace (visual-debugger PR2): the wire-contract JSON
     /// for the last real frame's entry-point invocations, replayed on demand
     /// while paused (the debug server's `GET /trace`). `paused` is the shell's

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -95,6 +95,11 @@ pub struct FunctorLangGame {
     module: functor_lang::ir::Module,
     session: Session,
     model: Value,
+    /// How many times [`Self::model`] has been replaced by game logic — the
+    /// debug protocol's `model_revision`. Counted by `FrameCtx::absorb`, and
+    /// deliberately NOT reset by a hot reload (which rebinds the model rather
+    /// than replacing it), so it stays monotone for the life of the process.
+    model_revision: u64,
     has_input: bool,
     has_sampled_input: bool,
     /// The shell samples physical state before a fixed simulation step. Hold
@@ -453,6 +458,7 @@ impl FunctorLangGame {
             module: loaded.module,
             session: loaded.session,
             model: loaded.init,
+            model_revision: 0,
             has_input: loaded.has_input,
             has_sampled_input: loaded.has_sampled_input,
             pending_sampled_input: None,
@@ -514,6 +520,7 @@ impl FunctorLangGame {
             session: &self.session,
             names: &self.names,
             model: &mut self.model,
+            model_revision: &mut self.model_revision,
             physics_rt: &mut self.physics_rt,
             physics_frame: &mut self.physics_frame,
             recorder: &mut self.recorder,
@@ -1377,6 +1384,10 @@ AudioScene.empty), got {}",
         functor_runtime_common::functor_lang_prelude::value_to_json(&self.model)
     }
 
+    fn model_revision(&self) -> u64 {
+        self.model_revision
+    }
+
     /// The paused-inspector trace (visual-debugger PR2). When NOT paused, a
     /// cheap early-out: `paused: false` with empty invocations — and NO
     /// `frame`/`tts`, which change every frame: the LSP's idle poll dedups on
@@ -1706,6 +1717,68 @@ mod tests {
         assert!(cmds
             .iter()
             .any(|c| matches!(c, ConnCommand::Send { conn: 22, payload } if payload == b"ping")));
+    }
+
+    /// `model_revision` is the version label a NETWORKED session needs, and
+    /// `frame` is not: an inbound message folds through `update` with no tick
+    /// at all — which is exactly what a paused authority does, since pausing
+    /// pins the clock and not the transport. So a delivery with no step must
+    /// still move the revision, and a delivery the game ignores must not.
+    #[test]
+    fn model_revision_counts_network_folds_that_no_tick_ran() {
+        let _guard = NET_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        use functor_runtime_common::net::drain_conn_commands;
+        const BIND: &str = "127.0.0.1:9002";
+        let dir = std::env::temp_dir().join(format!("functor-lang-net-rev-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("game.fun"),
+            "type Model = { clients: Float }\n\
+             type Msg = | Joined(id: Float) | Other\n\
+             let toMsg = (ev: Net.NetEvent): Msg =>\n\
+               match ev with\n\
+               | Net.Connected(id) => Joined(id)\n\
+               | Net.Message(id, text) => Other\n\
+               | Net.Disconnected(id) => Other\n\
+               | Net.Error(id, e) => Other\n\
+             let init = { clients: 0.0 }\n\
+             let update = (m: Model, msg: Msg) =>\n\
+               match msg with\n\
+               | Joined(id) => { m with clients: m.clients + 1.0 }\n\
+               | Other => m\n\
+             let subscriptions = (m: Model) => Sub.listen(\"127.0.0.1:9002\", toMsg)\n\
+             let tick = (m: Model, dt: Float, tts: Float) => m\n\
+             let draw = (m: Model, tts: Float) =>\n\
+               Frame.create(Camera3D.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n",
+        )
+        .unwrap();
+        let _ = drain_conn_commands();
+        let mut game = FunctorLangGame::create(dir.join("game.fun").to_str().unwrap());
+        game.tick(FrameTime {
+            tts: 0.0,
+            dts: 0.016,
+        });
+        let _ = drain_conn_commands();
+
+        // No tick from here on: every later revision is network-driven.
+        let quiet = game.model_revision();
+        game.net_push_connected(BIND.to_string(), 11);
+        let after_join = game.model_revision();
+        assert!(
+            after_join > quiet,
+            "a fold with no tick must move the revision ({quiet} -> {after_join})"
+        );
+        assert!(
+            game.state_debug().contains("clients: 1"),
+            "{}",
+            game.state_debug()
+        );
+
+        // Monotone, and it counts the FOLD rather than the change: a second
+        // client is a second revision.
+        game.net_push_connected(BIND.to_string(), 22);
+        assert!(game.model_revision() > after_join);
     }
 
     /// Write `src` as `game.fun` in its own temp directory (a directory is

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -829,12 +829,20 @@ unsafe fn capture_framebuffer(gl: &glow::Context, width: u32, height: u32, path:
 
 /// Deliver async HTTP + WebSocket results into the game's inbox *before* tick, so
 /// this frame's executor drain sees them.
+///
+/// This is also where the `pending_net` gauge comes back down: a sender counts
+/// an event UP before it reaches the channel (`ws_host`, and the HTTP dispatch
+/// below), and every event delivered here counts DOWN. Counting in that order
+/// means the gauge can read high for an instant but never reads 0 while
+/// something already received is still undelivered — which is the only
+/// direction a driver waiting for quiescence can safely trust.
 fn deliver_net_ws(
     game: &mut dyn Game,
     net_rx: &std::sync::mpsc::Receiver<net_dispatch::NetResult>,
     ws_rx: &std::sync::mpsc::Receiver<ws_host::HostNetEvent>,
 ) {
     while let Ok(result) = net_rx.try_recv() {
+        functor_runtime_common::net::note_inbound_delivered();
         match result {
             net_dispatch::NetResult::Response {
                 token,
@@ -847,6 +855,7 @@ fn deliver_net_ws(
         }
     }
     while let Ok(event) = ws_rx.try_recv() {
+        functor_runtime_common::net::note_inbound_delivered();
         match event {
             ws_host::HostNetEvent::Connected { key, id } => game.net_push_connected(key, id as i32),
             ws_host::HostNetEvent::Message { key, id, text } => {
@@ -878,7 +887,11 @@ fn dispatch_net_ws(
                     let tx = net_tx.clone();
                     let client = http_client.clone();
                     tokio::spawn(async move {
-                        let _ = tx.send(net_dispatch::perform_http(&client, cmd).await);
+                        let result = net_dispatch::perform_http(&client, cmd).await;
+                        functor_runtime_common::net::note_inbound_queued();
+                        if tx.send(result).is_err() {
+                            functor_runtime_common::net::note_inbound_delivered();
+                        }
                     });
                 }
             }
@@ -945,6 +958,8 @@ fn service_debug_request(
                 frame: *frame_count,
                 tts,
                 pending_steps: clock.pending_steps(),
+                model_revision: game.model_revision(),
+                pending_net: functor_runtime_common::net::inbound_pending(),
                 viewport: debug_server::RuntimeViewport::new(width, height),
                 views: vec![debug_server::RuntimeView::new("main", width, height)],
                 model: game.state_json(),

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -888,10 +888,9 @@ fn dispatch_net_ws(
                     let client = http_client.clone();
                     tokio::spawn(async move {
                         let result = net_dispatch::perform_http(&client, cmd).await;
-                        functor_runtime_common::net::note_inbound_queued();
-                        if tx.send(result).is_err() {
-                            functor_runtime_common::net::note_inbound_delivered();
-                        }
+                        // The same counted hand-off `ws_host` uses: an HTTP
+                        // response is inbound network work like any other.
+                        functor_runtime_common::net::send_inbound(&tx, result);
                     });
                 }
             }

--- a/runtime/functor-runtime-desktop/src/ws_host.rs
+++ b/runtime/functor-runtime-desktop/src/ws_host.rs
@@ -59,10 +59,7 @@ struct EventTx(Sender<HostNetEvent>);
 
 impl EventTx {
     fn send(&self, event: HostNetEvent) {
-        functor_runtime_common::net::note_inbound_queued();
-        if self.0.send(event).is_err() {
-            functor_runtime_common::net::note_inbound_delivered();
-        }
+        functor_runtime_common::net::send_inbound(&self.0, event);
     }
 }
 

--- a/runtime/functor-runtime-desktop/src/ws_host.rs
+++ b/runtime/functor-runtime-desktop/src/ws_host.rs
@@ -45,6 +45,27 @@ pub enum HostNetEvent {
     },
 }
 
+/// The inbound-event sender every socket task holds — a `Sender<HostNetEvent>`
+/// that also maintains the shell's `pending_net` gauge (`GET /state`,
+/// protocol v10).
+///
+/// It is a newtype rather than a bare `Sender` so a socket path added later
+/// cannot forget to count: there is exactly one way to hand an event to the
+/// main loop, and it counts. The count goes UP before the event is queued and
+/// back DOWN either when `deliver_net_ws` hands it to the game, or immediately
+/// if the main loop is gone and the send fails.
+#[derive(Clone)]
+struct EventTx(Sender<HostNetEvent>);
+
+impl EventTx {
+    fn send(&self, event: HostNetEvent) {
+        functor_runtime_common::net::note_inbound_queued();
+        if self.0.send(event).is_err() {
+            functor_runtime_common::net::note_inbound_delivered();
+        }
+    }
+}
+
 /// What a per-connection task should do next.
 enum OutMsg {
     Send(Vec<u8>),
@@ -67,7 +88,7 @@ pub struct WsManager {
     /// Active listeners: bind key -> accept-loop task.
     listeners: HashMap<String, tokio::task::JoinHandle<()>>,
     next_id: Arc<AtomicU64>,
-    events: Sender<HostNetEvent>,
+    events: EventTx,
 }
 
 impl WsManager {
@@ -77,7 +98,7 @@ impl WsManager {
             client_by_key: HashMap::new(),
             listeners: HashMap::new(),
             next_id: Arc::new(AtomicU64::new(1)),
-            events,
+            events: EventTx(events),
         }
     }
 
@@ -152,13 +173,13 @@ async fn run_client(
     key: String,
     id: u64,
     url: String,
-    events: Sender<HostNetEvent>,
+    events: EventTx,
     conns: SharedConns,
 ) {
     let ws = match tokio_tungstenite::connect_async(&url).await {
         Ok((ws, _resp)) => ws,
         Err(e) => {
-            let _ = events.send(HostNetEvent::Error {
+            events.send(HostNetEvent::Error {
                 key,
                 id,
                 message: e.to_string(),
@@ -175,13 +196,13 @@ async fn accept_loop(
     key: String,
     addr: String,
     next_id: Arc<AtomicU64>,
-    events: Sender<HostNetEvent>,
+    events: EventTx,
     conns: SharedConns,
 ) {
     let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(l) => l,
         Err(e) => {
-            let _ = events.send(HostNetEvent::Error {
+            events.send(HostNetEvent::Error {
                 key,
                 id: 0,
                 message: format!("bind {addr}: {e}"),
@@ -200,7 +221,7 @@ async fn accept_loop(
                     match tokio_tungstenite::accept_async(stream).await {
                         Ok(ws) => serve(ws, key, id, events, conns).await,
                         Err(e) => {
-                            let _ = events.send(HostNetEvent::Error {
+                            events.send(HostNetEvent::Error {
                                 key,
                                 id,
                                 message: e.to_string(),
@@ -221,7 +242,7 @@ async fn serve<S>(
     ws: tokio_tungstenite::WebSocketStream<S>,
     key: String,
     id: u64,
-    events: Sender<HostNetEvent>,
+    events: EventTx,
     conns: SharedConns,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
@@ -234,7 +255,7 @@ async fn serve<S>(
             key: key.clone(),
         },
     );
-    let _ = events.send(HostNetEvent::Connected {
+    events.send(HostNetEvent::Connected {
         key: key.clone(),
         id,
     });
@@ -260,10 +281,10 @@ async fn serve<S>(
             },
             incoming = read.next() => match incoming {
                 Some(Ok(Message::Text(text))) => {
-                    let _ = events.send(HostNetEvent::Message { key: key.clone(), id, text });
+                    events.send(HostNetEvent::Message { key: key.clone(), id, text });
                 }
                 Some(Ok(Message::Binary(data))) => {
-                    let _ = events.send(HostNetEvent::Message {
+                    events.send(HostNetEvent::Message {
                         key: key.clone(),
                         id,
                         text: String::from_utf8_lossy(&data).to_string(),
@@ -272,7 +293,7 @@ async fn serve<S>(
                 Some(Ok(Message::Close(_))) | None => break,
                 Some(Ok(_)) => {}
                 Some(Err(e)) => {
-                    let _ = events.send(HostNetEvent::Error { key: key.clone(), id, message: e.to_string() });
+                    events.send(HostNetEvent::Error { key: key.clone(), id, message: e.to_string() });
                     break;
                 }
             },
@@ -280,7 +301,7 @@ async fn serve<S>(
     }
 
     conns.lock().unwrap().remove(&id);
-    let _ = events.send(HostNetEvent::Disconnected { key, id });
+    events.send(HostNetEvent::Disconnected { key, id });
 }
 
 #[cfg(test)]

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -639,6 +639,11 @@ fn service_debug_request(
                 frame: debug.frame_count,
                 tts: clock.current_tts(),
                 pending_steps: clock.pending_steps(),
+                model_revision: game.model_revision(),
+                // The device shell delivers inbound net events through the same
+                // process-global gauge the desktop shell counts on; it reads 0
+                // until a device transport counts into it.
+                pending_net: functor_runtime_common::net::inbound_pending(),
                 viewport: RuntimeViewport::new(width, height),
                 views,
                 model: game.state_json(),

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -345,7 +345,14 @@ export async function waitFor<T>(
  *
  * Rejects (via `Promise.all`) if any client's step fails — but the others may
  * already have advanced, so a rejection means the simulation is desynced with
- * no automatic rollback; treat it as terminal for the run. */
+ * no automatic rollback; treat it as terminal for the run.
+ *
+ * Concurrent stepping is **not reproducible** across runs when the clients
+ * talk to each other: whether a client's packet reaches the authority before
+ * or after the authority's own step is a race. When the run must repeat
+ * exactly, step producer → authority → observer sequentially instead (each
+ * step awaited before the next begins) — the ordering law in
+ * `docs/mcp.md`, which the MCP `step_all` tool enforces. */
 export function stepAll(
   clients: readonly Pick<FunctorClient, "step">[],
   dts: number = DEFAULT_STEP_DT,

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -121,6 +121,16 @@ export interface RuntimeState {
   /** Clock steps queued by `advance` that have not run yet. `0` means every
    * requested step has been simulated. */
   pending_steps: number;
+  /** How many times the model has been REPLACED by game logic since load —
+   * the version label for a NETWORKED model, since pausing pins the clock and
+   * not the transport, so a paused game keeps folding inbound messages while
+   * `frame` stands still. Protocol v10+; a pre-v10 runtime omits it. */
+  model_revision?: number;
+  /** Inbound network events the shell has accepted but not yet delivered to
+   * the game. Poll until `0` for quiescence before snapshotting a baseline.
+   * Protocol v10+; a pre-v10 runtime omits it, so gate on `protocol_version`
+   * rather than reading a missing field as quiescent. */
+  pending_net?: number;
   /** Combined/legacy output extent. Use `views` when view identity matters. */
   viewport: RuntimeViewport;
   views: RuntimeView[];


### PR DESCRIPTION
Phase 1 of the **agent-driven multiplayer** track (design doc Addendum 7), with every item evidence-ranked by a probe experiment: an agent built a multiplayer game from scratch and evaluated it over `functor mcp`, then reported ranked friction. This PR is that report, implemented.

**`step_all`** — the missing multi-session primitive. `{sessions, dts?, frames?}` steps strictly sequentially in the caller's declared order, draining each session's step queue (`pending_steps → 0`) *and* its already-received network events (`pending_net → 0`) before the next session steps. Documented with the ordering law the probe discovered empirically (step producer → authority → observer; concurrent stepping is not reproducible — 19 vs 20 across identical runs) and an explicit "what it does not promise" (it is not a transport barrier). A new e2e (`e2e/mcp-step-all.mjs`) proves it: two from-scratch three-role orbs sessions, ordered lockstep, byte-identical displacement traces — run 3× flake-free.

**`/state` v10: `model_revision` + `pending_net`** — the probe's sharpest finding was that *pause freezes the clock, not the network*: a "paused" server absorbed 76 model mutations from inbound messages, and nothing on any endpoint said so. `model_revision` (counted at `FrameCtx::absorb`, the single choke point where game logic replaces the model — tick, input, effect folds, and network delivery all count identically; reload/seek replacements deliberately don't, as documented) is the honest version label `frame` never was. `pending_net` (a high-side-counted gauge on the one inbound hand-off) gives harnesses a quiescence signal before snapshotting baselines. Both `serde(default)` so pre-v10 runtimes read 0; docs say to gate on `protocol_version`.

**`save_project` corruption fixed** — a session launched inline with a multi-entry `functor.json` was saved as `{"entry":"game.fun"}`: builds green, fails at run. Sessions now remember and write the manifest they booted with, with two refusals (manifest no longer describing the file set; `overwrite` into a directory whose manifest declares different entries). The regression test covers the hardest shape: same-file roles, where the file set alone cannot distinguish one role from two.

**Docs** — `docs/mcp.md` gains the `entry` launch parameter (previously discoverable only by reading the source) and a "Running a multiplayer session" section: roles, the ordering law, quiescence, the pause law, launch-the-authority-first (an orbs client dials once, no retry), and that hot-reloading the authority mid-session preserves seats and connections.

**Trivia** — `launch_game` returns `protocol_version` instead of ~2KB of discovery boilerplate per session (index behind `discovery: true`); `functor build --entry X` names the role it checked.

**Cross-engine review** (Claude + Codex + dedup): four [AGREED] findings fixed — the `step_all` reproducibility overclaim (drains + honest docs), `model_revision` doc scope, URL-based group dedup, the lost partial-advance warning; plus the `overwrite` manifest clash and a shared e2e RPC client extracted before it became a third copy. Two declines with reasons in the commit bodies.

**Verification** (post-rebase over #649, e2e re-pointed at orbs): functor_runtime_common 692; desktop 86 (incl. the network-fold revision test); functor-cli 121 (1 pre-existing main failure, stash-verified); strict build clean; `mcp-server` e2e 87 (1 pre-existing); the new determinism e2e 3× green; site + SDK tsc clean. Perf: one integer per model assignment, one relaxed atomic per inbound event — nothing per-frame.

Next in the track (Addendum 7): Phase 2 — the native embedder (the MCP host process as the coordinator: routing + the packet log), then barrier stepping + whole-environment seek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)