### PR TITLE
feat(site): link impairment — latency and jitter become real

### DIFF
--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -174,11 +174,19 @@ id per pair, both ends told `connected`, FIFO per pane. No sockets are opened
 and no server process runs.
 
 Its routing properties mirror `functor_runtime_common::net::VirtualNet`, which
-it does not call: the coordinator ships **perfect links, next-rAF delivery**
-today, not step-time delivery. `VirtualNet`'s scheduling — packets as
-`{deliver_tick, seq, dest, event}` data over a seeded SplitMix64 and a per-link
-`LinkProfile` — is the basis planned for latency, jitter, loss, partitions, and
-the step-time delivery barrier that makes them reproducible.
+it does not call — including its scheduling: each routed packet is given a
+delivery FRAME (`sent + latency + jitter`, drawn from a seeded SplitMix64 and
+clamped so it can never overtake an earlier packet on the same connection) and
+flushed when the session's reference clock reaches it. Every pane's link chip
+sets that latency and jitter; the wire rows print `sent → delivered`.
+
+**Latency and jitter only, and that is a decision** (design Addendum 8.2):
+`Sub.connect` promises reliable, ordered delivery, so the coordinator must never
+drop or reorder a packet. The chips keep their loss numbers, labelled as
+applying to datagrams, and those activate with `Net.Udp`. Still to come:
+partitions, and the step-time delivery barrier — the schedule is keyed to the
+session's reference clock rather than to each receiving pane's own step, which
+is what stands between the reproducible jitter DRAWS and reproducible runs.
 
 `e2e/net-coordinator.mjs` (`npm run test:net-coordinator`) drives `examples/orbs`
 as a server plus two clients in headless Chromium and asserts the handshake,

--- a/docs/physics.md
+++ b/docs/physics.md
@@ -754,8 +754,9 @@ phase (7):
   with a physics scene under `LinkProfile { latency, jitter, loss }`; assert each
   client's read-back converges to the server within tolerance after reconcile.
   Sweep profiles; add a partition→heal case (predict through, snap back on heal).
-  Blocked on the coordinator gaining link impairment and step-time delivery — it
-  routes over perfect links today.
+  The coordinator now applies latency and jitter per link; loss, partitions, and
+  step-time delivery are still outstanding, so the latency half of this sweep is
+  writable today and the loss half is not.
 - **Multi-pane overlays**: render the authoritative server transform as a
   translucent **ghost** beside the client's predicted body (see prediction error +
   the reconcile snap); per-client metrics (max prediction error, rewinds/sec,

--- a/e2e/fixtures/net-host.html
+++ b/e2e/fixtures/net-host.html
@@ -28,10 +28,26 @@
       // One file, both roles (file = module; the roles are `module` blocks).
       const GAME = "examples/orbs/game.fun";
 
-      const net = new NetCoordinator();
       const traces = new Map();
       const consoleLines = [];
       const frames = new Map();
+
+      // The session's reference clock and its links — the two seams impairment
+      // runs on (site/src/net-coordinator.ts). The sandbox reads the same two
+      // things off its panes; here the server pane IS the clock, and every
+      // client is on the same LAN profile the sandbox defaults to, whose 8ms
+      // rounds to zero frames. So the substrate this file tests is the impaired
+      // path, at the default that leaves delivery in the frame it was sent.
+      // Pinned here rather than imported: this fixture bundles only the
+      // coordinator, so retuning LINK_PRESETS[0] means retuning this too.
+      const LAN = { ms: 8, jitter: 2 };
+      const net = new NetCoordinator({
+        // The pane's LIVE HEAD, like the sandbox's reference clock — not its
+        // parked `frame()`, which is where a scrubber happens to sit.
+        referenceFrame: () =>
+          frames.get("server")?.contentWindow?.__scrub?.range()?.[1] ?? null,
+        link: () => LAN,
+      });
 
       const mount = (id, role) => {
         const frame = document.createElement("iframe");

--- a/e2e/net-coordinator.mjs
+++ b/e2e/net-coordinator.mjs
@@ -15,7 +15,8 @@
 //   2. the coordinator routes the connect handshake — both clients get
 //      `connected`, and so does the server, twice;
 //   3. traffic flows BOTH ways (client -> server Steer, server -> client
-//      Snapshot broadcasts);
+//      Snapshot broadcasts) — on the DEFAULT LAN link, whose delay rounds to
+//      zero frames, so every packet is delivered in the frame it was sent;
 //   4. the server's model seats two pilots, and each client's board contains
 //      BOTH ships — i.e. client 1's state reached client 2 through the server;
 //   5. input propagates: holding `w` in client 1 reaches the server as THAT
@@ -144,6 +145,20 @@ try {
     toServer.length >= 2,
     "the clients send to the server",
     `${toServer.length} packets from ${[...new Set(toServer.map((p) => p.from))].join(", ")}`
+  );
+
+  // 3b. The DEFAULT link is LAN, and LAN is the decision that keeps every check
+  // above measuring what it used to: 8ms ± 2 rounds to zero frames, so a packet
+  // is delivered in the frame it was sent. Impairment is opt-in, one chip away
+  // (site/src/mp-panes.ts DEFAULT_LINK) — a default that quietly delayed every
+  // session would change what every sample feels like.
+  const scheduled = messages.filter((p) => p.frame !== null && p.deliveredFrame !== null);
+  check(
+    scheduled.length > 10 && scheduled.every((p) => p.deliveredFrame === p.frame),
+    "on the default LAN link a packet is delivered in the frame it was sent",
+    `${scheduled.length} scheduled; deltas ${[
+      ...new Set(scheduled.map((p) => p.deliveredFrame - p.frame)),
+    ].join(", ")}`
   );
 
   // Input path: HOLD `w` in client 1. Orbs' client streams a Steer every tick

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -32,7 +32,11 @@
 //   9. the WIRE TAB — the same traffic monitor docked in the status bar — is
 //      present (and counting) in every layout, filters by link and direction,
 //      opens payloads into the value tree, stays scrub-locked, and is absent
-//      from a single-role example.
+//      from a single-role example;
+//  10. LINK IMPAIRMENT: a pane's link chip really delays that client's packets
+//      (sent → delivered on every row), only that client's, never out of order,
+//      and without breaking convergence — while loss stays a labelled datagram
+//      setting (design Addendum 8.2).
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -106,6 +110,24 @@ for (let i = 0; ; i++) {
 const installProbe = (page) =>
   page.evaluate(() => {
     const traces = new Map();
+    // One row of traffic, as both surfaces render it: the SENT frame, the
+    // DELIVERED frame beside it (impairment — Addendum 8.2), and whether the
+    // playhead has it mid-flight.
+    const readRow = (row) => {
+      const stamps = [...row.querySelector(".f").textContent.matchAll(/-?\d+/g)].map((m) =>
+        Number(m[0])
+      );
+      return {
+        frame: stamps[0] ?? NaN,
+        delivered: stamps[1] ?? stamps[0] ?? NaN,
+        flight: row.classList.contains("flight"),
+        link: row.querySelector(".l")?.textContent.trim() ?? null,
+        dir: row.querySelector(".d").textContent.trim(),
+        payload: row.querySelector(".payload").textContent.trim(),
+        bytes: row.querySelector(".n").textContent.trim(),
+        at: row.classList.contains("at"),
+      };
+    };
     const shells = () =>
       [...document.querySelectorAll(".mp-pane")].map((shell, index) => ({
         role: shell.classList.contains("server") ? "server" : `client ${index + 1}`,
@@ -151,13 +173,7 @@ const installProbe = (page) =>
             w: Math.round(box.width),
             h: Math.round(box.height),
           },
-          rows: [...panel.querySelectorAll(".mp-wl")].map((row) => ({
-            frame: Number((row.querySelector(".f").textContent.match(/-?\d+/) ?? [NaN])[0]),
-            dir: row.querySelector(".d").textContent.trim(),
-            payload: row.querySelector(".payload").textContent.trim(),
-            bytes: row.querySelector(".n").textContent.trim(),
-            at: row.classList.contains("at"),
-          })),
+          rows: [...panel.querySelectorAll(".mp-wl")].map(readRow),
         };
       },
       /** Open the FATTEST payload on the pinned log — the snapshot, i.e. the
@@ -221,6 +237,38 @@ const installProbe = (page) =>
         return true;
       },
       clickEdge: (index) => document.querySelectorAll(".mp-edge-chip")[index].click(),
+      /** A client pane's link chip: what it says, and what it promises. */
+      linkChip: (index) => {
+        const chip = document.querySelectorAll(".mp-pane .mp-link-chip")[index];
+        return chip ? { label: chip.textContent.trim(), title: chip.title } : null;
+      },
+      /** Set a client's link from the chip menu — the reader's own path: open
+       * the chip, press a preset, close it again. */
+      setLink: (index, name) => {
+        const chip = document.querySelectorAll(".mp-pane .mp-link-chip")[index];
+        if (!chip) return false;
+        chip.click();
+        const menu = chip.closest(".mp-link-host").querySelector(".mp-link-menu");
+        const preset = [...menu.querySelectorAll(".mp-link-presets button")].find(
+          (one) => one.dataset.name === name
+        );
+        if (!preset) return false;
+        preset.click();
+        chip.click();
+        return true;
+      },
+      /** The link menu's loss field and the label that says who reads it. */
+      lossField: (index) => {
+        const menu = document
+          .querySelectorAll(".mp-pane .mp-link-host")
+          [index]?.querySelector(".mp-link-menu");
+        if (!menu) return null;
+        return {
+          value: menu.querySelector(".mp-l-loss").value,
+          badge: menu.querySelector(".mp-link-soon")?.textContent.trim() ?? "",
+          note: menu.querySelector(".mp-link-note").textContent.replace(/\s+/g, " ").trim(),
+        };
+      },
       /** The WIRE TAB in the status bar: the docked traffic monitor. Read from
        * the bar's own chrome, so "present" means the tab a reader can click. */
       wireTab: () => {
@@ -241,14 +289,7 @@ const installProbe = (page) =>
             (chip) => `${chip.textContent.trim()}:${chip.getAttribute("aria-pressed")}`
           ),
           footer: document.querySelector(".wire-ft")?.textContent.trim() ?? "",
-          rows: [...document.querySelectorAll(".wire-rows .mp-wl")].map((row) => ({
-            frame: Number((row.querySelector(".f").textContent.match(/-?\d+/) ?? [NaN])[0]),
-            link: row.querySelector(".l")?.textContent.trim() ?? null,
-            dir: row.querySelector(".d").textContent.trim(),
-            payload: row.querySelector(".payload").textContent.trim(),
-            bytes: row.querySelector(".n").textContent.trim(),
-            at: row.classList.contains("at"),
-          })),
+          rows: [...document.querySelectorAll(".wire-rows .mp-wl")].map(readRow),
         };
       },
       openWireTab: () => document.querySelector('.statusbar-tab[data-tab="wire"]').click(),
@@ -952,8 +993,8 @@ try {
       JSON.stringify(ends.map((w) => [Math.round(w.from.x), Math.round(w.from.y), Math.round(w.to.x), Math.round(w.to.y)]))
     );
     check(
-      graph.chips.length === 2 && graph.chips.every((c) => c.includes("Wi-Fi")),
-      "each edge carries its client's link chip mid-wire",
+      graph.chips.length === 2 && graph.chips.every((c) => c.startsWith("LAN · 8ms <1f")),
+      "each edge carries its client's link chip mid-wire, sub-frame pace and all",
       graph.chips.join(" | ")
     );
     check(
@@ -1471,6 +1512,156 @@ try {
         start.rows.at(-1).frame < (head.rows.at(-1)?.frame ?? Infinity),
       "seeking sweeps the tab's viewport with the playhead",
       `head ended at #f ${head.rows.at(-1)?.frame}, start ends at #f ${start.rows.at(-1)?.frame}`
+    );
+    await page.close();
+  }
+
+  // --- 4h. LINK IMPAIRMENT: the chips are controls now. -----------------------
+  // Addendum 8.2. A client's link chip schedules that client's packets in the
+  // coordinator — latency plus a jitter draw, and NOTHING else: `Sub.connect`
+  // is reliable-ordered, so no packet may be dropped or overtaken. The
+  // assertions are exactly those two halves. The delay is REAL (mobile's 132ms
+  // is eight frames of the timeline, and the rows print sent → delivered), and
+  // the guarantees are intact (FIFO per link per direction; the session still
+  // converges; the untouched client is still on LAN, i.e. same-frame).
+  {
+    const page = await browser.newPage({ viewport: { width: 1600, height: 1000 } });
+    await page.goto(`${BASE}/sandbox.html?example=orbs#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    await page.evaluate(() => window.__mpProbe.openWireTab());
+    await page.waitForFunction(() => window.__mpProbe.wireTab().rows.length > 4, null, {
+      timeout: 25000,
+    });
+
+    // The default is LAN, and LAN is a decision (mp-panes' DEFAULT_LINK): 8ms
+    // rounds to zero frames, so an untouched session behaves exactly as it did
+    // before impairment existed.
+    const before = await page.evaluate(() => window.__mpProbe.wireTab());
+    check(
+      before.rows.length > 4 && before.rows.every((row) => row.delivered === row.frame),
+      "the default LAN link delivers in the frame it was sent — impairment is opt-in",
+      `deltas ${[...new Set(before.rows.map((row) => row.delivered - row.frame))].join(", ")}`
+    );
+
+    // Now slow client 1's link down, through the chip a reader would use.
+    const set = await page.evaluate(() => window.__mpProbe.setLink(0, "mobile"));
+    const chip = await page.evaluate(() => window.__mpProbe.linkChip(0));
+    check(
+      set && chip.label === "⇅ mobile ▾" && /132ms/.test(chip.title),
+      "picking `mobile` on a pane's chip re-labels it with what it now does",
+      `${chip?.label} — "${chip?.title}"`
+    );
+    // Long enough that every row in the 60-row viewport was routed AFTER the
+    // change: orbs puts ~240 packets a second on the wires at two clients.
+    await sleep(2500);
+    const after = await page.evaluate(() => window.__mpProbe.wireTab());
+    const on = (id) => after.rows.filter((row) => row.link === id);
+    const deltas = (id) => on(id).map((row) => row.delivered - row.frame);
+    // 132ms is 7.92 frames of the timeline → 8, and 38ms of jitter is 2 more at
+    // most. Nothing may arrive EARLY: jitter is extra delay, never a head start.
+    const mobile = deltas("c1");
+    check(
+      mobile.length > 4 && mobile.every((d) => d >= 8 && d <= 10),
+      "a mobile link delays client 1's packets by its latency, plus a jitter draw",
+      `${mobile.length} rows, deltas ${[...new Set(mobile)].sort().join(", ")}`
+    );
+    check(
+      new Set(mobile).size > 1,
+      "the jitter draw actually varies packet to packet",
+      `deltas ${[...new Set(mobile)].sort().join(", ")}`
+    );
+    // The other client never changed, and is still same-frame: one chip impairs
+    // one link.
+    const lan = deltas("c2");
+    check(
+      lan.length > 4 && lan.every((d) => d === 0),
+      "client 2's LAN link is untouched — same frame, still sub-frame-ish",
+      `${lan.length} rows, deltas ${[...new Set(lan)].sort().join(", ")}`
+    );
+
+    // FIFO, the invariant impairment may not break: on one link in one
+    // direction, a later-sent packet never lands before an earlier one, however
+    // the jitter drew.
+    const ordered = [];
+    const seen = new Map();
+    for (const row of after.rows) {
+      const key = `${row.link}|${row.dir}`;
+      const previous = seen.get(key);
+      if (previous !== undefined && row.delivered < previous) {
+        ordered.push(`${key}: ${previous} then ${row.delivered}`);
+      }
+      seen.set(key, row.delivered);
+    }
+    check(
+      after.rows.length > 8 && ordered.length === 0,
+      "no packet overtakes an earlier one on its link (FIFO under jitter)",
+      ordered.slice(0, 3).join(" | ") || `${after.rows.length} rows in order`
+    );
+
+    // Loss stays a SETTING, labelled for the channel that will read it.
+    const loss = await page.evaluate(() => window.__mpProbe.lossField(0));
+    check(
+      loss?.badge === "datagrams" && /Net\.Udp/.test(loss.note) && /reliable-ordered/.test(loss.note),
+      "the loss field says it applies to datagrams, and why nothing is dropped here",
+      `badge "${loss?.badge}" — "${loss?.note}"`
+    );
+
+    // PACE IS A MEASUREMENT (Addendum 5a): the impaired edge's dots fly its real
+    // delay, and the LAN edge — whose delay is below the visibility floor — says
+    // on its chip how much it is being stretched.
+    await page.click("#mp-view-network");
+    await settle(page);
+    const chips = await page.evaluate(() => window.__mpProbe.network().chips);
+    check(
+      chips.length === 2 &&
+        /^mobile · 132ms/.test(chips[0]) &&
+        !/<1f/.test(chips[0]) &&
+        /^LAN · 8ms <1f/.test(chips[1]),
+      "the mid-edge chips show the real profile, and flag the edge whose pace is floored",
+      chips.join(" | ")
+    );
+
+    // CONVERGENCE: eight frames of delay is a delay, not a break — both clients
+    // still hold both ships.
+    await page.evaluate(() => window.__mpProbe.pauseAll());
+    await sleep(1500);
+    const boards = await page.evaluate(() => ({
+      c1: window.__mpProbe.model("client 1"),
+      c2: window.__mpProbe.model("client 2"),
+    }));
+    const ships = (text) => (text?.match(/pid: /g) ?? []).length;
+    check(
+      ships(boards.c1) >= 2 && ships(boards.c2) >= 2,
+      "the session still converges over an impaired link — orbs plays, delayed",
+      `client 1 holds ${ships(boards.c1)} ships, client 2 ${ships(boards.c2)}`
+    );
+
+    // Parked, a packet SENT before the playhead but delivered after it is drawn
+    // as what it is: still crossing. The window keys on the sent frame (that is
+    // the row's place on the rail), so the in-flight rows are the newest ones.
+    await page.evaluate(() => window.__mpProbe.openWireTab());
+    await page.focus("#mp-playhead");
+    await page.keyboard.press("End");
+    await sleep(600);
+    const parked = await page.evaluate(() => ({
+      ...window.__mpProbe.wireTab(),
+      label: window.__mpProbe.railFrame(),
+    }));
+    const playhead = Number(parked.label.match(/-?\d+/)?.[0] ?? NaN);
+    const flying = parked.rows.filter((row) => row.flight);
+    check(
+      flying.length > 0 &&
+        flying.every(
+          (row) => row.link === "c1" && row.frame <= playhead && row.delivered > playhead
+        ),
+      "parked, a packet sent before the playhead and delivered after it reads as in flight",
+      `playhead #f ${playhead}; ${flying.length} in flight: ${flying
+        .slice(0, 3)
+        .map((row) => `${row.link} ${row.frame}→${row.delivered}`)
+        .join(", ")}`
     );
     await page.close();
   }

--- a/site/src/mp-network.ts
+++ b/site/src/mp-network.ts
@@ -15,17 +15,19 @@
 //      circles: client → server is the client's player color, sized by payload;
 //      server → client is the server's slate (--scrub-server) in a TIGHT size
 //      range, so the per-frame snapshot stream never dominates the picture.
-//   2. PACE is a measurement. See FLIGHT_MS.
+//   2. PACE is a measurement — a dot's flight is the delay its packet really
+//      took. See `shownFlightMs`, and the one stated exception.
 //
 // The third rule is the WIRE LOG: clicking an edge pins a panel, tethered to
 // that wire with a dashed leader, showing that link's traffic as DECODED VALUES
 // (`Steer {turn:1}`) rather than as bytes — and locked to the chrono rail, so
 // scrubbing sweeps the rows the same way it sweeps the dots.
 
-import type { NetCoordinator, Packet } from "./net-coordinator.js";
+import { TIMELINE_FPS, type NetCoordinator, type Packet } from "./net-coordinator.js";
 import {
   buildWireRow,
   indexAfter,
+  inFlightAt,
   LIVE_ROW_MS,
   logWindow,
   onLink,
@@ -37,48 +39,65 @@ import type { WireValue } from "./wire-value.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 
+const MS_PER_FRAME = 1000 / TIMELINE_FPS;
+
 /**
- * How long a packet takes to cross its edge, in ms.
+ * PACE IS A MEASUREMENT (Addendum 5, rule 2), and this is the ONE exception —
+ * stated here, and stated on the chip.
  *
- * A FIXED value, and that is honest today: the coordinator routes on perfect
- * links (net-coordinator.ts — no latency, no jitter, no loss), so there is no
- * measurement to render and every edge is genuinely the same speed. The link
- * chips are configured profiles, not observations, which is why they are
- * labelled as such.
+ * A dot flies for the delay its packet actually took: `deliveredFrame - frame`
+ * from the coordinator's schedule, in wall-time. Every link with a delay of at
+ * least one frame therefore flies TRUE — Wi-Fi's three frames really are a
+ * third of mobile's eight, and the picture says so.
  *
- * When impairment lands, this becomes the MEASURED latency of the packet's
- * link, per Addendum 5's "pace is a measurement": flight time is never scaled
- * for looks, and if sub-perceptual links ever force a floor or a log scale, the
- * UI must SAY so with a "×N" chip on the edge.
+ * A link under half a frame (LAN's 8ms) schedules zero frames of delay, so its
+ * true flight is zero milliseconds: nothing would ever appear on that wire. Only
+ * those are drawn at a floor — long enough to read as a streak, short enough to
+ * read as instant beside anything impaired — and their chip carries `<1f`, so a
+ * reader is never invited to compare that edge's pace with a real one.
  */
-const FLIGHT_MS = 600;
+const FLOOR_FLIGHT_MS = 40;
+
+/** How long a dot is shown flying, given the delay it really took. */
+const shownFlightMs = (trueMs: number): number => (trueMs > 0 ? trueMs : FLOOR_FLIGHT_MS);
+
+/** The chip's honesty suffix: `<1f` on the one kind of edge whose dots are not
+ * a measurement, "" everywhere else. Read off the SCHEDULED delay — the frames
+ * the coordinator actually applies — not off the chip's milliseconds, which is
+ * the number that gets rounded away. */
+const paceScale = (linkMs: number): string =>
+  Math.round((linkMs * TIMELINE_FPS) / 1000) > 0 ? "" : " <1f";
 
 /**
  * Concurrent dots, hard cap. Oldest is dropped first, so a runaway session sheds
  * packets instead of growing the DOM without bound.
  *
  * Sized for the honest steady state rather than for looks: with one dot per
- * edge per direction per frame (see the batching in `step`), a 60Hz session
- * keeps `FLIGHT_MS / 16.7 ≈ 36` dots in the air per edge per direction, so
- * MAX_CLIENTS × 2 directions ≈ 216 at the busiest. A cap below that is not a
- * safety valve, it is a visual bug: every dot is evicted mid-wire and the
- * stream never reaches the far end.
+ * edge per direction per frame (see the batching in `step`), a 60Hz session on
+ * an unimpaired link keeps `FLOOR_FLIGHT_MS / 16.7 ≈ 2` dots in the air per edge
+ * per direction, and a slow link keeps its whole latency's worth — a 400ms
+ * "awful" link, ≈24. MAX_CLIENTS × 2 directions × 24 ≈ 144 at the busiest preset. A
+ * link slower than that sheds its oldest dots, which is a stated bound: below
+ * the steady state it would not be a safety valve but a visual bug, every dot
+ * evicted mid-wire and the stream never reaching the far end.
  */
 const MAX_DOTS = 260;
 
 /**
- * How wide a window of the packet log the REPLAY renders, in reference-clock
- * frames.
+ * How far back the REPLAY walks the log, in reference-clock frames.
  *
- * The live feed keeps `FLIGHT_MS` of traffic in the air at once; parking the
- * session must show the same picture at the same density, so the window is that
- * flight time expressed in frames (the timeline's fixed 60fps), DERIVED rather
- * than written down so the two cannot drift apart. A packet routed AT the
- * playhead is at the start of its flight and one a full window
- * back is arriving — so scrubbing sweeps the traffic along the wires exactly as
- * running it would, in either direction.
+ * A bound on the WALK, not the window: which packets are on the wires at the
+ * playhead is decided per packet now, by its own flight (`frame` →
+ * `deliveredFrame`), because that is what the live feed shows too — so a parked
+ * frame and the live frame it was draw the same picture.
+ *
+ * DERIVED from the deepest flight this session has actually carried, not
+ * written down: the link fields take a hand-typed latency with no ceiling, and
+ * a fixed horizon would make a slow link's dots simply vanish when the session
+ * is parked — visible live, gone on the rail, which is the one thing this
+ * replay exists not to do. The floor keeps a quiet session's walk short.
  */
-const REPLAY_WINDOW_FRAMES = Math.round((FLIGHT_MS / 1000) * 60);
+const REPLAY_MIN_LOOKBACK_FRAMES = 30;
 
 /**
  * Rows in the pinned wire log's viewport.
@@ -123,9 +142,12 @@ export interface NetworkNode {
   shell: HTMLElement;
   /** The pane's player color, as a CSS value. */
   color: string;
-  /** The client's configured link profile, as a label. Read live: the chip is a
-   * label of the CONFIGURED profile, never a claim about the wire. */
+  /** The client's link profile, as a label. Read live: the chip is a control,
+   * and it changes under the reader's hand. */
   linkLabel: () => string;
+  /** That profile's latency in ms — what the chip's pace-scale suffix is
+   * measured against (`paceScale`). */
+  linkMs: () => number;
 }
 
 export interface NetworkGraphOptions {
@@ -198,6 +220,9 @@ interface Dot {
   dir: Direction;
   /** When the dot was spawned, on the host clock — the LIVE feed's animation. */
   start: number;
+  /** How long this dot's flight lasts, in ms: the delay its packet actually
+   * took, floored so a sub-frame link is still visible (`shownFlightMs`). */
+  flight: number;
   /** Fixed position along the wire (0..1), for a REPLAYED dot: a parked session
    * has no host-clock flight, its position is decided by the playhead. */
   held: number | null;
@@ -283,6 +308,9 @@ export function initNetworkGraph({
   /** The frame the replay is currently drawn for, so a held playhead rebuilds
    * nothing. `null` = nothing drawn yet. */
   let replayFrame: number | null = null;
+  /** How far the parked walk reaches back — the deepest flight seen so far
+   * (`flightOf`), never below `REPLAY_MIN_LOOKBACK_FRAMES`. */
+  let lookbackFrames = REPLAY_MIN_LOOKBACK_FRAMES;
   /** The link whose wire log is pinned (a client pane id), or null. */
   let selected: string | null = null;
   /** What the panel's rows currently say, so a steady session rewrites nothing. */
@@ -448,15 +476,21 @@ export function initNetworkGraph({
   // frame — cheaper than the bookkeeping a throttle would need.
   const paintChips = () => {
     for (const edge of edges.values()) {
-      const label = edge.node.linkLabel();
+      const scale = paceScale(edge.node.linkMs());
+      const label = `${edge.node.linkLabel()}${scale}`;
       if (edge.chipLabel.textContent !== label) {
         edge.chipLabel.textContent = label;
-        // The chip labels a CONFIGURED profile — the links themselves are still
-        // perfect (net-coordinator.ts). Say that, rather than implying a
-        // measurement the coordinator cannot make yet.
+        // The chip is the link's real profile now: these packets are delayed by
+        // it. Where the dots are NOT at true pace, the chip says so and the
+        // tooltip says by how much — the pace-is-a-measurement claim survives
+        // only if the one exception is stated (Addendum 5a).
         edge.chip.title =
-          `${label} — this client's configured link profile. Impairment is ` +
-          `recorded, not applied yet, so every packet crosses at the same pace. ` +
+          `${edge.node.linkLabel()} — this client's link, applied to its packets by the ` +
+          `host coordinator (latency and jitter; loss waits for datagrams). ` +
+          (scale
+            ? `Its delay rounds to under one frame, so its dots are drawn at a ` +
+              `${FLOOR_FLIGHT_MS}ms floor to be visible at all — not a measurement. `
+            : `The dots fly at the delay the packets actually took. `) +
           `Click to pin this link's wire log.`;
       }
       const count = `${edge.count} pkt`;
@@ -570,8 +604,11 @@ export function initNetworkGraph({
     const { highlight } = live;
     // A row that scrubbed out of the window takes its tree with it.
     if (opened && !shown.includes(opened.packet)) opened = null;
+    // The parked frame is in the hash: which rows are IN FLIGHT changes as the
+    // playhead crosses a delivery, even when the window and its highlight have
+    // not moved.
     const key =
-      `${selected}|${highlight}|${opened ? packetKey(opened.packet) : ""}|` +
+      `${selected}|${parked ? frame : ""}|${highlight}|${opened ? packetKey(opened.packet) : ""}|` +
       // `at` disambiguates two packets that share a frame, a direction and a
       // size — a fixed-width intent (`Steer {turn:0}` vs `{turn:1}`) otherwise
       // hashes the same and the rows would go stale.
@@ -592,6 +629,7 @@ export function initNetworkGraph({
         const built = buildWireRow({
           packet,
           at: index === highlight,
+          inFlight: inFlightAt(packet, parked && frame !== null ? frame : null),
           tree: isOpen && opened ? opened.host : null,
           onOpen: (value) => openRow(packet, value, shown),
         });
@@ -690,11 +728,30 @@ export function initNetworkGraph({
     selectEdge(null)
   );
 
+  /**
+   * A packet's flight, in ms: the delay the coordinator's schedule gave it,
+   * floored only when that delay is zero frames (`shownFlightMs`).
+   *
+   * Every flight is remembered as the replay's horizon, so a link slow enough
+   * to still be crossing 30 frames later is walked back to when the rail is
+   * parked instead of vanishing off the end of a fixed window.
+   */
+  const flightOf = (packet: Packet): number => {
+    const flight = shownFlightMs(
+      packet.deliveredFrame !== null && packet.frame !== null
+        ? (packet.deliveredFrame - packet.frame) * MS_PER_FRAME
+        : 0
+    );
+    lookbackFrames = Math.max(lookbackFrames, Math.ceil(flight / MS_PER_FRAME));
+    return flight;
+  };
+
   const spawn = (
     edge: Edge,
     dir: Direction,
     bytes: number,
     now: number,
+    flight: number,
     held: number | null = null
   ) => {
     // Both directions are circles; size scales MILDLY with the bytes the dot
@@ -715,7 +772,7 @@ export function initNetworkGraph({
       oldest?.el.remove();
     }
     packets.appendChild(el);
-    dots.push({ el, edge, dir, start: now, held });
+    dots.push({ el, edge, dir, start: now, flight, held });
   };
 
   /**
@@ -734,35 +791,59 @@ export function initNetworkGraph({
   };
 
   /**
-   * Draw the log's window at `frame`: one dot per edge per direction per frame
-   * of recorded traffic, held at the position that frame's age gives it.
+   * Draw what is ON THE WIRES at `frame`: one dot per edge per direction per
+   * frame of recorded traffic, held at the point of its own flight the playhead
+   * has reached.
    *
-   * The same batching rule the live feed uses (Addendum 5a.5), applied to the
-   * record rather than to the moment — so a parked frame and the live frame it
-   * was show the same picture.
+   * The same batching rule the live feed uses (Addendum 5a.5) applied to the
+   * record rather than to the moment — and, since impairment, the same FLIGHTS:
+   * a packet is drawn only while `frame` is inside its `sent → delivered`
+   * window, so a parked frame shows exactly the packets that were in the air
+   * then. Scrubbing therefore sweeps the traffic along the wires the way
+   * running it does, in either direction.
    */
   const renderReplay = (frame: number, now: number) => {
     clearDots();
     replayFrame = frame;
     if (reduceMotion.matches) return;
-    const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number; age: number }>();
-    // Straight to the playhead by binary search, then back one window — the
-    // walk costs the window, never the session (same rule as viewportRows).
+    const batched = new Map<
+      string,
+      { edge: Edge; dir: Direction; bytes: number; flight: number; t: number }
+    >();
+    // Straight to the playhead by binary search, then back over the deepest
+    // flight a link could have — the walk costs that, never the session (same
+    // rule as viewportRows).
     const log = net.packets();
     for (let i = indexAfter(log, frame) - 1; i >= 0; i--) {
       const packet = log[i];
       if (packet.frame === null) break;
       const age = frame - packet.frame;
-      if (age >= REPLAY_WINDOW_FRAMES) break;
+      if (age >= lookbackFrames) break;
       const link = linkOf(packet);
       if (!link) continue;
+      // Its own flight decides whether it is still in the air at the playhead.
+      // Note this is the flight as DRAWN — an unimpaired link's dot is on the
+      // wire for the visibility floor, where `inFlightAt` (wire-rows.ts, which
+      // marks the ROWS) reads the schedule and says the packet has landed. The
+      // rows speak in frames and the wires in pixels; the `<1f` on that edge's
+      // chip is where the two are reconciled.
+      const flightFrames = flightOf(packet) / MS_PER_FRAME;
+      if (age >= flightFrames) continue;
       const key = `${link.edge.node.id}|${link.dir}|${packet.frame}`;
       const carried = batched.get(key);
       if (carried) carried.bytes += packet.size;
-      else batched.set(key, { edge: link.edge, dir: link.dir, bytes: packet.size, age });
+      else {
+        batched.set(key, {
+          edge: link.edge,
+          dir: link.dir,
+          bytes: packet.size,
+          flight: flightFrames * MS_PER_FRAME,
+          t: age / flightFrames,
+        });
+      }
     }
-    for (const { edge, dir, bytes, age } of batched.values()) {
-      spawn(edge, dir, bytes, now, age / REPLAY_WINDOW_FRAMES);
+    for (const { edge, dir, bytes, flight, t } of batched.values()) {
+      spawn(edge, dir, bytes, now, flight, t);
     }
   };
 
@@ -792,7 +873,10 @@ export function initNetworkGraph({
     // about the rate; a dot per frame is exactly what the wire did, at the rate
     // the screen can show.
     if (!replay) {
-      const batched = new Map<string, { edge: Edge; dir: Direction; bytes: number }>();
+      const batched = new Map<
+        string,
+        { edge: Edge; dir: Direction; bytes: number; flight: number }
+      >();
       for (const packet of seen) {
         const link = linkOf(packet);
         if (!link) continue;
@@ -804,9 +888,14 @@ export function initNetworkGraph({
         const key = `${edge.node.id}|${dir}`;
         const carried = batched.get(key);
         if (carried) carried.bytes += packet.size;
-        else batched.set(key, { edge, dir, bytes: packet.size });
+        // The batch flies at the FIRST packet's flight: a batch is one frame of
+        // one link, so its members differ only by their jitter draw, and the
+        // dot stands for the frame rather than for any one of them.
+        else batched.set(key, { edge, dir, bytes: packet.size, flight: flightOf(packet) });
       }
-      for (const { edge, dir, bytes } of batched.values()) spawn(edge, dir, bytes, now);
+      for (const { edge, dir, bytes, flight } of batched.values()) {
+        spawn(edge, dir, bytes, now, flight);
+      }
       // The preference can flip while the view is open; whatever is still in the
       // air stops immediately rather than finishing its flight.
       if (reduceMotion.matches && dots.length > 0) clearDots();
@@ -819,7 +908,7 @@ export function initNetworkGraph({
       const dot = dots[i];
       // A replayed dot is HELD where the playhead put it; a live one flies on
       // the host clock. Both then travel the same wire the same way.
-      const t = dot.held ?? (now - dot.start) / FLIGHT_MS;
+      const t = dot.held ?? (now - dot.start) / dot.flight;
       if (t >= 1 || dot.edge.length === 0) {
         dot.el.remove();
         dots.splice(i, 1);

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -6,7 +6,7 @@
 //
 //   ┌ chrono bar ─ ⏸ ⏭ ══rail══╪═ 🔮 | ⊞ tiled ▦ grid ▤ tabs ┐ (game side only —
 //   ├ pane grid ──────────────────────────────────────────────┤    the editor keeps
-//   │  ╔ 1 client · cyan  ⇅ Wi-Fi ▾   #f 841 ● ╗  ┌ 2 client ┐│    its full height)
+//   │  ╔ 1 client · cyan  ⇅ LAN ▾     #f 841 ● ╗  ┌ 2 client ┐│    its full height)
 //   │  ║             iframe                    ║  │  iframe   ││
 //   └──╚══════════════════════════════════════╝──└───────────┘┘
 //
@@ -22,9 +22,10 @@
 //  - every pane (the sandbox player included) boots with `?scrubber=hidden`
 //    — the seam without the bar — and the chrono bar is the ONE transport
 //    instrument at every client count, single included;
-//  - the per-pane link chip (LAN / Wi-Fi / mobile / awful) records a
-//    LinkProfile per client but impairs nothing until the transport carries
-//    it. It is labelled as such.
+//  - the per-pane link chip (LAN / Wi-Fi / mobile / awful) IS the client's
+//    link: its latency and jitter schedule that client's packets in the
+//    coordinator (Addendum 8.2). Its loss number is inert on purpose —
+//    `Sub.connect` is reliable-ordered, so loss waits for `Net.Udp`.
 //
 // This module is imperative DOM on purpose: it owns the preview column
 // OUTSIDE the React islands (like CodeMirror owns #editor), and publishes to
@@ -34,7 +35,7 @@ import { PlayerBridge } from "./player-bridge.js";
 import { asPlayerMessage } from "./protocol.js";
 import type { StatusBar } from "./status-bar-store.js";
 import type { PillState } from "./components/StatusPill.js";
-import { NetCoordinator } from "./net-coordinator.js";
+import { NetCoordinator, TIMELINE_FPS } from "./net-coordinator.js";
 import { initNetworkGraph, type NetworkNode } from "./mp-network.js";
 import { initWireTab } from "./wire-tab.js";
 
@@ -122,8 +123,16 @@ interface TimelineView {
 
 interface LinkProfile {
   name: string;
+  /** One-way latency, in ms — applied by the coordinator's delivery schedule. */
   ms: number;
+  /** Extra delay drawn per packet, in ms — also applied. */
   jitter: number;
+  /**
+   * Packet loss, in percent — RECORDED ONLY, and the label says so. Dropping a
+   * packet on `Sub.connect` would contradict the reliable-ordered delivery the
+   * game is written against (Addendum 8.2); this number becomes live for
+   * datagrams when `Net.Udp` lands.
+   */
   loss: number;
 }
 
@@ -218,15 +227,23 @@ const PLAYER_COLORS = ["var(--scrub-p1)", "var(--scrub-p2)", "var(--scrub-p3)", 
 /** One clamp for every entry point (the select offers the same range). */
 export const MAX_CLIENTS = 3;
 
-/** The timeline's fixed tick rate (timeline-model.js TIMELINE_FPS). */
-const TIMELINE_FPS = 60;
-
 const LINK_PRESETS: LinkProfile[] = [
   { name: "LAN", ms: 8, jitter: 2, loss: 0 },
   { name: "Wi-Fi", ms: 45, jitter: 12, loss: 1.2 },
   { name: "mobile", ms: 132, jitter: 38, loss: 3.4 },
   { name: "awful", ms: 400, jitter: 120, loss: 12 },
 ];
+
+/**
+ * A new client starts on LAN, and that is a decision the impairment PR had to
+ * take: the chips used to default to Wi-Fi because they impaired NOTHING, and a
+ * default that now silently puts three frames of delay on every session would
+ * change what every sample feels like — and what the coordinator's own e2e
+ * measures — without anyone asking for it. LAN's 8ms rounds to zero frames, so
+ * the default session behaves exactly as it did; slowing a link is the
+ * deliberate act, one chip away.
+ */
+const DEFAULT_LINK = LINK_PRESETS[0];
 
 const seamOf = (iframe: HTMLIFrameElement): ScrubSeam | null => {
   try {
@@ -426,7 +443,8 @@ export function initMultiplayerPanes({
 
   // Every pane's networking routes through ONE coordinator (net-coordinator.ts):
   // the panes boot `?net=embedder`, post their conn commands to this page, and
-  // it routes them between panes on perfect links. This module owns it because
+  // it routes them between panes, delayed by each client's link chip. This
+  // module owns it because
   // it owns every pane — including pane 1, the page's own #player — so no pane
   // can be created outside its view. It is inert for a game that declares no
   // `Sub.connect`/`Sub.listen`: those panes never post a command.
@@ -438,7 +456,14 @@ export function initMultiplayerPanes({
   // (a server pane mounting, a client count going to zero and back).
   // Measured once per frame by `measureClocks` (see the frame-offset block).
   let referenceFrame: number | null = null;
-  const net = new NetCoordinator({ referenceFrame: () => referenceFrame });
+  const net = new NetCoordinator({
+    referenceFrame: () => referenceFrame,
+    // The link chip, made real (Addendum 8.2). Read live and per packet, so a
+    // profile change takes effect on the next thing routed; the coordinator
+    // takes latency and jitter only, and the chip's loss number stays a
+    // datagram setting it does not consume.
+    link: (id) => panes.find((pane) => pane.id === id)?.link ?? null,
+  });
 
   const panes: Pane[] = [];
 
@@ -459,6 +484,7 @@ export function initMultiplayerPanes({
     shell: pane.shell,
     color: pane.color,
     linkLabel: () => `${pane.link.name} · ${pane.link.ms}ms`,
+    linkMs: () => pane.link.ms,
   });
   // Where the SESSION is parked, in reference-clock frames — the one number the
   // rail's label already shows, published for the views that have to agree with
@@ -510,7 +536,7 @@ export function initMultiplayerPanes({
           client
             ? `<span class="mp-link-host">
           <button class="mp-link-chip"
-            title="Link impairment for this client (prototype — recorded per client; applies once the coordinator's link impairment lands)">⇅ Wi-Fi ▾</button>
+            title="This client's link: latency and jitter delay its packets in the host coordinator">⇅ ${DEFAULT_LINK.name} ▾</button>
         </span>`
             : `<span class="mp-authority">authority</span>`
         }
@@ -557,7 +583,7 @@ export function initMultiplayerPanes({
       tab,
       scope: new AbortController(),
       state: "busy",
-      link: { ...LINK_PRESETS[1] },
+      link: { ...DEFAULT_LINK },
       frameLabels: [
         shell.querySelector(".mp-pf-n") as HTMLElement,
         tab.querySelector(".mp-pf-n") as HTMLElement,
@@ -1021,13 +1047,16 @@ export function initMultiplayerPanes({
       <div class="mp-link-presets">
         ${LINK_PRESETS.map(
           (preset) =>
-            `<button data-name="${preset.name}" aria-pressed="${preset.name === "Wi-Fi"}">${preset.name}</button>`
+            `<button data-name="${preset.name}" aria-pressed="${preset.name === DEFAULT_LINK.name}">${preset.name}</button>`
         ).join("")}
       </div>
-      <label>⇅ <input class="mp-l-ms" type="number" min="0" value="45"> ms
-        ± <input class="mp-l-j" type="number" min="0" value="12"></label>
-      <label>✂ <input class="mp-l-loss" type="number" min="0" max="100" step="0.1" value="1.2"> % loss</label>
-      <p class="mp-link-note">prototype: recorded per client, applied when link impairment lands</p>`;
+      <label>⇅ <input class="mp-l-ms" type="number" min="0" value="${DEFAULT_LINK.ms}"> ms
+        ± <input class="mp-l-j" type="number" min="0" value="${DEFAULT_LINK.jitter}"></label>
+      <label class="off">✂ <input class="mp-l-loss" type="number" min="0" max="100" step="0.1" value="${DEFAULT_LINK.loss}"> % loss
+        <b class="mp-link-soon">datagrams</b></label>
+      <p class="mp-link-note">latency and jitter are live — they delay this client's packets from
+        the next one on. Loss applies to datagrams (Net.Udp, coming): Sub.connect is
+        reliable-ordered, so nothing here drops or reorders it.</p>`;
     host.appendChild(menu);
 
     const msInput = menu.querySelector(".mp-l-ms") as HTMLInputElement;
@@ -1036,6 +1065,12 @@ export function initMultiplayerPanes({
 
     const paintChip = () => {
       chip.textContent = `⇅ ${pane.link.name === "custom" ? `${pane.link.ms}ms` : pane.link.name} ▾`;
+      // The chip states what it DOES, in the numbers it is currently set to —
+      // it is a control now, not a label (Addendum 8.2).
+      chip.title =
+        `${pane.link.name}: ${pane.link.ms}ms ± ${pane.link.jitter}ms delays this client's ` +
+        `packets, from the next one routed. Loss (${pane.link.loss}%) applies to datagrams — ` +
+        `Sub.connect is reliable-ordered, so nothing is dropped or reordered.`;
       msInput.value = String(pane.link.ms);
       jitterInput.value = String(pane.link.jitter);
       lossInput.value = String(pane.link.loss);
@@ -1712,8 +1747,8 @@ export function initMultiplayerPanes({
         );
       }
     }
-    // Link state, straight from the coordinator's connection table — the seed
-    // of the link chip becoming real. Only a session that HAS an authority
+    // Link state, straight from the coordinator's connection table (the chip
+    // beside it owns the link's PACE). Only a session that HAS an authority
     // shows it: in a single-player example there is nothing to wait for.
     const links = serverPane ? net.connectionCounts() : null;
     for (const pane of allPanes()) {
@@ -1738,7 +1773,7 @@ export function initMultiplayerPanes({
         pane.conn.dataset.linked = String(count > 0);
         pane.conn.title =
           count > 0
-            ? "Connected through the host net coordinator (perfect link)"
+            ? "Connected through the host net coordinator (this pane's link chip sets the delay)"
             : "No connection yet — waiting for the server pane's Sub.listen";
       }
     }

--- a/site/src/net-coordinator.ts
+++ b/site/src/net-coordinator.ts
@@ -28,12 +28,29 @@
 //     `Sub.listen` tagger;
 //   • FIFO per pane: deliveries queue in arrival order and flush as one batch.
 //
-// PERFECT LINKS ONLY. Everything a link profile would add — latency, jitter,
-// loss, partitions — is deliberately absent, and so is the step barrier: a
-// routed packet is delivered on the host's NEXT rAF, not on the receiving
-// pane's next fixed step. Impairment and the barrier are later PRs; when the
-// barrier lands, `flush()` becomes step-time delivery and a packet's frame
-// stops being a measurement and becomes the step it was scheduled in.
+// IMPAIRMENT (design Addendum 8.2) — LATENCY AND JITTER ONLY, and that is a
+// semantic decision, not a missing feature: `Sub.connect` promises RELIABLE,
+// ORDERED delivery, so a coordinator that dropped or reordered its packets
+// would be lying about the API the game is written against. Loss and reorder
+// belong to unreliable channels and arrive with `Net.Udp` (Addendum 6a); the
+// link chips keep showing their loss numbers, labelled as applying to
+// datagrams.
+//
+// So a routed packet is no longer delivered on the host's next rAF. It is
+// SCHEDULED — `sentFrame + latency ± jitter`, in reference-clock frames — and
+// flushed when the reference clock reaches that frame, exactly the way
+// `VirtualNet::send` schedules a `deliver_tick` (see
+// `runtime/functor-runtime-common/src/net/virtual_net.rs`, mirrored here rather
+// than called into). Its FIFO discipline comes with it: a later-sent packet
+// never overtakes an earlier one on the same connection, whatever the jitter
+// draw says, because its delivery is clamped to the previous packet's.
+//
+// The step barrier is still a later PR: the schedule is keyed to the SESSION's
+// reference clock, not to the receiving pane's own fixed step, so a delivery
+// lands on the host frame that reaches it rather than inside the receiver's
+// step. That is what stands between this and cross-run determinism — the jitter
+// DRAWS are already reproducible (a seeded SplitMix64 per session), but which
+// frame a pane happened to send in is still wall-clock.
 //
 // The packet log is the record every traffic view reads. Each row is keyed to
 // the REFERENCE CLOCK (`Packet.frame`) so traffic lives on the same axis the
@@ -69,13 +86,28 @@ export interface Packet {
    *
    * MEASURED, not scheduled: there is no step barrier yet, so this is the
    * reference pane's live head at route time, ±a frame. When the barrier lands
-   * it becomes the step the packet is delivered in, by construction.
+   * it becomes the step the packet is SENT in, by construction.
    *
    * `null` when there is no reference clock to key against — a host that passed
    * no `referenceFrame`, or a session whose reference pane has not recorded a
    * frame yet (a packet from the boot handshake).
    */
   frame: number | null;
+  /**
+   * The frame the packet is DELIVERED on — `frame` plus its link's latency and
+   * jitter draw, clamped so it never overtakes the previous packet on the same
+   * connection (see `schedule`). Scheduled at route time, which is what makes
+   * an in-flight packet queryable: a packet is on the wire at playhead `p` when
+   * `frame <= p < deliveredFrame`, and its flight LASTS `deliveredFrame -
+   * frame` frames — the number the wire rows print and the dots fly.
+   *
+   * Equal to `frame` on a link fast enough to round to zero frames (LAN).
+   * `null` in the two cases where there is no crossing to describe: no
+   * reference clock to schedule against (the boot handshake — it delivers on
+   * the next flush), or a delivery ABANDONED because the destination document
+   * navigated away before its frame came up.
+   */
+  deliveredFrame: number | null;
   /** When the coordinator routed it (`performance.now()`). Host-clock time, not
    * game time: the wall-clock sibling of `frame`, kept because a live view
    * animates on the host's clock while `frame` places the packet in the
@@ -135,6 +167,75 @@ const CONNECT_GRACE_MS = 15_000;
 /** Hot path: one decoder for every `Send` that crosses the coordinator. */
 const DECODER = new TextDecoder();
 
+/**
+ * The timeline's fixed tick rate (timeline-model.js TIMELINE_FPS) — how a link
+ * profile's milliseconds become the frames the schedule is expressed in.
+ *
+ * Exported because the schedule is what everything downstream now measures in:
+ * the pane grid's rail (mp-panes) and the packet dots' flight (mp-network) have
+ * to mean the same frame this file scheduled against, and three private 60s
+ * would be three things to keep in step.
+ */
+export const TIMELINE_FPS = 60;
+
+/** A link profile's delay, in reference-clock frames. Rounded, so a link faster
+ * than half a frame (LAN's 8ms) is honestly zero: the frame is the finest
+ * resolution the schedule has. */
+const framesOf = (ms: number): number =>
+  Math.max(0, Math.round((ms * TIMELINE_FPS) / 1000));
+
+/**
+ * Delivery is never abandoned. If the reference clock stalls (a paused session
+ * whose panes somehow keep sending, a background tab) the queue would otherwise
+ * grow without bound — so past this many packets the oldest are delivered
+ * EARLY. Dropping them is the one thing a reliable-ordered channel may not do
+ * (Addendum 8.2), so the pressure valve gives up the impairment instead.
+ */
+const MAX_IN_FLIGHT = 2_000;
+
+/**
+ * Deterministic PRNG (SplitMix64), the same algorithm and constants as
+ * `functor_runtime_common::net::Rng` — the jitter draws must be reproducible
+ * from a seed, so nothing here touches `Math.random`.
+ *
+ * BigInt because the algorithm is defined on 64-bit wrapping arithmetic: a
+ * 32-bit stand-in would be a different generator wearing its name. It costs a
+ * handful of BigInt ops per IMPAIRED packet (none at all on a jitter-free
+ * link), against a JSON decode per packet on the same path.
+ */
+const MASK64 = (1n << 64n) - 1n;
+
+class Rng {
+  private state: bigint;
+
+  constructor(seed: bigint) {
+    this.state = seed & MASK64;
+  }
+
+  next(): bigint {
+    this.state = (this.state + 0x9e3779b97f4a7c15n) & MASK64;
+    let z = this.state;
+    z = ((z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n) & MASK64;
+    z = ((z ^ (z >> 27n)) * 0x94d049bb133111ebn) & MASK64;
+    return (z ^ (z >> 31n)) & MASK64;
+  }
+
+  /** An integer in `[0, hi]` inclusive (Rust's `range_u32(0, hi)`). */
+  upTo(hi: number): number {
+    if (hi <= 0) return 0;
+    return Number(this.next() % BigInt(hi + 1));
+  }
+}
+
+/**
+ * Seeds run 1, 2, 3… per page, so a session's jitter is stable while it lives
+ * (a rebuilt coordinator is a new session and gets the next seed). Not a
+ * wall-clock seed: "stable within a session" is what makes two reads of the
+ * same log agree, and a fixed sequence is what will make cross-run replay
+ * possible once barrier stepping pins WHEN a pane sends.
+ */
+let nextSessionSeed = 1n;
+
 /** The authority (host:port) of an endpoint, ignoring scheme and path — the
  * same rule the Rust `authority()` applies, so both agree on what matches. */
 const authorityOf = (endpoint: string): string => {
@@ -145,8 +246,6 @@ const authorityOf = (endpoint: string): string => {
 interface Pane {
   id: string;
   frame: HTMLIFrameElement;
-  /** Events queued for this pane, flushed in order on the next host rAF. */
-  outbox: DeliveredEvent[];
   /** Everything this pane registered outside the coordinator's own scope
    * (the iframe `load` hook and the current document's `pagehide`). */
   scope: AbortController;
@@ -169,6 +268,23 @@ interface PendingConnect {
   since: number;
 }
 
+/**
+ * What a link does to the packets crossing it. LATENCY AND JITTER ONLY — the
+ * chips' loss/reorder fields are not here, and deliberately so (Addendum 8.2:
+ * dropping a packet on a reliable-ordered channel would be a lie about
+ * `Sub.connect`).
+ *
+ * `jitter` is EXTRA delay, drawn uniformly from `[0, jitter]` — the same
+ * one-sided shape `VirtualNet` uses. A packet can arrive late, never early:
+ * arriving early would mean the link beat its own latency.
+ */
+export interface LinkImpairment {
+  /** One-way latency, in ms. */
+  ms: number;
+  /** Jitter, in ms — the width of the extra-delay draw. */
+  jitter: number;
+}
+
 export interface NetCoordinatorOptions {
   /**
    * The session's REFERENCE CLOCK, as a frame number — what every routed packet
@@ -181,6 +297,30 @@ export interface NetCoordinatorOptions {
    * time it is. `null` while nothing has recorded a frame yet.
    */
   referenceFrame?: () => number | null;
+  /**
+   * The impairment on a client's link, by its pane id — the link chip, read
+   * live at ROUTE time so a profile change takes effect on the next packet.
+   * Packets already in flight keep the schedule they were given (re-timing them
+   * could reorder a reliable channel, which is the one thing this may not do).
+   *
+   * The pane asked about is always the CLIENT end of the pair: a link belongs
+   * to a client, and the authority has none. `null`/omitted is a perfect link.
+   */
+  link?: (clientPane: string) => LinkImpairment | null;
+}
+
+/** One packet waiting for its delivery frame. */
+interface InFlight {
+  /** The destination pane. */
+  pane: string;
+  event: DeliveredEvent;
+  /** The reference frame it is due on; `null` delivers on the next flush. */
+  due: number | null;
+  /** Its row in the log, so the record can be CORRECTED when the schedule is
+   * not what happens: an early flush under the pressure valve, or a delivery
+   * abandoned because the destination document navigated away. Without this the
+   * log would keep claiming a crossing that never took place. */
+  packet: Packet;
 }
 
 export class NetCoordinator {
@@ -195,6 +335,21 @@ export class NetCoordinator {
   /** Payload text the log is holding, in characters (see PACKET_LOG_BYTES). */
   private logBytes = 0;
   private readonly watchers = new Set<(packet: Packet) => void>();
+  /** Scheduled packets, in send order — which is also delivery order within a
+   * connection, because the clamp in `schedule` keeps it so. */
+  private readonly inFlight: InFlight[] = [];
+  /** `conn|destination pane` -> the last delivery frame scheduled that way: the
+   * FIFO clamp's state, keyed by where a packet is GOING — which is one entry
+   * per direction for every connection between two panes, and one shared entry
+   * for the loopback row `open()` documents (a pane that dials its own
+   * authority). Sharing it there over-clamps and never reorders, and keying by
+   * destination is also what keeps a `disconnected` clamped behind the messages
+   * still in flight, after its connection row is already gone. */
+  private readonly lastDue = new Map<string, number>();
+  private readonly rng = new Rng(nextSessionSeed++);
+  /** The reference frame the last flush saw — how a clock that went backwards
+   * (a reloaded or newly promoted reference pane) is noticed. */
+  private lastNow: number | null = null;
   private nextConn = 1;
   private raf = 0;
   private readonly abort = new AbortController();
@@ -231,7 +386,7 @@ export class NetCoordinator {
    */
   addPane(id: string, frame: HTMLIFrameElement, signal?: AbortSignal): void {
     const scope = new AbortController();
-    this.panes.set(id, { id, frame, outbox: [], scope });
+    this.panes.set(id, { id, frame, scope });
     const armUnload = () => {
       frame.contentWindow?.addEventListener("pagehide", () => this.resetPane(id), {
         once: true,
@@ -310,6 +465,8 @@ export class NetCoordinator {
     this.listeners.clear();
     this.conns.clear();
     this.pending.length = 0;
+    this.inFlight.length = 0;
+    this.lastDue.clear();
     this.watchers.clear();
   }
 
@@ -419,6 +576,10 @@ export class NetCoordinator {
     for (const side of [row.client, row.server]) {
       this.deliver(byPane, side, { kind: "disconnected", key: side.key, conn }, 0);
     }
+    // The clamp's state dies with the connection: a new connection reusing this
+    // id is a new stream, and inheriting a delivery frame from the old one
+    // would delay its first packets by whatever the last one was carrying.
+    for (const side of [row.client, row.server]) this.lastDue.delete(`${conn}|${side.pane}`);
     // A client whose peer went away (the server pane reloaded, or closed the
     // connection) can never ask again: its runtime only emits `Connect` for a
     // key it has not already declared, and a `disconnected` does not clear
@@ -452,12 +613,46 @@ export class NetCoordinator {
     return null;
   }
 
+  /**
+   * When this event lands, in reference-clock frames.
+   *
+   * Only MESSAGES are impaired: the lifecycle events are the coordinator's own
+   * bookkeeping, not traffic the game put on the wire (they carry no payload
+   * and the pane headers, not the log, are what read them). They still take the
+   * FIFO clamp, so a `disconnected` can never overtake a message still in
+   * flight on the connection it closes.
+   *
+   * `null` sent frame — no reference clock yet — schedules nothing: an
+   * unscheduled packet flushes immediately, which is exactly the boot
+   * handshake's old behaviour.
+   */
+  private schedule(sent: number | null, to: Side, event: DeliveredEvent): number | null {
+    if (sent === null) return null;
+    const conn = this.conns.get(event.conn);
+    const profile =
+      event.kind === "message" && conn ? this.options.link?.(conn.client.pane) : null;
+    const jitter = profile ? framesOf(profile.jitter) : 0;
+    let due = sent + (profile ? framesOf(profile.ms) : 0) + this.rng.upTo(jitter);
+    // FIFO per connection per direction (VirtualNet's rule): a later-sent
+    // packet never overtakes an earlier one, whatever the jitter drew. Clamped
+    // to the previous delivery rather than PAST it — packets that land on the
+    // same frame still arrive in send order (one flush, one ordered batch), and
+    // a burst must not be spread a frame apart per packet.
+    const key = `${event.conn}|${to.pane}`;
+    const previous = this.lastDue.get(key);
+    if (previous !== undefined && due < previous) due = previous;
+    this.lastDue.set(key, due);
+    return due;
+  }
+
   private deliver(from: string, to: Side, event: DeliveredEvent, size: number): void {
     const pane = this.panes.get(to.pane);
     if (!pane) return;
-    pane.outbox.push(event);
+    const frame = this.options.referenceFrame?.() ?? null;
+    const due = this.schedule(frame, to, event);
     const packet: Packet = {
-      frame: this.options.referenceFrame?.() ?? null,
+      frame,
+      deliveredFrame: due,
       at: performance.now(),
       from,
       to: to.pane,
@@ -466,6 +661,7 @@ export class NetCoordinator {
       size,
       ...(event.kind === "message" ? { text: event.text } : {}),
     };
+    this.inFlight.push({ pane: to.pane, event, due, packet });
     this.log.push(packet);
     this.logBytes += packet.text?.length ?? 0;
     if (this.log.length > PACKET_LOG_CAP + PACKET_LOG_SLACK) {
@@ -491,8 +687,15 @@ export class NetCoordinator {
       if (side.pane === id) this.listeners.delete(authority);
     }
     this.dropPending((p) => p.pane === id);
-    const pane = this.panes.get(id);
-    if (pane) pane.outbox.length = 0;
+    // A navigating pane is a NEW game: everything addressed to the document
+    // that is going away goes with it. (The other end of each connection keeps
+    // its `disconnected` — that is how it learns.) The log is told: an
+    // abandoned packet has no delivery frame, so no view claims it landed.
+    for (let i = this.inFlight.length - 1; i >= 0; i--) {
+      if (this.inFlight[i].pane !== id) continue;
+      this.inFlight[i].packet.deliveredFrame = null;
+      this.inFlight.splice(i, 1);
+    }
   }
 
   private dropPending(match: (p: PendingConnect) => boolean): void {
@@ -537,20 +740,64 @@ export class NetCoordinator {
   // ------------------------------------------------------------------- egress
 
   /**
-   * One batch per pane, in arrival order. This is the "perfect link": a packet
-   * routed during frame N is delivered at the start of the host's frame N+1,
-   * with no impairment applied. The barrier PR moves this to the receiving
-   * pane's step boundary.
+   * Everything whose delivery frame has arrived, one batch per pane, in send
+   * order — the impaired link's egress.
+   *
+   * A single pass over the queue, which is in send order and (per destination)
+   * therefore in delivery order too, so "due" is decided packet by packet and
+   * the survivors keep their relative order by construction. An unscheduled
+   * packet (routed before there was a reference clock) is due immediately; a
+   * SCHEDULED one waits for its frame even while the clock is momentarily
+   * unreadable, or the impairment would be silently skipped exactly when a pane
+   * is between documents.
+   *
+   * Two escapes, and both DELIVER rather than drop — the channel is reliable:
+   *
+   *   • the clock went BACKWARDS. It is a live measurement of whichever pane is
+   *     currently the reference, so a reloaded (or newly promoted) reference
+   *     pane restarts it near zero. Every schedule and every FIFO watermark
+   *     belongs to the old timeline, and holding them would stall the session
+   *     for as long as the clock was ahead — so a regression opens a new epoch:
+   *     drain the queue in order, forget the watermarks.
+   *   • more than `MAX_IN_FLIGHT` waiting. A clock that has stopped advancing
+   *     must not grow the queue without bound, so the oldest are delivered
+   *     early. `forced` is a PREFIX of a send-ordered queue, so this cannot
+   *     reorder anything.
+   *
+   * Both correct the log on the way past: a packet delivered off its schedule
+   * says so, because `deliveredFrame` is read as what happened.
    */
   private flush(): void {
     this.retryPending();
-    for (const pane of this.panes.values()) {
-      if (pane.outbox.length === 0) continue;
-      const events = pane.outbox.splice(0);
-      pane.frame.contentWindow?.postMessage(
-        { type: "functor-net-deliver", events },
-        window.location.origin
-      );
+    const now = this.options.referenceFrame?.() ?? null;
+    const rewound = now !== null && this.lastNow !== null && now < this.lastNow;
+    if (rewound) this.lastDue.clear();
+    this.lastNow = now ?? this.lastNow;
+    if (this.inFlight.length > 0) {
+      // One outbox per pane, per flush: a delivery is never held across frames,
+      // so this is the whole batch a pane receives.
+      const outboxes = new Map<string, DeliveredEvent[]>();
+      const forced = Math.max(0, this.inFlight.length - MAX_IN_FLIGHT);
+      let kept = 0;
+      for (let i = 0; i < this.inFlight.length; i++) {
+        const waiting = this.inFlight[i];
+        const early = rewound || i < forced;
+        if (early || waiting.due === null || (now !== null && waiting.due <= now)) {
+          if (early) waiting.packet.deliveredFrame = now;
+          const outbox = outboxes.get(waiting.pane);
+          if (outbox) outbox.push(waiting.event);
+          else outboxes.set(waiting.pane, [waiting.event]);
+        } else {
+          this.inFlight[kept++] = waiting;
+        }
+      }
+      this.inFlight.length = kept;
+      for (const [id, events] of outboxes) {
+        this.panes.get(id)?.frame.contentWindow?.postMessage(
+          { type: "functor-net-deliver", events },
+          window.location.origin
+        );
+      }
     }
   }
 }

--- a/site/src/wire-rows.ts
+++ b/site/src/wire-rows.ts
@@ -1,4 +1,5 @@
-// The ROW GRAMMAR of the traffic monitor: `#f · direction · payload · bytes`,
+// The ROW GRAMMAR of the traffic monitor: `#f sent→delivered · direction ·
+// payload · bytes`,
 // and the two log walks that decide which packets a viewport holds.
 //
 // It exists because the same grammar is now read in two places — the pinned
@@ -80,6 +81,26 @@ export const packetKey = (packet: Packet): string =>
   `${packet.frame}:${packet.from}:${packet.size}:${packet.at}`;
 
 /**
+ * Is this packet still on the wire at `at`? Sent by then, not yet delivered.
+ *
+ * The scrub-locked window keys on the SENT frame (that is the frame the row
+ * prints first, and the axis the log is ordered by), which means a parked
+ * playhead can sit in the middle of a packet's flight — under a mobile link,
+ * eight frames of the window are exactly that. Rather than hide those rows or
+ * pretend they had landed, they render in an IN-FLIGHT state: the row is in the
+ * list because it was sent, and it says the receiving game has not seen it yet.
+ *
+ * Live (`at === null`) nothing is marked: the tail's newest rows would all be
+ * mid-flight, which is true and useless — the dots are where flight is read.
+ */
+export const inFlightAt = (packet: Packet, at: number | null): boolean =>
+  at !== null &&
+  packet.frame !== null &&
+  packet.deliveredFrame !== null &&
+  packet.frame <= at &&
+  at < packet.deliveredFrame;
+
+/**
  * The scrub-lock itself: a window of matching packets around `at`, and which of
  * its rows the playhead is on (-1 while live).
  *
@@ -139,6 +160,8 @@ export interface WireRowOptions {
   packet: Packet;
   /** The playhead's row, while the session is parked. */
   at?: boolean;
+  /** The packet is still crossing its link at the playhead (`inFlightAt`). */
+  inFlight?: boolean;
   /** The open row's value tree, moved in by its host — present only on the one
    * row that is open. */
   tree?: HTMLElement | null;
@@ -171,6 +194,7 @@ export interface WireRow {
 export const buildWireRow = ({
   packet,
   at = false,
+  inFlight = false,
   tree = null,
   link = null,
   color,
@@ -180,7 +204,9 @@ export const buildWireRow = ({
   const decoded = decodeWire(packet.text);
   const open = tree !== null;
   const row = document.createElement("div");
-  row.className = `mp-wl${link === null ? "" : " linked"}${at ? " at" : ""}${open ? " open" : ""}`;
+  row.className =
+    `mp-wl${link === null ? "" : " linked"}${at ? " at" : ""}` +
+    `${inFlight ? " flight" : ""}${open ? " open" : ""}`;
   if (color) row.style.setProperty("--pc", color);
   // The full rendering is built ON HOVER, once: rendering every row's whole
   // payload unelided (a world snapshot, per row, per repaint) to fill a tooltip
@@ -202,7 +228,22 @@ export const buildWireRow = ({
     el.textContent = text;
     return el;
   };
-  const cells: HTMLElement[] = [cell("f", `#f ${packet.frame ?? "—"}`)];
+  // The frame cell carries the WHOLE crossing: sent, then delivered. The delay
+  // is the link chip made visible per packet (Addendum 8.2) — subdued, because
+  // the sent frame is what the row is filed under and what the rail matches.
+  // A same-frame delivery (a link under half a frame) prints no arrow: there is
+  // nothing to say, and an unbroken column of "→" would say it loudest.
+  const frames = cell("f", `#f ${packet.frame ?? "—"}`);
+  if (packet.deliveredFrame !== null && packet.deliveredFrame !== packet.frame) {
+    const delivered = document.createElement("i");
+    delivered.className = "dl";
+    delivered.textContent = `→${packet.deliveredFrame}${inFlight ? " ⋯" : ""}`;
+    delivered.title = inFlight
+      ? `sent at #f ${packet.frame}, still crossing at the playhead — it lands at #f ${packet.deliveredFrame}`
+      : `sent at #f ${packet.frame}, delivered at #f ${packet.deliveredFrame}`;
+    frames.append(delivered);
+  }
+  const cells: HTMLElement[] = [frames];
   if (link !== null) cells.push(cell("l", link));
   cells.push(
     cell(`d ${up ? "up" : "dn"}`, up ? `${shortName(packet.from)}→srv` : `srv→${shortName(packet.to)}`)

--- a/site/src/wire-tab.ts
+++ b/site/src/wire-tab.ts
@@ -36,6 +36,7 @@ import type { NetCoordinator, Packet } from "./net-coordinator.js";
 import type { WireSlot } from "./status-bar-store.js";
 import {
   buildWireRow,
+  inFlightAt,
   LIVE_ROW_MS,
   linkIdOf,
   logWindow,
@@ -321,8 +322,10 @@ export function initWireTab({ slot, net, links, clock }: WireTabOptions): WireTa
     // two hundred rows, ten times a second, hashing the whole list costs more
     // than the rebuild it is there to avoid. Any shift of the window moves an
     // end (the log only ever grows at the tail, and a scrub moves both).
+    // `at` is in the hash because which rows are IN FLIGHT changes as the
+    // playhead crosses a delivery, even when the window has not moved.
     const key =
-      `${link}|${dir}|${highlight}|${shown.length}|` +
+      `${link}|${dir}|${at}|${highlight}|${shown.length}|` +
       `${shown[0] ? packetKey(shown[0]) : ""}|${shown.at(-1) ? packetKey(shown.at(-1)!) : ""}|` +
       `${opened ? packetKey(opened.packet) : ""}`;
     if (key === rowKey) return;
@@ -339,6 +342,7 @@ export function initWireTab({ slot, net, links, clock }: WireTabOptions): WireTa
         const built = buildWireRow({
           packet,
           at: index === highlight,
+          inFlight: inFlightAt(packet, at),
           tree: isOpen && opened ? opened.host : null,
           // ALL interleaves several links, so each row says which one it
           // crossed and wears that client's ink; a focused link says it once,

--- a/site/styles.css
+++ b/site/styles.css
@@ -3705,8 +3705,8 @@ a:hover {
    gets everything left over. */
 .mp-wl {
   display: grid;
-  grid-template-columns: 54px 62px 1fr 46px;
-  gap: 8px;
+  grid-template-columns: 84px 62px 1fr 46px;
+  gap: 6px;
   padding: 3px 10px;
   font: 10.5px/1.5 var(--font-mono);
   color: var(--text);
@@ -3725,8 +3725,32 @@ a:hover {
   background: color-mix(in srgb, var(--pc) 14%, transparent);
 }
 
+/* Sent frame, then delivered — the link's delay, per packet. The sent frame is
+   the row's file-under number and keeps the ink; the arrival is an annotation
+   on it, so it sits quieter and one notch smaller. */
 .mp-wl .f {
   color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.mp-wl .f .dl {
+  margin-left: 4px;
+  font-style: normal;
+  font-size: 9.5px;
+  color: color-mix(in srgb, var(--text-dim) 65%, transparent);
+}
+
+/* IN FLIGHT at the playhead: sent by this frame, not yet delivered. The row is
+   the one place the parked timeline can say "the receiving game has not seen
+   this yet", so the arrival stamp lights up and the payload — which is the part
+   that has not landed — goes ghosted. */
+.mp-wl.flight .f .dl {
+  color: var(--cyan);
+}
+
+.mp-wl.flight .payload,
+.mp-wl.flight .n {
+  opacity: 0.45;
 }
 
 /* Direction takes the ink of whoever SENT it: the client's own color going up,
@@ -4033,7 +4057,7 @@ button.mp-vt-row:focus-visible {
 /* ALL interleaves several links, so every row gains a column naming the one it
    crossed — inserted after the frame, before the direction it qualifies. */
 .mp-wl.linked {
-  grid-template-columns: 54px 32px 62px 1fr 46px;
+  grid-template-columns: 84px 32px 62px 1fr 46px;
 }
 
 .mp-wl .l {
@@ -4555,6 +4579,24 @@ button.mp-vt-row:focus-visible {
   padding: 3px 5px;
   text-align: right;
   font-variant-numeric: tabular-nums;
+}
+
+/* Loss is set here but not applied: it belongs to datagrams (Net.Udp), and
+   Sub.connect is reliable-ordered. The field stays usable — it is a setting,
+   not a broken control — and wears the badge that says who will read it. */
+.mp-link-menu label.off {
+  opacity: 0.65;
+}
+
+.mp-link-soon {
+  padding: 1px 5px;
+  font: 9px/1.5 var(--font-mono);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pink);
+  background: color-mix(in srgb, var(--pink) 14%, transparent);
+  border-radius: 3px;
 }
 
 .mp-link-note {


### PR DESCRIPTION
![link impairment — the network view under a mobile link](https://gist.githubusercontent.com/tommy-xr/d4a477a6acd68d287b2c9260e950b1d7/raw/impair-hero.gif)

<sub>Pace is the measurement: the mobile·132ms edge carries a visibly slower, denser dot train than LAN·8ms — and the wire rows' sent→delivered arithmetic agrees, because they are the same fact.</sub>

![network view — mobile·132ms beside LAN·8ms](https://gist.githubusercontent.com/tommy-xr/d4a477a6acd68d287b2c9260e950b1d7/raw/impair-network.png)

![wire rows with sent→delivered deltas](https://gist.githubusercontent.com/tommy-xr/d4a477a6acd68d287b2c9260e950b1d7/raw/impair-wire-rows-crop.png)

<sub>The rows carry the same number the dots do: `#f 517 →527` on the impaired link, bare on the unimpaired one.</sub>

![in-flight rows parked under the playhead](https://gist.githubusercontent.com/tommy-xr/d4a477a6acd68d287b2c9260e950b1d7/raw/impair-inflight.png)

<sub>Parked at the playhead: rows still in flight are shown as in-flight, not as delivered.</sub>

<details>
<summary>The link menu — presets, latency ± jitter, and the datagram-scoped loss field</summary>

![link menu with the DATAGRAMS-badged loss field](https://gist.githubusercontent.com/tommy-xr/d4a477a6acd68d287b2c9260e950b1d7/raw/impair-link-menu.png)

</details>

PR 3 of the **inspection stack** (on #653 ← #651): the link chips stop being labels — **latency and jitter become real**, per design doc Addendum 8.2.

**The semantics decision, enforced**: `Sub.connect` promises reliable-ordered delivery, so the coordinator **never drops or reorders** — impairment v1 is latency + jitter only, FIFO-clamped per connection (a later packet's delivery clamps to ≥ its predecessor's; `max`, not VirtualNet's `+1`, because a rAF flush posts ordered batches and `+1` would spread bursts). The chips keep their loss/reorder fields, now wearing a DATAGRAMS badge — they activate when `Net.Udp` lands (Addendum 6a), where dropping is the contract.

**The scheduler** (`net-coordinator.ts`): step-time from the start — `framesOf(ms)` at the shared `TIMELINE_FPS` (mobile 132ms → 8 frames; LAN 8ms → 0), jitter as one-sided extra delay drawn from a faithful **BigInt SplitMix64 port of `functor_runtime_common::net::Rng`** (same constants and shifts — the Rust↔TS mirror is intentional and commented), seeded per session so a session is stable; cross-run determinism is documented as arriving with barrier stepping. Delivery escapes never drop: a backwards reference clock (pane reload) opens a new epoch and drains in order; the in-flight cap forces the oldest prefix through; both correct `deliveredFrame` honestly, and an abandoned delivery records `null` rather than a lie.

**Default = LAN** (was Wi-Fi): 0 frames, so untouched sessions — and every existing test — behave exactly as before. Impairment is opt-in per pane.

**What you see**:
- **Wire rows** (tab + pinned panel): `#f 517 →527` — sent → delivered, the delta subtle. Parked, a packet with `sent ≤ playhead < delivered` renders **in flight** (ghosted payload, arrival stamp) instead of hidden or falsely landed.
- **Dots**: flight time IS the link's latency. The Addendum 5a honesty rule implemented exactly: a visibility floor applies **only to zero-frame links** (40ms so LAN dots exist at all), and that chip reads `<1f` — the LAN↔mobile contrast is never flattened ([AGREED] review finding: the first cut floored everything and erased the difference).
- **Chips**: presets and custom values take effect on subsequently routed packets; in-flight keep their schedule (documented). Every "impairs nothing" caveat in the codebase is gone.

**Cross-engine review (Claude + Codex + dedup), all dispositioned** — the four [AGREED]: the floor flattening (above); backwards-clock queue stranding; `deliveredFrame` lying on forced paths; a fixed replay horizon vs unbounded hand-typed latency (now derived from the deepest flight seen). Plus Codex's null-clock early-drain High. Declined with in-code reasons: per-side FIFO keying (breaks the disconnect clamp), a PRNG golden vector (nothing JS-side to pin against yet).

**Verification**: site tsc clean; `test:site` at the two known pre-existing failures only; `net-coordinator` 16/16; `sandbox-mp` **99/99** — with delay-bound assertions (8–10 frames on mobile, 0 on LAN), jitter variance, FIFO invariants per link and direction, chip-change-takes-effect, convergence under delay (orbs plays fine at 132ms — delayed, not broken), and the parked in-flight rows.

The chips' pace and the wire's arithmetic are now the same fact. Next on this foundation: simulated `Net.Udp` datagram semantics (loss/reorder where they're honest), and the native coordinator (MCP Phase 2) reusing the identical schedule discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

