### PR TITLE
feat(input): gamepad device domain on the sampled snapshot

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -366,8 +366,10 @@ let grab = (s) =>
   are `0..1`; face buttons are POSITIONAL (`south` is the bottom face button —
   A on Xbox, Cross on PlayStation), plus bumpers, stick clicks, dpad, and
   `start`/`select`. Levels only, raw values: detect edges against your model
-  and apply your own deadzone. A future mobile-touch domain belongs as another
-  typed sibling on the snapshot.
+  and apply your own deadzone. No shell polls a physical pad yet — today the
+  domain is supplied by desktop debug injection only (`POST /input`
+  `{"type":"gamepad",…}`), so it is `Option.None` everywhere else. A future
+  mobile-touch domain belongs as another typed sibling on the snapshot.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -359,8 +359,15 @@ let grab = (s) =>
   +Y up, and -Z forward. Each controller also carries `active`, analog
   trigger/squeeze/thumbstick state, and named button booleans. Missing XR,
   inactive controllers, and temporarily invalid poses are explicit
-  `Option.None`/`active: false`, never stale values. Future gamepad and mobile
-  touch domains belong as typed siblings of `xr` on the snapshot.
+  `Option.None`/`active: false`, never stale values. The snapshot also
+  contains `gamepad: Option.t<Input.gamepad>` — the primary connected pad's
+  held state, `Option.None` while no pad is connected. Sticks are `point2` in
+  `-1..1` with **up-positive `y`** (the XR thumbstick convention); triggers
+  are `0..1`; face buttons are POSITIONAL (`south` is the bottom face button —
+  A on Xbox, Cross on PlayStation), plus bumpers, stick clicks, dpad, and
+  `start`/`select`. Levels only, raw values: detect edges against your model
+  and apply your own deadzone. A future mobile-touch domain belongs as another
+  typed sibling on the snapshot.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -1358,11 +1358,14 @@ MCP server before reconnecting or reusing that runtime URL.",
     /// `{"type":"mouse_button","button":"left","down":true}`,
     /// `{"type":"ui_event","slot":0,"kind":"Clicked"}` (also
     /// `{"SliderChanged":0.5}` / `{"TextChanged":"hi"}`),
-    /// `{"type":"xr", "head":…, "left":…, "right":…}`, `{"type":"xr_clear"}`.
+    /// `{"type":"xr", "head":…, "left":…, "right":…}`, `{"type":"xr_clear"}`,
+    /// `{"type":"gamepad", "left_stick":[0,1], "south":true}`,
+    /// `{"type":"gamepad_clear"}`.
     /// The list mirrors `POST /input` and is not exhaustive; an unrecognized
     /// shape comes back as the runtime's own 400, which names the problem.
-    /// Keys, held buttons and XR samples are LEVEL state: they stay in force
-    /// across steps until released, which is how a paused session is scripted.
+    /// Keys, held buttons, XR and gamepad samples are LEVEL state: they stay
+    /// in force across steps until released, which is how a paused session is
+    /// scripted.
     #[tool]
     async fn send_input(
         &self,
@@ -2525,6 +2528,27 @@ still be alive; stop an owned session, or restart both an attached runtime and t
                     url,
                     "/input",
                     serde_json::json!({ "type": "xr_clear" }).to_string(),
+                )
+                .await?;
+                Ok(nothing())
+            }
+            "gamepad" => {
+                require_arity(method, args, 1)?;
+                let sample = args[0]
+                    .as_object()
+                    .ok_or_else(|| "gamepad sample must be an object".to_string())?;
+                let mut command = sample.clone();
+                command.insert("type".into(), Value::String("gamepad".into()));
+                self.post(url, "/input", Value::Object(command).to_string())
+                    .await?;
+                Ok(nothing())
+            }
+            "gamepadClear" => {
+                require_arity(method, args, 0)?;
+                self.post(
+                    url,
+                    "/input",
+                    serde_json::json!({ "type": "gamepad_clear" }).to_string(),
                 )
                 .await?;
                 Ok(nothing())

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -231,8 +231,9 @@ only be driven this way. `held_keys` and `mouse` stay live alongside it.
 level state (no entry point call, recorded, replayable), a whole-sample
 replacement whose omitted fields take their defaults (centered sticks,
 released triggers/buttons), `deny_unknown_fields`, and `{"type":"gamepad_clear"}`
-as the release half — restoring a physically connected pad, or no `gamepad`
-domain at all. The body is the snake_case [`gamepad` sample]
+as the release half — today restoring no `gamepad` domain at all (no shell
+polls a physical pad yet, so injection is the domain's only source). The
+body is the snake_case [`gamepad` sample]
 (#sampled-input-in-get-state) `GET /state` reports: `left_stick`/`right_stick`
 (`[-1..1]`, up-positive Y), `left_trigger`/`right_trigger` (`0..1`), and the
 positional booleans `south`/`east`/`west`/`north`, `left_bumper`/`right_bumper`,
@@ -301,7 +302,8 @@ needs a two-coordinate line shape rather than this `<control> <down|up>` triple.
 
 `input` is runtime-owned data sampled for one fixed simulation step. Keyboard and
 mouse keep their existing event entry points while also exposing deterministic
-held and pressed/released sets. Quest adds `xr` while head tracking is valid:
+held and pressed/released sets. Quest adds `xr` while head tracking is valid;
+`gamepad` appears while a pad sample is live (today: injected):
 
 These edge fields were added in debug protocol v6. Against an older runtime,
 clients should treat absent edge arrays/button sets as empty.
@@ -347,6 +349,26 @@ clients should treat absent edge arrays/button sets as empty.
       "thumbstick_pressed": false,
       "menu_pressed": false
     }
+  },
+  "gamepad": {
+    "left_stick": [0.0, 0.0],
+    "right_stick": [0.0, 0.0],
+    "left_trigger": 0.0,
+    "right_trigger": 0.0,
+    "south": false,
+    "east": false,
+    "west": false,
+    "north": false,
+    "left_bumper": false,
+    "right_bumper": false,
+    "left_stick_pressed": false,
+    "right_stick_pressed": false,
+    "dpad_up": false,
+    "dpad_down": false,
+    "dpad_left": false,
+    "dpad_right": false,
+    "start": false,
+    "select": false
   }
 }
 ```
@@ -362,11 +384,13 @@ Analog values are normalized to `0..1`; thumbstick axes to `-1..1`.
 
 Non-XR runtimes omit `xr`, and padless runtimes omit `gamepad` — each domain
 is a typed sibling field, present only when its device is live. `gamepad`
-carries the primary connected (or injected) pad's held state: sticks as
-`[x, y]` in `-1..1` with up-positive Y, triggers in `0..1`, positional face
-buttons (`south` is the bottom one), bumpers, stick clicks, dpad, and
-`start`/`select`. Future mobile-touch support should add another typed sibling
-field rather than target-specific endpoints or string-keyed capability bags.
+carries the pad's held state: sticks as `[x, y]` in `-1..1` with up-positive
+Y, triggers in `0..1`, positional face buttons (`south` is the bottom one),
+bumpers, stick clicks, dpad, and `start`/`select`. No shell polls a physical
+pad yet, so today the domain appears only while a sample is injected
+(`{"type":"gamepad"}` above). Future mobile-touch support should add another
+typed sibling field rather than target-specific endpoints or string-keyed
+capability bags.
 
 ### `POST /time` — frame-loop control
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -166,6 +166,8 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 {"type":"ui_event","slot":2,"kind":{"TextChanged":"hi"}}       // edit text input slot 2
 {"type":"xr","left":{...},"right":{...},"head":{...}}          // set the XR device sample
 {"type":"xr_clear"}                                            // drop it again
+{"type":"gamepad","left_stick":[0.0,1.0],"south":true}         // set the gamepad sample
+{"type":"gamepad_clear"}                                       // drop it again
 ```
 
 `mouse_button` is both an edge and level state, exactly like `key`: it calls the
@@ -224,6 +226,18 @@ without it. That is the point: the mouse/keyboard emulator pins both hands to
 `z = -0.55` with identity orientations, so gestures like pulling a hand back
 toward your face, or aiming with a rotated grip, are inexpressible there and can
 only be driven this way. `held_keys` and `mouse` stay live alongside it.
+
+`{"type":"gamepad"}` is the same contract for the gamepad domain: sampled
+level state (no entry point call, recorded, replayable), a whole-sample
+replacement whose omitted fields take their defaults (centered sticks,
+released triggers/buttons), `deny_unknown_fields`, and `{"type":"gamepad_clear"}`
+as the release half — restoring a physically connected pad, or no `gamepad`
+domain at all. The body is the snake_case [`gamepad` sample]
+(#sampled-input-in-get-state) `GET /state` reports: `left_stick`/`right_stick`
+(`[-1..1]`, up-positive Y), `left_trigger`/`right_trigger` (`0..1`), and the
+positional booleans `south`/`east`/`west`/`north`, `left_bumper`/`right_bumper`,
+`left_stick_pressed`/`right_stick_pressed`, `dpad_up`/`dpad_down`/`dpad_left`/
+`dpad_right`, `start`/`select`.
 
 Pair it with `POST /time` to step one frame per pose — and **wait for `frame` to
 increment before sending the next pose**. Advances accumulate (one advance is
@@ -346,9 +360,13 @@ source is available for that hand. Grip and aim are independently nullable
 because buttons can remain available during a temporary pose-tracking loss.
 Analog values are normalized to `0..1`; thumbstick axes to `-1..1`.
 
-Non-XR runtimes omit `xr`, preserving the previous desktop JSON shape. Future
-gamepad and mobile-touch support should add typed sibling fields rather than
-target-specific endpoints or string-keyed capability bags.
+Non-XR runtimes omit `xr`, and padless runtimes omit `gamepad` — each domain
+is a typed sibling field, present only when its device is live. `gamepad`
+carries the primary connected (or injected) pad's held state: sticks as
+`[x, y]` in `-1..1` with up-positive Y, triggers in `0..1`, positional face
+buttons (`south` is the bottom one), bumpers, stick clicks, dpad, and
+`start`/`select`. Future mobile-touch support should add another typed sibling
+field rather than target-specific endpoints or string-keyed capability bags.
 
 ### `POST /time` — frame-loop control
 

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -1,9 +1,9 @@
 //! Target-neutral continuously sampled input.
 //!
 //! The optional `sampledInput(model, snapshot)` game hook receives one
-//! `Input.snapshot` immediately before every fixed simulation step. XR is the first
-//! typed device domain; future gamepad and mobile-touch records belong beside
-//! `xr` on the snapshot.
+//! `Input.snapshot` immediately before every fixed simulation step. XR and
+//! gamepad are typed device domains; a future mobile-touch record belongs
+//! beside them on the snapshot.
 
 /// A plain two-dimensional point or axis pair.
 type point2 = { x: float, y: float }
@@ -33,6 +33,34 @@ type xr = {
   head: Option.t<pose>,
   left: controller,
   right: controller
+}
+
+/// The primary connected gamepad's held state, aligned to the standard
+/// mapping desktop and web pads share. Face buttons are POSITIONAL — `south`
+/// is the bottom face button (A on Xbox, Cross on PlayStation, B on
+/// Nintendo) — because letter names swap between vendors. Sticks are `-1..1`
+/// with up-positive `y` (the XR thumbstick convention); triggers are `0..1`.
+/// Values are raw — apply your own deadzone. Levels only: detect edges
+/// against your model, as XR games do.
+type gamepad = {
+  leftStick: point2,
+  rightStick: point2,
+  leftTrigger: float,
+  rightTrigger: float,
+  south: bool,
+  east: bool,
+  west: bool,
+  north: bool,
+  leftBumper: bool,
+  rightBumper: bool,
+  leftStickPressed: bool,
+  rightStickPressed: bool,
+  dpadUp: bool,
+  dpadDown: bool,
+  dpadLeft: bool,
+  dpadRight: bool,
+  start: bool,
+  select: bool
 }
 
 /// A fixed set of mouse buttons. `mouse.buttons` uses it for held levels;
@@ -65,5 +93,6 @@ type snapshot = {
   pressedKeys: List<Key.t>,
   releasedKeys: List<Key.t>,
   mouse: mouse,
-  xr: Option.t<xr>
+  xr: Option.t<xr>,
+  gamepad: Option.t<gamepad>
 }

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -41,7 +41,9 @@ type xr = {
 /// Nintendo) — because letter names swap between vendors. Sticks are `-1..1`
 /// with up-positive `y` (the XR thumbstick convention); triggers are `0..1`.
 /// Values are raw — apply your own deadzone. Levels only: detect edges
-/// against your model, as XR games do.
+/// against your model, as XR games do. No shell polls a physical pad yet:
+/// today the domain is supplied by desktop debug injection only, and it is
+/// `Option.None` everywhere else.
 type gamepad = {
   leftStick: point2,
   rightStick: point2,

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -294,12 +294,14 @@ pub enum InputCommand {
     /// The `Xr` contract exactly: level state until the next `gamepad` command
     /// replaces it, a WHOLE-sample replacement (an omitted field takes its
     /// default), no entry-point call — the sample reaches the game through the
-    /// same `sampled_input` path a real pad takes, which is what makes it land
-    /// in the recorded input log and replay identically.
-    Gamepad(Box<GamepadSnapshot>),
+    /// same `sampled_input` path a real pad would take, which is what makes it
+    /// land in the recorded input log and replay identically. Unboxed, unlike
+    /// `Xr`: the sample is a few words of `Copy` scalars, not an order of
+    /// magnitude above the other commands.
+    Gamepad(GamepadSnapshot),
     /// Drop an injected gamepad sample, restoring whatever the runtime would
-    /// sample on its own — a physically connected pad, or no `gamepad` domain
-    /// at all. The release half of `Gamepad`'s held-key contract.
+    /// sample on its own — today no `gamepad` domain at all (no shell polls a
+    /// physical pad yet). The release half of `Gamepad`'s held-key contract.
     GamepadClear,
 }
 
@@ -863,7 +865,7 @@ mod tests {
         assert!(!sample.select);
 
         let bare = serde_json::from_str::<InputCommand>(r#"{"type":"gamepad"}"#).unwrap();
-        assert_eq!(bare, InputCommand::Gamepad(Box::default()));
+        assert_eq!(bare, InputCommand::Gamepad(GamepadSnapshot::default()));
 
         assert_eq!(
             serde_json::from_str::<InputCommand>(r#"{"type":"gamepad_clear"}"#).unwrap(),

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::Sender;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ui::UiEventKind, InputSnapshot, XrInputSnapshot};
+use crate::{ui::UiEventKind, GamepadSnapshot, InputSnapshot, XrInputSnapshot};
 
 /// Stable name returned by the discovery endpoint on every runtime target.
 pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
@@ -53,7 +53,12 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// contract (so `functor run vr` refuses to push a role to one), and a v9
 /// runtime treats a push with no role query as "the role already in force
 /// stands".
-pub const DEBUG_PROTOCOL_VERSION: u32 = 9;
+///
+/// 10 adds gamepad injection — `POST /input` `{"type":"gamepad",…}` /
+/// `{"type":"gamepad_clear"}` (the `xr`/`xr_clear` contract for the gamepad
+/// domain) — and the optional `gamepad` field on `GET /state`'s input
+/// snapshot.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 10;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -107,7 +112,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr/gamepad), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -122,7 +127,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "POST",
         path: "/input",
-        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"mouse_button\",\"button\":\"left\",\"down\":true} (edge + held level, like key) | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device)",
+        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"mouse_button\",\"button\":\"left\",\"down\":true} (edge + held level, like key) | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device) | {\"type\":\"gamepad\",\"left_stick\":[0.0,1.0],\"south\":true,...} (desktop only; level state until the next gamepad command) | {\"type\":\"gamepad_clear\"} (drop it, restoring the physical pad or no device)",
     },
     DebugRoute {
         method: "POST",
@@ -283,6 +288,19 @@ pub enum InputCommand {
     /// one-way door: the first `xr` command would disable the emulator and make
     /// a game's "no XR device" branch unreachable for the rest of the process.
     XrClear,
+    /// Set the gamepad sample the next fixed step's `sampledInput` sees, so
+    /// stick/trigger/button state is scriptable without a physical pad.
+    ///
+    /// The `Xr` contract exactly: level state until the next `gamepad` command
+    /// replaces it, a WHOLE-sample replacement (an omitted field takes its
+    /// default), no entry-point call — the sample reaches the game through the
+    /// same `sampled_input` path a real pad takes, which is what makes it land
+    /// in the recorded input log and replay identically.
+    Gamepad(Box<GamepadSnapshot>),
+    /// Drop an injected gamepad sample, restoring whatever the runtime would
+    /// sample on its own — a physically connected pad, or no `gamepad` domain
+    /// at all. The release half of `Gamepad`'s held-key contract.
+    GamepadClear,
 }
 
 /// A clock command sent through `POST /time`.
@@ -816,6 +834,55 @@ mod tests {
             .expect("a well-formed body still decodes");
     }
 
+    /// The gamepad command follows the `xr` contract: a partial body defaults
+    /// what it omits, a misspelled field is a 400 (same silent-success trap —
+    /// an all-default sample would flip a game from "no pad" to "pad present,
+    /// nothing held" and pin it there), and the minimal body is a fully
+    /// default sample.
+    #[test]
+    fn a_gamepad_command_decodes_partially_and_rejects_typos() {
+        let command = serde_json::from_str::<InputCommand>(
+            r#"{"type":"gamepad",
+                "left_stick": [-0.5, 1.0],
+                "right_trigger": 0.25,
+                "south": true,
+                "dpad_left": true}"#,
+        )
+        .expect("gamepad command decodes");
+        let InputCommand::Gamepad(sample) = command else {
+            panic!("expected a gamepad command");
+        };
+        assert_eq!(sample.left_stick, [-0.5, 1.0]);
+        assert_eq!(sample.right_trigger, 0.25);
+        assert!(sample.south);
+        assert!(sample.dpad_left);
+        // Omitted controls take their defaults.
+        assert_eq!(sample.right_stick, [0.0, 0.0]);
+        assert_eq!(sample.left_trigger, 0.0);
+        assert!(!sample.east);
+        assert!(!sample.select);
+
+        let bare = serde_json::from_str::<InputCommand>(r#"{"type":"gamepad"}"#).unwrap();
+        assert_eq!(bare, InputCommand::Gamepad(Box::default()));
+
+        assert_eq!(
+            serde_json::from_str::<InputCommand>(r#"{"type":"gamepad_clear"}"#).unwrap(),
+            InputCommand::GamepadClear
+        );
+
+        for body in [
+            r#"{"type":"gamepad","lstick":[0.0,0.0]}"#, // misspelled stick
+            r#"{"type":"gamepad","suoth":true}"#,       // misspelled button
+        ] {
+            let err = serde_json::from_str::<InputCommand>(body)
+                .expect_err(&format!("{body} must be rejected"));
+            assert!(
+                err.to_string().contains("unknown field"),
+                "{body} rejected for the wrong reason: {err}"
+            );
+        }
+    }
+
     #[test]
     fn routes_are_unique_complete_and_drive_discovery() {
         let labels: BTreeSet<_> = DEBUG_ROUTES.iter().map(|route| route.label()).collect();
@@ -858,6 +925,6 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 9);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 10);
     }
 }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -1567,9 +1567,16 @@ let init = {
   released: 0.0,
   mousePressed: false,
   mouseReleased: false,
-  mouseX: 0.0
+  mouseX: 0.0,
+  padX: 0.0,
+  padSouth: false,
+  padTrigger: 0.0
 }
 let sampledInput = (model, snapshot: Input.snapshot) =>
+  let (padX, padSouth, padTrigger) =
+    (match snapshot.gamepad with
+     | Option.Some(pad) => (pad.leftStick.x, pad.south, pad.rightTrigger)
+     | Option.None => (0.0, false, 0.0)) in
   match snapshot.xr with
   | Option.Some(xr) => {
       trigger: xr.right.trigger,
@@ -1578,7 +1585,10 @@ let sampledInput = (model, snapshot: Input.snapshot) =>
       released: List.length(snapshot.releasedKeys),
       mousePressed: snapshot.mouse.pressed.left,
       mouseReleased: snapshot.mouse.released.right,
-      mouseX: snapshot.mouse.x
+      mouseX: snapshot.mouse.x,
+      padX: padX,
+      padSouth: padSouth,
+      padTrigger: padTrigger
     }
   | Option.None => model
 let tick = (model, dt, tts) => model
@@ -1619,6 +1629,12 @@ let draw = (model, tts) =>
                 },
                 ..crate::XrInputSnapshot::default()
             }),
+            gamepad: Some(crate::GamepadSnapshot {
+                left_stick: [-0.5, 1.0],
+                south: true,
+                right_trigger: 0.25,
+                ..crate::GamepadSnapshot::default()
+            }),
             ..crate::InputSnapshot::default()
         };
         game.sampled_input(&snapshot);
@@ -1632,6 +1648,9 @@ let draw = (model, tts) =>
         assert!(model.contains("mousePressed: true"), "{model}");
         assert!(model.contains("mouseReleased: true"), "{model}");
         assert!(model.contains("mouseX: 42"), "{model}");
+        assert!(model.contains("padX: -0.5"), "{model}");
+        assert!(model.contains("padSouth: true"), "{model}");
+        assert!(model.contains("padTrigger: 0.25"), "{model}");
         assert!(matches!(
             game.recorded_inputs_at(0).as_slice(),
             [crate::RecordedInput::Snapshot(recorded)] if recorded.as_ref() == &snapshot

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -6,10 +6,9 @@ use crate::TrackingPose;
 ///
 /// Keyboard and mouse retain their event entry points, while this plain-data
 /// snapshot exposes both levels and de-duplicated transitions through the
-/// extensible shell → producer seam. XR is the first typed device domain;
-/// gamepads and mobile touches can add sibling fields without turning device
-/// capabilities into stringly-typed maps or adding target-specific producer
-/// methods.
+/// extensible shell → producer seam. XR and gamepad are typed device domains;
+/// mobile touch can add a sibling field without turning device capabilities
+/// into stringly-typed maps or adding target-specific producer methods.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct InputSnapshot {
     /// Keys currently held, in canonical discriminant order.
@@ -31,6 +30,13 @@ pub struct InputSnapshot {
     /// the existing desktop `/state` wire shape.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub xr: Option<XrInputSnapshot>,
+    /// Live state of the primary connected gamepad when the target supplies
+    /// one. `None` means no pad is connected — a capability signal, so a game
+    /// can key control hints off it.
+    ///
+    /// Omitted rather than serialized as `null` when absent, like `xr`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gamepad: Option<GamepadSnapshot>,
 }
 
 /// Last known mouse position in logical shell coordinates, the matching
@@ -273,6 +279,47 @@ pub struct XrControllerSnapshot {
     pub secondary_pressed: bool,
     pub thumbstick_pressed: bool,
     pub menu_pressed: bool,
+}
+
+/// Target-neutral state for the primary connected gamepad, aligned to the
+/// standard mapping GLFW (`glfwGetGamepadState`) and the Web Gamepad API
+/// share.
+///
+/// Face buttons are POSITIONAL (`south` is the bottom face button — A on
+/// Xbox, Cross on PlayStation, B on Nintendo), because letter names swap
+/// between vendors. Sticks are `-1..1` with **up-positive Y**, matching the
+/// XR thumbstick convention — shells negate GLFW's and the browser's
+/// down-positive axes at the boundary. Triggers are `0..1`. Values are raw
+/// (no deadzone shaping); games apply their own.
+///
+/// Levels only, no edge sets: pads are polled, so a press always spans at
+/// least one render frame and shows up in at least one sample — games detect
+/// edges against their model, exactly as XR games do.
+///
+/// Deserialization defaults every missing field, so a debug-injected sample
+/// (`POST /input` `{"type":"gamepad",…}`) can name only the controls it
+/// drives.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct GamepadSnapshot {
+    pub left_stick: [f32; 2],
+    pub right_stick: [f32; 2],
+    pub left_trigger: f32,
+    pub right_trigger: f32,
+    pub south: bool,
+    pub east: bool,
+    pub west: bool,
+    pub north: bool,
+    pub left_bumper: bool,
+    pub right_bumper: bool,
+    pub left_stick_pressed: bool,
+    pub right_stick_pressed: bool,
+    pub dpad_up: bool,
+    pub dpad_down: bool,
+    pub dpad_left: bool,
+    pub dpad_right: bool,
+    pub start: bool,
+    pub select: bool,
 }
 
 /// Canonical key identifier shared across the F# <-> Rust boundary and all
@@ -715,6 +762,47 @@ fn controller_value(controller: &XrControllerSnapshot) -> functor_lang::Value {
     ])
 }
 
+fn gamepad_value(pad: &GamepadSnapshot) -> functor_lang::Value {
+    let stick = |axes: [f32; 2]| {
+        record([
+            ("x", functor_lang::Value::Number(axes[0] as f64)),
+            ("y", functor_lang::Value::Number(axes[1] as f64)),
+        ])
+    };
+    record([
+        ("leftStick", stick(pad.left_stick)),
+        ("rightStick", stick(pad.right_stick)),
+        (
+            "leftTrigger",
+            functor_lang::Value::Number(pad.left_trigger as f64),
+        ),
+        (
+            "rightTrigger",
+            functor_lang::Value::Number(pad.right_trigger as f64),
+        ),
+        ("south", functor_lang::Value::Bool(pad.south)),
+        ("east", functor_lang::Value::Bool(pad.east)),
+        ("west", functor_lang::Value::Bool(pad.west)),
+        ("north", functor_lang::Value::Bool(pad.north)),
+        ("leftBumper", functor_lang::Value::Bool(pad.left_bumper)),
+        ("rightBumper", functor_lang::Value::Bool(pad.right_bumper)),
+        (
+            "leftStickPressed",
+            functor_lang::Value::Bool(pad.left_stick_pressed),
+        ),
+        (
+            "rightStickPressed",
+            functor_lang::Value::Bool(pad.right_stick_pressed),
+        ),
+        ("dpadUp", functor_lang::Value::Bool(pad.dpad_up)),
+        ("dpadDown", functor_lang::Value::Bool(pad.dpad_down)),
+        ("dpadLeft", functor_lang::Value::Bool(pad.dpad_left)),
+        ("dpadRight", functor_lang::Value::Bool(pad.dpad_right)),
+        ("start", functor_lang::Value::Bool(pad.start)),
+        ("select", functor_lang::Value::Bool(pad.select)),
+    ])
+}
+
 /// Convert the shared shell snapshot into the typed, plain-data
 /// `Input.snapshot` record delivered to a Functor Lang game's optional
 /// `sampledInput` hook.
@@ -763,6 +851,10 @@ pub fn input_snapshot_value(snapshot: &InputSnapshot) -> functor_lang::Value {
             ]),
         ),
         ("xr", option_value(xr)),
+        (
+            "gamepad",
+            option_value(snapshot.gamepad.as_ref().map(gamepad_value)),
+        ),
     ])
 }
 
@@ -770,8 +862,8 @@ pub fn input_snapshot_value(snapshot: &InputSnapshot) -> functor_lang::Value {
 mod tests {
     use super::{
         apply_key_transition_to_snapshot, apply_mouse_transition_to_snapshot, input_snapshot_value,
-        mouse_button_input_value, tracking_pose_from_value, tracking_pose_value, InputEdges,
-        InputSnapshot, Key, MouseButton, MouseButtons, MouseSnapshot, RecordedInput,
+        mouse_button_input_value, tracking_pose_from_value, tracking_pose_value, GamepadSnapshot,
+        InputEdges, InputSnapshot, Key, MouseButton, MouseButtons, MouseSnapshot, RecordedInput,
         XrControllerSnapshot, XrInputSnapshot,
     };
     use crate::TrackingPose;
@@ -1000,6 +1092,25 @@ mod tests {
         };
         let encoded = serde_json::to_string(&xr).unwrap();
         assert_eq!(serde_json::from_str::<InputSnapshot>(&encoded).unwrap(), xr);
+
+        // The gamepad domain follows the same wire contract: omitted when
+        // absent (asserted by the exact desktop JSON above), round-tripped
+        // when present.
+        let pad = InputSnapshot {
+            gamepad: Some(GamepadSnapshot {
+                left_stick: [0.5, -0.5],
+                left_trigger: 1.0,
+                south: true,
+                select: true,
+                ..GamepadSnapshot::default()
+            }),
+            ..InputSnapshot::default()
+        };
+        let encoded = serde_json::to_string(&pad).unwrap();
+        assert_eq!(
+            serde_json::from_str::<InputSnapshot>(&encoded).unwrap(),
+            pad
+        );
     }
 
     #[test]
@@ -1038,6 +1149,13 @@ mod tests {
                     ..XrControllerSnapshot::default()
                 },
             }),
+            gamepad: Some(GamepadSnapshot {
+                left_stick: [-0.5, 1.0],
+                right_trigger: 0.25,
+                south: true,
+                dpad_left: true,
+                ..GamepadSnapshot::default()
+            }),
         };
         let rendered = input_snapshot_value(&snapshot).to_string();
         assert!(
@@ -1059,6 +1177,23 @@ mod tests {
         assert!(rendered.contains("xr: Option.Some("), "{rendered}");
         assert!(rendered.contains("trigger: 0.75"), "{rendered}");
         assert!(rendered.contains("primaryPressed: true"), "{rendered}");
+        assert!(rendered.contains("gamepad: Option.Some("), "{rendered}");
+        assert!(
+            rendered.contains("leftStick: { x: -0.5, y: 1 }"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("rightTrigger: 0.25"), "{rendered}");
+        assert!(rendered.contains("south: true"), "{rendered}");
+        assert!(rendered.contains("dpadLeft: true"), "{rendered}");
+        assert!(rendered.contains("select: false"), "{rendered}");
+
+        // Without a pad the domain is an explicit None, never a zeroed record.
+        let no_pad = InputSnapshot::default();
+        assert!(
+            input_snapshot_value(&no_pad)
+                .to_string()
+                .contains("gamepad: Option.None"),
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -288,9 +288,13 @@ pub struct XrControllerSnapshot {
 /// Face buttons are POSITIONAL (`south` is the bottom face button — A on
 /// Xbox, Cross on PlayStation, B on Nintendo), because letter names swap
 /// between vendors. Sticks are `-1..1` with **up-positive Y**, matching the
-/// XR thumbstick convention — shells negate GLFW's and the browser's
-/// down-positive axes at the boundary. Triggers are `0..1`. Values are raw
-/// (no deadzone shaping); games apply their own.
+/// XR thumbstick convention — a shell that polls a pad must negate GLFW's
+/// and the browser's down-positive axes at its boundary. Triggers are
+/// `0..1`. Values are raw (no deadzone shaping); games apply their own.
+///
+/// No shell polls a physical pad yet: today the domain's only source is
+/// debug injection (`POST /input` `{"type":"gamepad",…}`); GLFW and Web
+/// Gamepad API polling land as `override > polled > None` in the shells.
 ///
 /// Levels only, no edge sets: pads are polled, so a press always spans at
 /// least one render frame and shows up in at least one sample — games detect
@@ -730,19 +734,7 @@ fn controller_value(controller: &XrControllerSnapshot) -> functor_lang::Value {
             "squeeze",
             functor_lang::Value::Number(controller.squeeze as f64),
         ),
-        (
-            "thumbstick",
-            record([
-                (
-                    "x",
-                    functor_lang::Value::Number(controller.thumbstick[0] as f64),
-                ),
-                (
-                    "y",
-                    functor_lang::Value::Number(controller.thumbstick[1] as f64),
-                ),
-            ]),
-        ),
+        ("thumbstick", axes2_value(controller.thumbstick)),
         (
             "primaryPressed",
             functor_lang::Value::Bool(controller.primary_pressed),
@@ -762,16 +754,18 @@ fn controller_value(controller: &XrControllerSnapshot) -> functor_lang::Value {
     ])
 }
 
-fn gamepad_value(pad: &GamepadSnapshot) -> functor_lang::Value {
-    let stick = |axes: [f32; 2]| {
-        record([
-            ("x", functor_lang::Value::Number(axes[0] as f64)),
-            ("y", functor_lang::Value::Number(axes[1] as f64)),
-        ])
-    };
+/// Convert a 2-axis pair into the plain-data `Input.point2` record.
+fn axes2_value(axes: [f32; 2]) -> functor_lang::Value {
     record([
-        ("leftStick", stick(pad.left_stick)),
-        ("rightStick", stick(pad.right_stick)),
+        ("x", functor_lang::Value::Number(axes[0] as f64)),
+        ("y", functor_lang::Value::Number(axes[1] as f64)),
+    ])
+}
+
+fn gamepad_value(pad: &GamepadSnapshot) -> functor_lang::Value {
+    record([
+        ("leftStick", axes2_value(pad.left_stick)),
+        ("rightStick", axes2_value(pad.right_stick)),
         (
             "leftTrigger",
             functor_lang::Value::Number(pad.left_trigger as f64),

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -71,6 +71,10 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v12: the gamepad device domain — [`crate::InputSnapshot::gamepad`],
+/// defaulted (and omitted when absent) when decoding older samples, so
+/// retained recordings remain readable.
+///
 /// v11: the `AnimExpr::Reach` two-bone IK variant nested in
 /// `ModelDescription.animation`.
 ///
@@ -106,7 +110,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 11;
+pub const PROTOCOL_VERSION: u32 = 12;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -603,7 +607,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 11);
+        assert_eq!(PROTOCOL_VERSION, 12);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -630,7 +634,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 11);
+        assert_eq!(PROTOCOL_VERSION, 12);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],
@@ -650,7 +654,7 @@ mod tests {
     fn two_bone_reach_animation_wire_is_pinned() {
         use crate::anim::AnimExpr;
 
-        assert_eq!(PROTOCOL_VERSION, 11);
+        assert_eq!(PROTOCOL_VERSION, 12);
         let reach = AnimExpr::Reach {
             root: "upper".to_string(),
             middle: "lower".to_string(),

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -15,7 +15,7 @@ use functor_runtime_common::asset::AssetCache;
 use functor_runtime_common::viewer::{camera_frustum_lines, DebugCamera, DebugPresentation};
 use functor_runtime_common::{
     Frame, FrameTime, GameClock, InputEdges, InputSnapshot, MouseButtons, MouseSnapshot,
-    RecordedInput, SceneContext, XrInputSnapshot,
+    GamepadSnapshot, RecordedInput, SceneContext, XrInputSnapshot,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -159,6 +159,7 @@ fn desktop_input_snapshot(
     xr_primary_down: bool,
     xr_surface: (i32, i32),
     xr_override: Option<&XrInputSnapshot>,
+    gamepad_override: Option<&GamepadSnapshot>,
 ) -> InputSnapshot {
     let xr = match xr_override {
         Some(injected) => Some(injected.clone()),
@@ -166,7 +167,13 @@ fn desktop_input_snapshot(
             crate::desktop_xr_emulator::sample(held_keys, mouse_pos, xr_primary_down, xr_surface)
         }),
     };
-    sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr)
+    let mut snapshot =
+        sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr);
+    // The gamepad domain's only desktop source for now is debug injection
+    // (`POST /input` `{"type":"gamepad"}`); GLFW pad polling slots in here as
+    // `override > polled > None`, the XR shape above.
+    snapshot.gamepad = gamepad_override.cloned();
+    snapshot
 }
 
 /// Release every mouse button the game currently holds — the button twin of
@@ -308,9 +315,11 @@ fn refresh_fixed_input_levels(
     held_buttons: MouseButtons,
     xr_primary_down: bool,
     xr_override: Option<&XrInputSnapshot>,
+    gamepad_override: Option<&GamepadSnapshot>,
 ) {
     snapshot.held_keys = held_keys.iter().copied().collect();
     snapshot.mouse.buttons = held_buttons;
+    snapshot.gamepad = gamepad_override.cloned();
     // An injected sample owns the whole XR domain — window keys must not
     // re-derive its trigger/thumbstick out from under the driver.
     match xr_override {
@@ -921,6 +930,8 @@ fn service_debug_request(
     // The debug-injected XR sample, if any: `{"type":"xr"}` sets it and every
     // later step samples it (see `desktop_input_snapshot`).
     xr_override: &mut Option<XrInputSnapshot>,
+    // The debug-injected gamepad sample — the XR contract for the pad domain.
+    gamepad_override: &mut Option<GamepadSnapshot>,
     state_input: InputSnapshot,
     emulate_xr: bool,
     clock: &mut GameClock,
@@ -1033,6 +1044,8 @@ fn service_debug_request(
                     | debug_server::InputCommand::MouseButton { .. }
                     | debug_server::InputCommand::Xr(_)
                     | debug_server::InputCommand::XrClear
+                    | debug_server::InputCommand::Gamepad(_)
+                    | debug_server::InputCommand::GamepadClear
             );
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => {
@@ -1120,6 +1133,18 @@ fn service_debug_request(
                     *xr_override = None;
                     Ok(())
                 }
+                debug_server::InputCommand::Gamepad(snapshot) => {
+                    // Like `Xr`: no entry-point call — the sample reaches the
+                    // game through the same `sampled_input` path a real pad
+                    // takes, so it lands in the recorded input log and
+                    // replays identically.
+                    *gamepad_override = Some(*snapshot);
+                    Ok(())
+                }
+                debug_server::InputCommand::GamepadClear => {
+                    *gamepad_override = None;
+                    Ok(())
+                }
             };
             // Input injected while PAUSED journals entry-point calls no `tick`
             // will sweep — fold them into the inspector's last-frame journal so
@@ -1169,6 +1194,7 @@ fn run_headless(
         (0, 0)
     };
     let mut xr_override: Option<XrInputSnapshot> = None;
+    let mut gamepad_override: Option<GamepadSnapshot> = None;
     // Keep the debug protocol target-isomorphic even without pixels: uploaded
     // assets can be accepted now and are ready if headless rendering gains an
     // asset path later.
@@ -1233,6 +1259,7 @@ fn run_headless(
                     false,
                     crate::desktop_xr_emulator::reference_surface(),
                     xr_override.as_ref(),
+                    gamepad_override.as_ref(),
                 );
                 game.sampled_input(&snapshot);
             }
@@ -1259,6 +1286,7 @@ fn run_headless(
                     false,
                     crate::desktop_xr_emulator::reference_surface(),
                     xr_override.as_ref(),
+                    gamepad_override.as_ref(),
                 );
                 service_debug_request(
                     req,
@@ -1273,6 +1301,7 @@ fn run_headless(
                     &mut held_buttons,
                     &mut input_edges,
                     &mut xr_override,
+                    &mut gamepad_override,
                     state_input,
                     emulate_xr,
                     &mut clock,
@@ -1626,6 +1655,7 @@ Escape releases while captured"
         let mut xr_primary_down = false;
         let mut xr_primary_clicked = false;
         let mut xr_override: Option<XrInputSnapshot> = None;
+        let mut gamepad_override: Option<GamepadSnapshot> = None;
         // `--fixed-time` is a deterministic capture pin: the one zero-delta
         // bootstrap step must not observe cursor motion from the host window.
         // Explicit debug input remains authoritative; key release/focus-loss
@@ -1640,6 +1670,7 @@ Escape releases while captured"
             false,
             window.get_size(),
             xr_override.as_ref(),
+            gamepad_override.as_ref(),
         );
         // Whether the window owns the pointer (free-look). Capture is always
         // entered by a non-overlay click; see the Escape / MouseButton / Focus
@@ -1816,6 +1847,7 @@ then restart the runner"
                             held_buttons,
                             false,
                             xr_override.as_ref(),
+                            gamepad_override.as_ref(),
                         );
                     }
                     window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -1925,6 +1957,7 @@ then restart the runner"
                                     held_buttons,
                                     false,
                                     xr_override.as_ref(),
+                                    gamepad_override.as_ref(),
                                 );
                             }
                             window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -1975,6 +2008,7 @@ Escape again to quit"
                                 held_buttons,
                                 false,
                                 xr_override.as_ref(),
+                                gamepad_override.as_ref(),
                             );
                         }
                         if !hidden {
@@ -2172,6 +2206,7 @@ Escape again to quit"
                                 held_buttons,
                                 xr_primary_down || xr_primary_clicked,
                                 xr_override.as_ref(),
+                                gamepad_override.as_ref(),
                             );
                         }
                     }
@@ -2217,6 +2252,7 @@ Escape again to quit"
                                     held_buttons,
                                     xr_primary_down || xr_primary_clicked,
                                     xr_override.as_ref(),
+                                    gamepad_override.as_ref(),
                                 );
                             }
                         }
@@ -2260,6 +2296,7 @@ Escape again to quit"
                                     held_buttons,
                                     xr_primary_down || xr_primary_clicked,
                                     xr_override.as_ref(),
+                                    gamepad_override.as_ref(),
                                 );
                             }
                         }
@@ -2302,6 +2339,7 @@ Escape again to quit"
                                 held_buttons,
                                 false,
                                 xr_override.as_ref(),
+                                gamepad_override.as_ref(),
                             );
                         }
                     }
@@ -2461,6 +2499,7 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
+                            gamepad_override.as_ref(),
                         );
                         game.sampled_input(&snapshot);
                     }
@@ -3249,6 +3288,7 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
+                            gamepad_override.as_ref(),
                         )
                     };
                     let sampled_input_changed = service_debug_request(
@@ -3264,6 +3304,7 @@ Escape again to quit"
                         &mut held_buttons,
                         &mut input_edges,
                         &mut xr_override,
+                        &mut gamepad_override,
                         state_input,
                         args.emulate_xr,
                         &mut clock,
@@ -3298,6 +3339,7 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
+                            gamepad_override.as_ref(),
                         );
                     }
                 }
@@ -3548,6 +3590,7 @@ mod tests {
             false,
             (800, 600),
             None,
+            None,
         );
         let pose = snapshot
             .xr
@@ -3565,6 +3608,7 @@ mod tests {
             &held,
             buttons,
             false,
+            None,
             None,
         );
 
@@ -3604,6 +3648,7 @@ mod tests {
             false,
             (800, 600),
             None,
+            None,
         );
         assert!(snapshot.held_keys.is_empty());
         assert_eq!(snapshot.pressed_keys, vec![InputKey::Space]);
@@ -3624,6 +3669,7 @@ mod tests {
             false,
             (800, 600),
             None,
+            None,
         );
         assert_eq!(before.mouse.surface_width, 800);
         assert_eq!(before.mouse.surface_height, 600);
@@ -3639,6 +3685,7 @@ mod tests {
             false,
             false,
             (1440, 900),
+            None,
             None,
         );
         assert_eq!(after.mouse.x, 777);
@@ -3691,6 +3738,7 @@ mod tests {
             true,
             (800, 600),
             Some(&injected),
+            None,
         );
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
         // Keyboard/mouse domains stay live alongside it.
@@ -3719,6 +3767,7 @@ mod tests {
             false,
             (800, 600),
             None,
+            None,
         );
         assert_eq!(plain.xr, None, "no XR domain without a device or injection");
 
@@ -3731,8 +3780,67 @@ mod tests {
             false,
             (800, 600),
             Some(&injected),
+            None,
         );
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
+    }
+
+    #[test]
+    fn an_injected_gamepad_sample_supplies_the_domain_and_survives_refresh() {
+        let pad = GamepadSnapshot {
+            left_stick: [-0.5, 1.0],
+            south: true,
+            ..GamepadSnapshot::default()
+        };
+        let plain = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            MouseButtons::default(),
+            &InputEdges::default(),
+            false,
+            false,
+            (800, 600),
+            None,
+            None,
+        );
+        assert_eq!(
+            plain.gamepad, None,
+            "no gamepad domain without a device or injection"
+        );
+
+        let mut snapshot = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            MouseButtons::default(),
+            &InputEdges::default(),
+            false,
+            false,
+            (800, 600),
+            None,
+            Some(&pad),
+        );
+        assert_eq!(snapshot.gamepad.as_ref(), Some(&pad));
+
+        // The injected sample is level state: the per-step refresh carries it,
+        // and clearing the override drops the domain.
+        refresh_fixed_input_levels(
+            &mut snapshot,
+            &BTreeSet::new(),
+            MouseButtons::default(),
+            false,
+            None,
+            Some(&pad),
+        );
+        assert_eq!(snapshot.gamepad.as_ref(), Some(&pad));
+        refresh_fixed_input_levels(
+            &mut snapshot,
+            &BTreeSet::new(),
+            MouseButtons::default(),
+            false,
+            None,
+            None,
+        );
+        assert_eq!(snapshot.gamepad, None);
     }
 
     #[test]
@@ -3747,6 +3855,7 @@ mod tests {
             false,
             (800, 600),
             Some(&injected),
+            None,
         );
         // Space would drive the EMULATOR's trigger to 1.0; the injected sample
         // owns the XR domain, so window keys must leave it alone.
@@ -3758,6 +3867,7 @@ mod tests {
             MouseButtons::default(),
             true,
             Some(&injected),
+            None,
         );
 
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1138,7 +1138,7 @@ fn service_debug_request(
                     // game through the same `sampled_input` path a real pad
                     // takes, so it lands in the recorded input log and
                     // replays identically.
-                    *gamepad_override = Some(*snapshot);
+                    *gamepad_override = Some(snapshot);
                     Ok(())
                 }
                 debug_server::InputCommand::GamepadClear => {

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -743,6 +743,15 @@ fn service_debug_request(
 tracking); use the desktop runtime's --headless/--debug-port path"
                         .to_string(),
                 ),
+                // Same story for the gamepad domain: the device runtime does
+                // not sample pads (Quest controllers ARE the xr domain), so
+                // honoring an injection here would invent a device the shell
+                // can never refresh or clear on its own.
+                InputCommand::Gamepad(_) | InputCommand::GamepadClear => Err(
+                    "gamepad injection is unsupported on the device runtime; use the \
+desktop runtime's --headless/--debug-port path"
+                        .to_string(),
+                ),
             };
             if clock.is_paused() {
                 game.absorb_paused_input();

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 305));
+        assert_eq!(count(ApiGroup::Engine), (27, 306));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -1,5 +1,7 @@
 import type { HttpClient } from "./client.js";
 import type {
+  GamepadInputSample,
+  GamepadSnapshot,
   InputCommand,
   KeyName,
   MouseButtonName,
@@ -67,6 +69,12 @@ export class FunctorClient {
    * targets and while XR tracking is unavailable. */
   async xrInput(): Promise<XrInputSnapshot | undefined> {
     return (await this.state()).input.xr;
+  }
+
+  /** Latest gamepad snapshot, or undefined while no pad is connected (or
+   * injected). */
+  async gamepadInput(): Promise<GamepadSnapshot | undefined> {
+    return (await this.state()).input.gamepad;
   }
 
   /** Capture the next rendered frame as PNG bytes. */
@@ -209,6 +217,21 @@ export class FunctorClient {
    * {@link xr}'s held-key contract. */
   xrClear(): Promise<void> {
     return this.input({ type: "xr_clear" });
+  }
+
+  /** Set the gamepad sample the next fixed step's `sampledInput` sees —
+   * sticks, triggers, and buttons without a physical pad (desktop runtimes
+   * only). The {@link xr} contract: level state until replaced, a whole-sample
+   * replacement whose omitted fields take their defaults. */
+  gamepad(sample: GamepadInputSample): Promise<void> {
+    return this.input({ type: "gamepad", ...sample });
+  }
+
+  /** Drop an injected gamepad sample, restoring what the runtime samples on
+   * its own — a physically connected pad, or no `gamepad` domain at all. The
+   * release half of {@link gamepad}'s held-key contract. */
+  gamepadClear(): Promise<void> {
+    return this.input({ type: "gamepad_clear" });
   }
 
   /** Click an interactive UI slot (`Clicked` in the runtime's UI protocol). */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -107,7 +107,8 @@ export interface InputSnapshot {
   };
   /** Present while an XR target has valid head tracking. */
   xr?: XrInputSnapshot;
-  /** Present while a gamepad is connected (or injected). */
+  /** Present while a gamepad sample is injected (no shell polls a physical
+   * pad yet; polling will make this "while a pad is connected"). */
   gamepad?: GamepadSnapshot;
 }
 

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -38,6 +38,31 @@ export interface XrInputSnapshot {
   right: XrControllerSnapshot;
 }
 
+/** The primary connected gamepad's held state, aligned to the standard
+ * mapping desktop and web pads share. Face buttons are positional (`south` is
+ * the bottom face button); sticks are `-1..1` with up-positive Y (the XR
+ * thumbstick convention); triggers are `0..1`. Levels only — no edge sets. */
+export interface GamepadSnapshot {
+  left_stick: [x: number, y: number];
+  right_stick: [x: number, y: number];
+  left_trigger: number;
+  right_trigger: number;
+  south: boolean;
+  east: boolean;
+  west: boolean;
+  north: boolean;
+  left_bumper: boolean;
+  right_bumper: boolean;
+  left_stick_pressed: boolean;
+  right_stick_pressed: boolean;
+  dpad_up: boolean;
+  dpad_down: boolean;
+  dpad_left: boolean;
+  dpad_right: boolean;
+  start: boolean;
+  select: boolean;
+}
+
 /** Wire spelling of a mouse button for `POST /input`. */
 export type MouseButtonName = "left" | "right" | "middle";
 
@@ -50,9 +75,9 @@ export interface MouseButtons {
 
 /** Runtime-owned input sampled independently of the game model.
  *
- * Typed device domains extend this record: XR is available today; gamepad and
- * mobile-touch snapshots can be added without replacing keyboard/mouse or
- * introducing target-specific clients. */
+ * Typed device domains extend this record: XR and gamepad are available
+ * today; a mobile-touch snapshot can be added without replacing
+ * keyboard/mouse or introducing target-specific clients. */
 export interface InputSnapshot {
   /** Keys currently held, by canonical name. */
   held_keys: KeyName[];
@@ -82,6 +107,8 @@ export interface InputSnapshot {
   };
   /** Present while an XR target has valid head tracking. */
   xr?: XrInputSnapshot;
+  /** Present while a gamepad is connected (or injected). */
+  gamepad?: GamepadSnapshot;
 }
 
 export interface RuntimeViewport {
@@ -164,7 +191,15 @@ export type InputCommand =
   | { type: "ui_event"; slot: number; kind: UiEventKind }
   | { type: "webview_event"; slot: number; kind: UiEventKind }
   | ({ type: "xr" } & XrInputSample)
-  | { type: "xr_clear" };
+  | { type: "xr_clear" }
+  | ({ type: "gamepad" } & GamepadInputSample)
+  | { type: "gamepad_clear" };
+
+/** An injected gamepad sample for `POST /input` (desktop only) — the
+ * {@link XrInputSample} contract for the pad domain: level state until
+ * replaced, a whole-sample replacement whose omitted fields take their
+ * defaults (centered sticks, released triggers/buttons). */
+export type GamepadInputSample = Partial<GamepadSnapshot>;
 
 /** An injected XR sample for `POST /input` (desktop only).
  *

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -329,6 +329,64 @@ test("xr() posts a flat, tagged sample and passes partials through", async () =>
   ]);
 });
 
+test("gamepadInput returns the typed optional input domain", async () => {
+  const gamepad = {
+    left_stick: [-0.5, 1] as [number, number],
+    right_stick: [0, 0] as [number, number],
+    left_trigger: 0,
+    right_trigger: 0.25,
+    south: true,
+    east: false,
+    west: false,
+    north: false,
+    left_bumper: false,
+    right_bumper: false,
+    left_stick_pressed: false,
+    right_stick_pressed: false,
+    dpad_up: false,
+    dpad_down: false,
+    dpad_left: true,
+    dpad_right: false,
+    start: false,
+    select: false,
+  };
+  const http = {
+    getJson: async () => ({
+      frame: 1,
+      tts: 0,
+      viewport: { width: 1, height: 1 },
+      views: [],
+      model: "{}",
+      input: { held_keys: [], mouse: { x: 0, y: 0 }, gamepad },
+    }),
+  } as unknown as HttpClient;
+  const client = new FunctorClient(http);
+
+  assert.deepEqual(await client.gamepadInput(), gamepad);
+});
+
+test("gamepad() posts a flat, tagged partial sample; gamepadClear() releases it", async () => {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const http = {
+    postText: async (path: string, body: unknown) => {
+      calls.push({ path, body });
+      return "ok";
+    },
+  } as HttpClient;
+  const client = new FunctorClient(http);
+
+  await client.gamepad({ left_stick: [-0.5, 1], south: true });
+  await client.gamepadClear();
+
+  assert.deepEqual(calls, [
+    {
+      path: "/input",
+      body: { type: "gamepad", left_stick: [-0.5, 1], south: true },
+    },
+    { path: "/input", body: { type: "gamepad_clear" } },
+  ]);
+});
+
 test("reloadAssets uploads binary envelopes then finalizes the manifest", async () => {
   const calls: Array<{ path: string; body: unknown }> = [];
   const http = {


### PR DESCRIPTION
Part 1 of the gamepad + touch input series (design: gamepad/touch domains as typed siblings of `xr` on `InputSnapshot`, per the seam's own extension contract). This slice is the domain core + headless injection; no shell polls a physical pad yet — GLFW polling (native) and `navigator.getGamepads()` (web) are the next two stacked PRs, slotting into `desktop_input_snapshot` as `override > polled > None`.

## What's here

- **`GamepadSnapshot`** (`input.rs`): the primary pad's held state, aligned to the standard mapping GLFW and the Web Gamepad API share. Positional face buttons (`south`/`east`/`west`/`north` — vendor letter swaps can't mislabel), sticks `-1..1` with **up-positive Y** (the XR thumbstick convention; polling shells negate the platform's down-positive axes), triggers `0..1`, raw values (no engine deadzone). **Levels only** — pads are polled so a press always spans a sample; games detect edges against their model exactly as XR games do, and the domain rides `RecordedInput::Snapshot` record/replay with zero `InputEdges` work.
- **`Input.gamepad`** in the `.funi` prelude + skill docs; the embedded end-to-end test reads `snapshot.gamepad` through the real typechecker+interpreter so a field drift on either side fails a test.
- **Injection**: `POST /input` `{"type":"gamepad",…}` / `{"type":"gamepad_clear"}` — the `xr`/`xr_clear` contract verbatim (level state until replaced, whole-sample replacement, `deny_unknown_fields` → typos 400, recorded + replayable, no entry-point call). Desktop threads `gamepad_override` beside `xr_override`; the device runtime rejects it like `xr`.
- **SDK**: `GamepadSnapshot`/`GamepadInputSample` types, `gamepad()`/`gamepadClear()`/`gamepadInput()`, plus the MCP `run_script` bridge arms.
- Protocol v12 / debug-protocol v10 notes + bumps.

## Verification

- `cargo test -p functor_runtime_common` (691 + 31) and `-p functor-runtime-desktop` (86) — includes new serde round-trip/omission, Value golden-shape, injection-threading, and partial-decode/typo-rejection tests.
- `npm run check:docs`; SDK `npm test` (20, incl. new gamepad sample/accessor tests).
- Live headless e2e: `functor run native --headless --debug-port` on a `sampledInput` game → inject `{"left_stick":[-0.5,1.0],"south":true}` → model reads `x:-0.5, y:1.0, south:true, connected:true` → `gamepad_clear` → `Option.None`; a misspelled field 400s naming the valid field list.

## xreview

Two-engine adversarial review + de-dup pass run; all findings addressed in the second commit:
- **[AGREED, High]** docs claimed physical-pad behavior the slice doesn't ship → every surface now states injection-only-today.
- **Medium** `.funi`↔Value drift unguarded → embedded typed test now reads the gamepad domain.
- **Medium** MCP `run_script` bridge missing the new methods → arms added.
- **Low** `GET /state` example JSON lacked the referenced `gamepad` block → added; **Low** unjustified `Box` on `InputCommand::Gamepad` → unboxed; de-dup `extract` → shared `axes2_value` for sticks/thumbstick.

No visual changes (data/protocol only, no rendering), so no pr-visuals capture. Not perf-sensitive beyond `input_snapshot_value`, which only gains an `Option.None` arm when no pad is present.