### PR TITLE
feat(desktop): poll GLFW gamepads into the sampled snapshot

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -370,11 +370,13 @@ let grab = (s) =>
   are `0..1`; face buttons are POSITIONAL (`south` is the bottom face button —
   A on Xbox, Cross on PlayStation), plus bumpers, stick clicks, dpad, and
   `start`/`select`. Levels only, raw values: detect edges against your model
-  and apply your own deadzone. Native polls the first connected
-  standard-mapping pad each frame (debug injection — `POST /input`
-  `{"type":"gamepad",…}` — wins over the poll); the web runtime does not
-  sample pads yet, so on wasm it is `Option.None`. A future mobile-touch
-  domain belongs as another typed sibling on the snapshot.
+  and apply your own deadzone. Native's windowed runtime polls the first
+  connected standard-mapping pad each frame (debug injection — `POST /input`
+  `{"type":"gamepad",…}` — wins over the poll); an unfocused window or a
+  pinned clock reads rest-level controls, not `Option.None`, so presence
+  stays a reliable capability signal. Headless and the web runtime do not
+  poll pads (`Option.None` unless injected). A future mobile-touch domain
+  belongs as another typed sibling on the snapshot.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -370,10 +370,11 @@ let grab = (s) =>
   are `0..1`; face buttons are POSITIONAL (`south` is the bottom face button —
   A on Xbox, Cross on PlayStation), plus bumpers, stick clicks, dpad, and
   `start`/`select`. Levels only, raw values: detect edges against your model
-  and apply your own deadzone. No shell polls a physical pad yet — today the
-  domain is supplied by desktop debug injection only (`POST /input`
-  `{"type":"gamepad",…}`), so it is `Option.None` everywhere else. A future
-  mobile-touch domain belongs as another typed sibling on the snapshot.
+  and apply your own deadzone. Native polls the first connected
+  standard-mapping pad each frame (debug injection — `POST /input`
+  `{"type":"gamepad",…}` — wins over the poll); the web runtime does not
+  sample pads yet, so on wasm it is `Option.None`. A future mobile-touch
+  domain belongs as another typed sibling on the snapshot.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -273,8 +273,8 @@ only be driven this way. `held_keys` and `mouse` stay live alongside it.
 level state (no entry point call, recorded, replayable), a whole-sample
 replacement whose omitted fields take their defaults (centered sticks,
 released triggers/buttons), `deny_unknown_fields`, and `{"type":"gamepad_clear"}`
-as the release half — today restoring no `gamepad` domain at all (no shell
-polls a physical pad yet, so injection is the domain's only source). The
+as the release half — restoring the GLFW-polled pad on desktop, or no
+`gamepad` domain at all when none is connected. The
 body is the snake_case [`gamepad` sample]
 (#sampled-input-in-get-state) `GET /state` reports: `left_stick`/`right_stick`
 (`[-1..1]`, up-positive Y), `left_trigger`/`right_trigger` (`0..1`), and the
@@ -459,11 +459,11 @@ Non-XR runtimes omit `xr`, and padless runtimes omit `gamepad` — each domain
 is a typed sibling field, present only when its device is live. `gamepad`
 carries the pad's held state: sticks as `[x, y]` in `-1..1` with up-positive
 Y, triggers in `0..1`, positional face buttons (`south` is the bottom one),
-bumpers, stick clicks, dpad, and `start`/`select`. No shell polls a physical
-pad yet, so today the domain appears only while a sample is injected
-(`{"type":"gamepad"}` above). Future mobile-touch support should add another
-typed sibling field rather than target-specific endpoints or string-keyed
-capability bags.
+bumpers, stick clicks, dpad, and `start`/`select`. Desktop polls the first
+standard-mapping pad each frame (an injected sample wins over the poll); the
+web runtime does not sample pads yet. Future mobile-touch support should add
+another typed sibling field rather than target-specific endpoints or
+string-keyed capability bags.
 
 ### `POST /time` — frame-loop control
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -273,8 +273,9 @@ only be driven this way. `held_keys` and `mouse` stay live alongside it.
 level state (no entry point call, recorded, replayable), a whole-sample
 replacement whose omitted fields take their defaults (centered sticks,
 released triggers/buttons), `deny_unknown_fields`, and `{"type":"gamepad_clear"}`
-as the release half — restoring the GLFW-polled pad on desktop, or no
-`gamepad` domain at all when none is connected. The
+as the release half — restoring the windowed runtime's GLFW-polled pad, or no
+`gamepad` domain at all when none is connected (headless has no GLFW
+instance, so clearing there always restores "no pad"). The
 body is the snake_case [`gamepad` sample]
 (#sampled-input-in-get-state) `GET /state` reports: `left_stick`/`right_stick`
 (`[-1..1]`, up-positive Y), `left_trigger`/`right_trigger` (`0..1`), and the
@@ -368,7 +369,8 @@ make the preview and the real run disagree.
 `input` is runtime-owned data sampled for one fixed simulation step. Keyboard and
 mouse keep their existing event entry points while also exposing deterministic
 held and pressed/released sets. Quest adds `xr` while head tracking is valid;
-`gamepad` appears while a pad sample is live (today: injected):
+`gamepad` appears while a pad sample is live (a desktop-polled pad or an
+injection):
 
 These edge fields were added in debug protocol v6. Against an older runtime,
 clients should treat absent edge arrays/button sets as empty.
@@ -459,9 +461,12 @@ Non-XR runtimes omit `xr`, and padless runtimes omit `gamepad` — each domain
 is a typed sibling field, present only when its device is live. `gamepad`
 carries the pad's held state: sticks as `[x, y]` in `-1..1` with up-positive
 Y, triggers in `0..1`, positional face buttons (`south` is the bottom one),
-bumpers, stick clicks, dpad, and `start`/`select`. Desktop polls the first
-standard-mapping pad each frame (an injected sample wins over the poll); the
-web runtime does not sample pads yet. Future mobile-touch support should add
+bumpers, stick clicks, dpad, and `start`/`select`. Desktop's windowed runtime
+polls the first standard-mapping pad each frame (an injected sample wins over
+the poll); presence is sticky while the pad is connected, with controls at
+rest level while the window is unfocused or the clock is pinned. `--headless`
+has no GLFW instance, so there (and on web, which does not sample pads yet)
+injection is the domain's only source. Future mobile-touch support should add
 another typed sibling field rather than target-specific endpoints or
 string-keyed capability bags.
 

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -41,9 +41,9 @@ type xr = {
 /// Nintendo) — because letter names swap between vendors. Sticks are `-1..1`
 /// with up-positive `y` (the XR thumbstick convention); triggers are `0..1`.
 /// Values are raw — apply your own deadzone. Levels only: detect edges
-/// against your model, as XR games do. No shell polls a physical pad yet:
-/// today the domain is supplied by desktop debug injection only, and it is
-/// `Option.None` everywhere else.
+/// against your model, as XR games do. Native polls the first connected
+/// standard-mapping pad (debug injection wins over the poll); the web
+/// runtime does not sample pads yet, so on wasm this is `Option.None`.
 type gamepad = {
   leftStick: point2,
   rightStick: point2,

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -41,9 +41,12 @@ type xr = {
 /// Nintendo) — because letter names swap between vendors. Sticks are `-1..1`
 /// with up-positive `y` (the XR thumbstick convention); triggers are `0..1`.
 /// Values are raw — apply your own deadzone. Levels only: detect edges
-/// against your model, as XR games do. Native polls the first connected
-/// standard-mapping pad (debug injection wins over the poll); the web
-/// runtime does not sample pads yet, so on wasm this is `Option.None`.
+/// against your model, as XR games do. Native's windowed runtime polls the
+/// first connected standard-mapping pad (debug injection wins over the
+/// poll); while the window is unfocused or the clock is pinned a connected
+/// pad reads rest-level controls rather than `Option.None`. Headless and
+/// the web runtime do not poll pads, so there this is `Option.None` unless
+/// injected.
 type gamepad = {
   leftStick: point2,
   rightStick: point2,

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -356,8 +356,9 @@ pub enum InputCommand {
     /// magnitude above the other commands.
     Gamepad(GamepadSnapshot),
     /// Drop an injected gamepad sample, restoring whatever the runtime would
-    /// sample on its own — today no `gamepad` domain at all (no shell polls a
-    /// physical pad yet). The release half of `Gamepad`'s held-key contract.
+    /// sample on its own — the GLFW-polled pad on desktop, or no `gamepad`
+    /// domain when none is connected. The release half of `Gamepad`'s
+    /// held-key contract.
     GamepadClear,
 }
 

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -292,9 +292,11 @@ pub struct XrControllerSnapshot {
 /// and the browser's down-positive axes at its boundary. Triggers are
 /// `0..1`. Values are raw (no deadzone shaping); games apply their own.
 ///
-/// No shell polls a physical pad yet: today the domain's only source is
-/// debug injection (`POST /input` `{"type":"gamepad",…}`); GLFW and Web
-/// Gamepad API polling land as `override > polled > None` in the shells.
+/// The desktop shell polls the first standard-mapping pad via GLFW
+/// (`desktop_gamepad` in `functor-runtime-desktop`), with debug injection
+/// (`POST /input` `{"type":"gamepad",…}`) winning over the poll; the web
+/// shell does not sample the browser Gamepad API yet, so on wasm the domain
+/// is absent.
 ///
 /// Levels only, no edge sets: pads are polled, so a press always spans at
 /// least one render frame and shows up in at least one sample — games detect

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -292,11 +292,13 @@ pub struct XrControllerSnapshot {
 /// and the browser's down-positive axes at its boundary. Triggers are
 /// `0..1`. Values are raw (no deadzone shaping); games apply their own.
 ///
-/// The desktop shell polls the first standard-mapping pad via GLFW
+/// The desktop windowed shell polls the first standard-mapping pad via GLFW
 /// (`desktop_gamepad` in `functor-runtime-desktop`), with debug injection
-/// (`POST /input` `{"type":"gamepad",…}`) winning over the poll; the web
-/// shell does not sample the browser Gamepad API yet, so on wasm the domain
-/// is absent.
+/// (`POST /input` `{"type":"gamepad",…}`) winning over the poll. Presence is
+/// sticky: while input is gated (window unfocused, clock pinned) a connected
+/// pad reads rest-level controls rather than vanishing. Headless has no GLFW
+/// instance and the web shell does not sample the browser Gamepad API yet —
+/// there the domain exists only while injected.
 ///
 /// Levels only, no edge sets: pads are polled, so a press always spans at
 /// least one render frame and shows up in at least one sample — games detect

--- a/runtime/functor-runtime-desktop/src/desktop_gamepad.rs
+++ b/runtime/functor-runtime-desktop/src/desktop_gamepad.rs
@@ -1,0 +1,153 @@
+//! Poll the first connected standard-mapping gamepad into the shared
+//! [`GamepadSnapshot`] domain.
+//!
+//! GLFW's `glfwGetGamepadState` is already the SDL-mapping-normalized view, so
+//! the field set matches the snapshot one-to-one; the two conversions this
+//! adapter owns are the ones the snapshot contract pins: stick Y is negated
+//! (GLFW reports down-positive; the domain is up-positive, matching the XR
+//! thumbstick), and triggers are normalized from GLFW's `-1..1` (rest = `-1`)
+//! to `0..1`. Values stay raw otherwise — no deadzone shaping.
+
+use functor_runtime_common::GamepadSnapshot;
+
+/// Raw GLFW gamepad axes in `glfwGetGamepadState` order:
+/// left X/Y, right X/Y, left/right trigger.
+pub type RawAxes = [f32; 6];
+
+/// Raw GLFW gamepad buttons in `glfwGetGamepadState` order: A, B, X, Y,
+/// left/right bumper, back, start, guide, left/right thumb,
+/// dpad up/right/down/left.
+pub type RawButtons = [bool; 15];
+
+/// Map one raw GLFW gamepad reading into the target-neutral snapshot.
+///
+/// Pure — the unit tests drive the axis conventions through this seam
+/// directly. The guide button has no snapshot field and is dropped.
+pub fn map_gamepad(axes: RawAxes, buttons: RawButtons) -> GamepadSnapshot {
+    let stick = |x: f32, y: f32| [x.clamp(-1.0, 1.0), (-y).clamp(-1.0, 1.0)];
+    let trigger = |v: f32| ((v + 1.0) / 2.0).clamp(0.0, 1.0);
+    GamepadSnapshot {
+        left_stick: stick(axes[0], axes[1]),
+        right_stick: stick(axes[2], axes[3]),
+        left_trigger: trigger(axes[4]),
+        right_trigger: trigger(axes[5]),
+        south: buttons[0],
+        east: buttons[1],
+        west: buttons[2],
+        north: buttons[3],
+        left_bumper: buttons[4],
+        right_bumper: buttons[5],
+        select: buttons[6],
+        start: buttons[7],
+        left_stick_pressed: buttons[9],
+        right_stick_pressed: buttons[10],
+        dpad_up: buttons[11],
+        dpad_right: buttons[12],
+        dpad_down: buttons[13],
+        dpad_left: buttons[14],
+    }
+}
+
+/// Poll the first present joystick that has a standard gamepad mapping.
+///
+/// `None` when no pad is connected (or none has a mapping) — the capability
+/// signal the snapshot contract requires, never a zeroed record.
+pub fn sample(glfw: &glfw::Glfw) -> Option<GamepadSnapshot> {
+    use glfw::{Action, GamepadAxis, GamepadButton, JoystickId};
+    const IDS: [JoystickId; 16] = [
+        JoystickId::Joystick1,
+        JoystickId::Joystick2,
+        JoystickId::Joystick3,
+        JoystickId::Joystick4,
+        JoystickId::Joystick5,
+        JoystickId::Joystick6,
+        JoystickId::Joystick7,
+        JoystickId::Joystick8,
+        JoystickId::Joystick9,
+        JoystickId::Joystick10,
+        JoystickId::Joystick11,
+        JoystickId::Joystick12,
+        JoystickId::Joystick13,
+        JoystickId::Joystick14,
+        JoystickId::Joystick15,
+        JoystickId::Joystick16,
+    ];
+    const AXES: [GamepadAxis; 6] = [
+        GamepadAxis::AxisLeftX,
+        GamepadAxis::AxisLeftY,
+        GamepadAxis::AxisRightX,
+        GamepadAxis::AxisRightY,
+        GamepadAxis::AxisLeftTrigger,
+        GamepadAxis::AxisRightTrigger,
+    ];
+    const BUTTONS: [GamepadButton; 15] = [
+        GamepadButton::ButtonA,
+        GamepadButton::ButtonB,
+        GamepadButton::ButtonX,
+        GamepadButton::ButtonY,
+        GamepadButton::ButtonLeftBumper,
+        GamepadButton::ButtonRightBumper,
+        GamepadButton::ButtonBack,
+        GamepadButton::ButtonStart,
+        GamepadButton::ButtonGuide,
+        GamepadButton::ButtonLeftThumb,
+        GamepadButton::ButtonRightThumb,
+        GamepadButton::ButtonDpadUp,
+        GamepadButton::ButtonDpadRight,
+        GamepadButton::ButtonDpadDown,
+        GamepadButton::ButtonDpadLeft,
+    ];
+    IDS.into_iter().find_map(|id| {
+        let joystick = glfw.get_joystick(id);
+        if !joystick.is_present() || !joystick.is_gamepad() {
+            return None;
+        }
+        let state = joystick.get_gamepad_state()?;
+        let axes = AXES.map(|axis| state.get_axis(axis));
+        let buttons = BUTTONS.map(|button| state.get_button_state(button) == Action::Press);
+        Some(map_gamepad(axes, buttons))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_gamepad;
+
+    #[test]
+    fn sticks_negate_y_and_triggers_normalize_to_unit() {
+        // GLFW: stick pushed UP reads negative Y; the domain is up-positive.
+        let pad = map_gamepad([0.25, -1.0, -0.5, 1.0, -1.0, 1.0], [false; 15]);
+        assert_eq!(pad.left_stick, [0.25, 1.0]);
+        assert_eq!(pad.right_stick, [-0.5, -1.0]);
+        // GLFW triggers rest at -1.0 and saturate at 1.0.
+        assert_eq!(pad.left_trigger, 0.0);
+        assert_eq!(pad.right_trigger, 1.0);
+        // Half-pulled: -1..1 midpoint 0.0 → 0.5.
+        assert_eq!(
+            map_gamepad([0.0; 6], [false; 15]).left_trigger,
+            0.5,
+            "GLFW's rest-at-zero would read as half-pulled — the adapter must \
+             see raw -1..1 trigger values"
+        );
+        // Out-of-range hardware values clamp instead of leaking.
+        let wild = map_gamepad([2.0, 2.0, 0.0, 0.0, 3.0, -3.0], [false; 15]);
+        assert_eq!(wild.left_stick, [1.0, -1.0]);
+        assert_eq!(wild.left_trigger, 1.0);
+        assert_eq!(wild.right_trigger, 0.0);
+    }
+
+    #[test]
+    fn buttons_map_positionally_and_guide_is_dropped() {
+        let mut buttons = [false; 15];
+        buttons[0] = true; // A → south
+        buttons[6] = true; // Back → select
+        buttons[8] = true; // Guide → (dropped)
+        buttons[14] = true; // DpadLeft
+        let pad = map_gamepad([0.0; 6], buttons);
+        assert!(pad.south && pad.select && pad.dpad_left);
+        assert!(!pad.east && !pad.west && !pad.north);
+        assert!(!pad.start && !pad.left_bumper && !pad.right_bumper);
+        assert!(!pad.left_stick_pressed && !pad.right_stick_pressed);
+        assert!(!pad.dpad_up && !pad.dpad_right && !pad.dpad_down);
+    }
+}

--- a/runtime/functor-runtime-desktop/src/desktop_gamepad.rs
+++ b/runtime/functor-runtime-desktop/src/desktop_gamepad.rs
@@ -7,6 +7,11 @@
 //! (GLFW reports down-positive; the domain is up-positive, matching the XR
 //! thumbstick), and triggers are normalized from GLFW's `-1..1` (rest = `-1`)
 //! to `0..1`. Values stay raw otherwise — no deadzone shaping.
+//!
+//! "Primary pad" is re-resolved every scan as the lowest-id mapped joystick,
+//! so if two pads are connected and the first disconnects, the game continues
+//! on the second with no discontinuity signal — a deliberate consequence of
+//! the single-pad contract, not an accident.
 
 use functor_runtime_common::GamepadSnapshot;
 
@@ -23,9 +28,22 @@ pub type RawButtons = [bool; 15];
 ///
 /// Pure — the unit tests drive the axis conventions through this seam
 /// directly. The guide button has no snapshot field and is dropped.
+///
+/// Trigger caveat: `glfwGetGamepadState` zero-initializes its axis array and
+/// only writes axes the pad's SDL mapping actually binds, so a pad WITHOUT
+/// analog triggers leaves them at `0.0` — which naive `-1..1 → 0..1`
+/// normalization would report as permanently half-pulled. An exact `0.0` is
+/// therefore treated as rest (a real mid-pull landing on exactly `0.0` is a
+/// measure-zero coincidence costing at most one frame).
 pub fn map_gamepad(axes: RawAxes, buttons: RawButtons) -> GamepadSnapshot {
     let stick = |x: f32, y: f32| [x.clamp(-1.0, 1.0), (-y).clamp(-1.0, 1.0)];
-    let trigger = |v: f32| ((v + 1.0) / 2.0).clamp(0.0, 1.0);
+    let trigger = |v: f32| {
+        if v == 0.0 {
+            0.0
+        } else {
+            ((v + 1.0) / 2.0).clamp(0.0, 1.0)
+        }
+    };
     GamepadSnapshot {
         left_stick: stick(axes[0], axes[1]),
         right_stick: stick(axes[2], axes[3]),
@@ -54,24 +72,6 @@ pub fn map_gamepad(axes: RawAxes, buttons: RawButtons) -> GamepadSnapshot {
 /// signal the snapshot contract requires, never a zeroed record.
 pub fn sample(glfw: &glfw::Glfw) -> Option<GamepadSnapshot> {
     use glfw::{Action, GamepadAxis, GamepadButton, JoystickId};
-    const IDS: [JoystickId; 16] = [
-        JoystickId::Joystick1,
-        JoystickId::Joystick2,
-        JoystickId::Joystick3,
-        JoystickId::Joystick4,
-        JoystickId::Joystick5,
-        JoystickId::Joystick6,
-        JoystickId::Joystick7,
-        JoystickId::Joystick8,
-        JoystickId::Joystick9,
-        JoystickId::Joystick10,
-        JoystickId::Joystick11,
-        JoystickId::Joystick12,
-        JoystickId::Joystick13,
-        JoystickId::Joystick14,
-        JoystickId::Joystick15,
-        JoystickId::Joystick16,
-    ];
     const AXES: [GamepadAxis; 6] = [
         GamepadAxis::AxisLeftX,
         GamepadAxis::AxisLeftY,
@@ -97,12 +97,11 @@ pub fn sample(glfw: &glfw::Glfw) -> Option<GamepadSnapshot> {
         GamepadButton::ButtonDpadDown,
         GamepadButton::ButtonDpadLeft,
     ];
-    IDS.into_iter().find_map(|id| {
-        let joystick = glfw.get_joystick(id);
-        if !joystick.is_present() || !joystick.is_gamepad() {
-            return None;
-        }
-        let state = joystick.get_gamepad_state()?;
+    // `get_gamepad_state` itself answers `None` for an absent, mapless, or
+    // mid-scan-disconnected joystick, so no presence pre-checks are needed —
+    // one platform poll per candidate instead of three.
+    (0..16).filter_map(JoystickId::from_i32).find_map(|id| {
+        let state = glfw.get_joystick(id).get_gamepad_state()?;
         let axes = AXES.map(|axis| state.get_axis(axis));
         let buttons = BUTTONS.map(|button| state.get_button_state(button) == Action::Press);
         Some(map_gamepad(axes, buttons))
@@ -122,13 +121,15 @@ mod tests {
         // GLFW triggers rest at -1.0 and saturate at 1.0.
         assert_eq!(pad.left_trigger, 0.0);
         assert_eq!(pad.right_trigger, 1.0);
-        // Half-pulled: -1..1 midpoint 0.0 → 0.5.
-        assert_eq!(
-            map_gamepad([0.0; 6], [false; 15]).left_trigger,
-            0.5,
-            "GLFW's rest-at-zero would read as half-pulled — the adapter must \
-             see raw -1..1 trigger values"
-        );
+        // An exact 0.0 is an UNMAPPED trigger axis (GLFW zero-initializes and
+        // only writes mapped axes), so it must read as rest — naive midpoint
+        // normalization would report a pad without analog triggers as
+        // permanently half-pulled.
+        assert_eq!(map_gamepad([0.0; 6], [false; 15]).left_trigger, 0.0);
+        // A nearly-centered REAL trigger still normalizes continuously.
+        let near = map_gamepad([0.0, 0.0, 0.0, 0.0, 0.001, -0.001], [false; 15]);
+        assert!((near.left_trigger - 0.5005).abs() < 1e-4);
+        assert!((near.right_trigger - 0.4995).abs() < 1e-4);
         // Out-of-range hardware values clamp instead of leaking.
         let wild = map_gamepad([2.0, 2.0, 0.0, 0.0, 3.0, -3.0], [false; 15]);
         assert_eq!(wild.left_stick, [1.0, -1.0]);

--- a/runtime/functor-runtime-desktop/src/lib.rs
+++ b/runtime/functor-runtime-desktop/src/lib.rs
@@ -24,6 +24,8 @@ mod audio;
 #[cfg(not(target_arch = "wasm32"))]
 mod debug_server;
 #[cfg(not(target_arch = "wasm32"))]
+mod desktop_gamepad;
+#[cfg(not(target_arch = "wasm32"))]
 mod desktop_xr_emulator;
 #[cfg(not(target_arch = "wasm32"))]
 mod net_dispatch;

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -160,10 +160,12 @@ fn desktop_input_snapshot(
     xr_primary_down: bool,
     xr_surface: (i32, i32),
     xr_override: Option<&XrInputSnapshot>,
-    // The RESOLVED gamepad sample: callers apply `override > polled > None`
-    // (the windowed loop passes its per-frame GLFW poll as the fallback;
-    // headless has no GLFW instance, so injection is its only source).
-    gamepad: Option<&GamepadSnapshot>,
+    // The gamepad domain resolves `override > polled > None` HERE (the one
+    // statement of the precedence rule, like the XR match below): a debug
+    // injection wins over the windowed loop's per-frame GLFW poll; headless
+    // has no GLFW instance and always passes `polled_gamepad: None`.
+    gamepad_override: Option<&GamepadSnapshot>,
+    polled_gamepad: Option<&GamepadSnapshot>,
 ) -> InputSnapshot {
     let xr = match xr_override {
         Some(injected) => Some(injected.clone()),
@@ -173,7 +175,7 @@ fn desktop_input_snapshot(
     };
     let mut snapshot =
         sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr);
-    snapshot.gamepad = gamepad.cloned();
+    snapshot.gamepad = gamepad_override.or(polled_gamepad).cloned();
     snapshot
 }
 
@@ -316,12 +318,13 @@ fn refresh_fixed_input_levels(
     held_buttons: MouseButtons,
     xr_primary_down: bool,
     xr_override: Option<&XrInputSnapshot>,
-    // Resolved `override > polled > None`, like `desktop_input_snapshot`.
-    gamepad: Option<&GamepadSnapshot>,
+    // `override > polled > None`, resolved here like `desktop_input_snapshot`.
+    gamepad_override: Option<&GamepadSnapshot>,
+    polled_gamepad: Option<&GamepadSnapshot>,
 ) {
     snapshot.held_keys = held_keys.iter().copied().collect();
     snapshot.mouse.buttons = held_buttons;
-    snapshot.gamepad = gamepad.cloned();
+    snapshot.gamepad = gamepad_override.or(polled_gamepad).cloned();
     // An injected sample owns the whole XR domain — window keys must not
     // re-derive its trigger/thumbstick out from under the driver.
     match xr_override {
@@ -1400,6 +1403,7 @@ fn run_headless(
                     crate::desktop_xr_emulator::reference_surface(),
                     xr_override.as_ref(),
                     gamepad_override.as_ref(),
+                    None,
                 );
                 game.sampled_input(&snapshot);
             }
@@ -1427,6 +1431,7 @@ fn run_headless(
                     crate::desktop_xr_emulator::reference_surface(),
                     xr_override.as_ref(),
                     gamepad_override.as_ref(),
+                    None,
                 );
                 service_debug_request(
                     req,
@@ -1831,7 +1836,8 @@ Escape releases while captured"
             false,
             window.get_size(),
             xr_override.as_ref(),
-            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+            gamepad_override.as_ref(),
+            polled_gamepad.as_ref(),
         );
         // Whether the window owns the pointer (free-look). Capture is always
         // entered by a non-overlay click; see the Escape / MouseButton / Focus
@@ -2008,7 +2014,8 @@ then restart the runner"
                             held_buttons,
                             false,
                             xr_override.as_ref(),
-                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                            gamepad_override.as_ref(),
+                            polled_gamepad.as_ref(),
                         );
                     }
                     window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -2035,12 +2042,18 @@ then restart the runner"
             // server's /input still work.
             let ignore_user_input = clock.is_pinned();
             // Poll the pad once per render frame — level state, refreshed
-            // whole. Gated like other window input: not while time is pinned,
-            // and only while the window has focus (an unfocused game must not
-            // keep steering; None also covers disconnect, never stale values).
-            polled_gamepad = (!ignore_user_input && window.is_focused())
-                .then(|| crate::desktop_gamepad::sample(&glfw))
-                .flatten();
+            // whole. PRESENCE is sticky while a pad is connected (`None`
+            // stays the no-pad capability signal); the CONTROLS read rest
+            // level while window input is gated — unfocused, or time pinned —
+            // the pad twin of the focus-loss held-key sweep. Disconnect is
+            // `None` next frame, never stale values.
+            polled_gamepad = crate::desktop_gamepad::sample(&glfw).map(|pad| {
+                if ignore_user_input || !window.is_focused() {
+                    GamepadSnapshot::default()
+                } else {
+                    pad
+                }
+            });
             // Keyboard events for a focused `Ui.textInput` this frame,
             // collected from the GLFW stream while the overlay wants the
             // keyboard and handed to `draw_view` below. While the clock is
@@ -2125,7 +2138,8 @@ then restart the runner"
                                     held_buttons,
                                     false,
                                     xr_override.as_ref(),
-                                    gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                                    gamepad_override.as_ref(),
+                                    polled_gamepad.as_ref(),
                                 );
                             }
                             window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -2176,7 +2190,8 @@ Escape again to quit"
                                 held_buttons,
                                 false,
                                 xr_override.as_ref(),
-                                gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                                gamepad_override.as_ref(),
+                                polled_gamepad.as_ref(),
                             );
                         }
                         if !hidden {
@@ -2374,7 +2389,8 @@ Escape again to quit"
                                 held_buttons,
                                 xr_primary_down || xr_primary_clicked,
                                 xr_override.as_ref(),
-                                gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                                gamepad_override.as_ref(),
+                                polled_gamepad.as_ref(),
                             );
                         }
                     }
@@ -2420,7 +2436,8 @@ Escape again to quit"
                                     held_buttons,
                                     xr_primary_down || xr_primary_clicked,
                                     xr_override.as_ref(),
-                                    gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                                    gamepad_override.as_ref(),
+                                    polled_gamepad.as_ref(),
                                 );
                             }
                         }
@@ -2464,7 +2481,8 @@ Escape again to quit"
                                     held_buttons,
                                     xr_primary_down || xr_primary_clicked,
                                     xr_override.as_ref(),
-                                    gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                                    gamepad_override.as_ref(),
+                                    polled_gamepad.as_ref(),
                                 );
                             }
                         }
@@ -2507,7 +2525,8 @@ Escape again to quit"
                                 held_buttons,
                                 false,
                                 xr_override.as_ref(),
-                                gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                                gamepad_override.as_ref(),
+                                polled_gamepad.as_ref(),
                             );
                         }
                     }
@@ -2669,7 +2688,8 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
-                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                            gamepad_override.as_ref(),
+                            polled_gamepad.as_ref(),
                         );
                         game.sampled_input(&snapshot);
                     }
@@ -3464,7 +3484,8 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
-                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                            gamepad_override.as_ref(),
+                            polled_gamepad.as_ref(),
                         )
                     };
                     let sampled_input_changed = service_debug_request(
@@ -3516,7 +3537,8 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
-                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
+                            gamepad_override.as_ref(),
+                            polled_gamepad.as_ref(),
                         );
                     }
                 }
@@ -3816,6 +3838,7 @@ mod tests {
             (800, 600),
             None,
             None,
+            None,
         );
         let pose = snapshot
             .xr
@@ -3833,6 +3856,7 @@ mod tests {
             &held,
             buttons,
             false,
+            None,
             None,
             None,
         );
@@ -3874,6 +3898,7 @@ mod tests {
             (800, 600),
             None,
             None,
+            None,
         );
         assert!(snapshot.held_keys.is_empty());
         assert_eq!(snapshot.pressed_keys, vec![InputKey::Space]);
@@ -3895,6 +3920,7 @@ mod tests {
             (800, 600),
             None,
             None,
+            None,
         );
         assert_eq!(before.mouse.surface_width, 800);
         assert_eq!(before.mouse.surface_height, 600);
@@ -3910,6 +3936,7 @@ mod tests {
             false,
             false,
             (1440, 900),
+            None,
             None,
             None,
         );
@@ -3964,6 +3991,7 @@ mod tests {
             (800, 600),
             Some(&injected),
             None,
+            None,
         );
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
         // Keyboard/mouse domains stay live alongside it.
@@ -3993,6 +4021,7 @@ mod tests {
             (800, 600),
             None,
             None,
+            None,
         );
         assert_eq!(plain.xr, None, "no XR domain without a device or injection");
 
@@ -4005,6 +4034,7 @@ mod tests {
             false,
             (800, 600),
             Some(&injected),
+            None,
             None,
         );
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
@@ -4027,6 +4057,7 @@ mod tests {
             (800, 600),
             None,
             None,
+            None,
         );
         assert_eq!(
             plain.gamepad, None,
@@ -4043,6 +4074,7 @@ mod tests {
             (800, 600),
             None,
             Some(&pad),
+            None,
         );
         assert_eq!(snapshot.gamepad.as_ref(), Some(&pad));
 
@@ -4055,6 +4087,7 @@ mod tests {
             false,
             None,
             Some(&pad),
+            None,
         );
         assert_eq!(snapshot.gamepad.as_ref(), Some(&pad));
         refresh_fixed_input_levels(
@@ -4064,8 +4097,43 @@ mod tests {
             false,
             None,
             None,
+            None,
         );
         assert_eq!(snapshot.gamepad, None);
+
+        // Precedence is resolved in the builders: an injected override wins
+        // over the windowed loop's polled pad, and the poll supplies the
+        // domain on its own.
+        let polled = GamepadSnapshot {
+            east: true,
+            ..GamepadSnapshot::default()
+        };
+        let resolved = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            MouseButtons::default(),
+            &InputEdges::default(),
+            false,
+            false,
+            (800, 600),
+            None,
+            Some(&pad),
+            Some(&polled),
+        );
+        assert_eq!(resolved.gamepad.as_ref(), Some(&pad));
+        let polled_only = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            MouseButtons::default(),
+            &InputEdges::default(),
+            false,
+            false,
+            (800, 600),
+            None,
+            None,
+            Some(&polled),
+        );
+        assert_eq!(polled_only.gamepad.as_ref(), Some(&polled));
     }
 
     #[test]
@@ -4081,6 +4149,7 @@ mod tests {
             (800, 600),
             Some(&injected),
             None,
+            None,
         );
         // Space would drive the EMULATOR's trigger to 1.0; the injected sample
         // owns the XR domain, so window keys must leave it alone.
@@ -4092,6 +4161,7 @@ mod tests {
             MouseButtons::default(),
             true,
             Some(&injected),
+            None,
             None,
         );
 

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -160,7 +160,10 @@ fn desktop_input_snapshot(
     xr_primary_down: bool,
     xr_surface: (i32, i32),
     xr_override: Option<&XrInputSnapshot>,
-    gamepad_override: Option<&GamepadSnapshot>,
+    // The RESOLVED gamepad sample: callers apply `override > polled > None`
+    // (the windowed loop passes its per-frame GLFW poll as the fallback;
+    // headless has no GLFW instance, so injection is its only source).
+    gamepad: Option<&GamepadSnapshot>,
 ) -> InputSnapshot {
     let xr = match xr_override {
         Some(injected) => Some(injected.clone()),
@@ -170,10 +173,7 @@ fn desktop_input_snapshot(
     };
     let mut snapshot =
         sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr);
-    // The gamepad domain's only desktop source for now is debug injection
-    // (`POST /input` `{"type":"gamepad"}`); GLFW pad polling slots in here as
-    // `override > polled > None`, the XR shape above.
-    snapshot.gamepad = gamepad_override.cloned();
+    snapshot.gamepad = gamepad.cloned();
     snapshot
 }
 
@@ -316,11 +316,12 @@ fn refresh_fixed_input_levels(
     held_buttons: MouseButtons,
     xr_primary_down: bool,
     xr_override: Option<&XrInputSnapshot>,
-    gamepad_override: Option<&GamepadSnapshot>,
+    // Resolved `override > polled > None`, like `desktop_input_snapshot`.
+    gamepad: Option<&GamepadSnapshot>,
 ) {
     snapshot.held_keys = held_keys.iter().copied().collect();
     snapshot.mouse.buttons = held_buttons;
-    snapshot.gamepad = gamepad_override.cloned();
+    snapshot.gamepad = gamepad.cloned();
     // An injected sample owns the whole XR domain — window keys must not
     // re-derive its trigger/thumbstick out from under the driver.
     match xr_override {
@@ -1813,6 +1814,9 @@ Escape releases while captured"
         let mut xr_primary_clicked = false;
         let mut xr_override: Option<XrInputSnapshot> = None;
         let mut gamepad_override: Option<GamepadSnapshot> = None;
+        // The pad polled from GLFW this frame; a debug-injected override wins
+        // over it at every sample site (`override > polled > None`).
+        let mut polled_gamepad: Option<GamepadSnapshot> = None;
         // `--fixed-time` is a deterministic capture pin: the one zero-delta
         // bootstrap step must not observe cursor motion from the host window.
         // Explicit debug input remains authoritative; key release/focus-loss
@@ -1827,7 +1831,7 @@ Escape releases while captured"
             false,
             window.get_size(),
             xr_override.as_ref(),
-            gamepad_override.as_ref(),
+            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
         );
         // Whether the window owns the pointer (free-look). Capture is always
         // entered by a non-overlay click; see the Escape / MouseButton / Focus
@@ -2004,7 +2008,7 @@ then restart the runner"
                             held_buttons,
                             false,
                             xr_override.as_ref(),
-                            gamepad_override.as_ref(),
+                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                         );
                     }
                     window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -2030,6 +2034,13 @@ then restart the runner"
             // capture can't turn the camera). Window close/escape and the debug
             // server's /input still work.
             let ignore_user_input = clock.is_pinned();
+            // Poll the pad once per render frame — level state, refreshed
+            // whole. Gated like other window input: not while time is pinned,
+            // and only while the window has focus (an unfocused game must not
+            // keep steering; None also covers disconnect, never stale values).
+            polled_gamepad = (!ignore_user_input && window.is_focused())
+                .then(|| crate::desktop_gamepad::sample(&glfw))
+                .flatten();
             // Keyboard events for a focused `Ui.textInput` this frame,
             // collected from the GLFW stream while the overlay wants the
             // keyboard and handed to `draw_view` below. While the clock is
@@ -2114,7 +2125,7 @@ then restart the runner"
                                     held_buttons,
                                     false,
                                     xr_override.as_ref(),
-                                    gamepad_override.as_ref(),
+                                    gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                                 );
                             }
                             window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -2165,7 +2176,7 @@ Escape again to quit"
                                 held_buttons,
                                 false,
                                 xr_override.as_ref(),
-                                gamepad_override.as_ref(),
+                                gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                             );
                         }
                         if !hidden {
@@ -2363,7 +2374,7 @@ Escape again to quit"
                                 held_buttons,
                                 xr_primary_down || xr_primary_clicked,
                                 xr_override.as_ref(),
-                                gamepad_override.as_ref(),
+                                gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                             );
                         }
                     }
@@ -2409,7 +2420,7 @@ Escape again to quit"
                                     held_buttons,
                                     xr_primary_down || xr_primary_clicked,
                                     xr_override.as_ref(),
-                                    gamepad_override.as_ref(),
+                                    gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                                 );
                             }
                         }
@@ -2453,7 +2464,7 @@ Escape again to quit"
                                     held_buttons,
                                     xr_primary_down || xr_primary_clicked,
                                     xr_override.as_ref(),
-                                    gamepad_override.as_ref(),
+                                    gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                                 );
                             }
                         }
@@ -2496,7 +2507,7 @@ Escape again to quit"
                                 held_buttons,
                                 false,
                                 xr_override.as_ref(),
-                                gamepad_override.as_ref(),
+                                gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                             );
                         }
                     }
@@ -2658,7 +2669,7 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
-                            gamepad_override.as_ref(),
+                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                         );
                         game.sampled_input(&snapshot);
                     }
@@ -3453,7 +3464,7 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
-                            gamepad_override.as_ref(),
+                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                         )
                     };
                     let sampled_input_changed = service_debug_request(
@@ -3505,7 +3516,7 @@ Escape again to quit"
                             xr_primary_down || xr_primary_clicked,
                             window.get_size(),
                             xr_override.as_ref(),
-                            gamepad_override.as_ref(),
+                            gamepad_override.as_ref().or(polled_gamepad.as_ref()),
                         );
                     }
                 }

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -107,8 +107,8 @@ export interface InputSnapshot {
   };
   /** Present while an XR target has valid head tracking. */
   xr?: XrInputSnapshot;
-  /** Present while a gamepad sample is injected (no shell polls a physical
-   * pad yet; polling will make this "while a pad is connected"). */
+  /** Present while a pad is connected (desktop GLFW polling) or a sample is
+   * injected; absent on web, which does not sample pads yet. */
   gamepad?: GamepadSnapshot;
 }
 

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -107,8 +107,9 @@ export interface InputSnapshot {
   };
   /** Present while an XR target has valid head tracking. */
   xr?: XrInputSnapshot;
-  /** Present while a pad is connected (desktop GLFW polling) or a sample is
-   * injected; absent on web, which does not sample pads yet. */
+  /** Present while a pad is connected (desktop windowed GLFW polling — rest
+   * levels while unfocused/pinned) or a sample is injected; absent on
+   * headless and web, which do not poll pads. */
   gamepad?: GamepadSnapshot;
 }
 


### PR DESCRIPTION
Part 2 of the gamepad + touch input series, stacked on #652. The first physical source for the `gamepad` domain: the windowed desktop loop polls the first present standard-mapping pad once per render frame via `glfwGetGamepadState` (already the SDL-mapping-normalized view) and resolves `override > polled > None` — debug injection still wins, and headless (no GLFW instance) stays injection-only.

## What's here

- **`desktop_gamepad.rs`** — a pure, unit-tested adapter owning exactly the two conversions the snapshot contract pins: stick Y negated (GLFW down-positive → domain up-positive, the XR thumbstick convention) and triggers normalized from GLFW's `-1..1` (rest `-1`) to `0..1`. Everything clamps; guide is dropped. An exact `0.0` trigger reads as rest — `glfwGetGamepadState` zero-initializes and only writes mapped axes, so a pad without analog triggers would otherwise report permanently half-pulled (verified against the vendored GLFW C).
- **Sticky presence**: `None` stays the no-pad capability signal. While window input is gated (unfocused, or clock pinned for deterministic captures) a connected pad reads rest-level controls instead of vanishing — the pad twin of the focus-loss held-key sweep, so a game keying control hints off `Option.Some/None` doesn't flip on alt-tab.
- **One precedence statement**: `override > polled > None` resolves inside `desktop_input_snapshot` / `refresh_fixed_input_levels` (the XR shape); call sites pass both raw values.
- Docs updated from #652's injection-only wording, stating the gate once per surface: windowed polls each frame; rest-level while unfocused/pinned; headless + web injection-only until the web slice lands.

## Verification

- `cargo test -p functor-runtime-desktop` (88 — new mapping tests: Y negation, trigger normalization + unmapped-axis rest, clamping, positional buttons, guide drop; precedence assertions) and `-p functor_runtime_common` (691+31); `npm run check:docs`; SDK build.
- Windowed-loop smoke: padless `--capture-frame` run of `examples/counter` (exercises the per-frame poll + gating).
- No physical pad was attached during development — the mapping seam is pinned against the GLFW C source and unit tests; a hands-on pad check is worth doing before merge if one is around.

## xreview

Two-engine adversarial review + de-dup pass; all findings addressed in the second commit: sticky presence [AGREED], unmapped-trigger rest [High], precedence resolved once + leaner scan (no presence pre-checks, `JoystickId::from_i32` range) [multi-strategy], doc gate wording + one stale line, pad-identity re-resolution documented. Declined one Low (making the polled value loop-local) because a pre-poll debug-step path legitimately reads the previous frame's level state.

Not perf-sensitive per CLAUDE.md's list (shell loop, not interpreter/prelude/producer/rendering); the poll is windowed-only, allocation-free, and one platform call per candidate id.