### PR TITLE
feat(web): poll the browser Gamepad API into the sampled snapshot

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -370,12 +370,13 @@ let grab = (s) =>
   are `0..1`; face buttons are POSITIONAL (`south` is the bottom face button —
   A on Xbox, Cross on PlayStation), plus bumpers, stick clicks, dpad, and
   `start`/`select`. Levels only, raw values: detect edges against your model
-  and apply your own deadzone. Native's windowed runtime polls the first
-  connected standard-mapping pad each frame (debug injection — `POST /input`
-  `{"type":"gamepad",…}` — wins over the poll); an unfocused window or a
-  pinned clock reads rest-level controls, not `Option.None`, so presence
-  stays a reliable capability signal. Headless and the web runtime do not
-  poll pads (`Option.None` unless injected). A future mobile-touch domain
+  and apply your own deadzone. Native's windowed runtime and the web runtime
+  both poll the first connected standard-mapping pad each frame (on native,
+  debug injection — `POST /input` `{"type":"gamepad",…}` — wins over the
+  poll); an unfocused window/document or a pinned clock reads rest-level
+  controls, not `Option.None`, so presence stays a reliable capability
+  signal. Browsers hide pads until a button is first pressed; headless polls
+  nothing (`Option.None` unless injected). A future mobile-touch domain
   belongs as another typed sibling on the snapshot.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -97,6 +97,13 @@ jobs:
       - name: Run wasm smoke
         run: npm run test:wasm-smoke
 
+      # The browser Gamepad API → sampledInput path, with faked pads: pins the
+      # standard-mapping conversion, the null/disconnected/non-standard
+      # selection rules, and the duck-typed property-read contract a
+      # wasm-bindgen bump could silently break with all Rust tests green.
+      - name: Run gamepad wasm e2e
+        run: npm run test:gamepad-wasm
+
       # The multiplayer session hosted in the browser: a server + two client
       # panes, each its own `player.html?net=embedder` runtime, routed by the
       # host page's net coordinator over the embedder seam. Same "works native,

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -462,10 +462,10 @@ is a typed sibling field, present only when its device is live. `gamepad`
 carries the pad's held state: sticks as `[x, y]` in `-1..1` with up-positive
 Y, triggers in `0..1`, positional face buttons (`south` is the bottom one),
 bumpers, stick clicks, dpad, and `start`/`select`. Desktop's windowed runtime
-polls the first standard-mapping pad each frame (an injected sample wins over
-the poll); presence is sticky while the pad is connected, with controls at
-rest level while the window is unfocused or the clock is pinned. `--headless`
-has no GLFW instance, so there (and on web, which does not sample pads yet)
+and the web runtime poll the first standard-mapping pad each frame (on
+desktop an injected sample wins over the poll); presence is sticky while the
+pad is connected, with controls at rest level while the window/document is
+unfocused or the clock is pinned. `--headless` has no GLFW instance, so there
 injection is the domain's only source. Future mobile-touch support should add
 another typed sibling field rather than target-specific endpoints or
 string-keyed capability bags.

--- a/e2e/fixtures/gamepad/functor.json
+++ b/e2e/fixtures/gamepad/functor.json
@@ -1,0 +1,1 @@
+{ "language": "functor-lang", "entry": "game.fun" }

--- a/e2e/fixtures/gamepad/game.fun
+++ b/e2e/fixtures/gamepad/game.fun
@@ -10,6 +10,8 @@ let sampledInput = (m: Model, snap: Input.snapshot) =>
   match snap.gamepad with
   | Option.Some(pad) =>
     if pad.south && not m.logged then
+      // The length test is only a sequencing device: Debug.log returns its
+      // value, and binding it forces the log before `logged` flips.
       let line: string =
         Debug.log(
           "e2e-gamepad",

--- a/e2e/fixtures/gamepad/game.fun
+++ b/e2e/fixtures/gamepad/game.fun
@@ -1,0 +1,28 @@
+// gamepad e2e fixture: log ONE line when the sampled snapshot first carries a
+// pad with south held, echoing the stick so the test can assert the whole
+// standard-mapping conversion (value + up-positive Y) crossed the boundary.
+
+type Model = { logged: bool }
+
+let init = { logged: false }
+
+let sampledInput = (m: Model, snap: Input.snapshot) =>
+  match snap.gamepad with
+  | Option.Some(pad) =>
+    if pad.south && not m.logged then
+      let line: string =
+        Debug.log(
+          "e2e-gamepad",
+          $"south x={pad.leftStick.x} y={pad.leftStick.y} rt={pad.rightTrigger}",
+        ) in
+      { logged: Text.length(line) > 0.0 }
+    else m
+  | Option.None => m
+
+let tick = (m: Model, dt, tts) => m
+
+let draw = (m: Model, tts) =>
+  Frame.create(
+    Camera3D.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.cube(),
+  )

--- a/e2e/gamepad-wasm.mjs
+++ b/e2e/gamepad-wasm.mjs
@@ -1,0 +1,140 @@
+// gamepad wasm e2e: the browser Gamepad API reaches a game's `sampledInput`
+// through the web runtime's per-frame poll, with the standard-mapping
+// conversion intact (analog trigger value + up-positive stick Y).
+//
+// The pad is FAKED by overriding `navigator.getGamepads` before the runtime
+// boots — headless CI has no controller, and a fake is also what pins exact
+// axis values. The fixture game (e2e/fixtures/gamepad) logs one
+// "e2e-gamepad" line the first time it samples a pad with south held,
+// echoing leftStick and rightTrigger; the test asserts that line and its
+// converted values (browser Y -1 → domain +1).
+//
+// Run manually (needs the built CLI so target/debug/functor embeds the web
+// runtime with pad polling):
+//
+//   npm run build:cli:debug
+//   node e2e/gamepad-wasm.mjs
+import { spawn } from "node:child_process";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PORT = 8080;
+const BASE = `http://127.0.0.1:${PORT}`;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function portInUse() {
+  return new Promise((resolve) => {
+    const sock = net
+      .connect(PORT, "127.0.0.1")
+      .on("connect", () => {
+        sock.destroy();
+        resolve(true);
+      })
+      .on("error", () => resolve(false));
+  });
+}
+
+async function waitPortFree(timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await portInUse())) return true;
+    await sleep(200);
+  }
+  return false;
+}
+
+async function main() {
+  if (!(await waitPortFree(15000))) {
+    throw new Error(`:${PORT} is in use — another dev server is running`);
+  }
+  const server = spawn(
+    "./target/debug/functor",
+    ["-d", "e2e/fixtures/gamepad", "run", "wasm", "--no-open"],
+    { cwd: ROOT, stdio: "ignore" },
+  );
+  const browser = await chromium.launch({
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+    ],
+  });
+  try {
+    const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+    const log = [];
+    page.on("console", (m) => log.push(m.text()));
+    page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+
+    // A standard-mapping pad: south held, left stick pushed right+up (browser
+    // Y is down-positive, so up is -1), right trigger analog at 0.25. Installed
+    // before any runtime script runs, so the first poll already sees it.
+    await page.addInitScript(() => {
+      const button = (pressed, value) => ({ pressed, touched: pressed, value });
+      const buttons = Array.from({ length: 17 }, () => button(false, 0));
+      buttons[0] = button(true, 1); // south
+      buttons[7] = button(false, 0.25); // right trigger's analog value
+      const pad = {
+        id: "e2e-fake-pad",
+        index: 0,
+        connected: true,
+        mapping: "standard",
+        timestamp: 0,
+        axes: [0.5, -1.0, 0.0, 0.0],
+        buttons,
+      };
+      navigator.getGamepads = () => [pad];
+    });
+
+    // Wait for the dev server, then load and let the game sample a few frames.
+    const deadline = Date.now() + 30000;
+    let up = false;
+    while (Date.now() < deadline && !up) {
+      up = await portInUse();
+      if (!up) await sleep(200);
+    }
+    if (!up) throw new Error("dev server never came up");
+    await page.goto(BASE, { waitUntil: "domcontentloaded" });
+
+    const found = async (pattern) => log.some((line) => pattern.test(line));
+    const waitFor = async (pattern, what) => {
+      const until = Date.now() + 20000;
+      while (Date.now() < until) {
+        if (await found(pattern)) return;
+        await sleep(200);
+      }
+      throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
+    };
+
+    await waitFor(/\[functor-lang\] loaded/, "the game to load");
+    await waitFor(/e2e-gamepad/, "the sampled pad to reach the game");
+
+    const line = log.find((l) => l.includes("e2e-gamepad"));
+    const expect = (cond, what) => {
+      console.log(`  ${cond ? "✓" : "✗"} ${what}`);
+      if (!cond) process.exitCode = 1;
+    };
+    expect(line.includes("x=0.5"), `stick X crossed raw (${line})`);
+    expect(line.includes("y=1"), "browser down-positive Y negated to up-positive");
+    expect(line.includes("rt=0.25"), "analog trigger value (not the digital shadow)");
+
+    const functorLangErrors = log.filter((l) => /\[functor-lang\].*error/.test(l));
+    expect(functorLangErrors.length === 0, "no [functor-lang] errors during the run");
+  } finally {
+    await browser.close();
+    server.kill("SIGKILL");
+    await waitPortFree(10000);
+  }
+}
+
+main().then(
+  () => {
+    console.log(process.exitCode ? "✗ gamepad wasm e2e FAILED" : "✓ gamepad wasm e2e passed");
+  },
+  (err) => {
+    console.error(`✗ gamepad wasm e2e FAILED: ${err.message}`);
+    process.exitCode = 1;
+  },
+);

--- a/e2e/gamepad-wasm.mjs
+++ b/e2e/gamepad-wasm.mjs
@@ -1,140 +1,139 @@
 // gamepad wasm e2e: the browser Gamepad API reaches a game's `sampledInput`
 // through the web runtime's per-frame poll, with the standard-mapping
-// conversion intact (analog trigger value + up-positive stick Y).
+// conversion intact (analog trigger value + up-positive stick Y) and the
+// selection rules honored (null slots, disconnected and non-standard pads
+// are all skipped).
 //
-// The pad is FAKED by overriding `navigator.getGamepads` before the runtime
+// The pads are FAKED by overriding `navigator.getGamepads` before the runtime
 // boots — headless CI has no controller, and a fake is also what pins exact
-// axis values. The fixture game (e2e/fixtures/gamepad) logs one
-// "e2e-gamepad" line the first time it samples a pad with south held,
-// echoing leftStick and rightTrigger; the test asserts that line and its
-// converted values (browser Y -1 → domain +1).
+// axis values AND the duck-typing contract: the runtime reads pads with
+// unchecked casts + plain property reads, so a wasm-bindgen toolchain bump
+// that broke that would fail here, not silently in a real browser. The
+// fixture game (e2e/fixtures/gamepad) logs one "e2e-gamepad" line the first
+// time it samples a pad with south held, echoing leftStick and rightTrigger.
 //
-// Run manually (needs the built CLI so target/debug/functor embeds the web
-// runtime with pad polling):
+// The bundle is exported with `build wasm` and served from an ephemeral port
+// (the e2e/module-role-wasm.mjs shape) rather than driven through `run wasm`
+// (which hardcodes :8080) — hermetic next to a dev server someone else runs.
 //
-//   npm run build:cli:debug
+//   npm run build:cli:debug   # once, so target/debug/functor embeds the runtime
 //   node e2e/gamepad-wasm.mjs
-import { spawn } from "node:child_process";
-import net from "node:net";
+import { execFileSync } from "node:child_process";
+import { createReadStream, statSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
-const PORT = 8080;
-const BASE = `http://127.0.0.1:${PORT}`;
+const DIR = path.join(ROOT, "e2e", "fixtures", "gamepad");
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-function portInUse() {
-  return new Promise((resolve) => {
-    const sock = net
-      .connect(PORT, "127.0.0.1")
-      .on("connect", () => {
-        sock.destroy();
-        resolve(true);
-      })
-      .on("error", () => resolve(false));
-  });
-}
-
-async function waitPortFree(timeoutMs) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!(await portInUse())) return true;
-    await sleep(200);
-  }
-  return false;
-}
-
-async function main() {
-  if (!(await waitPortFree(15000))) {
-    throw new Error(`:${PORT} is in use — another dev server is running`);
-  }
-  const server = spawn(
-    "./target/debug/functor",
-    ["-d", "e2e/fixtures/gamepad", "run", "wasm", "--no-open"],
-    { cwd: ROOT, stdio: "ignore" },
-  );
-  const browser = await chromium.launch({
-    args: [
-      "--use-gl=angle",
-      "--use-angle=swiftshader",
-      "--enable-unsafe-swiftshader",
-      "--ignore-gpu-blocklist",
-    ],
-  });
-  try {
-    const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
-    const log = [];
-    page.on("console", (m) => log.push(m.text()));
-    page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
-
-    // A standard-mapping pad: south held, left stick pushed right+up (browser
-    // Y is down-positive, so up is -1), right trigger analog at 0.25. Installed
-    // before any runtime script runs, so the first poll already sees it.
-    await page.addInitScript(() => {
-      const button = (pressed, value) => ({ pressed, touched: pressed, value });
-      const buttons = Array.from({ length: 17 }, () => button(false, 0));
-      buttons[0] = button(true, 1); // south
-      buttons[7] = button(false, 0.25); // right trigger's analog value
-      const pad = {
-        id: "e2e-fake-pad",
-        index: 0,
-        connected: true,
-        mapping: "standard",
-        timestamp: 0,
-        axes: [0.5, -1.0, 0.0, 0.0],
-        buttons,
-      };
-      navigator.getGamepads = () => [pad];
-    });
-
-    // Wait for the dev server, then load and let the game sample a few frames.
-    const deadline = Date.now() + 30000;
-    let up = false;
-    while (Date.now() < deadline && !up) {
-      up = await portInUse();
-      if (!up) await sleep(200);
-    }
-    if (!up) throw new Error("dev server never came up");
-    await page.goto(BASE, { waitUntil: "domcontentloaded" });
-
-    const found = async (pattern) => log.some((line) => pattern.test(line));
-    const waitFor = async (pattern, what) => {
-      const until = Date.now() + 20000;
-      while (Date.now() < until) {
-        if (await found(pattern)) return;
-        await sleep(200);
-      }
-      throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
-    };
-
-    await waitFor(/\[functor-lang\] loaded/, "the game to load");
-    await waitFor(/e2e-gamepad/, "the sampled pad to reach the game");
-
-    const line = log.find((l) => l.includes("e2e-gamepad"));
-    const expect = (cond, what) => {
-      console.log(`  ${cond ? "✓" : "✗"} ${what}`);
-      if (!cond) process.exitCode = 1;
-    };
-    expect(line.includes("x=0.5"), `stick X crossed raw (${line})`);
-    expect(line.includes("y=1"), "browser down-positive Y negated to up-positive");
-    expect(line.includes("rt=0.25"), "analog trigger value (not the digital shadow)");
-
-    const functorLangErrors = log.filter((l) => /\[functor-lang\].*error/.test(l));
-    expect(functorLangErrors.length === 0, "no [functor-lang] errors during the run");
-  } finally {
-    await browser.close();
-    server.kill("SIGKILL");
-    await waitPortFree(10000);
-  }
-}
-
-main().then(
-  () => {
-    console.log(process.exitCode ? "✗ gamepad wasm e2e FAILED" : "✓ gamepad wasm e2e passed");
-  },
-  (err) => {
-    console.error(`✗ gamepad wasm e2e FAILED: ${err.message}`);
-    process.exitCode = 1;
-  },
+console.log(
+  execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", DIR, "build", "wasm"], {
+    encoding: "utf8",
+  })
 );
+
+const TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".wasm": "application/wasm",
+  ".fun": "text/plain",
+};
+const root = path.join(DIR, "dist", "web");
+const server = http.createServer((req, res) => {
+  let rel = decodeURIComponent(req.url.split("?")[0]);
+  if (rel === "/") rel = "/index.html";
+  const file = path.join(root, rel);
+  try {
+    statSync(file);
+  } catch {
+    res.writeHead(404).end("not found");
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
+  });
+  createReadStream(file).pipe(res);
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const { port } = server.address();
+
+// Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
+// runner — no real GPU needed; this check compares no pixels.
+const browser = await chromium.launch({
+  args: [
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+  ],
+});
+try {
+  const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
+  const log = [];
+  page.on("console", (m) => log.push(m.text()));
+  page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+
+  // The pad the runtime must SELECT sits behind a null slot (a disconnected
+  // index — getGamepads() explicitly returns those), a disconnected pad, and
+  // a non-standard-mapping pad, all of which must be skipped. It holds south,
+  // pushes the left stick right+up (browser Y is down-positive, so up is -1),
+  // and rests the right trigger's ANALOG value at 0.25 while its digital
+  // `pressed` stays false — pinning value-over-shadow.
+  await page.addInitScript(() => {
+    const button = (pressed, value) => ({ pressed, touched: pressed, value });
+    const pad = (overrides) => ({
+      id: "e2e-fake-pad",
+      index: 0,
+      connected: true,
+      mapping: "standard",
+      timestamp: 0,
+      axes: [0, 0, 0, 0],
+      buttons: Array.from({ length: 17 }, () => button(false, 0)),
+      ...overrides,
+    });
+    const buttons = Array.from({ length: 17 }, () => button(false, 0));
+    buttons[0] = button(true, 1); // south
+    buttons[7] = button(false, 0.25); // right trigger's analog value
+    const live = pad({ index: 3, axes: [0.5, -1.0, 0.0, 0.0], buttons });
+    navigator.getGamepads = () => [
+      null, // a disconnected slot
+      pad({ index: 1, connected: false, buttons: [button(true, 1)] }),
+      pad({ index: 2, mapping: "", buttons: [button(true, 1)] }),
+      live,
+    ];
+  });
+
+  await page.goto(`http://127.0.0.1:${port}/`);
+  const waitFor = async (pattern, what) => {
+    const until = Date.now() + 30000;
+    while (Date.now() < until) {
+      if (log.some((line) => pattern.test(line))) return;
+      await sleep(200);
+    }
+    throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
+  };
+
+  await waitFor(/\[functor-lang\] loaded/, "the game to load");
+  await waitFor(/e2e-gamepad/, "the sampled pad to reach the game");
+
+  const line = log.find((l) => l.includes("e2e-gamepad"));
+  const expect = (cond, what) => {
+    console.log(`  ${cond ? "✓" : "✗"} ${what}`);
+    if (!cond) process.exitCode = 1;
+  };
+  expect(line.includes("x=0.5"), `stick X crossed raw (${line})`);
+  expect(line.includes("y=1"), "browser down-positive Y negated to up-positive");
+  expect(line.includes("rt=0.25"), "analog trigger value (not the digital shadow)");
+  expect(
+    !log.some((l) => /\[functor-lang\].*error/.test(l)),
+    "no [functor-lang] errors during the run",
+  );
+} finally {
+  await browser.close();
+  server.close();
+}
+
+console.log(process.exitCode ? "✗ gamepad wasm e2e FAILED" : "✓ gamepad wasm e2e passed");

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -41,12 +41,13 @@ type xr = {
 /// Nintendo) — because letter names swap between vendors. Sticks are `-1..1`
 /// with up-positive `y` (the XR thumbstick convention); triggers are `0..1`.
 /// Values are raw — apply your own deadzone. Levels only: detect edges
-/// against your model, as XR games do. Native's windowed runtime polls the
-/// first connected standard-mapping pad (debug injection wins over the
-/// poll); while the window is unfocused or the clock is pinned a connected
-/// pad reads rest-level controls rather than `Option.None`. Headless and
-/// the web runtime do not poll pads, so there this is `Option.None` unless
-/// injected.
+/// against your model, as XR games do. Native's windowed runtime and the
+/// web runtime both poll the first connected standard-mapping pad each
+/// frame (on native, debug injection wins over the poll); while the
+/// window/document is unfocused or the clock is pinned a connected pad
+/// reads rest-level controls rather than `Option.None`. Browsers hide pads
+/// until a button is first pressed, and headless polls nothing — there this
+/// is `Option.None` unless injected.
 type gamepad = {
   leftStick: point2,
   rightStick: point2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "functor2",
+  "name": "functor3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:wasm-golden": "playwright test",
     "test:wasm-golden:update": "playwright test --update-snapshots",
     "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
+    "test:gamepad-wasm": "node e2e/gamepad-wasm.mjs",
     "test:wasm-remote-assets": "node e2e/remote-assets.mjs",
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -294,11 +294,12 @@ pub struct XrControllerSnapshot {
 ///
 /// The desktop windowed shell polls the first standard-mapping pad via GLFW
 /// (`desktop_gamepad` in `functor-runtime-desktop`), with debug injection
-/// (`POST /input` `{"type":"gamepad",…}`) winning over the poll. Presence is
-/// sticky: while input is gated (window unfocused, clock pinned) a connected
-/// pad reads rest-level controls rather than vanishing. Headless has no GLFW
-/// instance and the web shell does not sample the browser Gamepad API yet —
-/// there the domain exists only while injected.
+/// (`POST /input` `{"type":"gamepad",…}`) winning over the poll; the web
+/// shell polls the browser Gamepad API each frame (`web_gamepad` in
+/// `functor-runtime-web`). Presence is sticky on both: while input is gated
+/// (window/document unfocused, clock pinned) a connected pad reads
+/// rest-level controls rather than vanishing. Headless has no GLFW instance,
+/// so there the domain exists only while injected.
 ///
 /// Levels only, no edge sets: pads are polled, so a press always spans at
 /// least one render frame and shows up in at least one sample — games detect
@@ -328,6 +329,42 @@ pub struct GamepadSnapshot {
     pub dpad_right: bool,
     pub start: bool,
     pub select: bool,
+}
+
+impl GamepadSnapshot {
+    /// Build a snapshot from the W3C Gamepad API's `"standard"` mapping — the
+    /// web shell's conversion, kept here (IO-free) so it unit-tests natively
+    /// while the wasm-only shell just gathers the raw arrays.
+    ///
+    /// `axes` are the four standard stick axes with the browser's
+    /// down-positive Y (negated here to the domain's up-positive convention).
+    /// `triggers` are standard buttons 6/7's ANALOG `value`s, already `0..1`.
+    /// `buttons` are the 16 standard buttons' `pressed` booleans — indices
+    /// 6/7 (the triggers' digital shadows) are ignored in favor of the analog
+    /// values, and 16 (guide) has no snapshot field.
+    pub fn from_standard_mapping(axes: [f32; 4], triggers: [f32; 2], buttons: [bool; 16]) -> Self {
+        let stick = |x: f32, y: f32| [x.clamp(-1.0, 1.0), (-y).clamp(-1.0, 1.0)];
+        GamepadSnapshot {
+            left_stick: stick(axes[0], axes[1]),
+            right_stick: stick(axes[2], axes[3]),
+            left_trigger: triggers[0].clamp(0.0, 1.0),
+            right_trigger: triggers[1].clamp(0.0, 1.0),
+            south: buttons[0],
+            east: buttons[1],
+            west: buttons[2],
+            north: buttons[3],
+            left_bumper: buttons[4],
+            right_bumper: buttons[5],
+            select: buttons[8],
+            start: buttons[9],
+            left_stick_pressed: buttons[10],
+            right_stick_pressed: buttons[11],
+            dpad_up: buttons[12],
+            dpad_down: buttons[13],
+            dpad_left: buttons[14],
+            dpad_right: buttons[15],
+        }
+    }
 }
 
 /// Canonical key identifier shared across the F# <-> Rust boundary and all
@@ -1194,6 +1231,40 @@ mod tests {
                 .to_string()
                 .contains("gamepad: Option.None"),
         );
+    }
+
+    #[test]
+    fn standard_mapping_converts_axes_triggers_and_positional_buttons() {
+        let mut buttons = [false; 16];
+        buttons[0] = true; // south
+        buttons[6] = true; // left trigger's digital shadow — ignored
+        buttons[8] = true; // select
+        buttons[15] = true; // dpad right
+        let pad = GamepadSnapshot::from_standard_mapping(
+            // Browser Y is down-positive: stick pushed UP reads negative.
+            [0.25, -1.0, -0.5, 1.0],
+            [0.75, 0.0],
+            buttons,
+        );
+        assert_eq!(pad.left_stick, [0.25, 1.0]);
+        assert_eq!(pad.right_stick, [-0.5, -1.0]);
+        assert_eq!(pad.left_trigger, 0.75);
+        assert_eq!(pad.right_trigger, 0.0);
+        assert!(pad.south && pad.select && pad.dpad_right);
+        assert!(!pad.east && !pad.west && !pad.north && !pad.start);
+        assert!(!pad.dpad_up && !pad.dpad_down && !pad.dpad_left);
+        assert!(!pad.left_bumper && !pad.right_bumper);
+        assert!(!pad.left_stick_pressed && !pad.right_stick_pressed);
+
+        // Out-of-range values clamp instead of leaking.
+        let wild = GamepadSnapshot::from_standard_mapping(
+            [2.0, 2.0, 0.0, 0.0],
+            [3.0, -1.0],
+            [false; 16],
+        );
+        assert_eq!(wild.left_stick, [1.0, -1.0]);
+        assert_eq!(wild.left_trigger, 1.0);
+        assert_eq!(wild.right_trigger, 0.0);
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -331,24 +331,41 @@ pub struct GamepadSnapshot {
     pub select: bool,
 }
 
+/// Clamp one device-reported stick pair into the domain convention: `-1..1`,
+/// up-positive Y (both GLFW and the browser report down-positive, so `y` is
+/// negated here — the ONE statement of that rule). NaN (a duck-typed or
+/// broken device value) reads as centered rather than poisoning the model.
+fn stick_pair(x: f32, y: f32) -> [f32; 2] {
+    let axis = |v: f32| if v.is_nan() { 0.0 } else { v.clamp(-1.0, 1.0) };
+    [axis(x), axis(-y)]
+}
+
+/// Clamp one trigger into `0..1`; NaN reads as released.
+fn unit_trigger(v: f32) -> f32 {
+    if v.is_nan() {
+        0.0
+    } else {
+        v.clamp(0.0, 1.0)
+    }
+}
+
 impl GamepadSnapshot {
     /// Build a snapshot from the W3C Gamepad API's `"standard"` mapping — the
-    /// web shell's conversion, kept here (IO-free) so it unit-tests natively
-    /// while the wasm-only shell just gathers the raw arrays.
+    /// web shell's conversion, kept here (IO-free) beside its GLFW twin so
+    /// both unit-test natively while the shells just gather raw arrays.
     ///
     /// `axes` are the four standard stick axes with the browser's
-    /// down-positive Y (negated here to the domain's up-positive convention).
+    /// down-positive Y (negated to the domain's up-positive convention).
     /// `triggers` are standard buttons 6/7's ANALOG `value`s, already `0..1`.
     /// `buttons` are the 16 standard buttons' `pressed` booleans — indices
     /// 6/7 (the triggers' digital shadows) are ignored in favor of the analog
     /// values, and 16 (guide) has no snapshot field.
     pub fn from_standard_mapping(axes: [f32; 4], triggers: [f32; 2], buttons: [bool; 16]) -> Self {
-        let stick = |x: f32, y: f32| [x.clamp(-1.0, 1.0), (-y).clamp(-1.0, 1.0)];
         GamepadSnapshot {
-            left_stick: stick(axes[0], axes[1]),
-            right_stick: stick(axes[2], axes[3]),
-            left_trigger: triggers[0].clamp(0.0, 1.0),
-            right_trigger: triggers[1].clamp(0.0, 1.0),
+            left_stick: stick_pair(axes[0], axes[1]),
+            right_stick: stick_pair(axes[2], axes[3]),
+            left_trigger: unit_trigger(triggers[0]),
+            right_trigger: unit_trigger(triggers[1]),
             south: buttons[0],
             east: buttons[1],
             west: buttons[2],
@@ -363,6 +380,48 @@ impl GamepadSnapshot {
             dpad_down: buttons[13],
             dpad_left: buttons[14],
             dpad_right: buttons[15],
+        }
+    }
+
+    /// Build a snapshot from `glfwGetGamepadState` raw arrays — the desktop
+    /// shell's conversion. Axes in GLFW order (left X/Y, right X/Y,
+    /// left/right trigger), buttons in GLFW order (A, B, X, Y, bumpers, back,
+    /// start, guide, thumbs, dpad up/right/down/left); guide is dropped.
+    ///
+    /// GLFW triggers are `-1..1` with rest at `-1` — but `glfwGetGamepadState`
+    /// zero-initializes its axis array and only writes axes the pad's SDL
+    /// mapping actually binds, so a pad WITHOUT analog triggers leaves them at
+    /// `0.0`, which naive midpoint normalization would report as permanently
+    /// half-pulled. An exact `0.0` is therefore treated as rest (a real
+    /// mid-pull landing on exactly `0.0` is a measure-zero coincidence
+    /// costing at most one frame).
+    pub fn from_glfw_mapping(axes: [f32; 6], buttons: [bool; 15]) -> Self {
+        let trigger = |v: f32| {
+            if v == 0.0 {
+                0.0
+            } else {
+                unit_trigger((v + 1.0) / 2.0)
+            }
+        };
+        GamepadSnapshot {
+            left_stick: stick_pair(axes[0], axes[1]),
+            right_stick: stick_pair(axes[2], axes[3]),
+            left_trigger: trigger(axes[4]),
+            right_trigger: trigger(axes[5]),
+            south: buttons[0],
+            east: buttons[1],
+            west: buttons[2],
+            north: buttons[3],
+            left_bumper: buttons[4],
+            right_bumper: buttons[5],
+            select: buttons[6],
+            start: buttons[7],
+            left_stick_pressed: buttons[9],
+            right_stick_pressed: buttons[10],
+            dpad_up: buttons[11],
+            dpad_right: buttons[12],
+            dpad_down: buttons[13],
+            dpad_left: buttons[14],
         }
     }
 }
@@ -1233,36 +1292,143 @@ mod tests {
         );
     }
 
+    /// The mapping tables' ONLY failure mode is a wrong index, so each entry
+    /// is checked one-hot: exactly the expected field lights up, every other
+    /// field stays false — a transposition anywhere fails.
+    fn assert_one_hot(pad: &GamepadSnapshot, lit: Option<usize>, source: &str) {
+        let fields: [(&str, bool); 14] = [
+            ("south", pad.south),
+            ("east", pad.east),
+            ("west", pad.west),
+            ("north", pad.north),
+            ("left_bumper", pad.left_bumper),
+            ("right_bumper", pad.right_bumper),
+            ("select", pad.select),
+            ("start", pad.start),
+            ("left_stick_pressed", pad.left_stick_pressed),
+            ("right_stick_pressed", pad.right_stick_pressed),
+            ("dpad_up", pad.dpad_up),
+            ("dpad_down", pad.dpad_down),
+            ("dpad_left", pad.dpad_left),
+            ("dpad_right", pad.dpad_right),
+        ];
+        for (index, (name, value)) in fields.iter().enumerate() {
+            assert_eq!(
+                *value,
+                lit == Some(index),
+                "{source}: field `{name}` wrong"
+            );
+        }
+    }
+
     #[test]
-    fn standard_mapping_converts_axes_triggers_and_positional_buttons() {
-        let mut buttons = [false; 16];
-        buttons[0] = true; // south
-        buttons[6] = true; // left trigger's digital shadow — ignored
-        buttons[8] = true; // select
-        buttons[15] = true; // dpad right
+    fn standard_mapping_converts_axes_triggers_and_every_button_index() {
+        // Field order of `assert_one_hot` for each standard button index;
+        // None = no snapshot field (trigger shadows 6/7, guide 16).
+        let expected: [Option<usize>; 16] = [
+            Some(0),  // 0 south
+            Some(1),  // 1 east
+            Some(2),  // 2 west
+            Some(3),  // 3 north
+            Some(4),  // 4 left bumper
+            Some(5),  // 5 right bumper
+            None,     // 6 left trigger's digital shadow
+            None,     // 7 right trigger's digital shadow
+            Some(6),  // 8 select
+            Some(7),  // 9 start
+            Some(8),  // 10 left stick click
+            Some(9),  // 11 right stick click
+            Some(10), // 12 dpad up
+            Some(11), // 13 dpad down
+            Some(12), // 14 dpad left
+            Some(13), // 15 dpad right
+        ];
+        for (index, lit) in expected.into_iter().enumerate() {
+            let mut buttons = [false; 16];
+            buttons[index] = true;
+            let pad = GamepadSnapshot::from_standard_mapping([0.0; 4], [0.0; 2], buttons);
+            assert_one_hot(&pad, lit, &format!("standard button {index}"));
+        }
+
+        // Browser Y is down-positive: stick pushed UP reads negative.
         let pad = GamepadSnapshot::from_standard_mapping(
-            // Browser Y is down-positive: stick pushed UP reads negative.
             [0.25, -1.0, -0.5, 1.0],
             [0.75, 0.0],
-            buttons,
+            [false; 16],
         );
         assert_eq!(pad.left_stick, [0.25, 1.0]);
         assert_eq!(pad.right_stick, [-0.5, -1.0]);
         assert_eq!(pad.left_trigger, 0.75);
         assert_eq!(pad.right_trigger, 0.0);
-        assert!(pad.south && pad.select && pad.dpad_right);
-        assert!(!pad.east && !pad.west && !pad.north && !pad.start);
-        assert!(!pad.dpad_up && !pad.dpad_down && !pad.dpad_left);
-        assert!(!pad.left_bumper && !pad.right_bumper);
-        assert!(!pad.left_stick_pressed && !pad.right_stick_pressed);
 
-        // Out-of-range values clamp instead of leaking.
+        // Out-of-range values clamp, and NaN (a duck-typed pad missing a
+        // numeric value) reads as rest instead of poisoning the model.
         let wild = GamepadSnapshot::from_standard_mapping(
-            [2.0, 2.0, 0.0, 0.0],
-            [3.0, -1.0],
+            [2.0, 2.0, f32::NAN, f32::NAN],
+            [3.0, f32::NAN],
             [false; 16],
         );
         assert_eq!(wild.left_stick, [1.0, -1.0]);
+        assert_eq!(wild.right_stick, [0.0, 0.0]);
+        assert_eq!(wild.left_trigger, 1.0);
+        assert_eq!(wild.right_trigger, 0.0);
+    }
+
+    #[test]
+    fn glfw_mapping_converts_axes_triggers_and_every_button_index() {
+        let expected: [Option<usize>; 15] = [
+            Some(0),  // 0 A → south
+            Some(1),  // 1 B → east
+            Some(2),  // 2 X → west
+            Some(3),  // 3 Y → north
+            Some(4),  // 4 left bumper
+            Some(5),  // 5 right bumper
+            Some(6),  // 6 back → select
+            Some(7),  // 7 start
+            None,     // 8 guide (dropped)
+            Some(8),  // 9 left thumb
+            Some(9),  // 10 right thumb
+            Some(10), // 11 dpad up
+            Some(13), // 12 dpad RIGHT (GLFW order differs from standard)
+            Some(11), // 13 dpad down
+            Some(12), // 14 dpad left
+        ];
+        for (index, lit) in expected.into_iter().enumerate() {
+            let mut buttons = [false; 15];
+            buttons[index] = true;
+            let pad = GamepadSnapshot::from_glfw_mapping([0.0; 6], buttons);
+            assert_one_hot(&pad, lit, &format!("glfw button {index}"));
+        }
+
+        // GLFW: stick pushed UP reads negative Y; triggers rest at -1.0.
+        let pad = GamepadSnapshot::from_glfw_mapping([0.25, -1.0, -0.5, 1.0, -1.0, 1.0], [false; 15]);
+        assert_eq!(pad.left_stick, [0.25, 1.0]);
+        assert_eq!(pad.right_stick, [-0.5, -1.0]);
+        assert_eq!(pad.left_trigger, 0.0);
+        assert_eq!(pad.right_trigger, 1.0);
+
+        // An exact 0.0 is an UNMAPPED trigger axis (GLFW zero-initializes and
+        // only writes mapped axes) and must read as rest — midpoint
+        // normalization would report it permanently half-pulled. A REAL
+        // near-center trigger still normalizes continuously.
+        assert_eq!(
+            GamepadSnapshot::from_glfw_mapping([0.0; 6], [false; 15]).left_trigger,
+            0.0
+        );
+        let near = GamepadSnapshot::from_glfw_mapping(
+            [0.0, 0.0, 0.0, 0.0, 0.001, -0.001],
+            [false; 15],
+        );
+        assert!((near.left_trigger - 0.5005).abs() < 1e-4);
+        assert!((near.right_trigger - 0.4995).abs() < 1e-4);
+
+        // Clamps and NaN guards, as with the standard mapping.
+        let wild = GamepadSnapshot::from_glfw_mapping(
+            [2.0, 2.0, f32::NAN, f32::NAN, 3.0, f32::NAN],
+            [false; 15],
+        );
+        assert_eq!(wild.left_stick, [1.0, -1.0]);
+        assert_eq!(wild.right_stick, [0.0, 0.0]);
         assert_eq!(wild.left_trigger, 1.0);
         assert_eq!(wild.right_trigger, 0.0);
     }

--- a/runtime/functor-runtime-desktop/src/desktop_gamepad.rs
+++ b/runtime/functor-runtime-desktop/src/desktop_gamepad.rs
@@ -1,12 +1,10 @@
 //! Poll the first connected standard-mapping gamepad into the shared
 //! [`GamepadSnapshot`] domain.
 //!
-//! GLFW's `glfwGetGamepadState` is already the SDL-mapping-normalized view, so
-//! the field set matches the snapshot one-to-one; the two conversions this
-//! adapter owns are the ones the snapshot contract pins: stick Y is negated
-//! (GLFW reports down-positive; the domain is up-positive, matching the XR
-//! thumbstick), and triggers are normalized from GLFW's `-1..1` (rest = `-1`)
-//! to `0..1`. Values stay raw otherwise — no deadzone shaping.
+//! The pure conversion — Y negation, trigger normalization, the
+//! unmapped-trigger rest rule — lives beside the domain as
+//! [`GamepadSnapshot::from_glfw_mapping`] (unit-tested there, next to its web
+//! twin); this module only gathers `glfwGetGamepadState`'s raw arrays.
 //!
 //! "Primary pad" is re-resolved every scan as the lowest-id mapped joystick,
 //! so if two pads are connected and the first disconnects, the game continues
@@ -14,57 +12,6 @@
 //! the single-pad contract, not an accident.
 
 use functor_runtime_common::GamepadSnapshot;
-
-/// Raw GLFW gamepad axes in `glfwGetGamepadState` order:
-/// left X/Y, right X/Y, left/right trigger.
-pub type RawAxes = [f32; 6];
-
-/// Raw GLFW gamepad buttons in `glfwGetGamepadState` order: A, B, X, Y,
-/// left/right bumper, back, start, guide, left/right thumb,
-/// dpad up/right/down/left.
-pub type RawButtons = [bool; 15];
-
-/// Map one raw GLFW gamepad reading into the target-neutral snapshot.
-///
-/// Pure — the unit tests drive the axis conventions through this seam
-/// directly. The guide button has no snapshot field and is dropped.
-///
-/// Trigger caveat: `glfwGetGamepadState` zero-initializes its axis array and
-/// only writes axes the pad's SDL mapping actually binds, so a pad WITHOUT
-/// analog triggers leaves them at `0.0` — which naive `-1..1 → 0..1`
-/// normalization would report as permanently half-pulled. An exact `0.0` is
-/// therefore treated as rest (a real mid-pull landing on exactly `0.0` is a
-/// measure-zero coincidence costing at most one frame).
-pub fn map_gamepad(axes: RawAxes, buttons: RawButtons) -> GamepadSnapshot {
-    let stick = |x: f32, y: f32| [x.clamp(-1.0, 1.0), (-y).clamp(-1.0, 1.0)];
-    let trigger = |v: f32| {
-        if v == 0.0 {
-            0.0
-        } else {
-            ((v + 1.0) / 2.0).clamp(0.0, 1.0)
-        }
-    };
-    GamepadSnapshot {
-        left_stick: stick(axes[0], axes[1]),
-        right_stick: stick(axes[2], axes[3]),
-        left_trigger: trigger(axes[4]),
-        right_trigger: trigger(axes[5]),
-        south: buttons[0],
-        east: buttons[1],
-        west: buttons[2],
-        north: buttons[3],
-        left_bumper: buttons[4],
-        right_bumper: buttons[5],
-        select: buttons[6],
-        start: buttons[7],
-        left_stick_pressed: buttons[9],
-        right_stick_pressed: buttons[10],
-        dpad_up: buttons[11],
-        dpad_right: buttons[12],
-        dpad_down: buttons[13],
-        dpad_left: buttons[14],
-    }
-}
 
 /// Poll the first present joystick that has a standard gamepad mapping.
 ///
@@ -104,51 +51,6 @@ pub fn sample(glfw: &glfw::Glfw) -> Option<GamepadSnapshot> {
         let state = glfw.get_joystick(id).get_gamepad_state()?;
         let axes = AXES.map(|axis| state.get_axis(axis));
         let buttons = BUTTONS.map(|button| state.get_button_state(button) == Action::Press);
-        Some(map_gamepad(axes, buttons))
+        Some(GamepadSnapshot::from_glfw_mapping(axes, buttons))
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::map_gamepad;
-
-    #[test]
-    fn sticks_negate_y_and_triggers_normalize_to_unit() {
-        // GLFW: stick pushed UP reads negative Y; the domain is up-positive.
-        let pad = map_gamepad([0.25, -1.0, -0.5, 1.0, -1.0, 1.0], [false; 15]);
-        assert_eq!(pad.left_stick, [0.25, 1.0]);
-        assert_eq!(pad.right_stick, [-0.5, -1.0]);
-        // GLFW triggers rest at -1.0 and saturate at 1.0.
-        assert_eq!(pad.left_trigger, 0.0);
-        assert_eq!(pad.right_trigger, 1.0);
-        // An exact 0.0 is an UNMAPPED trigger axis (GLFW zero-initializes and
-        // only writes mapped axes), so it must read as rest — naive midpoint
-        // normalization would report a pad without analog triggers as
-        // permanently half-pulled.
-        assert_eq!(map_gamepad([0.0; 6], [false; 15]).left_trigger, 0.0);
-        // A nearly-centered REAL trigger still normalizes continuously.
-        let near = map_gamepad([0.0, 0.0, 0.0, 0.0, 0.001, -0.001], [false; 15]);
-        assert!((near.left_trigger - 0.5005).abs() < 1e-4);
-        assert!((near.right_trigger - 0.4995).abs() < 1e-4);
-        // Out-of-range hardware values clamp instead of leaking.
-        let wild = map_gamepad([2.0, 2.0, 0.0, 0.0, 3.0, -3.0], [false; 15]);
-        assert_eq!(wild.left_stick, [1.0, -1.0]);
-        assert_eq!(wild.left_trigger, 1.0);
-        assert_eq!(wild.right_trigger, 0.0);
-    }
-
-    #[test]
-    fn buttons_map_positionally_and_guide_is_dropped() {
-        let mut buttons = [false; 15];
-        buttons[0] = true; // A → south
-        buttons[6] = true; // Back → select
-        buttons[8] = true; // Guide → (dropped)
-        buttons[14] = true; // DpadLeft
-        let pad = map_gamepad([0.0; 6], buttons);
-        assert!(pad.south && pad.select && pad.dpad_left);
-        assert!(!pad.east && !pad.west && !pad.north);
-        assert!(!pad.start && !pad.left_bumper && !pad.right_bumper);
-        assert!(!pad.left_stick_pressed && !pad.right_stick_pressed);
-        assert!(!pad.dpad_up && !pad.dpad_right && !pad.dpad_down);
-    }
 }

--- a/runtime/functor-runtime-web/Cargo.toml
+++ b/runtime/functor-runtime-web/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 
 [dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'WebGlContextAttributes', 'WebGlPowerPreference', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'Event']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'WebGlContextAttributes', 'WebGlPowerPreference', 'console', 'Window', 'Location', 'Performance', 'PerformanceTiming', 'Document', 'Element', 'Node', 'HtmlElement', 'Request', 'RequestInit', 'RequestCache', 'Response', 'Headers', 'AudioContext', 'BaseAudioContext', 'AudioBuffer', 'AudioBufferSourceNode', 'AudioDestinationNode', 'AudioNode', 'AudioParam', 'GainNode', 'StereoPannerNode', 'WebSocket', 'MessageEvent', 'CloseEvent', 'Event', 'Navigator', 'Gamepad', 'GamepadButton', 'GamepadMappingType']
 
 [profile.release]
 codegen-units = 1

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -35,6 +35,7 @@ use wasm_bindgen_futures::{spawn_local, JsFuture};
 use wasm_bindgen::prelude::*;
 
 mod functor_lang_game;
+mod web_gamepad;
 use functor_lang_game::WebPlatform;
 
 fn window() -> web_sys::Window {
@@ -1629,6 +1630,22 @@ async fn run_async() -> Result<(), JsValue> {
             // Retina-scaled drawable buffer updated later in this frame.
             input_snapshot.mouse.surface_width = canvas.client_width().max(0) as u32;
             input_snapshot.mouse.surface_height = canvas.client_height().max(0) as u32;
+            // Poll the pad once per render frame — the desktop windowed
+            // contract: presence is sticky while a standard-mapping pad is
+            // connected, and controls read rest level while the clock is
+            // pinned or the document unfocused (the pad twin of the page's
+            // blur key sweep). Disconnect is `None` next frame, never stale.
+            let document_focused = web_sys::window()
+                .and_then(|w| w.document())
+                .and_then(|d| d.has_focus().ok())
+                .unwrap_or(true);
+            input_snapshot.gamepad = web_gamepad::sample().map(|pad| {
+                if suspended || !document_focused {
+                    functor_runtime_common::GamepadSnapshot::default()
+                } else {
+                    pad
+                }
+            });
             functor_lang_game::drain_input(
                 &mut **game,
                 &mut input_snapshot,

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1635,17 +1635,27 @@ async fn run_async() -> Result<(), JsValue> {
             // connected, and controls read rest level while the clock is
             // pinned or the document unfocused (the pad twin of the page's
             // blur key sweep). Disconnect is `None` next frame, never stale.
-            let document_focused = web_sys::window()
-                .and_then(|w| w.document())
-                .and_then(|d| d.has_focus().ok())
-                .unwrap_or(true);
-            input_snapshot.gamepad = web_gamepad::sample().map(|pad| {
-                if suspended || !document_focused {
-                    functor_runtime_common::GamepadSnapshot::default()
-                } else {
-                    pad
-                }
-            });
+            // Gated on `samples_input()`: a game without `sampledInput` never
+            // sees the snapshot, so it must not pay the ~40 JS crossings the
+            // poll costs. Note for `?fixed-time` captures: a live pad still
+            // reads as PRESENT (at rest) — presence, unlike controls, is
+            // hardware state, and browsers hide pads until an in-page button
+            // press anyway, so automated capture contexts see none.
+            input_snapshot.gamepad = if game.samples_input() {
+                let document_focused = window
+                    .document()
+                    .and_then(|d| d.has_focus().ok())
+                    .unwrap_or(true);
+                web_gamepad::sample().map(|pad| {
+                    if suspended || !document_focused {
+                        functor_runtime_common::GamepadSnapshot::default()
+                    } else {
+                        pad
+                    }
+                })
+            } else {
+                None
+            };
             functor_lang_game::drain_input(
                 &mut **game,
                 &mut input_snapshot,

--- a/runtime/functor-runtime-web/src/web_gamepad.rs
+++ b/runtime/functor-runtime-web/src/web_gamepad.rs
@@ -1,0 +1,55 @@
+//! Poll the browser Gamepad API into the shared [`GamepadSnapshot`] domain —
+//! the web twin of the desktop shell's `desktop_gamepad`.
+//!
+//! Only pads reporting the `"standard"` mapping are considered (anything else
+//! has no reliable axis/button identity), and the first connected one wins —
+//! the same lowest-id primary-pad contract as desktop, with the same caveat
+//! that identity silently re-resolves if that pad disconnects. The pure
+//! conversion ([`GamepadSnapshot::from_standard_mapping`]) lives in
+//! `functor_runtime_common` so it unit-tests natively; this module only
+//! gathers the raw arrays across the js boundary.
+//!
+//! Browsers expose nothing through `getGamepads()` until the user presses a
+//! button on the pad (a fingerprinting defense) — until then this returns
+//! `None`, which is exactly the domain's no-pad capability signal.
+
+use functor_runtime_common::GamepadSnapshot;
+use wasm_bindgen::JsCast;
+
+/// Sample the first connected standard-mapping pad, or `None`.
+pub fn sample() -> Option<GamepadSnapshot> {
+    let navigator = web_sys::window()?.navigator();
+    let pads = navigator.get_gamepads().ok()?;
+    pads.iter()
+        // Unchecked rather than `dyn_into`: web-sys accessors are structural
+        // (plain property reads), and an `instanceof Gamepad` check would
+        // reject the duck-typed pads test harnesses install over
+        // `navigator.getGamepads`. Null slots (disconnected indices) are
+        // filtered first.
+        .filter(|entry| !entry.is_null() && !entry.is_undefined())
+        .map(|entry| entry.unchecked_into::<web_sys::Gamepad>())
+        .find(|pad| {
+            pad.connected() && pad.mapping() == web_sys::GamepadMappingType::Standard
+        })
+        .map(|pad| {
+            let axes = pad.axes();
+            let axis = |i: u32| axes.get(i).as_f64().unwrap_or(0.0) as f32;
+            let buttons = pad.buttons();
+            let button = |i: u32| {
+                let entry = buttons.get(i);
+                (!entry.is_null() && !entry.is_undefined())
+                    .then(|| entry.unchecked_into::<web_sys::GamepadButton>())
+            };
+            let pressed = |i: u32| button(i).is_some_and(|b| b.pressed());
+            let value = |i: u32| button(i).map_or(0.0, |b| b.value() as f32);
+            let mut held = [false; 16];
+            for (i, slot) in held.iter_mut().enumerate() {
+                *slot = pressed(i as u32);
+            }
+            GamepadSnapshot::from_standard_mapping(
+                [axis(0), axis(1), axis(2), axis(3)],
+                [value(6), value(7)],
+                held,
+            )
+        })
+}

--- a/runtime/functor-runtime-web/src/web_gamepad.rs
+++ b/runtime/functor-runtime-web/src/web_gamepad.rs
@@ -21,11 +21,14 @@ pub fn sample() -> Option<GamepadSnapshot> {
     let navigator = web_sys::window()?.navigator();
     let pads = navigator.get_gamepads().ok()?;
     pads.iter()
-        // Unchecked rather than `dyn_into`: web-sys accessors are structural
-        // (plain property reads), and an `instanceof Gamepad` check would
-        // reject the duck-typed pads test harnesses install over
-        // `navigator.getGamepads`. Null slots (disconnected indices) are
-        // filtered first.
+        // Unchecked rather than `dyn_into`: an `instanceof Gamepad` check
+        // would reject the duck-typed pads test harnesses install over
+        // `navigator.getGamepads`. That works because wasm-bindgen emits a
+        // plain property read (`arg0.connected`) for these getters even
+        // though web-sys does not mark them `structural` — an implementation
+        // detail of the codegen that `e2e/gamepad-wasm.mjs` pins, so a
+        // toolchain bump that broke it would fail the e2e, not silently
+        // misread pads. Null slots (disconnected indices) are filtered first.
         .filter(|entry| !entry.is_null() && !entry.is_undefined())
         .map(|entry| entry.unchecked_into::<web_sys::Gamepad>())
         .find(|pad| {
@@ -40,15 +43,18 @@ pub fn sample() -> Option<GamepadSnapshot> {
                 (!entry.is_null() && !entry.is_undefined())
                     .then(|| entry.unchecked_into::<web_sys::GamepadButton>())
             };
-            let pressed = |i: u32| button(i).is_some_and(|b| b.pressed());
-            let value = |i: u32| button(i).map_or(0.0, |b| b.value() as f32);
             let mut held = [false; 16];
             for (i, slot) in held.iter_mut().enumerate() {
-                *slot = pressed(i as u32);
+                // 6/7 are the analog triggers' digital shadows — the
+                // conversion ignores them, so skip their boundary crossings.
+                if i != 6 && i != 7 {
+                    *slot = button(i as u32).is_some_and(|b| b.pressed());
+                }
             }
+            let trigger = |i: u32| button(i).map_or(0.0, |b| b.value() as f32);
             GamepadSnapshot::from_standard_mapping(
                 [axis(0), axis(1), axis(2), axis(3)],
-                [value(6), value(7)],
+                [trigger(6), trigger(7)],
                 held,
             )
         })

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -107,9 +107,9 @@ export interface InputSnapshot {
   };
   /** Present while an XR target has valid head tracking. */
   xr?: XrInputSnapshot;
-  /** Present while a pad is connected (desktop windowed GLFW polling — rest
-   * levels while unfocused/pinned) or a sample is injected; absent on
-   * headless and web, which do not poll pads. */
+  /** Present while a pad is connected (desktop GLFW / browser Gamepad API
+   * polling — rest levels while unfocused/pinned) or a sample is injected;
+   * absent on headless, which polls nothing. */
   gamepad?: GamepadSnapshot;
 }
 


### PR DESCRIPTION
Part 3 of the gamepad + touch input series, stacked on #655. The web half of the gamepad domain's physical sources: the wasm frame loop polls `navigator.getGamepads()` once per render frame and takes the first connected `"standard"`-mapping pad, completing the domain across all shells (native windowed = GLFW poll, web = Gamepad API, headless = injection).

## What's here

- **Both pad mappings co-located on `GamepadSnapshot`** (`functor-runtime-common`): `from_standard_mapping` (W3C — analog trigger `value`s over their digital shadows, browser down-positive Y negated) and `from_glfw_mapping` (moved in from `desktop_gamepad.rs`, which shrinks to the GLFW gather). They share the single statement of the Y-negation rule plus NaN-sanitizing clamps, and both button tables are unit-tested with **one-hot sweeps** — any index transposition fails.
- **`web_gamepad.rs`**: the wasm gather. Pads are read via unchecked casts after a null filter — wasm-bindgen emits plain property reads for these getters, which is what lets test harnesses duck-type `navigator.getGamepads` (the e2e pins that contract). Null slots, disconnected pads, and non-standard mappings are skipped; trigger shadows 6/7 skip their boundary crossings.
- **Frame-loop wiring** (`lib.rs`): sticky presence — rest-level controls while the clock is pinned or the document unfocused, `None` only when no pad exists. Gated on `samples_input()`, so games without `sampledInput` pay none of the ~40 JS crossings.
- **Hermetic e2e** (`npm run test:gamepad-wasm`, wired into `wasm-smoke.yml`): exports the fixture with `build wasm`, serves on an ephemeral port, fakes `[null, disconnected, non-standard, live]` pads, and asserts the fixture game's `sampledInput` logged the converted values (`x=0.5`, `y=1` from browser `-1`, `rt=0.25` analog) with no `[functor-lang]` errors.

## Verification

`cargo test -p functor_runtime_common` (693, incl. the one-hot sweeps + NaN guards) and `-p functor-runtime-desktop` (86); wasm-target build; `node e2e/gamepad-wasm.mjs` passing against the freshly built bundle; `npm run check:docs`; SDK build.

## xreview

Two-engine adversarial review + de-dup pass; all findings addressed in the second commit — CI wiring for the e2e [High], one-hot mapping tests, NaN sanitization, the `samples_input()` gate, mapping co-location + shared stick rule, hermetic e2e harness + hardened fake, and comment honesty (the real `unchecked_into` guarantee, the fixed-time presence caveat). The reviewer verified the frame-loop placement, replay/scrub interaction, and focus gating clean against the actual web-sys/wasm-bindgen codegen.

Not perf-sensitive beyond the poll itself, which is gated off entirely for games without `sampledInput`.