### PR TITLE
feat(site): the wire tab — the traffic monitor lives in the bottom panel

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -28,7 +28,11 @@
 //      and network views, the "+" seat is last in reading order, and the
 //      network wires anchor to the cards rather than to the cells;
 //   8. parked, the wires and the pinned wire log replay the packet LOG at the
-//      playhead rather than showing a frozen live feed.
+//      playhead rather than showing a frozen live feed;
+//   9. the WIRE TAB — the same traffic monitor docked in the status bar — is
+//      present (and counting) in every layout, filters by link and direction,
+//      opens payloads into the value tree, stays scrub-locked, and is absent
+//      from a single-role example.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -197,7 +201,9 @@ const installProbe = (page) =>
         return {
           mounted: true,
           openRows: open,
-          footer: document.querySelector(".mp-wl-ft").textContent.trim(),
+          // The pinned panel's footer, when it is the tree's host; the wire tab
+          // has its own (`.wire-ft`, read by wireTab()).
+          footer: document.querySelector(".mp-wl-ft")?.textContent.trim() ?? "",
           nodes: [...tree.querySelectorAll(".mp-vt-row")]
             // A node inside a CLOSED parent is in the DOM but not on screen.
             .filter((row) => !row.closest(".mp-vt-kids[hidden]"))
@@ -215,6 +221,46 @@ const installProbe = (page) =>
         return true;
       },
       clickEdge: (index) => document.querySelectorAll(".mp-edge-chip")[index].click(),
+      /** The WIRE TAB in the status bar: the docked traffic monitor. Read from
+       * the bar's own chrome, so "present" means the tab a reader can click. */
+      wireTab: () => {
+        const tab = document.querySelector('.statusbar-tab[data-tab="wire"]');
+        const badge = tab?.querySelector(".wire-badge");
+        const list = document.querySelector(".wire-list");
+        return {
+          present: !!tab,
+          active: !!tab?.classList.contains("active"),
+          badge: badge?.textContent?.trim() ?? "",
+          badgeHidden: !badge || badge.hidden,
+          // The panel is toggled with `display`, like every other tab's list.
+          open: !!list && getComputedStyle(list).display !== "none",
+          // Which layout the panes are in — the whole point is that this works
+          // outside the network view.
+          view: document.querySelector(".mp-grid").dataset.view,
+          chips: [...document.querySelectorAll(".wire-filters .wire-chip")].map(
+            (chip) => `${chip.textContent.trim()}:${chip.getAttribute("aria-pressed")}`
+          ),
+          footer: document.querySelector(".wire-ft")?.textContent.trim() ?? "",
+          rows: [...document.querySelectorAll(".wire-rows .mp-wl")].map((row) => ({
+            frame: Number((row.querySelector(".f").textContent.match(/-?\d+/) ?? [NaN])[0]),
+            link: row.querySelector(".l")?.textContent.trim() ?? null,
+            dir: row.querySelector(".d").textContent.trim(),
+            payload: row.querySelector(".payload").textContent.trim(),
+            bytes: row.querySelector(".n").textContent.trim(),
+            at: row.classList.contains("at"),
+          })),
+        };
+      },
+      openWireTab: () => document.querySelector('.statusbar-tab[data-tab="wire"]').click(),
+      /** Pick a filter chip by its label prefix (`c2`, `intent`, `all`). */
+      pickWireChip: (label) => {
+        const chip = [...document.querySelectorAll(".wire-filters .wire-chip")].find((one) =>
+          one.textContent.trim().startsWith(label)
+        );
+        if (!chip) return false;
+        chip.click();
+        return true;
+      },
       pauseAll: () => document.getElementById("mp-pause").click(),
       layout: () => ({
         view: document.querySelector(".mp-grid").dataset.view,
@@ -1271,6 +1317,164 @@ try {
     await page.close();
   }
 
+  // --- 4g. The WIRE TAB: the traffic monitor, docked. -------------------------
+  // Addendum 8.2. The pinned panel above lives in the network view and hangs off
+  // one wire; this is the same rows as a permanent tab in the bottom panel, so
+  // the assertions here are the ones the pinned panel cannot make: the tab is
+  // there while the panes are in TILED, its badge counts packets while it is
+  // closed, the link filter narrows the list, and the rows are still
+  // scrub-locked to the rail.
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`${BASE}/sandbox.html?example=orbs#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+
+    // CLOSED, in the default layout: the tab exists and its badge is counting.
+    const counting = await page
+      .waitForFunction(() => Number(window.__mpProbe.wireTab().badge) > 0, null, {
+        timeout: 25000,
+      })
+      .then(() => page.evaluate(() => window.__mpProbe.wireTab()))
+      .catch(() => page.evaluate(() => window.__mpProbe.wireTab()));
+    check(
+      counting.present && counting.view === "tiled" && !counting.open && !counting.badgeHidden,
+      "the wire tab sits in the bottom panel from the start, closed, in TILED",
+      JSON.stringify({ view: counting.view, open: counting.open, badge: counting.badge })
+    );
+    check(
+      Number(counting.badge) > 0,
+      "its badge counts routed packets while the panel is closed",
+      counting.badge
+    );
+
+    // OPEN: rows, in a layout that draws no wires at all — the whole point.
+    await page.evaluate(() => window.__mpProbe.openWireTab());
+    await sleep(400);
+    const opened = await page.evaluate(() => window.__mpProbe.wireTab());
+    check(
+      opened.open && opened.active && opened.view === "tiled" && opened.rows.length > 0,
+      "opening it shows traffic in TILED — no network view needed",
+      `${opened.rows.length} rows in ${opened.view}`
+    );
+    check(
+      opened.badgeHidden,
+      "the count steps aside once the rows are on screen",
+      `badge "${opened.badge}"`
+    );
+    check(
+      opened.rows.some((row) => /Snapshot|Steer|Welcome|Join|Claim/.test(row.payload)) &&
+        opened.rows.every((row) => /^\d+ B$/.test(row.bytes)),
+      "the rows are the same grammar as the pinned panel — decoded values and bytes",
+      `e.g. "${opened.rows.at(-1)?.payload ?? ""}" ${opened.rows.at(-1)?.bytes ?? ""}`
+    );
+    // ALL is the default, so every row names the link it crossed and both
+    // clients are in the one list.
+    const linksSeen = new Set(opened.rows.map((row) => row.link));
+    check(
+      opened.chips[0] === "all links:true" &&
+        opened.rows.every((row) => row.link) &&
+        linksSeen.size > 1,
+      "ALL interleaves every link, each row naming the wire it crossed",
+      `${[...linksSeen].join(", ")} — chips ${opened.chips.join(" | ")}`
+    );
+    check(
+      /showing the last \d+ of \d+ rows|^\d+ rows?/.test(opened.footer),
+      "the footer says how much of the log it is showing",
+      opened.footer
+    );
+
+    // The LINK FILTER narrows the list to one wire (and drops the now-redundant
+    // link column with it).
+    await page.evaluate(() => window.__mpProbe.pickWireChip("c2"));
+    await sleep(400);
+    const filtered = await page.evaluate(() => window.__mpProbe.wireTab());
+    check(
+      filtered.rows.length > 0 &&
+        filtered.rows.every((row) => /c2/.test(row.dir)) &&
+        filtered.rows.every((row) => row.link === null) &&
+        filtered.chips.includes("c2 ↔ srv:true"),
+      "picking a link narrows the monitor to that wire",
+      `${filtered.rows.length} rows: ${[...new Set(filtered.rows.map((r) => r.dir))].join(" ")}`
+    );
+    // ...and the direction filter drops half the conversation.
+    await page.evaluate(() => window.__mpProbe.pickWireChip("intent"));
+    await sleep(400);
+    const intent = await page.evaluate(() => window.__mpProbe.wireTab());
+    check(
+      intent.rows.length > 0 && intent.rows.every((row) => row.dir === "c2→srv"),
+      "the direction filter keeps intent only",
+      [...new Set(intent.rows.map((r) => r.dir))].join(" ")
+    );
+    await page.evaluate(() => window.__mpProbe.pickWireChip("both"));
+    await sleep(300);
+
+    // The value tree opens in the tab exactly as it does in the panel.
+    const compact = await page.evaluate(() => window.__mpProbe.openBiggestRow());
+    await sleep(200);
+    const tree = await page.evaluate(() => window.__mpProbe.valueTree());
+    check(
+      tree.mounted && tree.openRows === 1 && tree.nodes.length > 1,
+      "a payload opens into its value tree inside the tab",
+      `${tree.nodes.length} nodes from "${compact}"`
+    );
+    const heldFooter = (await page.evaluate(() => window.__mpProbe.wireTab())).footer;
+    check(
+      /tail is held/.test(heldFooter),
+      "opening a row holds the tail, and the footer says so",
+      heldFooter
+    );
+    // A held tail is a FROZEN list, so changing the filter under one would keep
+    // showing rows the pressed chip excludes. Changing a filter closes the row.
+    await page.evaluate(() => window.__mpProbe.pickWireChip("intent"));
+    await sleep(400);
+    const refiltered = await page.evaluate(() => ({
+      ...window.__mpProbe.wireTab(),
+      tree: window.__mpProbe.valueTree(),
+    }));
+    check(
+      !refiltered.tree.mounted &&
+        refiltered.tree.openRows === 0 &&
+        refiltered.rows.length > 0 &&
+        refiltered.rows.every((row) => row.dir === "c2→srv"),
+      "changing a filter while a row is open closes it — the held rows are the old filter's",
+      `${refiltered.rows.length} rows: ${[...new Set(refiltered.rows.map((r) => r.dir))].join(" ")}`
+    );
+    await page.evaluate(() => window.__mpProbe.pickWireChip("both"));
+    await sleep(300);
+
+    // SCRUB-LOCKED: parked, the tab's viewport follows the rail and marks the
+    // row nearest the playhead — the same promise the pinned panel makes.
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(600);
+    await page.focus("#mp-playhead");
+    await page.keyboard.press("End");
+    await sleep(500);
+    const head = await page.evaluate(() => ({
+      ...window.__mpProbe.wireTab(),
+      label: window.__mpProbe.railFrame(),
+    }));
+    const playhead = Number(head.label.match(/-?\d+/)?.[0] ?? NaN);
+    const marked = head.rows.find((row) => row.at);
+    check(
+      !!marked && Math.abs(marked.frame - playhead) <= 60,
+      "parked, the tab marks the row nearest the playhead",
+      `playhead #f ${playhead}; marked ${JSON.stringify(marked ?? null)}`
+    );
+    await page.keyboard.press("Home");
+    await sleep(500);
+    const start = await page.evaluate(() => window.__mpProbe.wireTab());
+    check(
+      start.rows.length === 0 ||
+        start.rows.at(-1).frame < (head.rows.at(-1)?.frame ?? Infinity),
+      "seeking sweeps the tab's viewport with the playhead",
+      `head ended at #f ${head.rows.at(-1)?.frame}, start ends at #f ${start.rows.at(-1)?.frame}`
+    );
+    await page.close();
+  }
+
   // --- 5. Switching away drops the server pane. -------------------------------
   {
     const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
@@ -1297,6 +1501,14 @@ try {
       (await page.evaluate(() => window.__mpProbe.layout().view)) !== "network",
       "losing the authority falls the layout back out of NETWORK",
       await page.evaluate(() => window.__mpProbe.layout().view)
+    );
+    // Same gate for the docked monitor: no authority, no links, no coordinator
+    // log — so the tab is absent rather than an empty panel.
+    const soloWire = await page.evaluate(() => window.__mpProbe.wireTab());
+    check(
+      !soloWire.present && !soloWire.open,
+      "a single-role example has no wire tab at all",
+      JSON.stringify(soloWire)
     );
 
     // No authority, no hub: NETWORK is disabled with a tooltip that says why,

--- a/site/src/components/StatusBar.tsx
+++ b/site/src/components/StatusBar.tsx
@@ -9,13 +9,14 @@
 // `display`, exactly as before.
 
 import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { ReactNode } from "react";
 import { outputPreamble } from "../status-bar-store.js";
 import type { StatusBarStore } from "../status-bar-store.js";
 import { EditorKeybindingsButton } from "./EditorKeybindingsButton.js";
 import type { EditorKeybindingsController } from "../editor-keybindings.js";
 
 /** Which panel a tab opens; also the tab's `data-tab`. */
-type TabName = "problems" | "output" | "executions";
+type TabName = "problems" | "output" | "executions" | "wire";
 
 // The Vim adapter renders its --MODE-- readout, pending keys, and `:`/`/`
 // command input into this segment (imperatively — React never writes children
@@ -57,9 +58,16 @@ export const StatusBar = ({
   store: StatusBarStore;
   editorKeybindings: EditorKeybindingsController;
 }) => {
-  const { problems, output, executions } = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const { problems, output, executions, wirePresent } = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot
+  );
   const [open, setOpen] = useState<TabName | null>(null);
   const outputList = useRef<HTMLDivElement>(null);
+  // The traffic monitor's two nodes (`store.wire`), mounted exactly like the
+  // view strip below: their owner is imperative and repaints per frame.
+  const wireHost = useRef<HTMLDivElement>(null);
+  const wireBadgeHost = useRef<HTMLSpanElement>(null);
   // The view-scoped strip (`store.viewStrip`): a node an imperative surface
   // fills — today the pane grid's NETWORK legend and pane readouts. React
   // mounts it and never renders into it, so its owner can repaint per frame
@@ -95,18 +103,31 @@ export const StatusBar = ({
     if (list && open === "output") list.scrollTop = list.scrollHeight;
   }, [open]);
 
-  // `replaceChildren`, not `appendChild`: React does not manage this node, so a
-  // swapped store would otherwise leave the previous strip mounted beside it.
+  // `replaceChildren`, not `appendChild`: React does not manage these nodes, so
+  // a swapped store would otherwise leave the previous ones mounted beside them.
   useLayoutEffect(() => {
     viewHost.current?.replaceChildren(store.viewStrip);
   }, [store]);
+
+  useLayoutEffect(() => {
+    wireHost.current?.replaceChildren(store.wire.panel);
+    wireBadgeHost.current?.replaceChildren(store.wire.badge);
+  }, [store, wirePresent]);
+
+  // The monitor polls this rather than being pushed to — see `WireSlot`. An
+  // example that drops its authority takes the tab with it, so an open wire
+  // panel closes rather than lingering over a session that no longer has one.
+  useEffect(() => {
+    store.wire.open = open === "wire" && wirePresent;
+    if (open === "wire" && !wirePresent) setOpen(null);
+  }, [store, open, wirePresent]);
 
   const panel = (name: TabName) => ({
     className: `statusbar-list ${name}-list`,
     style: open === name ? undefined : { display: "none" },
   });
 
-  const tab = (name: TabName, label: string, extra = "") => (
+  const tab = (name: TabName, label: ReactNode, extra = "") => (
     <button
       type="button"
       className={`statusbar-tab${open === name ? " active" : ""}${extra}`}
@@ -162,11 +183,37 @@ export const StatusBar = ({
             ))
           )}
         </div>
+        {/* The traffic monitor, filled by wire-tab.ts. Mounted only while the
+            session has an authority, so its rows can never outlive their
+            session's links. */}
+        {wirePresent && <div {...panel("wire")} ref={wireHost} />}
       </div>
       <div className="statusbar-strip">
         {tab("problems", problemsLabel(problems.length, errors), errors > 0 ? " has-problems" : "")}
         {tab("output", "output")}
         {tab("executions", executions.length ? `⏸ ${executions.length} executions` : "executions")}
+        {wirePresent &&
+          tab(
+            "wire",
+            <>
+              wire
+              {/* The live packet count. Hidden while the panel is open — the
+                  rows are the count then, and a number ticking beside them is
+                  noise.
+
+                  `aria-hidden` deliberately: it changes ten times a second, and
+                  a control whose ACCESSIBLE NAME churns at that rate is worse
+                  than one without the number. The tab keeps the stable name
+                  "wire"; the traffic itself is real text once the panel is
+                  open — the rows and the footer's "showing N of M". */}
+              <span
+                className="wire-badge"
+                ref={wireBadgeHost}
+                hidden={open === "wire"}
+                aria-hidden="true"
+              />
+            </>
+          )}
         <div className="statusbar-view-host" ref={viewHost} />
         <EditorKeybindingsButton controller={editorKeybindings} />
         <VimSegment controller={editorKeybindings} />

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -23,8 +23,17 @@
 // scrubbing sweeps the rows the same way it sweeps the dots.
 
 import type { NetCoordinator, Packet } from "./net-coordinator.js";
-import { hasTree, mountValueTree } from "./value-tree.js";
-import { decodeWire, fullWire, type WireValue } from "./wire-value.js";
+import {
+  buildWireRow,
+  indexAfter,
+  LIVE_ROW_MS,
+  logWindow,
+  onLink,
+  openTree,
+  packetKey,
+  shortName,
+} from "./wire-rows.js";
+import type { WireValue } from "./wire-value.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
@@ -88,17 +97,6 @@ const WIRE_LOG_LEAD = 3;
 const PANEL_MARGIN = 10;
 
 /**
- * How often the LIVE tail repaints its rows, in ms.
- *
- * A tail that turns over sixty times a second is not a log, it is a blur — and
- * each repaint decodes a dozen payloads and rebuilds the rows, on a page that
- * is already running three games. Ten a second reads as live and costs a sixth
- * as much. Parked, there is no throttle at all: the panel must answer the rail
- * on the frame the playhead moves.
- */
-const LIVE_ROW_MS = 100;
-
-/**
  * Payload bytes at which a dot reaches its largest size, per direction.
  *
  * INTENT is a keypress-sized message, so it saturates early and its range is
@@ -147,6 +145,17 @@ export interface NetworkGraphOptions {
    * timeline, so the rail decides which packets are on the wires.
    */
   clock: () => { parked: boolean; frame: number | null };
+  /**
+   * A wire was pinned (or unpinned, with null) — the one place a reader says
+   * "THIS link is the interesting one".
+   *
+   * The wire tab in the bottom panel follows the non-null half of it (see
+   * wire-tab.ts's note on the selection model): pinning a wire here focuses the
+   * same link there, so one click aims both surfaces. Unpinning is deliberately
+   * NOT propagated — "no pin" and "every link" are different statements, and
+   * this panel unpins itself whenever the network view closes.
+   */
+  onSelect?: (id: string | null) => void;
 }
 
 export interface NetworkGraph {
@@ -217,6 +226,7 @@ export function initNetworkGraph({
   clients,
   server,
   clock,
+  onSelect,
 }: NetworkGraphOptions): NetworkGraph {
   const layer = document.createElement("div");
   layer.className = "mp-net-layer";
@@ -302,11 +312,6 @@ export function initNetworkGraph({
    * a repaint rebuilds every row, and the button the reader just pressed with
    * the keyboard is one of the ones it destroys. */
   let refocus: Packet | null = null;
-
-  /** A row's cache key — the four fields that make two rows different. Identity
-   * is the `Packet` itself (see `opened`); this is only for the change hash. */
-  const packetKey = (packet: Packet): string =>
-    `${packet.frame}:${packet.from}:${packet.size}:${packet.at}`;
 
   const addEdge = (node: NetworkNode): Edge => {
     const path = document.createElementNS(SVG_NS, "path");
@@ -465,41 +470,9 @@ export function initNetworkGraph({
   // game sent. It is a panel rather than a hover tooltip precisely because it
   // has to stay readable while the other hand is scrubbing.
 
-  /** `client 2` → `c2`, `server` → `srv`: a direction column has to fit. */
-  const shortName = (id: string): string =>
-    id === "server" ? "srv" : id.startsWith("client ") ? `c${id.slice(7)}` : id;
-
-  /**
-   * Is this packet traffic on the pinned link?
-   *
-   * A link is a PANE PAIR, not a connection id: a game that opened two
-   * connections to the same authority would interleave both here. Nothing in
-   * the samples does, and the pane pair is what the wire on screen represents.
-   */
-  const onLink = (packet: Packet, id: string): boolean =>
-    packet.kind === "message" &&
-    ((packet.from === id && packet.to === "server") ||
-      (packet.from === "server" && packet.to === id));
-
-  /**
-   * The first index in the log whose frame is after `at` — the playhead's place
-   * in the record, by binary search.
-   *
-   * The log is sorted by frame because the reference clock only ever advances;
-   * an unframed packet (the boot handshake, routed before the reference pane
-   * had recorded a frame) sorts before everything, which is also where it
-   * belongs on the timeline.
-   */
-  const indexAfter = (log: readonly Packet[], at: number): number => {
-    let lo = 0;
-    let hi = log.length;
-    while (lo < hi) {
-      const mid = (lo + hi) >> 1;
-      if ((log[mid].frame ?? -Infinity) <= at) lo = mid + 1;
-      else hi = mid;
-    }
-    return lo;
-  };
+  // The row grammar itself — `#f · direction · payload · bytes`, plus the log
+  // walks that place a viewport on the playhead — is shared with the wire tab
+  // (wire-rows.ts), so the two surfaces read identically.
 
   const selectEdge = (id: string | null) => {
     if (id !== null && !edges.has(id)) return;
@@ -520,6 +493,7 @@ export function initNetworkGraph({
     // A new link is a new tether and a new free quadrant to find, even when the
     // row count happens to match (which is what renderPanel re-places on).
     placePanel();
+    onSelect?.(id);
   };
 
   /**
@@ -528,38 +502,20 @@ export function initNetworkGraph({
    * means when the log is already in routing order), plus which row the
    * playhead is on.
    *
-   * SCRUB-LOCKED: parked, the window ends a few rows PAST the playhead's row so
-   * the parked frame is not the last line on the panel; live, it tails the
-   * newest traffic. One time axis, two representations (design §5).
-   *
-   * Costs a screenful, not a session: the log is ordered by frame (the
-   * reference clock only advances), so the playhead's position is found by
-   * BINARY SEARCH and the walk starts there. A linear scan from the end would
-   * traverse all ten thousand packets every time the rail is parked in the
-   * past — exactly the state this feature exists for.
+   * SCRUB-LOCKED, and the lock itself is shared with the wire tab
+   * (`logWindow`): one time axis, two representations (design §5), so the two
+   * surfaces cannot answer the rail differently. All this adds is WHICH packets
+   * count as this panel's — the pinned link's.
    */
   const viewportRows = (
     id: string,
     at: number | null
-  ): { rows: Packet[]; highlight: number } => {
-    const log = net.packets();
-    const before: Packet[] = [];
-    const after: Packet[] = [];
-    // The lead rows first, walking FORWARD from the playhead: the ones nearest
-    // it, not the newest in the session.
-    const pivot = at === null ? log.length : indexAfter(log, at);
-    for (let i = pivot; i < log.length && after.length < WIRE_LOG_LEAD; i++) {
-      if (onLink(log[i], id)) after.push(log[i]);
-    }
-    for (let i = pivot - 1; i >= 0 && before.length < WIRE_LOG_ROWS; i--) {
-      if (onLink(log[i], id)) before.push(log[i]);
-    }
-    before.reverse();
-    const rows = before.slice(Math.max(0, before.length - (WIRE_LOG_ROWS - after.length)));
-    const highlight = at === null || rows.length === 0 ? -1 : rows.length - 1;
-    rows.push(...after);
-    return { rows, highlight };
-  };
+  ): { rows: Packet[]; highlight: number } =>
+    logWindow(net.packets(), at, {
+      match: (packet) => onLink(packet, id),
+      back: WIRE_LOG_ROWS,
+      lead: WIRE_LOG_LEAD,
+    });
 
   /**
    * Open a row into a value tree — or close the one that is open.
@@ -574,14 +530,13 @@ export function initNetworkGraph({
     if (opened?.packet === packet) {
       opened = null;
     } else {
-      const host = document.createElement("div");
-      host.className = "mp-wl-tree";
-      // The rows are a `role="log"` live region; a tree opening inside one
-      // would otherwise be read out in full on every repaint that re-parents
-      // it. It is a thing to explore, not an announcement.
-      host.setAttribute("aria-live", "off");
-      mountValueTree(host, value, placePanel);
-      opened = { packet, host, held: clock().parked ? null : [...shown] };
+      // The panel positions itself against its own height, so a node opening
+      // inside the tree has to re-place it.
+      opened = {
+        packet,
+        host: openTree(value, placePanel),
+        held: clock().parked ? null : [...shown],
+      };
     }
     // The reader may have pressed this button with the keyboard, and the
     // repaint below destroys it — hand the focus to its replacement.
@@ -633,76 +588,16 @@ export function initNetworkGraph({
     let focusTarget: HTMLElement | null = null;
     panelRows.replaceChildren(
       ...shown.map((packet, index) => {
-        const up = packet.from !== "server";
-        const decoded = decodeWire(packet.text);
-        if (!decoded.typed) anyPlain = true;
         const isOpen = opened?.packet === packet;
-        const row = document.createElement("div");
-        row.className = `mp-wl${index === highlight ? " at" : ""}`;
-        // The full rendering is built ON HOVER, once: rendering every row's
-        // whole payload unelided (a world snapshot, per row, per repaint) to
-        // fill a tooltip nobody has asked for yet is the most expensive thing
-        // this panel could do. An OPEN row skips it: the tooltip would cover
-        // the tree that already says the same thing, better.
-        if (!isOpen) {
-          row.addEventListener(
-            "mouseenter",
-            () => {
-              row.title = fullWire(packet.text);
-            },
-            { once: true }
-          );
-        }
-        const frameCell = document.createElement("span");
-        frameCell.className = "f";
-        frameCell.textContent = `#f ${packet.frame ?? "—"}`;
-        const dirCell = document.createElement("span");
-        dirCell.className = `d ${up ? "up" : "dn"}`;
-        dirCell.textContent = up
-          ? `${shortName(packet.from)}→srv`
-          : `srv→${shortName(packet.to)}`;
-        // The payload cell is the disclosure control when there is something to
-        // disclose: a typed payload WITH structure, whose whole value the page
-        // already holds (the frame is decoded client-side, so opening it costs
-        // nothing but the DOM). A plain `Effect.send` text — or a bare
-        // `Welcome(2)`, which the row already shows completely — stays a plain
-        // cell rather than a control that opens the line you are looking at.
-        //
-        // textContent, never innerHTML: this is a running game's own data.
-        const value = decoded.value && hasTree(decoded.value) ? decoded.value : null;
-        let payload: HTMLElement;
-        if (value) {
-          const button = document.createElement("button");
-          button.type = "button";
-          button.setAttribute("aria-expanded", String(isOpen));
-          button.addEventListener("click", () => openRow(packet, value, shown));
-          if (refocus === packet) focusTarget = button;
-          payload = button;
-        } else {
-          payload = document.createElement("span");
-        }
-        payload.className = "payload";
-        if (decoded.head) {
-          const ctor = document.createElement("b");
-          ctor.textContent = decoded.head;
-          const args = document.createElement("em");
-          args.textContent = decoded.body;
-          payload.append(ctor, args);
-        } else {
-          payload.textContent = decoded.body;
-        }
-        const bytes = document.createElement("span");
-        bytes.className = "n";
-        bytes.textContent = `${packet.size} B`;
-        row.append(frameCell, dirCell, payload, bytes);
-        // The tree is the SAME element across repaints, moved into the rebuilt
-        // row: every node the reader opened inside it stays open, because its
-        // state never left the DOM.
-        if (isOpen && opened) {
-          row.classList.add("open");
-          row.append(opened.host);
-        }
-        return row;
+        const built = buildWireRow({
+          packet,
+          at: index === highlight,
+          tree: isOpen && opened ? opened.host : null,
+          onOpen: (value) => openRow(packet, value, shown),
+        });
+        if (!built.typed) anyPlain = true;
+        if (refocus === packet) focusTarget = built.button;
+        return built.el;
       })
     );
     // The rebuild threw away the element the keyboard was on; put the focus on

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -36,6 +36,7 @@ import type { StatusBar } from "./status-bar-store.js";
 import type { PillState } from "./components/StatusPill.js";
 import { NetCoordinator } from "./net-coordinator.js";
 import { initNetworkGraph, type NetworkNode } from "./mp-network.js";
+import { initWireTab } from "./wire-tab.js";
 
 /** The shared scrubber's `window.__scrub` seam (runtime/functor-runtime-web/scrubber.js). */
 interface ScrubSeam {
@@ -466,6 +467,17 @@ export function initMultiplayerPanes({
   // Written once per frame by `paint`, read by the graph on the same rAF.
   let sessionClock: { parked: boolean; frame: number | null } = { parked: false, frame: null };
 
+  // The TRAFFIC MONITOR, docked in the status bar's wire tab (wire-tab.ts): the
+  // same rows the pinned panel shows, in every layout rather than only in the
+  // network view, filterable per link. It reads the same coordinator log and
+  // the same session clock — one record, two framings.
+  const wireTab = initWireTab({
+    slot: statusBar.wire,
+    net,
+    links: () => panes.map((pane) => ({ id: pane.id, color: pane.color })),
+    clock: () => sessionClock,
+  });
+
   const graph = initNetworkGraph({
     stage,
     grid,
@@ -473,6 +485,11 @@ export function initMultiplayerPanes({
     clients: () => panes.map(asNode),
     server: () => (serverPane ? asNode(serverPane.pane) : null),
     clock: () => sessionClock,
+    // Pinning a wire aims the docked monitor at the same link (see wire-tab's
+    // note on the selection model). Unpinning is not propagated.
+    onSelect: (id) => {
+      if (id !== null) wireTab.focus(id);
+    },
   });
 
   const makePane = (role: PaneRole, index: number, iframe: HTMLIFrameElement): Pane => {
@@ -928,6 +945,11 @@ export function initMultiplayerPanes({
     // thumbnails too), so the frame counters need a home wherever that happens.
     // Only the packet legend is network-scoped, via `data-view` above.
     viewStrip.hidden = single;
+    // The wire tab is present exactly when there is an authority to talk to:
+    // links, and a coordinator log to read. A single-role example has neither,
+    // so the tab is absent rather than empty (the NETWORK view's gate, and the
+    // CLIENTS control's discipline).
+    statusBar.setWirePresent(serverPane !== null);
     const canAdd = !single && panes.length < MAX_CLIENTS;
     addTile.hidden = !canAdd;
     addTab.hidden = !canAdd;
@@ -1734,8 +1756,10 @@ export function initMultiplayerPanes({
     // the cards.
     if (animating > 0 && grid.dataset.view === "network") graph.relayout();
     // One loop for the whole preview column: the network graph advances its
-    // packets here rather than running a second rAF beside this one.
+    // packets here rather than running a second rAF beside this one, and the
+    // docked monitor repaints on it too (closed, that is one guarded write).
     graph.step();
+    wireTab.step();
     raf = requestAnimationFrame(tickLoop);
   };
   raf = requestAnimationFrame(tickLoop);
@@ -1763,6 +1787,7 @@ export function initMultiplayerPanes({
       // land under the new session's playhead.
       net.clearLog();
       graph.resetCounts();
+      wireTab.reset();
       updateChrome();
       paintAggregate();
     },
@@ -1789,6 +1814,8 @@ export function initMultiplayerPanes({
       cancelAnimationFrame(raf);
       viewStrip.hidden = true;
       viewStrip.replaceChildren();
+      statusBar.setWirePresent(false);
+      wireTab.destroy();
       graph.destroy();
       net.destroy();
       moduleScope.abort();

--- a/site/src/status-bar-store.ts
+++ b/site/src/status-bar-store.ts
@@ -33,6 +33,28 @@ export interface Execution {
   onPick?: () => void;
 }
 
+/**
+ * The wire tab's two nodes and its open flag (the traffic monitor —
+ * `wire-tab.ts`).
+ *
+ * ELEMENTS rather than store state, for the same reason `viewStrip` is one: the
+ * monitor's owner is imperative DOM outside the React islands and repaints off
+ * the pane grid's rAF, and routing a live packet count through the store would
+ * re-render the whole bar — output list included — every frame.
+ */
+export interface WireSlot {
+  /** The tab's panel body. React mounts it and never looks inside. */
+  panel: HTMLElement;
+  /** The packet count on the tab itself, written imperatively. */
+  badge: HTMLElement;
+  /**
+   * Whether the wire panel is the OPEN tab. The view writes it whenever the
+   * open tab changes; the monitor polls it on its own frame, so a tab nobody
+   * opened costs nothing and no read of it can re-render anything.
+   */
+  open: boolean;
+}
+
 /** The handle the producing pages hold. */
 export interface StatusBar {
   setProblems: (items: Problem[]) => void;
@@ -49,6 +71,15 @@ export interface StatusBar {
    * never looks inside it.
    */
   viewStrip: HTMLElement;
+  /** The traffic monitor's nodes (see `WireSlot`). */
+  wire: WireSlot;
+  /**
+   * Show the wire tab at all. A session with an authority has links and a
+   * coordinator log to show; a single-player example has neither, so the tab is
+   * absent rather than empty — the same gating discipline as the CLIENTS
+   * control and the NETWORK view.
+   */
+  setWirePresent: (on: boolean) => void;
 }
 
 /** One rendered output row. `time` is stamped at append, not at flush. */
@@ -65,6 +96,8 @@ export interface StatusBarSnapshot {
   problems: Problem[];
   output: OutputLine[];
   executions: Execution[];
+  /** Whether the wire tab exists in the strip (see `setWirePresent`). */
+  wirePresent: boolean;
 }
 
 export interface StatusBarStore extends StatusBar {
@@ -83,10 +116,20 @@ export const outputPreamble = (frame: number | null, time: string): string =>
   frame == null ? `[${time}]` : `[Frame ${frame} | ${time}]`;
 
 export const createStatusBarStore = (): StatusBarStore => {
-  let snapshot: StatusBarSnapshot = { problems: [], output: [], executions: [] };
+  let snapshot: StatusBarSnapshot = {
+    problems: [],
+    output: [],
+    executions: [],
+    wirePresent: false,
+  };
   const listeners = new Set<() => void>();
   const viewStrip = document.createElement("div");
   viewStrip.className = "statusbar-view";
+  const wirePanel = document.createElement("div");
+  wirePanel.className = "wire-host";
+  const wireBadge = document.createElement("span");
+  wireBadge.className = "wire-count";
+  const wire: WireSlot = { panel: wirePanel, badge: wireBadge, open: false };
 
   const emit = (next: StatusBarSnapshot): void => {
     snapshot = next;
@@ -111,6 +154,12 @@ export const createStatusBarStore = (): StatusBarStore => {
 
   return {
     viewStrip,
+    wire,
+    // Rare (a program load mounts or drops the authority), so plain store state
+    // — unlike the packet count on the same tab, which is a live measurement
+    // and stays on `wire.badge`.
+    setWirePresent: (on) =>
+      on === snapshot.wirePresent ? undefined : emit({ ...snapshot, wirePresent: on }),
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {

--- a/site/src/wire-rows.ts
+++ b/site/src/wire-rows.ts
@@ -1,0 +1,245 @@
+// The ROW GRAMMAR of the traffic monitor: `#f · direction · payload · bytes`,
+// and the two log walks that decide which packets a viewport holds.
+//
+// It exists because the same grammar is now read in two places — the pinned
+// panel tethered to a wire in the network view (mp-network.ts) and the wire tab
+// in the bottom panel (wire-tab.ts) — and a reader who learns to scan one must
+// not have to re-learn the other. One builder, one set of class names, one
+// stylesheet: the two surfaces differ in what they SHOW (a window on one link
+// versus a filterable session-wide monitor), never in how a row reads.
+//
+// DOM-imperative, like both of its hosts: these rows are rebuilt on a throttled
+// repaint beside three running games, and a row's only state (the open tree) is
+// held by the host that owns the disclosure.
+
+import type { Packet } from "./net-coordinator.js";
+import { hasTree, mountValueTree } from "./value-tree.js";
+import { decodeWire, fullWire, type WireValue } from "./wire-value.js";
+
+/**
+ * How often a LIVE tail repaints, in ms — shared, because both surfaces make
+ * the same promise about it.
+ *
+ * A tail that turns over sixty times a second is not a log, it is a blur — and
+ * each repaint decodes a screenful of payloads and rebuilds the rows, on a page
+ * already running three games. Ten a second reads as live and costs a sixth as
+ * much. PARKED there is no throttle at all: the rows must answer the rail on
+ * the frame the playhead moves.
+ */
+export const LIVE_ROW_MS = 100;
+
+/** `client 2` → `c2`, `server` → `srv`: a direction column has to fit. */
+export const shortName = (id: string): string =>
+  id === "server" ? "srv" : id.startsWith("client ") ? `c${id.slice(7)}` : id;
+
+/**
+ * Is this packet traffic on `id`'s link?
+ *
+ * A link is a PANE PAIR, not a connection id: a game that opened two
+ * connections to the same authority would interleave both here. Nothing in the
+ * samples does, and the pane pair is what the wire on screen represents.
+ */
+export const onLink = (packet: Packet, id: string): boolean =>
+  packet.kind === "message" &&
+  ((packet.from === id && packet.to === "server") ||
+    (packet.from === "server" && packet.to === id));
+
+/** Which link a packet crossed — the client end of the pair, whichever way it
+ * went. Null for anything that is not client↔server message traffic. */
+export const linkIdOf = (packet: Packet): string | null => {
+  if (packet.kind !== "message") return null;
+  if (packet.from === "server") return packet.to;
+  if (packet.to === "server") return packet.from;
+  return null;
+};
+
+/**
+ * The first index in the log whose frame is after `at` — the playhead's place
+ * in the record, by binary search.
+ *
+ * The log is sorted by frame because the reference clock only ever advances; an
+ * unframed packet (the boot handshake, routed before the reference pane had
+ * recorded a frame) sorts before everything, which is also where it belongs on
+ * the timeline.
+ */
+export const indexAfter = (log: readonly Packet[], at: number): number => {
+  let lo = 0;
+  let hi = log.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if ((log[mid].frame ?? -Infinity) <= at) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+};
+
+/** A row's cache key — the fields that make two rows different. Identity is the
+ * `Packet` itself (the hosts hold the open row by reference); this is only for
+ * the change hash that decides whether a repaint has anything to say. */
+export const packetKey = (packet: Packet): string =>
+  `${packet.frame}:${packet.from}:${packet.size}:${packet.at}`;
+
+/**
+ * The scrub-lock itself: a window of matching packets around `at`, and which of
+ * its rows the playhead is on (-1 while live).
+ *
+ * Parked, the window ends `lead` matching rows PAST the playhead so the parked
+ * frame is not the last line on screen, and the rest of it is the `back` rows
+ * before — so scrubbing sweeps the list exactly as running it would. Live
+ * (`at === null`) it is simply the newest `back` rows.
+ *
+ * Costs a screenful, not a session: the log is ordered by frame (the reference
+ * clock only advances), so the playhead's place is found by BINARY SEARCH and
+ * both walks start there. A linear scan from the end would traverse all ten
+ * thousand packets every time the rail is parked in the past — exactly the
+ * state this feature exists for.
+ */
+export const logWindow = (
+  log: readonly Packet[],
+  at: number | null,
+  { match, back, lead }: { match: (packet: Packet) => boolean; back: number; lead: number }
+): { rows: Packet[]; highlight: number } => {
+  const before: Packet[] = [];
+  const after: Packet[] = [];
+  // The lead rows first, walking FORWARD from the playhead: the ones nearest
+  // it, not the newest in the session. They also decide how many rows are left
+  // for the walk backwards, which is why they are collected first.
+  const pivot = at === null ? log.length : indexAfter(log, at);
+  for (let i = pivot; i < log.length && after.length < lead; i++) {
+    if (match(log[i])) after.push(log[i]);
+  }
+  for (let i = pivot - 1; i >= 0 && before.length < back - after.length; i--) {
+    if (match(log[i])) before.push(log[i]);
+  }
+  before.reverse();
+  const highlight = at === null || before.length === 0 ? -1 : before.length - 1;
+  return { rows: [...before, ...after], highlight };
+};
+
+/**
+ * A value tree ready to hang under its row (`value-tree.ts`).
+ *
+ * Shared because the details are the ones that must not drift between the two
+ * surfaces: the rows are a `role="log"` live region, and a tree opening inside
+ * one would otherwise be read out IN FULL on every repaint that re-parents it.
+ * It is a thing to explore, not an announcement.
+ *
+ * `onResize` fires when the tree's height changes — a host that positions
+ * itself against it (the pinned panel) re-places from there.
+ */
+export const openTree = (value: WireValue, onResize: () => void = () => {}): HTMLElement => {
+  const host = document.createElement("div");
+  host.className = "mp-wl-tree";
+  host.setAttribute("aria-live", "off");
+  mountValueTree(host, value, onResize);
+  return host;
+};
+
+export interface WireRowOptions {
+  packet: Packet;
+  /** The playhead's row, while the session is parked. */
+  at?: boolean;
+  /** The open row's value tree, moved in by its host — present only on the one
+   * row that is open. */
+  tree?: HTMLElement | null;
+  /** The link this packet crossed (`c2`), for a list that interleaves several.
+   * Omitted by a single-link viewport, whose whole panel says the link once. */
+  link?: string | null;
+  /** The ink the row's direction cell takes (a client's player color). Omitted
+   * leaves the host's own `--pc`. */
+  color?: string | undefined;
+  /** Opens the payload. Absent — or a payload with nothing to disclose — leaves
+   * the cell a plain span rather than a control that reveals the line you are
+   * already looking at. */
+  onOpen?: (value: WireValue) => void;
+}
+
+export interface WireRow {
+  el: HTMLElement;
+  /** The payload's disclosure, when it has one — what a host re-focuses after a
+   * repaint destroys the button the keyboard was on. */
+  button: HTMLButtonElement | null;
+  /** False for a plain `Effect.send` text payload: the footer says so. */
+  typed: boolean;
+}
+
+/**
+ * One row of traffic.
+ *
+ * textContent, never innerHTML: every cell here is a running game's own data.
+ */
+export const buildWireRow = ({
+  packet,
+  at = false,
+  tree = null,
+  link = null,
+  color,
+  onOpen,
+}: WireRowOptions): WireRow => {
+  const up = packet.from !== "server";
+  const decoded = decodeWire(packet.text);
+  const open = tree !== null;
+  const row = document.createElement("div");
+  row.className = `mp-wl${link === null ? "" : " linked"}${at ? " at" : ""}${open ? " open" : ""}`;
+  if (color) row.style.setProperty("--pc", color);
+  // The full rendering is built ON HOVER, once: rendering every row's whole
+  // payload unelided (a world snapshot, per row, per repaint) to fill a tooltip
+  // nobody has asked for yet is the most expensive thing this list could do. An
+  // OPEN row skips it: the tooltip would cover the tree that already says the
+  // same thing, better.
+  if (!open) {
+    row.addEventListener(
+      "mouseenter",
+      () => {
+        row.title = fullWire(packet.text);
+      },
+      { once: true }
+    );
+  }
+  const cell = (className: string, text: string): HTMLSpanElement => {
+    const el = document.createElement("span");
+    el.className = className;
+    el.textContent = text;
+    return el;
+  };
+  const cells: HTMLElement[] = [cell("f", `#f ${packet.frame ?? "—"}`)];
+  if (link !== null) cells.push(cell("l", link));
+  cells.push(
+    cell(`d ${up ? "up" : "dn"}`, up ? `${shortName(packet.from)}→srv` : `srv→${shortName(packet.to)}`)
+  );
+
+  // The payload cell is the disclosure control when there is something to
+  // disclose: a typed payload WITH structure, whose whole value the page already
+  // holds (the frame is decoded client-side, so opening it costs nothing but the
+  // DOM). A bare `Welcome(2)`, which the row already shows completely, stays a
+  // plain cell.
+  const value = decoded.value && onOpen && hasTree(decoded.value) ? decoded.value : null;
+  let payload: HTMLElement;
+  let button: HTMLButtonElement | null = null;
+  if (value && onOpen) {
+    button = document.createElement("button");
+    button.type = "button";
+    button.setAttribute("aria-expanded", String(open));
+    button.addEventListener("click", () => onOpen(value));
+    payload = button;
+  } else {
+    payload = document.createElement("span");
+  }
+  payload.className = "payload";
+  if (decoded.head) {
+    const ctor = document.createElement("b");
+    ctor.textContent = decoded.head;
+    const args = document.createElement("em");
+    args.textContent = decoded.body;
+    payload.append(ctor, args);
+  } else {
+    payload.textContent = decoded.body;
+  }
+  cells.push(payload, cell("n", `${packet.size} B`));
+  row.append(...cells);
+  // The tree is the SAME element across repaints, moved into the rebuilt row:
+  // every node the reader opened inside it stays open, because its state never
+  // left the DOM.
+  if (tree) row.append(tree);
+  return { el: row, button, typed: decoded.typed };
+};

--- a/site/src/wire-tab.ts
+++ b/site/src/wire-tab.ts
@@ -1,0 +1,483 @@
+// THE WIRE TAB — the traffic monitor as a permanent tab in the sandbox's
+// bottom panel, beside problems / output / executions (design:
+// ~/notes/projects/functor/design-multiplayer-ide-frontend.md, Addendum 8.2 —
+// "an in-editor wireshark").
+//
+// WHY A SECOND SURFACE. The pinned panel (mp-network.ts) is the IN-CONTEXT
+// reading: it hangs off the wire you clicked, in the one view that draws wires,
+// and it answers "what is crossing THIS link?". That is the wrong instrument
+// for "the protocol did something odd four seconds ago" — a question you ask
+// while looking at the editor, in whatever layout you were already in. So the
+// monitor also lives where a monitor belongs: docked, always reachable, with a
+// packet count on the tab, showing every link at once and filterable down.
+//
+// Both surfaces read the SAME rows (wire-rows.ts) against the SAME log
+// (net-coordinator.ts) on the SAME clock — live they tail at 10Hz, parked they
+// window around the playhead and mark the nearest row. A reader who learns one
+// has learned the other; only the framing differs.
+//
+// THE SELECTION MODEL. One value, propagated one way. Pinning a wire in the
+// network view focuses that link's chip here (mp-network's `onSelect`), so a
+// single click aims both surfaces at the same link. UNPINNING is not
+// propagated, because the two surfaces mean different things by "nothing
+// selected": the panel means "no panel", and this tab means "every link" — and
+// the panel unpins itself every time the network view closes, which must not
+// silently widen a filter the reader chose here. Picking a chip here likewise
+// stays here: this tab is the session-wide view, and reaching back to re-pin a
+// panel in a view that may not even be open would be a change you did not make.
+//
+// DOM-imperative, like the view strip it sits beside: it repaints off the pane
+// grid's rAF beside three running games, and routing a live packet count
+// through React state would re-render the whole status bar (output list
+// included) every frame. React mounts these two nodes and never looks inside
+// them — see `status-bar-store.ts`'s `WireSlot`.
+
+import type { NetCoordinator, Packet } from "./net-coordinator.js";
+import type { WireSlot } from "./status-bar-store.js";
+import {
+  buildWireRow,
+  LIVE_ROW_MS,
+  linkIdOf,
+  logWindow,
+  onLink,
+  openTree,
+  packetKey,
+  shortName,
+} from "./wire-rows.js";
+import type { WireValue } from "./wire-value.js";
+
+/**
+ * Rows the monitor renders at once.
+ *
+ * A cap, because the log holds ten thousand packets and a snapshot protocol
+ * fills it in under a minute: rendering all of it would rebuild ten thousand
+ * rows ten times a second for a reader looking at eleven. The footer says the
+ * number it is showing AND the number it has, so the cap is a stated bound
+ * rather than a silent one — and the rail is how you reach the rest, which is
+ * the whole point of a scrub-locked log.
+ *
+ * Sixty is five screenfuls of the 180px panel — enough scrollback to read back
+ * through a burst — and the price is paid ten times a second in full: every row
+ * is rebuilt AND its payload re-decoded on each repaint, so this number is a
+ * `JSON.parse` budget as much as a DOM one. (At 780-byte snapshots, sixty rows
+ * is ~47KB parsed per repaint; two hundred was three times that, for scrollback
+ * that scrolls away while you read it.)
+ */
+const MAX_ROWS = 60;
+
+/** Rows of context kept AFTER the playhead's row, so the parked frame is not
+ * the last line in the list. */
+const LEAD_ROWS = 8;
+
+/** Which half of the conversation to show. `intent` is client → server, and
+ * `authority` is the snapshot stream coming back. */
+type DirFilter = "all" | "intent" | "authority";
+
+const DIR_FILTERS: { id: DirFilter; label: string; title: string }[] = [
+  { id: "all", label: "both", title: "Every packet on the selected links" },
+  { id: "intent", label: "intent", title: "Client → server only" },
+  { id: "authority", label: "authority", title: "Server → client only" },
+];
+
+/** A link the monitor can filter to: the client end of a client↔server pair,
+ * and the ink that client is drawn in everywhere else. */
+export interface WireLink {
+  id: string;
+  color: string;
+}
+
+export interface WireTabOptions {
+  /** The status bar's two nodes: the tab's panel body and its count badge. */
+  slot: WireSlot;
+  net: NetCoordinator;
+  /** The session's links, in pane order. Read live: clients come and go. */
+  links: () => WireLink[];
+  /** The session clock, in reference-clock frames — the same one the pinned
+   * panel and the wires read (mp-panes' `sessionClock`). */
+  clock: () => { parked: boolean; frame: number | null };
+}
+
+export interface WireTab {
+  /** One frame: the badge always, the rows only while the panel is open. */
+  step(): void;
+  /** Focus a link's filter — what pinning a wire in the network view does. */
+  focus(id: string): void;
+  /** A new program is a new session: the count and the open row go with it. */
+  reset(): void;
+  destroy(): void;
+}
+
+export function initWireTab({ slot, net, links, clock }: WireTabOptions): WireTab {
+  const root = document.createElement("div");
+  root.className = "wire-tab";
+  root.innerHTML = `
+    <div class="wire-filters">
+      <span class="wire-group" role="group" aria-label="Link filter"></span>
+      <span class="wire-group wire-dirs" role="group" aria-label="Direction filter"></span>
+    </div>
+    <div class="wire-rows" role="log" aria-label="Wire traffic"></div>
+    <footer class="wire-ft"></footer>`;
+  const linkChips = root.querySelector(".wire-group") as HTMLElement;
+  const dirChips = root.querySelector(".wire-dirs") as HTMLElement;
+  const rowsHost = root.querySelector(".wire-rows") as HTMLElement;
+  const foot = root.querySelector(".wire-ft") as HTMLElement;
+  slot.panel.replaceChildren(root);
+
+  /** The focused link, or null for ALL (every link interleaved by frame, with a
+   * link column added). */
+  let link: string | null = null;
+  let dir: DirFilter = "all";
+  /** The link chips currently built, as their ids — the rebuild guard. */
+  let chipKey = "";
+  /** What the rows currently say, so a steady session rewrites nothing. */
+  let rowKey = "";
+  /** When the rows last repainted — the live tail's throttle. */
+  let lastPaint = 0;
+  /**
+   * What the last pass was built from: the parked frame (null while live) and
+   * the log's length. PARKED there is no throttle — the panel must answer the
+   * rail on the frame the playhead moves — so this is what keeps a held
+   * playhead from re-walking the log sixty times a second for a window that
+   * cannot have moved. `dirty` forces a pass through it after a change the log
+   * cannot express (a filter, a disclosure).
+   */
+  let lastAt: number | null = null;
+  let lastLength = -1;
+  let dirty = true;
+  /**
+   * The row opened into a value tree: which packet (BY IDENTITY — the row hash
+   * can genuinely collide, see mp-network's note), the tree's own DOM (kept
+   * across repaints so opened nodes stay open), and, when it opened on a live
+   * tail, the viewport to hold there. Opening a row IS the pause: a tail that
+   * kept moving would scroll the row away before it could be read.
+   */
+  let opened: { packet: Packet; host: HTMLElement; held: Packet[] | null } | null = null;
+  /** The packet whose payload button takes focus after the next repaint — a
+   * repaint destroys the button the keyboard was on. */
+  let refocus: Packet | null = null;
+  /** Messages routed this session — the tab's badge. Counted on the way past
+   * rather than by scanning the log, which is capped (and 10k long). */
+  let routed = 0;
+  let badgeText = "";
+  let lastBadge = 0;
+  /** Whether the panel was open on the previous frame — the reopen edge. */
+  let wasOpen = false;
+
+  const dirOf = (packet: Packet): DirFilter =>
+    packet.from === "server" ? "authority" : "intent";
+
+  const matches = (packet: Packet): boolean => {
+    if (packet.kind !== "message") return false;
+    if (link === null ? linkIdOf(packet) === null : !onLink(packet, link)) return false;
+    return dir === "all" || dirOf(packet) === dir;
+  };
+
+  /** The chips on screen, each with the question "am I the current filter?" —
+   * so a press can be reflected IN PLACE (see `syncChips`). */
+  const chips: { button: HTMLButtonElement; on: () => boolean }[] = [];
+
+  const chip = (
+    label: string,
+    on: () => boolean,
+    title: string,
+    pick: () => void
+  ): HTMLButtonElement => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "wire-chip";
+    button.textContent = label;
+    button.title = title;
+    button.addEventListener("click", () => {
+      pick();
+      // A different filter is other traffic, so the open row is not in it — and
+      // its HELD viewport is a frozen list from the OLD filter, which would
+      // otherwise keep showing rows the pressed chip says are excluded.
+      opened = null;
+      // A filter change is a different list: repaint now rather than on the
+      // tail's next tick, so the press and the rows agree in one turn.
+      rowKey = "";
+      lastPaint = 0;
+      dirty = true;
+      syncChips();
+      render();
+    });
+    chips.push({ button, on });
+    return button;
+  };
+
+  /**
+   * Reflect the current filter on the chips that already exist.
+   *
+   * In place, never a rebuild: the reader may have pressed this chip with the
+   * KEYBOARD, and replacing the button under them drops focus to `<body>` and
+   * restarts Tab at the top of the document. (The rows solve the same problem
+   * the other way — they must be rebuilt, so they carry `refocus`.)
+   */
+  const syncChips = () => {
+    for (const one of chips) {
+      one.button.setAttribute("aria-pressed", String(one.on()));
+    }
+  };
+
+  /**
+   * Rebuild the chip row when the SESSION's links change — a client arriving or
+   * leaving. A mere filter press never gets here; `syncChips` handles that.
+   */
+  const buildChips = () => {
+    const live = links();
+    const key = live.map((one) => one.id).join(",");
+    if (key === chipKey) return;
+    chipKey = key;
+    // A link that left the session cannot stay focused — its rows would freeze
+    // on a client that is no longer here.
+    if (link !== null && !live.some((one) => one.id === link)) link = null;
+    chips.length = 0;
+    // The ALL chip wears no ink dot: it stands for no one client.
+    const all = chip("all links", () => link === null, "Every link, interleaved by frame", () => {
+      link = null;
+    });
+    all.classList.add("all");
+    linkChips.replaceChildren(
+      all,
+      ...live.map((one) => {
+        const button = chip(
+          `${shortName(one.id)} ↔ srv`,
+          () => link === one.id,
+          `Only traffic between ${one.id} and the authority`,
+          () => {
+            link = one.id;
+          }
+        );
+        button.style.setProperty("--pc", one.color);
+        return button;
+      })
+    );
+    dirChips.replaceChildren(
+      ...DIR_FILTERS.map((one) =>
+        chip(one.label, () => dir === one.id, one.title, () => {
+          dir = one.id;
+        })
+      )
+    );
+    syncChips();
+  };
+
+  /**
+   * How many rows the filter matches in the whole log — the footer's honesty
+   * about what the cap is hiding.
+   *
+   * The one pass that cannot avoid the whole log, so it runs only on a repaint
+   * that is actually going to write the footer, never on the guard path.
+   */
+  const countMatches = (): number => {
+    let total = 0;
+    for (const packet of net.packets()) if (matches(packet)) total += 1;
+    return total;
+  };
+
+  /** The monitor's viewport onto the log — the SAME scrub-lock the pinned panel
+   * uses (`logWindow`), over this tab's filter instead of one link. */
+  const viewport = (at: number | null) =>
+    logWindow(net.packets(), at, { match: matches, back: MAX_ROWS, lead: LEAD_ROWS });
+
+  /** Open a row into a value tree — or close the one that is open. One row at a
+   * time: two open snapshots in a 180px panel is a scroll, not a reading. */
+  const openRow = (packet: Packet, value: WireValue, shown: readonly Packet[]) => {
+    if (opened?.packet === packet) {
+      opened = null;
+    } else {
+      // No re-place callback: this panel is docked and its own height is fixed,
+      // so a node opening inside the tree scrolls the list rather than moving
+      // anything (unlike the pinned panel, which is positioned).
+      opened = { packet, host: openTree(value), held: clock().parked ? null : [...shown] };
+    }
+    refocus = packet;
+    rowKey = "";
+    lastPaint = 0;
+    dirty = true;
+    render();
+  };
+
+  const render = () => {
+    const { parked, frame } = clock();
+    const at = parked && frame !== null ? frame : null;
+    const length = net.packets().length;
+    // Parked on the same frame with nothing new routed: the window cannot have
+    // moved, and there is no throttle here to catch it (see `lastAt`).
+    if (!dirty && at !== null && at === lastAt && length === lastLength) return;
+    const now = performance.now();
+    if (!dirty && at === null && now - lastPaint < LIVE_ROW_MS) return;
+    dirty = false;
+    lastAt = at;
+    lastLength = length;
+    const live = viewport(at);
+    // An open row holds the LIVE viewport; parked, the rail keeps deciding the
+    // window and the tree travels with its row until the row leaves it.
+    const held = opened?.held;
+    const shown = held && !parked ? held : live.rows;
+    const { highlight } = live;
+    if (opened && !shown.includes(opened.packet)) opened = null;
+    // The change hash is the window's ENDS plus its length, not every row: at
+    // two hundred rows, ten times a second, hashing the whole list costs more
+    // than the rebuild it is there to avoid. Any shift of the window moves an
+    // end (the log only ever grows at the tail, and a scrub moves both).
+    const key =
+      `${link}|${dir}|${highlight}|${shown.length}|` +
+      `${shown[0] ? packetKey(shown[0]) : ""}|${shown.at(-1) ? packetKey(shown.at(-1)!) : ""}|` +
+      `${opened ? packetKey(opened.packet) : ""}`;
+    if (key === rowKey) return;
+    rowKey = key;
+    lastPaint = now;
+
+    const inks = new Map(links().map((one) => [one.id, one.color]));
+    let anyPlain = false;
+    let focusTarget: HTMLButtonElement | null = null;
+    rowsHost.replaceChildren(
+      ...shown.map((packet, index) => {
+        const isOpen = opened?.packet === packet;
+        const id = linkIdOf(packet);
+        const built = buildWireRow({
+          packet,
+          at: index === highlight,
+          tree: isOpen && opened ? opened.host : null,
+          // ALL interleaves several links, so each row says which one it
+          // crossed and wears that client's ink; a focused link says it once,
+          // on its chip, and keeps the narrower row.
+          link: link === null && id ? shortName(id) : null,
+          color: id ? inks.get(id) : undefined,
+          onOpen: (value) => openRow(packet, value, shown),
+        });
+        if (!built.typed) anyPlain = true;
+        if (refocus === packet) focusTarget = built.button;
+        return built.el;
+      })
+    );
+    if (shown.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "mp-wl-empty";
+      empty.textContent = parked
+        ? "nothing matching had crossed yet at this frame"
+        : "no traffic matches this filter yet";
+      rowsHost.appendChild(empty);
+    }
+    // Live, the newest row is the one being read, so the list stays pinned to
+    // the bottom. Parked, the playhead's row is — and it can be anywhere in the
+    // window, so centre the list on it. Written as scrollTop rather than
+    // `scrollIntoView`, which also scrolls every ANCESTOR: this panel sits in
+    // the page's chrome, and moving the page to show a log row is not something
+    // the reader asked for. (`.wire-rows` is positioned, so a row's `offsetTop`
+    // is its offset within the list.)
+    const marked = rowsHost.children[highlight] as HTMLElement | undefined;
+    if (parked && marked) {
+      rowsHost.scrollTop = Math.max(
+        0,
+        marked.offsetTop - rowsHost.clientHeight / 2 + marked.offsetHeight / 2
+      );
+    } else if (!opened) {
+      rowsHost.scrollTop = rowsHost.scrollHeight;
+    }
+    // The rebuild threw away the element the keyboard was on; put the focus on
+    // its replacement, and only for the repaint the press caused. (The cast is
+    // load-bearing: the assignment happens inside the map callback, which
+    // control-flow analysis cannot see, so the checker narrows this to `never`.)
+    if (focusTarget) (focusTarget as HTMLButtonElement).focus();
+    refocus = null;
+    // The footer says WHICH rows these are, not only how many: "the last N" is
+    // true of a live tail and false of everything else — parked, the window is
+    // centred on the playhead, and a held one is wherever the tail stopped. A
+    // count that is right while the sentence around it is wrong is the kind of
+    // honesty this panel exists to have.
+    const total = countMatches();
+    const showing =
+      total <= shown.length
+        ? `${total} row${total === 1 ? "" : "s"}`
+        : at !== null
+          ? `showing ${shown.length} of ${total} rows around #f ${at}`
+          : opened
+            ? `showing ${shown.length} of ${total} rows`
+            : `showing the last ${shown.length} of ${total} rows`;
+    foot.textContent = [
+      showing,
+      opened && !parked ? "the tail is held while a row is open" : null,
+      anyPlain ? "Effect.send text — shown exactly as sent" : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+  };
+
+  /**
+   * The tab's packet count.
+   *
+   * Change-guarded AND rate-limited: a snapshot protocol routes a packet per
+   * client per frame, so "has it changed?" is true on every single frame — the
+   * guard alone would still write the DOM sixty times a second for a number
+   * nobody can read at that rate. It ticks at the tail's rate, like the rows.
+   */
+  const paintBadge = (now: number) => {
+    const text = `${routed}`;
+    if (text === badgeText || now - lastBadge < LIVE_ROW_MS) return;
+    lastBadge = now;
+    badgeText = text;
+    slot.badge.textContent = text;
+    slot.badge.title = `${routed} packets routed this session`;
+  };
+
+  const unsubscribe = net.onPacket((packet) => {
+    if (packet.kind === "message") routed += 1;
+  });
+
+  return {
+    step() {
+      paintBadge(performance.now());
+      // Closed, the tab costs a change-guarded badge write and nothing else —
+      // no decode, no rows, no layout.
+      if (!slot.open) {
+        wasOpen = false;
+        return;
+      }
+      // Reopening is a repaint even when nothing changed: `display:none` threw
+      // the scroll box away, so the rows come back at the top — and PARKED
+      // (nothing routing, the window fixed) no later frame would correct it.
+      if (!wasOpen) {
+        wasOpen = true;
+        dirty = true;
+      }
+      buildChips();
+      render();
+    },
+    focus(id) {
+      if (link === id) return;
+      link = id;
+      opened = null;
+      rowKey = "";
+      lastPaint = 0;
+      dirty = true;
+      buildChips();
+      syncChips();
+      if (slot.open) render();
+    },
+    reset() {
+      routed = 0;
+      link = null;
+      dir = "all";
+      opened = null;
+      refocus = null;
+      rowKey = "";
+      chipKey = "";
+      lastPaint = 0;
+      lastBadge = 0;
+      dirty = true;
+      paintBadge(performance.now());
+    },
+    destroy() {
+      unsubscribe();
+      slot.panel.replaceChildren();
+      slot.badge.textContent = "";
+      // The slot outlives this monitor (the store owns it), and React only
+      // rewrites `open` when the bar re-renders — which a torn-down page may
+      // never do. A stale `true` would have the NEXT monitor rendering into a
+      // panel nobody opened.
+      slot.open = false;
+    },
+  };
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -3917,11 +3917,142 @@ button.mp-vt-row:focus-visible {
   color: var(--text-dim);
 }
 
-.mp-wl-ft {
+.mp-wl-ft,
+.wire-ft {
   padding: 5px 10px;
   border-top: 1px solid var(--line);
   font: 9.5px/1.4 var(--font-mono);
   color: var(--text-dim);
+}
+
+/* ---- the wire tab (Addendum 8.2) ----
+
+   The same rows, docked. The pinned panel above is a floating card tethered to
+   a wire; this is an instrument bay in the status bar, so it takes the bar's
+   flat chrome — no border, no shadow, no radius — and spends its one piece of
+   color on the filter chips, where each link wears its client's ink. That is
+   the network view's own rule (color carries identity), carried into a list
+   that has to say WHICH wire each row crossed. */
+
+.wire-list {
+  /* The rows own the scroll (the header rail and footer must not leave with
+     it), so the list itself is a column that clips. */
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.wire-host,
+.wire-tab {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.wire-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 14px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.wire-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+/* The direction filter is the secondary axis — pushed to the far end so the
+   links, which are what a reader picks between, hold the left. */
+.wire-dirs {
+  margin-left: auto;
+}
+
+.wire-chip {
+  --pc: var(--cyan);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: none;
+  color: var(--text-dim);
+  font: 10px/1.5 var(--font-mono);
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+
+/* The ink dot: whose traffic this chip selects, in that client's own color. */
+.wire-chip::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--pc);
+}
+
+.wire-chip.all::before,
+.wire-dirs .wire-chip::before {
+  display: none;
+}
+
+.wire-chip:hover {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--pc) 45%, var(--line));
+}
+
+.wire-chip:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 1px;
+}
+
+.wire-chip[aria-pressed="true"] {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--pc) 60%, var(--line));
+  background: color-mix(in srgb, var(--pc) 12%, transparent);
+}
+
+.wire-rows {
+  --pc: var(--cyan);
+  /* The positioning context the parked scroll measures a row's offset in
+     (wire-tab.ts) — never `scrollIntoView`, which would move the page too. */
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+/* ALL interleaves several links, so every row gains a column naming the one it
+   crossed — inserted after the frame, before the direction it qualifies. */
+.mp-wl.linked {
+  grid-template-columns: 54px 32px 62px 1fr 46px;
+}
+
+.mp-wl .l {
+  color: var(--pc);
+}
+
+/* The count on the tab itself, while the panel is closed. */
+.wire-badge {
+  margin-left: 6px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.wire-badge[hidden] {
+  display: none;
+}
+
+.statusbar-tab.active .wire-badge {
+  color: inherit;
 }
 
 /* ---- the network status strip (Addendum 5a.3) ----


### PR DESCRIPTION
![wire tab — tiled layout, all links](https://gist.githubusercontent.com/tommy-xr/ae55ea20dcb2f5ffcf28b23365fd7b00/raw/wiretab-tiled-all.png)

<sub>The in-editor Wireshark: the wire tab beside problems/output/executions, in TILED layout — full protocol visibility with no network view in sight.</sub>

![wire tab — payload expanded into the value tree](https://gist.githubusercontent.com/tommy-xr/ae55ea20dcb2f5ffcf28b23365fd7b00/raw/wiretab-expanded.png)

<sub>A payload cell expanded into #651's value tree — and the footer says so honestly: "showing 60 of 2100 rows · the tail is held while a row is open".</sub>

<details>
<summary>More: per-link filter + bottom-panel closeups</summary>

![wire tab — narrowed to one link](https://gist.githubusercontent.com/tommy-xr/ae55ea20dcb2f5ffcf28b23365fd7b00/raw/wiretab-link-filter.png)

<sub>Narrowed to a single link via its filter chip (`c2 ↔ srv`) — the row count drops with it.</sub>

![panel closeup — all links](https://gist.githubusercontent.com/tommy-xr/ae55ea20dcb2f5ffcf28b23365fd7b00/raw/wiretab-panel-all.png)

<sub>Closeup: the ALL-links view, interleaved by frame with a per-client link column.</sub>

![panel closeup — expanded](https://gist.githubusercontent.com/tommy-xr/ae55ea20dcb2f5ffcf28b23365fd7b00/raw/wiretab-panel-expanded.png)

<sub>Closeup: the value tree open inside the panel, tail held.</sub>

![panel closeup — link filter](https://gist.githubusercontent.com/tommy-xr/ae55ea20dcb2f5ffcf28b23365fd7b00/raw/wiretab-panel-link-filter.png)

<sub>Closeup: one link selected, direction filter still on `both`.</sub>

</details>

---

PR 2 of the **inspection stack** (on #651): Bryan's "pin the traffic monitor to the bottom with tabs so we can always view (ie, an in-editor wireshark)" — realized.

**The `wire` tab** joins `problems / output / executions` in the bottom panel, present whenever the session has an authority (same gating as the NETWORK view), with a live packet-count badge while closed. Open it and the traffic monitor is there in **every layout** — the tiled screenshot is the point: full protocol visibility with no network view in sight.

**Content**: the pinned panel's row grammar (`#f · direction · decoded payload · bytes`) plus what a persistent monitor needs — an **ALL-links view** interleaved by frame with a link column, per-link filter chips, a direction filter (both / intent / authority), a row cap with an honest footer ("showing the last 60 of 2056 rows"), the same scrub-lock semantics (parked = window at the playhead, live = 10Hz tail), and payload cells expanding into #651's value tree (opening holds the tail, stated in the footer).

**Selection model, one way**: pinning a wire in the network view focuses that link's chip in the tab — one click aims both surfaces. Unpinning deliberately does *not* propagate: the panel's "nothing" means *no panel*, the tab's means *every link*, and the panel auto-unpins when the view closes — sharing the null would silently widen a filter the reader chose. Reasoning pinned in `wire-tab.ts`.

**Pattern conformance**: the store owns mounted elements (`WireSlot`), React never renders into them — the view-strip precedent, because the monitor repaints off the pane grid's rAF and a per-frame store write would re-render the whole bar. Only presence is store state. No resizer invented; the panel keeps the standard height.

**Cross-engine review (Claude + Codex + dedup), all dispositioned** — [AGREED] fixes: filter-change while a row was open kept rendering the held tail's old-filter rows; the footer's claim now matches held/parked states; the parked-playhead log walk and whole-log count moved behind repaint guards. Plus: row cap 200→60 (documented as a JSON.parse budget), badge writes rate-limited, chip focus survives link-set changes, `destroy()` hygiene. Dedup extracted `wire-rows.ts` (row grammar + scrub-lock + tree-opening shared with the pinned panel — removed a 23-line clone). Declined with reasons: the badge stays `aria-hidden` (a name churning 10×/s is worse than none); intentionally different empty-state wording between surfaces.

**Verification**: site tsc clean; `sandbox-mp` ALL PASSED (+12 tab checks incl. rows-outside-network-view, filters, tree-in-tab, scrub-lock, single-role absence); `net-coordinator` ALL PASSED; `test:site` at exactly the two known pre-existing main failures and no others.

Next on the stack: **impairment** (Addendum 8.2) — latency + jitter per link chip (loss honestly deferred to unreliable channels), sent→delivered frames as wire-row columns, dot pace becoming the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

