### PR TITLE
feat(site): the value tree viewer — expandable inspection for decoded values

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -156,6 +156,64 @@ const installProbe = (page) =>
           })),
         };
       },
+      /** Open the FATTEST payload on the pinned log — the snapshot, i.e. the
+       * row whose one-line rendering elides the most. Returns its compact
+       * text, so the test can compare it with what the tree then shows. */
+      openBiggestRow: () => {
+        let button = null;
+        let best = -1;
+        for (const row of document.querySelectorAll(".mp-wl")) {
+          const bytes = Number((row.querySelector(".n").textContent.match(/\d+/) ?? [0])[0]);
+          const control = row.querySelector("button.payload");
+          if (control && bytes > best) {
+            best = bytes;
+            button = control;
+          }
+        }
+        if (!button) return null;
+        const compact = button.textContent.trim();
+        button.click();
+        return compact;
+      },
+      /** Open the shallowest still-CLOSED node labelled `label` (the child
+       * index / field name), so repeating a label drills down a level rather
+       * than closing what the last call opened. */
+      openNode: (label) => {
+        const node = [...document.querySelectorAll("button.mp-vt-row")].find(
+          (row) =>
+            row.querySelector(".mp-vt-k")?.textContent === label &&
+            row.getAttribute("aria-expanded") !== "true"
+        );
+        if (!node) return false;
+        node.click();
+        return true;
+      },
+      /** The open row's tree, flattened: every visible node's label, its
+       * rendered value, and whether it is open. */
+      valueTree: () => {
+        const tree = document.querySelector(".mp-wl-tree");
+        const open = document.querySelectorAll('.mp-wl .payload[aria-expanded="true"]').length;
+        if (!tree) return { mounted: false, openRows: open, nodes: [] };
+        return {
+          mounted: true,
+          openRows: open,
+          footer: document.querySelector(".mp-wl-ft").textContent.trim(),
+          nodes: [...tree.querySelectorAll(".mp-vt-row")]
+            // A node inside a CLOSED parent is in the DOM but not on screen.
+            .filter((row) => !row.closest(".mp-vt-kids[hidden]"))
+            .map((row) => ({
+              key: row.querySelector(".mp-vt-k")?.textContent ?? "",
+              value: row.querySelector(".mp-vt-v")?.textContent ?? "",
+              open: row.getAttribute("aria-expanded") === "true",
+            })),
+        };
+      },
+      closeOpenRow: () => {
+        const button = document.querySelector('.mp-wl .payload[aria-expanded="true"]');
+        if (!button) return false;
+        button.click();
+        return true;
+      },
       clickEdge: (index) => document.querySelectorAll(".mp-edge-chip")[index].click(),
       pauseAll: () => document.getElementById("mp-pause").click(),
       layout: () => ({
@@ -1072,6 +1130,51 @@ try {
       overlaps(pinned.box, hub) === 0,
       "the panel never covers the hub",
       `${JSON.stringify(pinned.box)} vs hub ${JSON.stringify([hub.x, hub.y, hub.w, hub.h])}`
+    );
+
+    // --- the value tree: a row opens into its whole payload ------------------
+    // The row's one line is a summary and says so (`…`); opening it must show
+    // the fields that line elided, with nothing elided in their place.
+    const compact = await page.evaluate(() => window.__mpProbe.openBiggestRow());
+    const tree = await page.evaluate(() => window.__mpProbe.valueTree());
+    check(
+      tree.mounted && tree.openRows === 1 && tree.nodes.length > 1,
+      "opening a payload mounts its value tree in the row",
+      `${tree.nodes.length} nodes from "${compact}"`
+    );
+    // Into the snapshot's first list, then its first entry: the ship record's
+    // own fields, which the row could never have shown.
+    await page.evaluate(() => window.__mpProbe.openNode("0"));
+    await sleep(50);
+    await page.evaluate(() => window.__mpProbe.openNode("0"));
+    await sleep(50);
+    const deep = await page.evaluate(() => window.__mpProbe.valueTree());
+    const leaves = deep.nodes.filter((node) => /^(pid|x|y|rot|id|owner)$/.test(node.key));
+    check(
+      leaves.length >= 4 && leaves.every((node) => !node.value.includes("…")),
+      "expanding reaches the record's own fields, each rendered whole",
+      JSON.stringify(leaves.slice(0, 6))
+    );
+    // The live tail turns over ten times a second: the open row survives it
+    // (opening holds the viewport — the panel says so).
+    await sleep(400);
+    const survived = await page.evaluate(() => window.__mpProbe.valueTree());
+    check(
+      survived.mounted &&
+        survived.openRows === 1 &&
+        survived.nodes.length === deep.nodes.length &&
+        /tail is held/.test(survived.footer),
+      "the open row survives the live tail, with its opened nodes still open",
+      `${survived.nodes.length} nodes (was ${deep.nodes.length}) — "${survived.footer}"`
+    );
+    const closed = await page
+      .evaluate(() => window.__mpProbe.closeOpenRow())
+      .then(() => sleep(100))
+      .then(() => page.evaluate(() => window.__mpProbe.valueTree()));
+    check(
+      !closed.mounted && closed.openRows === 0,
+      "closing the row puts the panel back to one line per packet",
+      JSON.stringify(closed)
     );
 
     await page.evaluate(() => window.__mpProbe.pauseAll());

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -23,7 +23,8 @@
 // scrubbing sweeps the rows the same way it sweeps the dots.
 
 import type { NetCoordinator, Packet } from "./net-coordinator.js";
-import { decodeWire, fullWire } from "./wire-value.js";
+import { hasTree, mountValueTree } from "./value-tree.js";
+import { decodeWire, fullWire, type WireValue } from "./wire-value.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -278,6 +279,34 @@ export function initNetworkGraph({
   let rowKey = "";
   /** When the rows last repainted — the live tail's throttle (LIVE_ROW_MS). */
   let lastRowPaint = 0;
+  /**
+   * The row opened into a value tree, if any: which packet it is, the tree's
+   * own DOM (kept across repaints, so the nodes the reader opened stay open),
+   * and — when it opened on a LIVE tail — the viewport to hold there.
+   *
+   * The packet is held BY IDENTITY, not by a hash: the panel and the log share
+   * the same `Packet` objects, and the row hash (frame/sender/size/arrival) can
+   * genuinely collide — `at` is a clamped `performance.now()`, so two
+   * same-sized intents routed in one turn of the loop can carry the same stamp,
+   * and two rows would then both claim the one tree.
+   *
+   * Holding the viewport is the point of `held`. A live tail turns a twelve-row
+   * window over in a fraction of a second at snapshot rates, so a row that
+   * opened and kept tailing would scroll off before it could be read: opening a
+   * row IS the pause. Parked, the rail stays in charge (scrub-lock is the
+   * panel's promise), `held` is null, and the tree simply travels with its row
+   * until the row leaves the window.
+   */
+  let opened: { packet: Packet; host: HTMLElement; held: Packet[] | null } | null = null;
+  /** The packet whose payload button should take focus after the next repaint —
+   * a repaint rebuilds every row, and the button the reader just pressed with
+   * the keyboard is one of the ones it destroys. */
+  let refocus: Packet | null = null;
+
+  /** A row's cache key — the four fields that make two rows different. Identity
+   * is the `Packet` itself (see `opened`); this is only for the change hash. */
+  const packetKey = (packet: Packet): string =>
+    `${packet.frame}:${packet.from}:${packet.size}:${packet.at}`;
 
   const addEdge = (node: NetworkNode): Edge => {
     const path = document.createElementNS(SVG_NS, "path");
@@ -477,6 +506,8 @@ export function initNetworkGraph({
     if (selected === id) return;
     selected = id;
     rowKey = "";
+    // Another link is other traffic: the open row is not in it.
+    opened = null;
     for (const [edgeId, edge] of edges) {
       const on = edgeId === id;
       edge.path.classList.toggle("selected", on);
@@ -530,6 +561,37 @@ export function initNetworkGraph({
     return { rows, highlight };
   };
 
+  /**
+   * Open a row into a value tree — or close the one that is open.
+   *
+   * One row at a time: the panel is a narrow column beside a running game, and
+   * two open snapshots would be a scroll, not a reading. Opening rebuilds the
+   * rows immediately (bypassing the live throttle) so the aria state of every
+   * payload button matches the DOM in the same tick, and re-places the panel,
+   * whose height just changed.
+   */
+  const openRow = (packet: Packet, value: WireValue, shown: readonly Packet[]) => {
+    if (opened?.packet === packet) {
+      opened = null;
+    } else {
+      const host = document.createElement("div");
+      host.className = "mp-wl-tree";
+      // The rows are a `role="log"` live region; a tree opening inside one
+      // would otherwise be read out in full on every repaint that re-parents
+      // it. It is a thing to explore, not an announcement.
+      host.setAttribute("aria-live", "off");
+      mountValueTree(host, value, placePanel);
+      opened = { packet, host, held: clock().parked ? null : [...shown] };
+    }
+    // The reader may have pressed this button with the keyboard, and the
+    // repaint below destroys it — hand the focus to its replacement.
+    refocus = packet;
+    rowKey = "";
+    lastRowPaint = 0;
+    renderPanel();
+    placePanel();
+  };
+
   const renderPanel = () => {
     if (!selected || !active) {
       panel.hidden = true;
@@ -545,16 +607,20 @@ export function initNetworkGraph({
     // throttle: the panel must answer the rail immediately.
     const now = performance.now();
     if (!parked && now - lastRowPaint < LIVE_ROW_MS) return;
-    const { rows: shown, highlight } = viewportRows(
-      selected,
-      parked && frame !== null ? frame : null
-    );
+    const live = viewportRows(selected, parked && frame !== null ? frame : null);
+    // An open row holds the LIVE viewport (see `opened`); parked, the rail
+    // keeps deciding the window and the tree travels with its row.
+    const held = opened?.held;
+    const shown = held && !parked ? held : live.rows;
+    const { highlight } = live;
+    // A row that scrubbed out of the window takes its tree with it.
+    if (opened && !shown.includes(opened.packet)) opened = null;
     const key =
-      `${selected}|${highlight}|` +
+      `${selected}|${highlight}|${opened ? packetKey(opened.packet) : ""}|` +
       // `at` disambiguates two packets that share a frame, a direction and a
       // size — a fixed-width intent (`Steer {turn:0}` vs `{turn:1}`) otherwise
       // hashes the same and the rows would go stale.
-      shown.map((packet) => `${packet.frame}:${packet.from}:${packet.size}:${packet.at}`).join(",");
+      shown.map(packetKey).join(",");
     if (key === rowKey) return;
     const rowCount = panelRows.childElementCount;
     lastRowPaint = now;
@@ -564,24 +630,29 @@ export function initNetworkGraph({
     panelLink.textContent = `${shortName(selected)} ↔ srv`;
     panel.style.setProperty("--pc", edge.node.color);
     let anyPlain = false;
+    let focusTarget: HTMLElement | null = null;
     panelRows.replaceChildren(
       ...shown.map((packet, index) => {
         const up = packet.from !== "server";
         const decoded = decodeWire(packet.text);
         if (!decoded.typed) anyPlain = true;
+        const isOpen = opened?.packet === packet;
         const row = document.createElement("div");
         row.className = `mp-wl${index === highlight ? " at" : ""}`;
         // The full rendering is built ON HOVER, once: rendering every row's
         // whole payload unelided (a world snapshot, per row, per repaint) to
         // fill a tooltip nobody has asked for yet is the most expensive thing
-        // this panel could do.
-        row.addEventListener(
-          "mouseenter",
-          () => {
-            row.title = fullWire(packet.text);
-          },
-          { once: true }
-        );
+        // this panel could do. An OPEN row skips it: the tooltip would cover
+        // the tree that already says the same thing, better.
+        if (!isOpen) {
+          row.addEventListener(
+            "mouseenter",
+            () => {
+              row.title = fullWire(packet.text);
+            },
+            { once: true }
+          );
+        }
         const frameCell = document.createElement("span");
         frameCell.className = "f";
         frameCell.textContent = `#f ${packet.frame ?? "—"}`;
@@ -590,8 +661,26 @@ export function initNetworkGraph({
         dirCell.textContent = up
           ? `${shortName(packet.from)}→srv`
           : `srv→${shortName(packet.to)}`;
+        // The payload cell is the disclosure control when there is something to
+        // disclose: a typed payload WITH structure, whose whole value the page
+        // already holds (the frame is decoded client-side, so opening it costs
+        // nothing but the DOM). A plain `Effect.send` text — or a bare
+        // `Welcome(2)`, which the row already shows completely — stays a plain
+        // cell rather than a control that opens the line you are looking at.
+        //
         // textContent, never innerHTML: this is a running game's own data.
-        const payload = document.createElement("span");
+        const value = decoded.value && hasTree(decoded.value) ? decoded.value : null;
+        let payload: HTMLElement;
+        if (value) {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.setAttribute("aria-expanded", String(isOpen));
+          button.addEventListener("click", () => openRow(packet, value, shown));
+          if (refocus === packet) focusTarget = button;
+          payload = button;
+        } else {
+          payload = document.createElement("span");
+        }
         payload.className = "payload";
         if (decoded.head) {
           const ctor = document.createElement("b");
@@ -606,9 +695,20 @@ export function initNetworkGraph({
         bytes.className = "n";
         bytes.textContent = `${packet.size} B`;
         row.append(frameCell, dirCell, payload, bytes);
+        // The tree is the SAME element across repaints, moved into the rebuilt
+        // row: every node the reader opened inside it stays open, because its
+        // state never left the DOM.
+        if (isOpen && opened) {
+          row.classList.add("open");
+          row.append(opened.host);
+        }
         return row;
       })
     );
+    // The rebuild threw away the element the keyboard was on; put the focus on
+    // its replacement, and only for the repaint the press caused.
+    if (focusTarget) (focusTarget as HTMLElement).focus();
+    refocus = null;
     if (shown.length === 0) {
       const empty = document.createElement("p");
       empty.className = "mp-wl-empty";
@@ -617,9 +717,12 @@ export function initNetworkGraph({
         : "no traffic on this link yet";
       panelRows.appendChild(empty);
     }
-    panelFoot.textContent = anyPlain
-      ? "Effect.send text — shown exactly as sent"
-      : "Effect.sendMsg — decoded as values, never bytes";
+    panelFoot.textContent =
+      opened && !parked
+        ? "the tail is held while a row is open — close it to resume"
+        : anyPlain
+          ? "Effect.send text — shown exactly as sent"
+          : "Effect.sendMsg — decoded as values, never bytes";
     // Only a change in the panel's SIZE can move it, and only the row count
     // changes that. Re-placing on every repaint would mean five forced layouts
     // per repaint (the panel's box, the cards' boxes, the wire's bbox) directly

--- a/site/src/value-tree.ts
+++ b/site/src/value-tree.ts
@@ -1,0 +1,251 @@
+// An expandable, indented view of one decoded value — the thing to reach for
+// when a one-line rendering is no longer the question being asked.
+//
+// WHY IT EXISTS. Every value surface in the sandbox renders a value the way a
+// ROW renders it: one line, depth-capped, elided (wire-value.ts's budgets, the
+// editor's inline previews). That is right for scanning — "which message is
+// this?" — and useless for the next question, "what is actually IN it?", which
+// is exactly when the reader is looking at a world snapshot. This module
+// answers the second question without changing how the first is answered: the
+// row keeps its compact line, and the tree opens underneath it.
+//
+// WHAT IT CAN HONESTLY SHOW. Only what the page actually has. The wire log's
+// payloads are decoded CLIENT-side from the full JSON frame (wire-value.ts), so
+// nothing is lost before this module sees them and every field expands. The
+// paused inspector's trace is a different story — its values arrive as RENDERED
+// TEXT, so it is not wired here; see the note at the end of this file.
+//
+// DOM-imperative on purpose: its two hosts (the pinned wire log, and the wire
+// tab that will consume it next) are imperative DOM inside a rAF-adjacent
+// panel, and a node's open/closed state is local to that node — there is no
+// shared state worth lifting anywhere.
+
+import { keyLabel, summarize, type WireValue } from "./wire-value.js";
+
+/**
+ * Children rendered before a big collection stops and offers the rest.
+ *
+ * A list here is a running game's own data: a snapshot can carry thousands of
+ * entities, and building thousands of rows the instant a triangle is clicked is
+ * a frame the panel does not have. The rest is one click away, and the count is
+ * on the button, so nothing is hidden — only deferred.
+ */
+const MAX_CHILDREN = 100;
+
+/**
+ * Characters of a string shown on its own row before it becomes expandable.
+ *
+ * Deliberately the same 40 as the row budget (wire-value's `MAX_STRING`), and
+ * a leaf renders its string WHOLE rather than through `summarize`: the two
+ * together are what guarantee the tree never elides something it offers no way
+ * to open. A larger budget here would leave a band of strings (41–72 chars)
+ * that the summary shortens and the tree does not expand — an ellipsis with
+ * nothing behind it, which is the exact failure this component exists to end.
+ */
+const MAX_INLINE_STRING = 40;
+
+/** One labelled child of a composite value. */
+interface Child {
+  label: string;
+  value: WireValue;
+}
+
+/**
+ * The children of a value, or null when it is a leaf.
+ *
+ * A single-argument variant (`Steer(intent)` — the common protocol shape)
+ * delegates to its argument, so `Steer {turn: 1}` expands straight to the
+ * record's fields instead of to a lone `0:` wrapper. Its summary already reads
+ * that way (wire-value renders it braced), so the tree matches the line it
+ * opens from. The delegation is deliberately wider than the summary's bracing
+ * (which is Record-only): a `Steer([a, b])` still has nothing to say about its
+ * lone argument, and a wrapper row that only ever holds one child is a level of
+ * indentation charged for nothing.
+ */
+const childrenOf = (value: WireValue): Child[] | null => {
+  if (typeof value !== "object" || value === null) return null;
+  if ("Record" in value && Array.isArray(value.Record)) {
+    return value.Record.map((entry) => ({ label: String(entry?.[0]), value: entry?.[1] }));
+  }
+  if ("Map" in value && Array.isArray(value.Map)) {
+    return value.Map.map((entry) => ({ label: keyLabel(entry?.[0]), value: entry?.[1] }));
+  }
+  if ("List" in value && Array.isArray(value.List)) {
+    return value.List.map((item, index) => ({ label: String(index), value: item }));
+  }
+  if ("Tuple" in value && Array.isArray(value.Tuple)) {
+    return value.Tuple.map((item, index) => ({ label: String(index), value: item }));
+  }
+  if ("Variant" in value && Array.isArray(value.Variant)) {
+    const args = value.Variant[1];
+    if (!Array.isArray(args) || args.length === 0) return null;
+    if (args.length === 1) return childrenOf(args[0]);
+    return args.map((arg, index) => ({ label: String(index), value: arg }));
+  }
+  return null;
+};
+
+/** The ink a scalar carries: the same three-way reading the wire rows use
+ * (data lit, text in the accent, everything structural dim). */
+const scalarClass = (value: WireValue): string => {
+  if (typeof value !== "object" || value === null) return "";
+  if ("Number" in value) return " num";
+  if ("Bool" in value) return " bool";
+  if ("Text" in value) return " str";
+  return "";
+};
+
+/** The whole string a `Text` node holds, or null for anything else. */
+const textOf = (value: WireValue): string | null =>
+  typeof value === "object" && value !== null && "Text" in value && typeof value.Text === "string"
+    ? value.Text
+    : null;
+
+const span = (className: string, text: string): HTMLSpanElement => {
+  const el = document.createElement("span");
+  el.className = className;
+  // textContent, never innerHTML: this is a running game's own data.
+  el.textContent = text;
+  return el;
+};
+
+/**
+ * One node: its row, and (lazily) its children.
+ *
+ * Children are built on FIRST expand and then kept, so re-opening a node is
+ * free and a closed node costs nothing — which is what makes a tree over a
+ * world snapshot affordable at all. Closing hides rather than discards: the
+ * reader who closes a node is usually about to open it again.
+ */
+const node = (
+  label: string,
+  value: WireValue,
+  depth: number,
+  onToggle: () => void
+): HTMLElement => {
+  const el = document.createElement("div");
+  el.className = "mp-vt-node";
+  const children = childrenOf(value);
+  const text = textOf(value);
+  const longText = text !== null && text.length > MAX_INLINE_STRING;
+  // A leaf string is rendered whole (`summarize` would elide it at the same
+  // budget that decides `longText`, and a leaf has no disclosure to offer).
+  const summary = text !== null && !longText ? JSON.stringify(text) : summarize(value);
+
+  if (!children && !longText) {
+    const row = document.createElement("div");
+    row.className = "mp-vt-row";
+    row.append(span("mp-vt-tw", ""));
+    if (label) row.append(span("mp-vt-k", label));
+    row.append(span(`mp-vt-v${scalarClass(value)}`, summary));
+    el.append(row);
+    return el;
+  }
+
+  const row = document.createElement("button");
+  row.type = "button";
+  row.className = "mp-vt-row";
+  row.setAttribute("aria-expanded", "false");
+  const twisty = span("mp-vt-tw", "▸");
+  row.append(twisty);
+  if (label) row.append(span("mp-vt-k", label));
+  row.append(span(`mp-vt-v${scalarClass(value)}`, summary));
+  const kids = document.createElement("div");
+  kids.className = "mp-vt-kids";
+  kids.hidden = true;
+  el.append(row, kids);
+
+  let built = false;
+  const build = () => {
+    if (built) return;
+    built = true;
+    if (longText && text !== null) {
+      kids.append(span("mp-vt-text", text));
+      return;
+    }
+    const all = children ?? [];
+    // A CHUNK at a time, always — including behind the "more" button. A list
+    // here is game data, so "the rest" can be a hundred thousand entries: both
+    // building that many nodes and spreading them as arguments are ways to take
+    // the page down, and neither is something a reader asked for.
+    const more = document.createElement("button");
+    more.type = "button";
+    more.className = "mp-vt-more";
+    let shown = 0;
+    const showChunk = () => {
+      const batch = document.createDocumentFragment();
+      for (const child of all.slice(shown, shown + MAX_CHILDREN)) {
+        batch.append(node(child.label, child.value, depth + 1, onToggle));
+      }
+      shown = Math.min(shown + MAX_CHILDREN, all.length);
+      kids.insertBefore(batch, more);
+      if (shown >= all.length) more.remove();
+      else more.textContent = `… ${all.length - shown} more`;
+    };
+    kids.append(more);
+    showChunk();
+    more.addEventListener("click", () => {
+      showChunk();
+      onToggle();
+    });
+  };
+
+  row.addEventListener("click", () => {
+    const open = row.getAttribute("aria-expanded") !== "true";
+    if (open) build();
+    row.setAttribute("aria-expanded", String(open));
+    twisty.textContent = open ? "▾" : "▸";
+    kids.hidden = !open;
+    // The tree just changed height, and its host may be positioned against it.
+    onToggle();
+  });
+  return el;
+};
+
+/** Is there anything to open? False for a scalar and for a nullary variant —
+ * values whose whole content is already the one line a row shows, and which
+ * should therefore not offer a disclosure that reveals nothing. */
+export const hasTree = (value: WireValue): boolean =>
+  childrenOf(value) !== null || (textOf(value)?.length ?? 0) > MAX_INLINE_STRING;
+
+/**
+ * Render `value` as an expandable tree inside `host`, replacing whatever was
+ * there. The root opens expanded: the reader asked for this by opening it.
+ *
+ * `onToggle` fires after any change to the tree's SIZE (a node opening or
+ * closing, a chunk of a long list arriving). A host that positions itself
+ * against its own height — the wire log's panel does — re-places from it.
+ */
+export const mountValueTree = (
+  host: HTMLElement,
+  value: WireValue,
+  onToggle: () => void = () => {}
+): void => {
+  const root = document.createElement("div");
+  root.className = "mp-vt";
+  const tree = node("", value, 0, onToggle);
+  root.append(tree);
+  host.replaceChildren(root);
+  // Open the root by clicking its own row, so "expanded" has exactly one
+  // implementation and the aria state can never disagree with the DOM.
+  tree.querySelector<HTMLButtonElement>(":scope > button.mp-vt-row")?.click();
+};
+
+// --- What is NOT wired here, and why -----------------------------------------
+//
+// The paused inspector's trace (the `functor-inspector-trace` relay) carries
+// its values as PRE-RENDERED TEXT, not as data: `RecordedBinding` in
+// functor-lang/src/eval.rs deliberately "owns no `Value`s" — it keeps a
+// `Display` string plus a depth-capped `preview` — so by the time
+// functor_runtime_common::inspector assembles the trace doc, the structure is
+// gone. (The full `value` string is not truncated; only the `preview` is. So
+// the trace's problem is SHAPE, not loss.)
+//
+// Giving the trace a real tree therefore means shipping structure from the
+// recorder — retaining values (or a `value_to_json`, which the prelude already
+// has for `/state`) through `RecordedInvocation` — a change inside the
+// interpreter's recorder with its own memory budget, not a page-side one.
+// Parsing the `Display` text back into a tree here would be a re-parser for a
+// rendering that was never specified as a format: it would be wrong on strings
+// containing `, ` and silently plausible when wrong. Neither belongs in this
+// PR, so the executions surface is left exactly as it was.

--- a/site/src/wire-value.test.ts
+++ b/site/src/wire-value.test.ts
@@ -36,7 +36,7 @@ test("elides deep and wide values, and keeps the full rendering for the tooltip"
 
 test("plain Effect.send text passes through, marked untyped", () => {
   const row = decodeWire("hello");
-  assert.deepEqual(row, { head: "", body: "hello", typed: false });
+  assert.deepEqual(row, { head: "", body: "hello", typed: false, value: null });
   assert.equal(fullWire("hello"), "hello");
 });
 

--- a/site/src/wire-value.ts
+++ b/site/src/wire-value.ts
@@ -74,6 +74,17 @@ export interface DecodedWire {
   /** False for a plain `Effect.send` text payload, or a frame that would not
    * parse — the row then shows the raw text and says so. */
   typed: boolean;
+  /**
+   * The payload as DATA, or null when it is not a typed frame — the same parse
+   * `head`/`body` were rendered from, handed back rather than thrown away.
+   *
+   * A row's consumer needs both: the compact line to show, and the value itself
+   * the moment the reader opens it (value-tree.ts). Returning it here is what
+   * keeps the panel to ONE `JSON.parse` per row per repaint — a world snapshot
+   * parsed twice a row, ten times a second, is the panel's largest avoidable
+   * cost.
+   */
+  value: WireValue | null;
 }
 
 /** A number as a game author wrote it: whole numbers without their `.0`, and
@@ -86,7 +97,8 @@ const num = (n: number): string =>
 const str = (value: string, full: boolean): string =>
   JSON.stringify(full || value.length <= MAX_STRING ? value : `${value.slice(0, MAX_STRING)}…`);
 
-const keyOf = (key: WireKey): string => {
+/** A map key as a row (or a tree node) labels it. */
+export const keyLabel = (key: WireKey): string => {
   if (typeof key !== "object" || key === null) return String(key);
   if ("Text" in key) return key.Text;
   if ("Number" in key) return num(key.Number);
@@ -131,7 +143,7 @@ const render = (value: WireValue, depth: number, full: boolean): string => {
   if ("Map" in value && Array.isArray(value.Map)) {
     if (deep) return "{…}";
     const shown = take(value.Map).map(
-      (entry) => `${keyOf(entry?.[0])}→${render(entry?.[1], depth + 1, full)}`
+      (entry) => `${keyLabel(entry?.[0])}→${render(entry?.[1], depth + 1, full)}`
     );
     return `{${[...shown, ...more(value.Map, "…")].join(", ")}}`;
   }
@@ -150,6 +162,13 @@ const render = (value: WireValue, depth: number, full: boolean): string => {
   // pretending — and rather than throwing.
   return asJson(value);
 };
+
+/**
+ * The one-line, depth-capped rendering of any value — the compact form a row
+ * shows, and the SUMMARY a collapsed tree node shows (value-tree.ts). One
+ * rendering for both, so a node and the row it opened from read the same.
+ */
+export const summarize = (value: WireValue): string => render(value, 0, false);
 
 /**
  * The typed payload inside a wire text, or null for plain `Effect.send` text
@@ -177,15 +196,15 @@ const parseWire = (raw: string): WireValue | null => {
 export function decodeWire(wire: string | undefined): DecodedWire {
   const raw = wire ?? "";
   const value = parseWire(raw);
-  if (!value) return { head: "", body: raw, typed: false };
+  if (!value) return { head: "", body: raw, typed: false, value: null };
   const compact = render(value, 0, false);
   if ("Variant" in value && Array.isArray(value.Variant) && typeof value.Variant[0] === "string") {
     const ctor = value.Variant[0];
     // `render` already puts the constructor at the front; the row prints the
     // head itself, so the body is only what follows it.
-    return { head: ctor, body: compact.slice(ctor.length).trim(), typed: true };
+    return { head: ctor, body: compact.slice(ctor.length).trim(), typed: true, value };
   }
-  return { head: "", body: compact, typed: true };
+  return { head: "", body: compact, typed: true, value };
 }
 
 /**

--- a/site/styles.css
+++ b/site/styles.css
@@ -3758,9 +3758,156 @@ a:hover {
   margin-left: 5px;
 }
 
+/* A typed payload is a disclosure control: same line, same ink, but it opens.
+   The button resets to the span it replaced so the row's rhythm is unchanged
+   until it is actually used. */
+button.payload {
+  border: 0;
+  padding: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+button.payload:hover b,
+button.payload[aria-expanded="true"] b {
+  color: var(--pc);
+}
+
+button.payload:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
+
 .mp-wl .n {
   text-align: right;
   color: var(--text-dim);
+}
+
+/* ---- the value tree (Addendum 8.1) ----
+
+   An open row keeps its one line and grows a tree beneath it, across all four
+   columns. Bounded height, not unbounded: a world snapshot is taller than the
+   stage, and a panel that grows past the window would push its own placement
+   off screen — so the deep end scrolls inside the row instead. */
+.mp-wl.open {
+  background: color-mix(in srgb, var(--pc) 8%, transparent);
+}
+
+.mp-wl-tree {
+  grid-column: 1 / -1;
+  max-height: 220px;
+  overflow: auto;
+  margin: 3px 0 5px;
+  padding: 3px 0;
+  border-top: 1px solid color-mix(in srgb, var(--pc) 20%, var(--line));
+}
+
+.mp-vt {
+  font: 10.5px/1.55 var(--font-mono);
+}
+
+.mp-vt-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  width: 100%;
+  padding: 0 2px;
+  border: 0;
+  background: none;
+  font: inherit;
+  text-align: left;
+  color: var(--text);
+}
+
+button.mp-vt-row {
+  cursor: pointer;
+}
+
+button.mp-vt-row:hover {
+  background: color-mix(in srgb, var(--pc) 10%, transparent);
+}
+
+button.mp-vt-row:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: -2px;
+}
+
+/* The twisty holds its column on leaf rows too, so names line up down the
+   level rather than stepping in and out with the disclosures. */
+.mp-vt-tw {
+  flex: none;
+  width: 9px;
+  color: var(--pc);
+  opacity: 0.8;
+}
+
+.mp-vt-k {
+  flex: none;
+  color: var(--text-dim);
+}
+
+.mp-vt-k::after {
+  content: ":";
+  opacity: 0.5;
+}
+
+/* Composites are dim (they are structure, and their contents are one click
+   below); scalars carry the data ink. */
+.mp-vt-v {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--text-dim);
+}
+
+.mp-vt-v.num {
+  color: var(--cyan);
+}
+
+.mp-vt-v.str {
+  color: var(--amber);
+}
+
+.mp-vt-v.bool {
+  color: var(--green);
+}
+
+/* One hairline per level: the indent is measurable rather than guessed, which
+   is what makes a deep snapshot readable at ten pixels. */
+.mp-vt-kids {
+  margin-left: 6px;
+  padding-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--pc) 22%, transparent);
+}
+
+.mp-vt-kids[hidden] {
+  display: none;
+}
+
+.mp-vt-text {
+  display: block;
+  padding: 2px 3px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: var(--amber);
+}
+
+.mp-vt-more {
+  padding: 1px 3px;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-style: italic;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.mp-vt-more:hover {
+  color: var(--text);
 }
 
 .mp-wl-empty {


### PR DESCRIPTION
![value tree viewer — an opened Snapshot payload in the wire log](https://gist.githubusercontent.com/tommy-xr/e505a0dc4ee69f498eb37f74b30edbb8/raw/valtree-final.png)

<sub>Click a payload and it opens: Snapshot → ships → pid/x/y/rot, every field readable, opened nodes surviving repaints. The live tail holds while you read.</sub>

<details>
<summary>In-page context — the pinned wire log over the running multiplayer sandbox</summary>

![sandbox stage with the wire log open](https://gist.githubusercontent.com/tommy-xr/e505a0dc4ee69f498eb37f74b30edbb8/raw/valtree-final-stage.png)

</details>

---

PR 1 of the **inspection stack** (design doc Addendum 8: value tree viewer → the wire tab → impairment): a dedicated, expandable data viewer, born from Bryan's "the data was truncated, so it was hard to inspect."

**The viewer**: `site/src/value-tree.ts` — an imperative, keyboard-accessible disclosure tree for decoded values. Records/lists/variants collapse to their one-line compact summary with a triangle; expanding reveals fields/elements recursively, each on its own line; long strings render whole once disclosed. Same DOM across repaints, so opened nodes stay open; `onToggle` lets a self-positioning host re-place when the tree changes size.

**Wired where truncation hurts today**: the pinned wire log's payload cells are now disclosure controls — click `Snapshot ([{…}, {…}], …)` and it opens into every ship and orb, fields untruncated. Opening **holds the live tail** (footer says so — a 12-row window turns over in fractions of a second at snapshot rates); parked, the tree travels with its row under the rail's control.

**The trace-path investigation (the honest scope)**: the spec assumed trace values were runtime-truncated — they are not. The `functor-inspector-trace` relay carries the **full** `Display` text; only the `preview` column is `Value::preview`-budgeted. The real blocker is *shape*: the recorder deliberately owns no `Value`s (strings only, by design — `RecordedBinding`/`RecordedInvocation`), so there is no structure left to tree, and the executions tab today renders no value surface at all. Page-side re-parsing of `Display` text was rejected (a re-parser for a rendering that was never a format). The runtime seam — emit `value_to_json` beside the strings, with the recorder's memory budget to answer — is filed as Addendum 8.1a and pinned in the component's closing comment. No faked ellipses.

**Cross-engine review (Claude + Codex + dedup), all findings dispositioned** — the agreed four: mid-band strings (41–72 chars) were elided with no expansion path (leaves now render whole); deep expansion resized the panel without re-placing it; packet identity by `frame:from:size:at` could collide (object identity now); keyboard focus survived the open-repaint. Plus: single-parse per row, chunked "show more" (no `RangeError` spread), `hasTree` gating, `aria-live="off"` inside the `role="log"` region. Dedup: no prior tree/disclosure renderer anywhere in site/, tools/, or the web runtime — this is the first.

**Verification**: site tsc clean; wire-value units 5/5; `sandbox-mp` ALL PASSED (+4 viewer checks: expansion present and untruncated, survives two tail updates, collapse works); `net-coordinator` ALL PASSED; `test:site` green except the two known pre-existing main failures (#643 codelens, animation pointer-lock).

Next in the stack: **the wire tab** — the traffic monitor docked beside `problems / output / executions`, visible in every layout: the in-editor Wireshark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

