### PR TITLE
feat(input): touch device domain on the sampled snapshot

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -376,8 +376,15 @@ let grab = (s) =>
   poll); an unfocused window/document or a pinned clock reads rest-level
   controls, not `Option.None`, so presence stays a reliable capability
   signal. Browsers hide pads until a button is first pressed; headless polls
-  nothing (`Option.None` unless injected). A future mobile-touch domain
-  belongs as another typed sibling on the snapshot.
+  nothing (`Option.None` unless injected). The snapshot also contains
+  `touch: Option.t<Input.touch>` — active contacts plus one-step
+  `pressed`/`released` transition lists (the keyboard edge contract for
+  fingers): `touches` are `{id, x, y}` levels in the mouse's logical
+  coordinate space, a quick tap can appear in both edge lists, and a
+  platform-cancelled contact reports through `released`. `Option.Some` with
+  empty lists = a touch surface exists but is idle (the cue to show touch
+  UI); native supplies the domain via debug injection only
+  (`POST /input` `{"type":"touch","phase":"begin",…}`).
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -383,8 +383,9 @@ let grab = (s) =>
   coordinate space, a quick tap can appear in both edge lists, and a
   platform-cancelled contact reports through `released`. `Option.Some` with
   empty lists = a touch surface exists but is idle (the cue to show touch
-  UI); native supplies the domain via debug injection only
-  (`POST /input` `{"type":"touch","phase":"begin",…}`).
+  UI). No shell produces the domain from hardware yet on ANY target — debug
+  injection (`POST /input` `{"type":"touch","phase":"begin",…}`) is its only
+  source until the web touch-event wiring lands.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -1725,12 +1725,14 @@ MCP server before reconnecting or reusing that runtime URL.",
     /// `{"SliderChanged":0.5}` / `{"TextChanged":"hi"}`),
     /// `{"type":"xr", "head":…, "left":…, "right":…}`, `{"type":"xr_clear"}`,
     /// `{"type":"gamepad", "left_stick":[0,1], "south":true}`,
-    /// `{"type":"gamepad_clear"}`.
+    /// `{"type":"gamepad_clear"}`,
+    /// `{"type":"touch", "phase":"begin", "id":0, "x":10, "y":20}` (phases
+    /// `begin`/`move`/`end`/`cancel`).
     /// The list mirrors `POST /input` and is not exhaustive; an unrecognized
     /// shape comes back as the runtime's own 400, which names the problem.
-    /// Keys, held buttons, XR and gamepad samples are LEVEL state: they stay
-    /// in force across steps until released, which is how a paused session is
-    /// scripted.
+    /// Keys, held buttons, XR and gamepad samples, and begun touch contacts
+    /// are LEVEL state: they stay in force across steps until released, which
+    /// is how a paused session is scripted.
     #[tool]
     async fn send_input(
         &self,
@@ -3438,6 +3440,26 @@ still be alive; stop an owned session, or restart both an attached runtime and t
                 .await?;
                 Ok(nothing())
             }
+            "touch" => {
+                require_arity(method, args, 4)?;
+                let phase = args[0]
+                    .as_str()
+                    .ok_or_else(|| "touch phase must be a string".to_string())?;
+                self.post(
+                    url,
+                    "/input",
+                    serde_json::json!({
+                        "type": "touch",
+                        "phase": phase,
+                        "id": u32_arg(method, args, 1)?,
+                        "x": f64_arg(method, args, 2)?,
+                        "y": f64_arg(method, args, 3)?,
+                    })
+                    .to_string(),
+                )
+                .await?;
+                Ok(nothing())
+            }
             "uiClick" => {
                 require_arity(method, args, 1)?;
                 let slot = u32_arg(method, args, 0)?;
@@ -4129,6 +4151,12 @@ fn u64_arg(method: &str, args: &[Value], index: usize) -> Result<u64, String> {
 fn u32_arg(method: &str, args: &[Value], index: usize) -> Result<u32, String> {
     u32::try_from(u64_arg(method, args, index)?)
         .map_err(|_| format!("{method} argument {} exceeds u32", index + 1))
+}
+
+fn f64_arg(method: &str, args: &[Value], index: usize) -> Result<f64, String> {
+    args.get(index)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| format!("{method} argument {} must be a number", index + 1))
 }
 
 fn i32_arg(method: &str, args: &[Value], index: usize) -> Result<i32, String> {

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -298,8 +298,12 @@ struct CodeOutputBudget {
 struct CodeInputRestore {
     baseline_keys: BTreeSet<String>,
     baseline_mouse_buttons: BTreeSet<String>,
+    // Active touch contacts at baseline, id → position, so a contact the code
+    // ended can be re-begun where it was.
+    baseline_touches: BTreeMap<u32, (f64, f64)>,
     touched_keys: BTreeSet<String>,
     touched_mouse_buttons: BTreeSet<String>,
+    touched_contacts: BTreeSet<u32>,
 }
 
 impl CodeInputRestore {
@@ -327,9 +331,22 @@ impl CodeInputRestore {
             })
             .map(str::to_string)
             .collect();
+        let baseline_touches = state
+            .pointer("/input/touch/touches")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|point| {
+                Some((
+                    u32::try_from(point.get("id")?.as_u64()?).ok()?,
+                    (point.get("x")?.as_f64()?, point.get("y")?.as_f64()?),
+                ))
+            })
+            .collect();
         Self {
             baseline_keys,
             baseline_mouse_buttons,
+            baseline_touches,
             ..Self::default()
         }
     }
@@ -345,8 +362,14 @@ impl CodeInputRestore {
             .insert(button.to_ascii_lowercase());
     }
 
+    fn touch_contact(&mut self, id: u32) {
+        self.touched_contacts.insert(id);
+    }
+
     fn is_empty(&self) -> bool {
-        self.touched_keys.is_empty() && self.touched_mouse_buttons.is_empty()
+        self.touched_keys.is_empty()
+            && self.touched_mouse_buttons.is_empty()
+            && self.touched_contacts.is_empty()
     }
 }
 
@@ -3442,18 +3465,19 @@ still be alive; stop an owned session, or restart both an attached runtime and t
             }
             "touch" => {
                 require_arity(method, args, 4)?;
-                let phase = args[0]
-                    .as_str()
-                    .ok_or_else(|| "touch phase must be a string".to_string())?;
+                let phase = string_arg(method, args, 0)?;
+                validate_touch_phase(&phase)?;
+                let id = u32_arg(method, args, 1)?;
+                input_restore.touch_contact(id);
                 self.post(
                     url,
                     "/input",
                     serde_json::json!({
                         "type": "touch",
                         "phase": phase,
-                        "id": u32_arg(method, args, 1)?,
-                        "x": f64_arg(method, args, 2)?,
-                        "y": f64_arg(method, args, 3)?,
+                        "id": id,
+                        "x": finite_f64_arg(method, args, 2)?,
+                        "y": finite_f64_arg(method, args, 3)?,
                     })
                     .to_string(),
                 )
@@ -3601,8 +3625,30 @@ runtime, restart both the runtime and this MCP server before reconnecting."
                 failures.push(format!("mouse button {button:?}: {error}"));
             }
         }
+        for id in &input_restore.touched_contacts {
+            let baseline = input_restore.baseline_touches.get(id);
+            let currently_active = current.baseline_touches.contains_key(id);
+            let command = match (baseline, currently_active) {
+                // A contact the code begun and left held: cancel it (the game
+                // sees a release, exactly as if the platform stole it).
+                (None, true) => serde_json::json!({
+                    "type": "touch", "phase": "cancel", "id": id, "x": 0.0, "y": 0.0,
+                }),
+                // A baseline contact the code ended: re-begin it where it was.
+                (Some((x, y)), false) => serde_json::json!({
+                    "type": "touch", "phase": "begin", "id": id, "x": x, "y": y,
+                }),
+                _ => continue,
+            };
+            if let Err(error) = self
+                .post(&target.url, "/input", command.to_string())
+                .await
+            {
+                failures.push(format!("touch contact {id}: {error}"));
+            }
+        }
         if failures.is_empty() {
-            format!("{cause}; code-touched key and mouse-button levels were restored")
+            format!("{cause}; code-touched key, mouse-button, and touch levels were restored")
         } else {
             target.quarantined.store(true, Ordering::Release);
             format!(
@@ -4153,10 +4199,13 @@ fn u32_arg(method: &str, args: &[Value], index: usize) -> Result<u32, String> {
         .map_err(|_| format!("{method} argument {} exceeds u32", index + 1))
 }
 
-fn f64_arg(method: &str, args: &[Value], index: usize) -> Result<f64, String> {
-    args.get(index)
-        .and_then(Value::as_f64)
-        .ok_or_else(|| format!("{method} argument {} must be a number", index + 1))
+fn validate_touch_phase(phase: &str) -> Result<(), String> {
+    match phase {
+        "begin" | "move" | "end" | "cancel" => Ok(()),
+        _ => Err(format!(
+            "unknown touch phase {phase:?}; expected begin, move, end, or cancel"
+        )),
+    }
 }
 
 fn i32_arg(method: &str, args: &[Value], index: usize) -> Result<i32, String> {
@@ -4221,6 +4270,19 @@ fn track_input_command(
                 return Err("mouse_button input requires a boolean `down`".into());
             }
             input_restore.touch_mouse_button(button);
+        }
+        "touch" => {
+            let phase = command
+                .get("phase")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "touch input requires a string `phase`".to_string())?;
+            validate_touch_phase(phase)?;
+            let id = command
+                .get("id")
+                .and_then(Value::as_u64)
+                .and_then(|id| u32::try_from(id).ok())
+                .ok_or_else(|| "touch input requires a non-negative integer `id`".to_string())?;
+            input_restore.touch_contact(id);
         }
         _ => {}
     }

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -210,6 +210,7 @@ JSON is tagged by `type`. Unknown keys/shapes return **400** with a message.
 {"type":"xr_clear"}                                            // drop it again
 {"type":"gamepad","left_stick":[0.0,1.0],"south":true}         // set the gamepad sample
 {"type":"gamepad_clear"}                                       // drop it again
+{"type":"touch","phase":"begin","id":0,"x":10,"y":20}          // one touch transition
 ```
 
 `mouse_button` is both an edge and level state, exactly like `key`: it calls the
@@ -268,6 +269,16 @@ without it. That is the point: the mouse/keyboard emulator pins both hands to
 `z = -0.55` with identity orientations, so gestures like pulling a hand back
 toward your face, or aiming with a rotated grip, are inexpressible there and can
 only be driven this way. `held_keys` and `mouse` stay live alongside it.
+
+`{"type":"touch"}` is EVENTED, like `key`, not whole-sample like `xr`: each
+command is one contact transition (phases `begin`/`move`/`end`/`cancel`, `id`
+a small stable ordinal, `x`/`y` in the mouse's logical coordinates) folded
+through the same reducer real platform touch events take — it updates the
+held contacts later steps' `sampledInput` sees and records the same
+de-duplicated one-step `pressed`/`released` edges, so a scripted tap or drag
+replays identically. A begun contact is level state until its `end` (or
+`cancel`, which the game sees as a release); there is no separate clear
+command — end every begun id.
 
 `{"type":"gamepad"}` is the same contract for the gamepad domain: sampled
 level state (no entry point call, recorded, replayable), a whole-sample
@@ -419,6 +430,11 @@ clients should treat absent edge arrays/button sets as empty.
       "menu_pressed": false
     }
   },
+  "touch": {
+    "touches": [{ "id": 0, "x": 120.0, "y": 48.0 }],
+    "pressed": [],
+    "released": []
+  },
   "gamepad": {
     "left_stick": [0.0, 0.0],
     "right_stick": [0.0, 0.0],
@@ -466,8 +482,11 @@ and the web runtime poll the first standard-mapping pad each frame (on
 desktop an injected sample wins over the poll); presence is sticky while the
 pad is connected, with controls at rest level while the window/document is
 unfocused or the clock is pinned. `--headless` has no GLFW instance, so there
-injection is the domain's only source. Future mobile-touch support should add
-another typed sibling field rather than target-specific endpoints or
+injection is the domain's only source. `touch` carries active contacts plus
+one-step `pressed`/`released` transition lists (the keyboard contract for
+fingers); `Some` with empty lists means a touch surface exists but is idle,
+and desktop supplies the domain through injection only. Further devices
+should add typed sibling fields rather than target-specific endpoints or
 string-keyed capability bags.
 
 ### `POST /time` — frame-loop control

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -430,11 +430,6 @@ clients should treat absent edge arrays/button sets as empty.
       "menu_pressed": false
     }
   },
-  "touch": {
-    "touches": [{ "id": 0, "x": 120.0, "y": 48.0 }],
-    "pressed": [],
-    "released": []
-  },
   "gamepad": {
     "left_stick": [0.0, 0.0],
     "right_stick": [0.0, 0.0],
@@ -454,6 +449,11 @@ clients should treat absent edge arrays/button sets as empty.
     "dpad_right": false,
     "start": false,
     "select": false
+  },
+  "touch": {
+    "touches": [{ "id": 0, "x": 120.0, "y": 48.0 }],
+    "pressed": [],
+    "released": []
   }
 }
 ```
@@ -484,8 +484,10 @@ pad is connected, with controls at rest level while the window/document is
 unfocused or the clock is pinned. `--headless` has no GLFW instance, so there
 injection is the domain's only source. `touch` carries active contacts plus
 one-step `pressed`/`released` transition lists (the keyboard contract for
-fingers); `Some` with empty lists means a touch surface exists but is idle,
-and desktop supplies the domain through injection only. Further devices
+fingers); `Some` with empty lists means a touch surface exists but is idle.
+No shell produces the domain from hardware yet on ANY target — debug
+injection is its only source until the web touch-event wiring lands.
+Further devices
 should add typed sibling fields rather than target-specific endpoints or
 string-keyed capability bags.
 

--- a/functor-prelude/prelude/input.funi
+++ b/functor-prelude/prelude/input.funi
@@ -1,9 +1,9 @@
 //! Target-neutral continuously sampled input.
 //!
 //! The optional `sampledInput(model, snapshot)` game hook receives one
-//! `Input.snapshot` immediately before every fixed simulation step. XR and
-//! gamepad are typed device domains; a future mobile-touch record belongs
-//! beside them on the snapshot.
+//! `Input.snapshot` immediately before every fixed simulation step. XR,
+//! gamepad, and touch are typed device domains; further devices belong as
+//! siblings beside them on the snapshot.
 
 /// A plain two-dimensional point or axis pair.
 type point2 = { x: float, y: float }
@@ -69,6 +69,25 @@ type gamepad = {
   select: bool
 }
 
+/// One touch contact in the same top-left-origin logical coordinate space as
+/// `mouse` (window points natively, CSS pixels on web). `id` is a small
+/// ordinal stable for the contact's lifetime.
+type touchPoint = { id: float, x: float, y: float }
+
+/// Active touch contacts plus this step's transitions — the keyboard
+/// contract for fingers: `touches` are held levels at current positions,
+/// `pressed`/`released` are de-duplicated one-step edges (a quick tap can
+/// appear in both while `touches` no longer carries it). A contact the
+/// platform steals (gesture navigation) reports through `released`, never a
+/// silently vanished touch. On the snapshot, `Option.Some` signals a touch
+/// surface EXISTS (empty lists while idle — the cue to show touch UI);
+/// `Option.None` means no touch input at all.
+type touch = {
+  touches: List<touchPoint>,
+  pressed: List<touchPoint>,
+  released: List<touchPoint>
+}
+
 /// A fixed set of mouse buttons. `mouse.buttons` uses it for held levels;
 /// `mouse.pressed` / `mouse.released` use it for one-step transitions.
 type mouseButtons = { left: bool, right: bool, middle: bool }
@@ -100,5 +119,6 @@ type snapshot = {
   releasedKeys: List<Key.t>,
   mouse: mouse,
   xr: Option.t<xr>,
-  gamepad: Option.t<gamepad>
+  gamepad: Option.t<gamepad>,
+  touch: Option.t<touch>
 }

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -1060,7 +1060,7 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 13);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 14);
     }
 
     /// The v10 fields are ADDITIVE: a pre-v10 payload (which carries neither)

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::Sender;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ui::UiEventKind, GamepadSnapshot, InputSnapshot, XrInputSnapshot};
+use crate::{ui::UiEventKind, GamepadSnapshot, InputSnapshot, TouchPhase, XrInputSnapshot};
 
 /// Stable name returned by the discovery endpoint on every runtime target.
 pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
@@ -81,7 +81,12 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// subtree plus compact per-copy channel records (position, quaternion
 /// rotation, per-axis scale, tint). Clients that decode scene variants
 /// exhaustively must gate before reading it.
-pub const DEBUG_PROTOCOL_VERSION: u32 = 13;
+///
+/// 14 adds touch injection — `POST /input` `{"type":"touch","phase":…}`
+/// transitions folded through the shared reducer (evented, like `key`, not
+/// whole-sample like `xr`) — and the optional `touch` field on `GET /state`'s
+/// input snapshot.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 14;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -135,7 +140,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "GET",
         path: "/state",
-        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), model_revision (model replacements so far — the version label for a networked model, since pause freezes the clock and not the network), pending_net (inbound network events accepted but not yet delivered to the game), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr/gamepad), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
+        description: "runtime state JSON: frame, tts, pending_steps (queued clock steps not yet run), model_revision (model replacements so far — the version label for a networked model, since pause freezes the clock and not the network), pending_net (inbound network events accepted but not yet delivered to the game), viewport, views, input snapshot (held_keys + mouse position/logical surface/buttons + optional xr/gamepad/touch), model (structured lossy JSON view of the model), model_debug (Rust Debug text)",
     },
     DebugRoute {
         method: "GET",
@@ -150,7 +155,7 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
     DebugRoute {
         method: "POST",
         path: "/input",
-        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"mouse_button\",\"button\":\"left\",\"down\":true} (edge + held level, like key) | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device) | {\"type\":\"gamepad\",\"left_stick\":[0.0,1.0],\"south\":true,...} (desktop only; level state until the next gamepad command) | {\"type\":\"gamepad_clear\"} (drop it, restoring the physical pad or no device)",
+        description: "inject input — {\"type\":\"key\",\"key\":\"w\",\"down\":true} | {\"type\":\"mouse_move\",\"x\":0,\"y\":0} | {\"type\":\"mouse_wheel\",\"delta\":1} | {\"type\":\"mouse_button\",\"button\":\"left\",\"down\":true} (edge + held level, like key) | {\"type\":\"ui_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"webview_event\",\"slot\":0,\"kind\":\"Clicked\"} | {\"type\":\"xr\",\"left\":{...},\"right\":{...},\"head\":{...}} (desktop only; level state until the next xr command) | {\"type\":\"xr_clear\"} (drop it, restoring the emulator or no device) | {\"type\":\"gamepad\",\"left_stick\":[0.0,1.0],\"south\":true,...} (desktop only; level state until the next gamepad command) | {\"type\":\"gamepad_clear\"} (drop it, restoring the physical pad or no device) | {\"type\":\"touch\",\"phase\":\"begin\",\"id\":0,\"x\":10,\"y\":20} (evented, like key: phases begin/move/end/cancel fold through the shared touch reducer)",
     },
     DebugRoute {
         method: "POST",
@@ -365,6 +370,21 @@ pub enum InputCommand {
     /// domain when none is connected. The release half of `Gamepad`'s
     /// held-key contract.
     GamepadClear,
+    /// One touch-contact transition — `{"type":"touch","phase":"begin",
+    /// "id":0,"x":10,"y":20}` with phases `begin`/`move`/`end`/`cancel`.
+    ///
+    /// Unlike `Xr`/`Gamepad` (whole-sample level state), touch is EVENTED:
+    /// each command folds through the same transition reducer real platform
+    /// touch events take, updating the held contacts later steps sample and
+    /// recording the same de-duplicated one-step edges — so a scripted tap
+    /// or drag replays identically. Ending every begun id releases the
+    /// domain's contacts; no separate clear command exists.
+    Touch {
+        phase: TouchPhase,
+        id: u32,
+        x: f32,
+        y: f32,
+    },
 }
 
 /// A clock command sent through `POST /time`.
@@ -966,6 +986,34 @@ mod tests {
                 "{body} rejected for the wrong reason: {err}"
             );
         }
+    }
+
+    #[test]
+    fn a_touch_command_decodes_each_phase_and_rejects_unknown_ones() {
+        for (phase, expected) in [
+            ("begin", TouchPhase::Begin),
+            ("move", TouchPhase::Move),
+            ("end", TouchPhase::End),
+            ("cancel", TouchPhase::Cancel),
+        ] {
+            let body = format!(r#"{{"type":"touch","phase":"{phase}","id":2,"x":10.5,"y":20}}"#);
+            assert_eq!(
+                serde_json::from_str::<InputCommand>(&body).unwrap(),
+                InputCommand::Touch {
+                    phase: expected,
+                    id: 2,
+                    x: 10.5,
+                    y: 20.0
+                }
+            );
+        }
+        // An unknown phase is a 400, like every malformed command.
+        assert!(
+            serde_json::from_str::<InputCommand>(
+                r#"{"type":"touch","phase":"start","id":0,"x":0,"y":0}"#
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -1596,13 +1596,23 @@ let init = {
   mouseX: 0.0,
   padX: 0.0,
   padSouth: false,
-  padTrigger: 0.0
+  padTrigger: 0.0,
+  touchCount: 0.0,
+  tapX: 0.0,
+  releasedCount: 0.0
 }
 let sampledInput = (model, snapshot: Input.snapshot) =>
   let (padX, padSouth, padTrigger) =
     (match snapshot.gamepad with
      | Option.Some(pad) => (pad.leftStick.x, pad.south, pad.rightTrigger)
      | Option.None => (0.0, false, 0.0)) in
+  let (touchCount, tapX, releasedCount) =
+    (match snapshot.touch with
+     | Option.Some(t) =>
+       (List.length(t.touches),
+        t.pressed |> List.head |> Option.map((p) => p.x) |> Option.defaultValue(0.0),
+        List.length(t.released))
+     | Option.None => (0.0, 0.0, 0.0)) in
   match snapshot.xr with
   | Option.Some(xr) => {
       trigger: xr.right.trigger,
@@ -1614,7 +1624,10 @@ let sampledInput = (model, snapshot: Input.snapshot) =>
       mouseX: snapshot.mouse.x,
       padX: padX,
       padSouth: padSouth,
-      padTrigger: padTrigger
+      padTrigger: padTrigger,
+      touchCount: touchCount,
+      tapX: tapX,
+      releasedCount: releasedCount
     }
   | Option.None => model
 let tick = (model, dt, tts) => model
@@ -1661,6 +1674,23 @@ let draw = (model, tts) =>
                 right_trigger: 0.25,
                 ..crate::GamepadSnapshot::default()
             }),
+            touch: Some(crate::TouchSnapshot {
+                touches: vec![crate::TouchPoint {
+                    id: 0,
+                    x: 120.0,
+                    y: 48.0,
+                }],
+                pressed: vec![crate::TouchPoint {
+                    id: 0,
+                    x: 118.5,
+                    y: 50.0,
+                }],
+                released: vec![crate::TouchPoint {
+                    id: 1,
+                    x: 10.0,
+                    y: 10.0,
+                }],
+            }),
             ..crate::InputSnapshot::default()
         };
         game.sampled_input(&snapshot);
@@ -1677,6 +1707,9 @@ let draw = (model, tts) =>
         assert!(model.contains("padX: -0.5"), "{model}");
         assert!(model.contains("padSouth: true"), "{model}");
         assert!(model.contains("padTrigger: 0.25"), "{model}");
+        assert!(model.contains("touchCount: 1"), "{model}");
+        assert!(model.contains("tapX: 118.5"), "{model}");
+        assert!(model.contains("releasedCount: 1"), "{model}");
         assert!(matches!(
             game.recorded_inputs_at(0).as_slice(),
             [crate::RecordedInput::Snapshot(recorded)] if recorded.as_ref() == &snapshot

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -39,10 +39,11 @@ pub struct InputSnapshot {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gamepad: Option<GamepadSnapshot>,
     /// Live touch contacts when the target supplies them. `Some` signals
-    /// touch CAPABILITY (a touch surface exists — the web shell sets it on
-    /// touch-capable devices before any contact), so a game can decide to
+    /// touch CAPABILITY (a touch surface exists), so a game can decide to
     /// show touch UI; an idle touchscreen is `Some` with empty lists, and
-    /// `None` means no touch surface at all.
+    /// `None` means no touch surface at all. Today the domain's only source
+    /// is debug injection — the web shell's touch-event wiring (which will
+    /// set `Some` on touch-capable devices before any contact) lands next.
     ///
     /// Omitted rather than serialized as `null` when absent, like `xr`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -50,9 +51,10 @@ pub struct InputSnapshot {
 }
 
 /// One touch contact in the same top-left-origin logical coordinate space as
-/// [`MouseSnapshot`] (window points natively, CSS pixels on web). `id` is a
-/// small shell-assigned ordinal stable for the contact's lifetime — shells
-/// remap the platform's arbitrary identifiers.
+/// [`MouseSnapshot`] (window points natively, CSS pixels on web; fractional
+/// `f32`, unlike the mouse's integer point). `id` is a small shell-assigned
+/// ordinal stable for the contact's lifetime — shells remap the platform's
+/// arbitrary identifiers.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TouchPoint {
@@ -219,10 +221,7 @@ impl InputEdges {
         } else {
             &mut self.released_touches
         };
-        match edges.iter_mut().find(|p| p.id == point.id) {
-            Some(existing) => *existing = point,
-            None => edges.push(point),
-        }
+        upsert_touch_point(edges, point);
     }
 
     /// Copy the pending transitions into a step snapshot.
@@ -333,34 +332,54 @@ pub fn apply_mouse_transition_to_snapshot(
     true
 }
 
+/// Insert or reposition an id-keyed point. Returns whether it was NEWLY
+/// inserted (a repeated begin repositions without a second press edge).
+fn upsert_touch_point(points: &mut Vec<TouchPoint>, point: TouchPoint) -> bool {
+    match points.iter_mut().find(|p| p.id == point.id) {
+        Some(existing) => {
+            *existing = point;
+            false
+        }
+        None => {
+            points.push(point);
+            true
+        }
+    }
+}
+
 /// Fold one touch-contact transition into shell-held touch level state.
 ///
 /// The ONE reducer every shell (web events, debug injection) shares, so live
 /// input and replay cannot drift. `touch` is the shell's persistent level
-/// state: `Begin` upserts the contact (materializing the domain — receiving a
+/// state: `Begin` adds the contact (materializing the domain — receiving a
 /// touch event IS the capability signal), `Move` repositions it, `End` and
 /// `Cancel` remove it. Edges record like keyboard edges — de-duplicated, a
 /// `Cancel` reporting through `released` so a stolen gesture never leaks a
-/// held contact. `record_edge` follows
-/// [`apply_key_transition_to_snapshot`]'s recovery-only semantics. Returns
+/// held contact. A `Begin` on an id already held means a release was lost
+/// (ids are reused ordinals): it records an implicit release at the stale
+/// position and a fresh press, so neither contact is swallowed. Unlike the
+/// keyboard reducers there is no silent-recovery mode — a touch removal is
+/// always model-visible, which is the never-leaks-held guarantee. Returns
 /// whether the level state actually changed.
 pub fn apply_touch_transition(
     touch: &mut Option<TouchSnapshot>,
     edges: &mut InputEdges,
     phase: TouchPhase,
     point: TouchPoint,
-    record_edge: bool,
 ) -> bool {
     match phase {
         TouchPhase::Begin => {
             let touch = touch.get_or_insert_with(TouchSnapshot::default);
-            let was_down = touch.touches.iter().any(|p| p.id == point.id);
             match touch.touches.iter_mut().find(|p| p.id == point.id) {
-                Some(existing) => *existing = point,
-                None => touch.touches.push(point),
-            }
-            if !was_down && record_edge {
-                edges.touch_transition(point, true);
+                Some(existing) => {
+                    edges.touch_transition(*existing, false);
+                    edges.touch_transition(point, true);
+                    *existing = point;
+                }
+                None => {
+                    touch.touches.push(point);
+                    edges.touch_transition(point, true);
+                }
             }
             true
         }
@@ -382,9 +401,7 @@ pub fn apply_touch_transition(
                 return false;
             };
             levels.touches.remove(index);
-            if record_edge {
-                edges.touch_transition(point, false);
-            }
+            edges.touch_transition(point, false);
             true
         }
     }
@@ -1520,7 +1537,6 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(0, 10.0, 20.0),
-            true,
         ));
         // Move repositions the level without a new edge; moving an unknown
         // contact is a no-op.
@@ -1529,14 +1545,12 @@ mod tests {
             &mut edges,
             TouchPhase::Move,
             point(0, 15.0, 25.0),
-            true,
         ));
         assert!(!apply_touch_transition(
             &mut touch,
             &mut edges,
             TouchPhase::Move,
             point(7, 0.0, 0.0),
-            true,
         ));
         // A second contact, then a quick tap of it before the step: both its
         // edges survive while the level is already gone.
@@ -1545,14 +1559,12 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(1, 100.0, 100.0),
-            true,
         ));
         assert!(apply_touch_transition(
             &mut touch,
             &mut edges,
             TouchPhase::End,
             point(1, 101.0, 99.0),
-            true,
         ));
 
         let mut snapshot = InputSnapshot {
@@ -1576,14 +1588,13 @@ mod tests {
         assert_eq!(sampled.touches, vec![point(0, 15.0, 25.0)]);
 
         // Cancel reports through released — a stolen gesture never leaks a
-        // held contact — and a recovery-only sweep (record_edge: false)
-        // clears the level without inventing a model-visible edge.
+        // held contact. There is deliberately no silent-recovery mode: every
+        // touch removal is model-visible.
         assert!(apply_touch_transition(
             &mut touch,
             &mut edges,
             TouchPhase::Cancel,
             point(0, 15.0, 25.0),
-            true,
         ));
         let mut cancelled = InputSnapshot {
             touch: touch.clone(),
@@ -1599,8 +1610,35 @@ mod tests {
             &mut edges,
             TouchPhase::End,
             point(0, 15.0, 25.0),
-            true,
         ));
+
+        // A Begin on an id already held means an End was lost (ids are
+        // reused ordinals): the reducer records an implicit release at the
+        // STALE position plus a fresh press, so neither contact is swallowed.
+        let mut edges = InputEdges::default();
+        let mut reused: Option<TouchSnapshot> = None;
+        apply_touch_transition(
+            &mut reused,
+            &mut edges,
+            TouchPhase::Begin,
+            point(0, 10.0, 10.0),
+        );
+        edges.clear();
+        apply_touch_transition(
+            &mut reused,
+            &mut edges,
+            TouchPhase::Begin,
+            point(0, 90.0, 90.0),
+        );
+        let mut relanded = InputSnapshot::default();
+        edges.apply_to(&mut relanded);
+        let sampled = relanded.touch.as_ref().unwrap();
+        assert_eq!(sampled.released, vec![point(0, 10.0, 10.0)]);
+        assert_eq!(sampled.pressed, vec![point(0, 90.0, 90.0)]);
+        assert_eq!(
+            reused.as_ref().unwrap().touches,
+            vec![point(0, 90.0, 90.0)]
+        );
 
         // A tap landing entirely between steps still reaches the game even
         // when no level state existed: pending edges materialize the domain.
@@ -1611,14 +1649,12 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(3, 5.0, 5.0),
-            true,
         );
         apply_touch_transition(
             &mut fresh,
             &mut edges,
             TouchPhase::End,
             point(3, 5.0, 5.0),
-            true,
         );
         let mut bare = InputSnapshot::default();
         edges.apply_to(&mut bare);

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -6,9 +6,10 @@ use crate::TrackingPose;
 ///
 /// Keyboard and mouse retain their event entry points, while this plain-data
 /// snapshot exposes both levels and de-duplicated transitions through the
-/// extensible shell → producer seam. XR and gamepad are typed device domains;
-/// mobile touch can add a sibling field without turning device capabilities
-/// into stringly-typed maps or adding target-specific producer methods.
+/// extensible shell → producer seam. XR, gamepad, and touch are typed device
+/// domains; further devices add sibling fields without turning device
+/// capabilities into stringly-typed maps or adding target-specific producer
+/// methods.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct InputSnapshot {
     /// Keys currently held, in canonical discriminant order.
@@ -37,6 +38,60 @@ pub struct InputSnapshot {
     /// Omitted rather than serialized as `null` when absent, like `xr`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gamepad: Option<GamepadSnapshot>,
+    /// Live touch contacts when the target supplies them. `Some` signals
+    /// touch CAPABILITY (a touch surface exists — the web shell sets it on
+    /// touch-capable devices before any contact), so a game can decide to
+    /// show touch UI; an idle touchscreen is `Some` with empty lists, and
+    /// `None` means no touch surface at all.
+    ///
+    /// Omitted rather than serialized as `null` when absent, like `xr`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub touch: Option<TouchSnapshot>,
+}
+
+/// One touch contact in the same top-left-origin logical coordinate space as
+/// [`MouseSnapshot`] (window points natively, CSS pixels on web). `id` is a
+/// small shell-assigned ordinal stable for the contact's lifetime — shells
+/// remap the platform's arbitrary identifiers.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TouchPoint {
+    pub id: u32,
+    pub x: f32,
+    pub y: f32,
+}
+
+/// Touch levels and this step's de-duplicated transitions.
+///
+/// `touches` are the active contacts at their current positions — the level
+/// complement of the edge lists, exactly the keyboard's
+/// `held`/`pressed`/`released` contract: `pressed`/`released` survive render
+/// frames with no simulation step, are consumed by the first catch-up step,
+/// and are empty on later substeps. A quick tap can appear in both edge
+/// lists while `touches` no longer carries the contact. A cancelled contact
+/// (the platform stole the gesture) reports through `released` — a touch
+/// never leaks held.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TouchSnapshot {
+    pub touches: Vec<TouchPoint>,
+    pub pressed: Vec<TouchPoint>,
+    pub released: Vec<TouchPoint>,
+}
+
+/// One touch contact transition at the shell boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TouchPhase {
+    /// A new contact landed.
+    Begin,
+    /// An active contact moved.
+    Move,
+    /// A contact lifted normally.
+    End,
+    /// The platform stole the contact (gesture navigation, an alert…).
+    /// Delivered to games as a release — never a silently vanished contact.
+    Cancel,
 }
 
 /// Last known mouse position in logical shell coordinates, the matching
@@ -116,12 +171,14 @@ impl MouseButtons {
 /// repeat it. Each control is a set, not an event count — a down/up/down burst
 /// may appear in both halves while the separately sampled held level records
 /// the final state.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct InputEdges {
     pressed_keys: Vec<Key>,
     released_keys: Vec<Key>,
     pressed_mouse: MouseButtons,
     released_mouse: MouseButtons,
+    pressed_touches: Vec<TouchPoint>,
+    released_touches: Vec<TouchPoint>,
 }
 
 impl InputEdges {
@@ -153,12 +210,40 @@ impl InputEdges {
         }
     }
 
+    /// Record a touch-contact edge. De-duplicated by id: a repeated begin (or
+    /// end) for a contact already in the list updates its position instead of
+    /// duplicating the entry.
+    fn touch_transition(&mut self, point: TouchPoint, is_down: bool) {
+        let edges = if is_down {
+            &mut self.pressed_touches
+        } else {
+            &mut self.released_touches
+        };
+        match edges.iter_mut().find(|p| p.id == point.id) {
+            Some(existing) => *existing = point,
+            None => edges.push(point),
+        }
+    }
+
     /// Copy the pending transitions into a step snapshot.
     pub fn apply_to(&self, snapshot: &mut InputSnapshot) {
         snapshot.pressed_keys.clone_from(&self.pressed_keys);
         snapshot.released_keys.clone_from(&self.released_keys);
         snapshot.mouse.pressed = self.pressed_mouse;
         snapshot.mouse.released = self.released_mouse;
+        // Touch edges land inside the optional domain. A tap that began and
+        // ended between steps still must reach the game, so pending edges
+        // materialize the domain even when no contact is currently held.
+        if let Some(touch) = snapshot.touch.as_mut() {
+            touch.pressed.clone_from(&self.pressed_touches);
+            touch.released.clone_from(&self.released_touches);
+        } else if !self.pressed_touches.is_empty() || !self.released_touches.is_empty() {
+            snapshot.touch = Some(TouchSnapshot {
+                touches: Vec::new(),
+                pressed: self.pressed_touches.clone(),
+                released: self.released_touches.clone(),
+            });
+        }
     }
 
     /// Clear consumed transitions while retaining key-vector capacity for the
@@ -168,6 +253,8 @@ impl InputEdges {
         self.released_keys.clear();
         self.pressed_mouse = MouseButtons::default();
         self.released_mouse = MouseButtons::default();
+        self.pressed_touches.clear();
+        self.released_touches.clear();
     }
 }
 
@@ -179,6 +266,10 @@ impl InputSnapshot {
         self.released_keys.clear();
         self.mouse.pressed = MouseButtons::default();
         self.mouse.released = MouseButtons::default();
+        if let Some(touch) = self.touch.as_mut() {
+            touch.pressed.clear();
+            touch.released.clear();
+        }
     }
 }
 
@@ -240,6 +331,63 @@ pub fn apply_mouse_transition_to_snapshot(
         edges.mouse_transition(button, was_down, is_down);
     }
     true
+}
+
+/// Fold one touch-contact transition into shell-held touch level state.
+///
+/// The ONE reducer every shell (web events, debug injection) shares, so live
+/// input and replay cannot drift. `touch` is the shell's persistent level
+/// state: `Begin` upserts the contact (materializing the domain — receiving a
+/// touch event IS the capability signal), `Move` repositions it, `End` and
+/// `Cancel` remove it. Edges record like keyboard edges — de-duplicated, a
+/// `Cancel` reporting through `released` so a stolen gesture never leaks a
+/// held contact. `record_edge` follows
+/// [`apply_key_transition_to_snapshot`]'s recovery-only semantics. Returns
+/// whether the level state actually changed.
+pub fn apply_touch_transition(
+    touch: &mut Option<TouchSnapshot>,
+    edges: &mut InputEdges,
+    phase: TouchPhase,
+    point: TouchPoint,
+    record_edge: bool,
+) -> bool {
+    match phase {
+        TouchPhase::Begin => {
+            let touch = touch.get_or_insert_with(TouchSnapshot::default);
+            let was_down = touch.touches.iter().any(|p| p.id == point.id);
+            match touch.touches.iter_mut().find(|p| p.id == point.id) {
+                Some(existing) => *existing = point,
+                None => touch.touches.push(point),
+            }
+            if !was_down && record_edge {
+                edges.touch_transition(point, true);
+            }
+            true
+        }
+        TouchPhase::Move => match touch
+            .as_mut()
+            .and_then(|t| t.touches.iter_mut().find(|p| p.id == point.id))
+        {
+            Some(existing) => {
+                *existing = point;
+                true
+            }
+            None => false,
+        },
+        TouchPhase::End | TouchPhase::Cancel => {
+            let Some(levels) = touch.as_mut() else {
+                return false;
+            };
+            let Some(index) = levels.touches.iter().position(|p| p.id == point.id) else {
+                return false;
+            };
+            levels.touches.remove(index);
+            if record_edge {
+                edges.touch_transition(point, false);
+            }
+            true
+        }
+    }
 }
 
 /// One frame of XR input in the tracking rig's local coordinates.
@@ -899,6 +1047,28 @@ fn gamepad_value(pad: &GamepadSnapshot) -> functor_lang::Value {
     ])
 }
 
+fn touch_value(touch: &TouchSnapshot) -> functor_lang::Value {
+    let points = |points: &[TouchPoint]| {
+        functor_lang::Value::List(std::rc::Rc::new(
+            points
+                .iter()
+                .map(|point| {
+                    record([
+                        ("id", functor_lang::Value::Number(point.id as f64)),
+                        ("x", functor_lang::Value::Number(point.x as f64)),
+                        ("y", functor_lang::Value::Number(point.y as f64)),
+                    ])
+                })
+                .collect(),
+        ))
+    };
+    record([
+        ("touches", points(&touch.touches)),
+        ("pressed", points(&touch.pressed)),
+        ("released", points(&touch.released)),
+    ])
+}
+
 /// Convert the shared shell snapshot into the typed, plain-data
 /// `Input.snapshot` record delivered to a Functor Lang game's optional
 /// `sampledInput` hook.
@@ -951,16 +1121,21 @@ pub fn input_snapshot_value(snapshot: &InputSnapshot) -> functor_lang::Value {
             "gamepad",
             option_value(snapshot.gamepad.as_ref().map(gamepad_value)),
         ),
+        (
+            "touch",
+            option_value(snapshot.touch.as_ref().map(touch_value)),
+        ),
     ])
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_key_transition_to_snapshot, apply_mouse_transition_to_snapshot, input_snapshot_value,
-        mouse_button_input_value, tracking_pose_from_value, tracking_pose_value, GamepadSnapshot,
-        InputEdges, InputSnapshot, Key, MouseButton, MouseButtons, MouseSnapshot, RecordedInput,
-        XrControllerSnapshot, XrInputSnapshot,
+        apply_key_transition_to_snapshot, apply_mouse_transition_to_snapshot,
+        apply_touch_transition, input_snapshot_value, mouse_button_input_value,
+        tracking_pose_from_value, tracking_pose_value, GamepadSnapshot, InputEdges, InputSnapshot,
+        Key, MouseButton, MouseButtons, MouseSnapshot, RecordedInput, TouchPhase, TouchPoint,
+        TouchSnapshot, XrControllerSnapshot, XrInputSnapshot,
     };
     use crate::TrackingPose;
 
@@ -1189,10 +1364,10 @@ mod tests {
         let encoded = serde_json::to_string(&xr).unwrap();
         assert_eq!(serde_json::from_str::<InputSnapshot>(&encoded).unwrap(), xr);
 
-        // The gamepad domain follows the same wire contract: omitted when
-        // absent (asserted by the exact desktop JSON above), round-tripped
-        // when present.
-        let pad = InputSnapshot {
+        // The gamepad and touch domains follow the same wire contract:
+        // omitted when absent (asserted by the exact desktop JSON above),
+        // round-tripped when present.
+        let devices = InputSnapshot {
             gamepad: Some(GamepadSnapshot {
                 left_stick: [0.5, -0.5],
                 left_trigger: 1.0,
@@ -1200,12 +1375,25 @@ mod tests {
                 select: true,
                 ..GamepadSnapshot::default()
             }),
+            touch: Some(TouchSnapshot {
+                touches: vec![TouchPoint {
+                    id: 2,
+                    x: 10.5,
+                    y: 20.0,
+                }],
+                pressed: vec![],
+                released: vec![TouchPoint {
+                    id: 0,
+                    x: 1.0,
+                    y: 2.0,
+                }],
+            }),
             ..InputSnapshot::default()
         };
-        let encoded = serde_json::to_string(&pad).unwrap();
+        let encoded = serde_json::to_string(&devices).unwrap();
         assert_eq!(
             serde_json::from_str::<InputSnapshot>(&encoded).unwrap(),
-            pad
+            devices
         );
     }
 
@@ -1252,6 +1440,23 @@ mod tests {
                 dpad_left: true,
                 ..GamepadSnapshot::default()
             }),
+            touch: Some(TouchSnapshot {
+                touches: vec![TouchPoint {
+                    id: 0,
+                    x: 120.0,
+                    y: 48.5,
+                }],
+                pressed: vec![TouchPoint {
+                    id: 0,
+                    x: 118.0,
+                    y: 50.0,
+                }],
+                released: vec![TouchPoint {
+                    id: 1,
+                    x: 300.0,
+                    y: 200.0,
+                }],
+            }),
         };
         let rendered = input_snapshot_value(&snapshot).to_string();
         assert!(
@@ -1283,13 +1488,144 @@ mod tests {
         assert!(rendered.contains("dpadLeft: true"), "{rendered}");
         assert!(rendered.contains("select: false"), "{rendered}");
 
-        // Without a pad the domain is an explicit None, never a zeroed record.
-        let no_pad = InputSnapshot::default();
+        assert!(rendered.contains("touch: Option.Some("), "{rendered}");
         assert!(
-            input_snapshot_value(&no_pad)
-                .to_string()
-                .contains("gamepad: Option.None"),
+            rendered.contains("touches: [{ id: 0, x: 120, y: 48.5 }]"),
+            "{rendered}"
         );
+        assert!(
+            rendered.contains("pressed: [{ id: 0, x: 118, y: 50 }]"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("released: [{ id: 1, x: 300, y: 200 }]"),
+            "{rendered}"
+        );
+
+        // Without a device the domains are explicit None, never zeroed records.
+        let bare = input_snapshot_value(&InputSnapshot::default()).to_string();
+        assert!(bare.contains("gamepad: Option.None"), "{bare}");
+        assert!(bare.contains("touch: Option.None"), "{bare}");
+    }
+
+    #[test]
+    fn touch_transitions_fold_like_keyboard_edges() {
+        let mut touch: Option<TouchSnapshot> = None;
+        let mut edges = InputEdges::default();
+        let point = |id, x, y| TouchPoint { id, x, y };
+
+        // Begin materializes the domain, records a press, and holds the level.
+        assert!(apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::Begin,
+            point(0, 10.0, 20.0),
+            true,
+        ));
+        // Move repositions the level without a new edge; moving an unknown
+        // contact is a no-op.
+        assert!(apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::Move,
+            point(0, 15.0, 25.0),
+            true,
+        ));
+        assert!(!apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::Move,
+            point(7, 0.0, 0.0),
+            true,
+        ));
+        // A second contact, then a quick tap of it before the step: both its
+        // edges survive while the level is already gone.
+        assert!(apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::Begin,
+            point(1, 100.0, 100.0),
+            true,
+        ));
+        assert!(apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::End,
+            point(1, 101.0, 99.0),
+            true,
+        ));
+
+        let mut snapshot = InputSnapshot {
+            touch: touch.clone(),
+            ..InputSnapshot::default()
+        };
+        edges.apply_to(&mut snapshot);
+        let sampled = snapshot.touch.as_ref().unwrap();
+        assert_eq!(sampled.touches, vec![point(0, 15.0, 25.0)]);
+        assert_eq!(
+            sampled.pressed,
+            vec![point(0, 10.0, 20.0), point(1, 100.0, 100.0)]
+        );
+        assert_eq!(sampled.released, vec![point(1, 101.0, 99.0)]);
+
+        // Consumed edges clear from both accumulator and snapshot; levels stay.
+        edges.clear();
+        snapshot.clear_edges();
+        let sampled = snapshot.touch.as_ref().unwrap();
+        assert!(sampled.pressed.is_empty() && sampled.released.is_empty());
+        assert_eq!(sampled.touches, vec![point(0, 15.0, 25.0)]);
+
+        // Cancel reports through released — a stolen gesture never leaks a
+        // held contact — and a recovery-only sweep (record_edge: false)
+        // clears the level without inventing a model-visible edge.
+        assert!(apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::Cancel,
+            point(0, 15.0, 25.0),
+            true,
+        ));
+        let mut cancelled = InputSnapshot {
+            touch: touch.clone(),
+            ..InputSnapshot::default()
+        };
+        edges.apply_to(&mut cancelled);
+        let sampled = cancelled.touch.as_ref().unwrap();
+        assert!(sampled.touches.is_empty());
+        assert_eq!(sampled.released, vec![point(0, 15.0, 25.0)]);
+        // Ending an already-gone contact is a no-op.
+        assert!(!apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::End,
+            point(0, 15.0, 25.0),
+            true,
+        ));
+
+        // A tap landing entirely between steps still reaches the game even
+        // when no level state existed: pending edges materialize the domain.
+        let mut edges = InputEdges::default();
+        let mut fresh: Option<TouchSnapshot> = None;
+        apply_touch_transition(
+            &mut fresh,
+            &mut edges,
+            TouchPhase::Begin,
+            point(3, 5.0, 5.0),
+            true,
+        );
+        apply_touch_transition(
+            &mut fresh,
+            &mut edges,
+            TouchPhase::End,
+            point(3, 5.0, 5.0),
+            true,
+        );
+        let mut bare = InputSnapshot::default();
+        edges.apply_to(&mut bare);
+        let sampled = bare.touch.as_ref().unwrap();
+        assert!(sampled.touches.is_empty());
+        assert_eq!(sampled.pressed, vec![point(3, 5.0, 5.0)]);
+        assert_eq!(sampled.released, vec![point(3, 5.0, 5.0)]);
     }
 
     /// The mapping tables' ONLY failure mode is a wrong index, so each entry

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -71,6 +71,10 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v15: the touch device domain — [`crate::InputSnapshot::touch`], defaulted
+/// (and omitted when absent) when decoding older samples, so retained
+/// recordings remain readable.
+///
 /// v14: generalized scene instancing — the `SceneObject::Instanced` variant,
 /// carrying a template subtree plus one compact channel record per copy
 /// (position, quaternion rotation, per-axis scale, tint). Only scenes that

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -124,7 +124,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 14;
+pub const PROTOCOL_VERSION: u32 = 15;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -638,7 +638,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 14);
+        assert_eq!(PROTOCOL_VERSION, 15);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -665,7 +665,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 14);
+        assert_eq!(PROTOCOL_VERSION, 15);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],
@@ -688,7 +688,7 @@ mod tests {
     fn opacity_subtree_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 14);
+        assert_eq!(PROTOCOL_VERSION, 15);
         let scene = SceneObject::Opacity(
             0.35,
             vec![Scene3D {
@@ -712,7 +712,7 @@ mod tests {
     fn instanced_wire_is_pinned() {
         use crate::{InstanceData, MaterialDescription, Scene3D, SceneObject};
 
-        assert_eq!(PROTOCOL_VERSION, 14);
+        assert_eq!(PROTOCOL_VERSION, 15);
         let template = Scene3D {
             obj: SceneObject::Material(
                 MaterialDescription::lit(1.0, 0.5, 0.25, 1.0),
@@ -742,7 +742,7 @@ mod tests {
     fn two_bone_reach_animation_wire_is_pinned() {
         use crate::anim::AnimExpr;
 
-        assert_eq!(PROTOCOL_VERSION, 14);
+        assert_eq!(PROTOCOL_VERSION, 15);
         let reach = AnimExpr::Reach {
             root: "upper".to_string(),
             middle: "lower".to_string(),

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -16,7 +16,7 @@ use functor_runtime_common::net::DeliveredEvent;
 use functor_runtime_common::viewer::{camera_frustum_lines, DebugCamera, DebugPresentation};
 use functor_runtime_common::{
     Frame, FrameTime, GameClock, InputEdges, InputSnapshot, MouseButtons, MouseSnapshot,
-    GamepadSnapshot, RecordedInput, SceneContext, XrInputSnapshot,
+    GamepadSnapshot, RecordedInput, SceneContext, TouchSnapshot, XrInputSnapshot,
 };
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -120,6 +120,10 @@ fn sampled_input_snapshot(
     held_buttons: MouseButtons,
     edges: &InputEdges,
     xr: Option<XrInputSnapshot>,
+    // Touch LEVELS (active contacts) — set before `edges.apply_to`, which
+    // fills the domain's pressed/released lists (and materializes it for a
+    // between-steps tap even when no contact is held).
+    touch: Option<&TouchSnapshot>,
 ) -> InputSnapshot {
     let mut snapshot = InputSnapshot {
         held_keys: held_keys.iter().copied().collect(),
@@ -132,6 +136,7 @@ fn sampled_input_snapshot(
             ..MouseSnapshot::default()
         },
         xr,
+        touch: touch.cloned(),
         ..InputSnapshot::default()
     };
     edges.apply_to(&mut snapshot);
@@ -166,6 +171,8 @@ fn desktop_input_snapshot(
     // has no GLFW instance and always passes `polled_gamepad: None`.
     gamepad_override: Option<&GamepadSnapshot>,
     polled_gamepad: Option<&GamepadSnapshot>,
+    // Injected touch level state (desktop has no touch hardware source).
+    touch: Option<&TouchSnapshot>,
 ) -> InputSnapshot {
     let xr = match xr_override {
         Some(injected) => Some(injected.clone()),
@@ -174,7 +181,7 @@ fn desktop_input_snapshot(
         }),
     };
     let mut snapshot =
-        sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr);
+        sampled_input_snapshot(held_keys, mouse_pos, xr_surface, held_buttons, edges, xr, touch);
     snapshot.gamepad = gamepad_override.or(polled_gamepad).cloned();
     snapshot
 }
@@ -321,10 +328,20 @@ fn refresh_fixed_input_levels(
     // `override > polled > None`, resolved here like `desktop_input_snapshot`.
     gamepad_override: Option<&GamepadSnapshot>,
     polled_gamepad: Option<&GamepadSnapshot>,
+    touch: Option<&TouchSnapshot>,
 ) {
     snapshot.held_keys = held_keys.iter().copied().collect();
     snapshot.mouse.buttons = held_buttons;
     snapshot.gamepad = gamepad_override.or(polled_gamepad).cloned();
+    // Refresh touch LEVELS only — the snapshot's pressed/released lists are
+    // owned by the separate edge application, exactly like keyboard edges.
+    if let Some(levels) = touch {
+        snapshot
+            .touch
+            .get_or_insert_with(TouchSnapshot::default)
+            .touches
+            .clone_from(&levels.touches);
+    }
     // An injected sample owns the whole XR domain — window keys must not
     // re-derive its trigger/thumbstick out from under the driver.
     match xr_override {
@@ -1034,6 +1051,9 @@ fn service_debug_request(
     xr_override: &mut Option<XrInputSnapshot>,
     // The debug-injected gamepad sample — the XR contract for the pad domain.
     gamepad_override: &mut Option<GamepadSnapshot>,
+    // Injected touch level state, maintained by the shared transition reducer
+    // (desktop has no touch hardware; injection is the domain's only source).
+    touch_levels: &mut Option<functor_runtime_common::TouchSnapshot>,
     state_input: InputSnapshot,
     emulate_xr: bool,
     clock: &mut GameClock,
@@ -1186,6 +1206,7 @@ fn service_debug_request(
                     | debug_server::InputCommand::XrClear
                     | debug_server::InputCommand::Gamepad(_)
                     | debug_server::InputCommand::GamepadClear
+                    | debug_server::InputCommand::Touch { .. }
             );
             let result = match cmd {
                 debug_server::InputCommand::Key { key, down } => {
@@ -1285,6 +1306,20 @@ fn service_debug_request(
                     *gamepad_override = None;
                     Ok(())
                 }
+                debug_server::InputCommand::Touch { phase, id, x, y } => {
+                    // Evented, not whole-sample: fold through the SAME
+                    // transition reducer platform touch events take, so the
+                    // injected tap/drag lands in the recorded input log and
+                    // replays identically.
+                    functor_runtime_common::apply_touch_transition(
+                        touch_levels,
+                        edges,
+                        phase,
+                        functor_runtime_common::TouchPoint { id, x, y },
+                        true,
+                    );
+                    Ok(())
+                }
             };
             // Input injected while PAUSED journals entry-point calls no `tick`
             // will sweep — fold them into the inspector's last-frame journal so
@@ -1336,6 +1371,7 @@ fn run_headless(
     };
     let mut xr_override: Option<XrInputSnapshot> = None;
     let mut gamepad_override: Option<GamepadSnapshot> = None;
+    let mut touch_levels: Option<TouchSnapshot> = None;
     // Keep the debug protocol target-isomorphic even without pixels: uploaded
     // assets can be accepted now and are ready if headless rendering gains an
     // asset path later.
@@ -1404,6 +1440,7 @@ fn run_headless(
                     xr_override.as_ref(),
                     gamepad_override.as_ref(),
                     None,
+                    touch_levels.as_ref(),
                 );
                 game.sampled_input(&snapshot);
             }
@@ -1432,6 +1469,7 @@ fn run_headless(
                     xr_override.as_ref(),
                     gamepad_override.as_ref(),
                     None,
+                    touch_levels.as_ref(),
                 );
                 service_debug_request(
                     req,
@@ -1447,6 +1485,7 @@ fn run_headless(
                     &mut input_edges,
                     &mut xr_override,
                     &mut gamepad_override,
+                    &mut touch_levels,
                     state_input,
                     emulate_xr,
                     &mut clock,
@@ -1821,6 +1860,7 @@ Escape releases while captured"
         let mut xr_primary_clicked = false;
         let mut xr_override: Option<XrInputSnapshot> = None;
         let mut gamepad_override: Option<GamepadSnapshot> = None;
+        let mut touch_levels: Option<TouchSnapshot> = None;
         // The pad polled from GLFW this frame; a debug-injected override wins
         // over it at every sample site (`override > polled > None`).
         let mut polled_gamepad: Option<GamepadSnapshot> = None;
@@ -1840,6 +1880,7 @@ Escape releases while captured"
             xr_override.as_ref(),
             gamepad_override.as_ref(),
             polled_gamepad.as_ref(),
+            touch_levels.as_ref(),
         );
         // Whether the window owns the pointer (free-look). Capture is always
         // entered by a non-overlay click; see the Escape / MouseButton / Focus
@@ -2018,6 +2059,7 @@ then restart the runner"
                             xr_override.as_ref(),
                             gamepad_override.as_ref(),
                             polled_gamepad.as_ref(),
+                            touch_levels.as_ref(),
                         );
                     }
                     window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -2142,6 +2184,7 @@ then restart the runner"
                                     xr_override.as_ref(),
                                     gamepad_override.as_ref(),
                                     polled_gamepad.as_ref(),
+                                    touch_levels.as_ref(),
                                 );
                             }
                             window.set_cursor_mode(glfw::CursorMode::Normal);
@@ -2194,6 +2237,7 @@ Escape again to quit"
                                 xr_override.as_ref(),
                                 gamepad_override.as_ref(),
                                 polled_gamepad.as_ref(),
+                                touch_levels.as_ref(),
                             );
                         }
                         if !hidden {
@@ -2393,6 +2437,7 @@ Escape again to quit"
                                 xr_override.as_ref(),
                                 gamepad_override.as_ref(),
                                 polled_gamepad.as_ref(),
+                                touch_levels.as_ref(),
                             );
                         }
                     }
@@ -2440,6 +2485,7 @@ Escape again to quit"
                                     xr_override.as_ref(),
                                     gamepad_override.as_ref(),
                                     polled_gamepad.as_ref(),
+                                    touch_levels.as_ref(),
                                 );
                             }
                         }
@@ -2485,6 +2531,7 @@ Escape again to quit"
                                     xr_override.as_ref(),
                                     gamepad_override.as_ref(),
                                     polled_gamepad.as_ref(),
+                                    touch_levels.as_ref(),
                                 );
                             }
                         }
@@ -2529,6 +2576,7 @@ Escape again to quit"
                                 xr_override.as_ref(),
                                 gamepad_override.as_ref(),
                                 polled_gamepad.as_ref(),
+                                touch_levels.as_ref(),
                             );
                         }
                     }
@@ -2692,6 +2740,7 @@ Escape again to quit"
                             xr_override.as_ref(),
                             gamepad_override.as_ref(),
                             polled_gamepad.as_ref(),
+                            touch_levels.as_ref(),
                         );
                         game.sampled_input(&snapshot);
                     }
@@ -3488,6 +3537,7 @@ Escape again to quit"
                             xr_override.as_ref(),
                             gamepad_override.as_ref(),
                             polled_gamepad.as_ref(),
+                            touch_levels.as_ref(),
                         )
                     };
                     let sampled_input_changed = service_debug_request(
@@ -3504,6 +3554,7 @@ Escape again to quit"
                         &mut input_edges,
                         &mut xr_override,
                         &mut gamepad_override,
+                        &mut touch_levels,
                         state_input,
                         args.emulate_xr,
                         &mut clock,
@@ -3541,6 +3592,7 @@ Escape again to quit"
                             xr_override.as_ref(),
                             gamepad_override.as_ref(),
                             polled_gamepad.as_ref(),
+                            touch_levels.as_ref(),
                         );
                     }
                 }
@@ -3852,6 +3904,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let pose = snapshot
             .xr
@@ -3869,6 +3922,7 @@ mod tests {
             &held,
             buttons,
             false,
+            None,
             None,
             None,
             None,
@@ -3912,6 +3966,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(snapshot.held_keys.is_empty());
         assert_eq!(snapshot.pressed_keys, vec![InputKey::Space]);
@@ -3934,6 +3989,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert_eq!(before.mouse.surface_width, 800);
         assert_eq!(before.mouse.surface_height, 600);
@@ -3949,6 +4005,7 @@ mod tests {
             false,
             false,
             (1440, 900),
+            None,
             None,
             None,
             None,
@@ -4005,6 +4062,7 @@ mod tests {
             Some(&injected),
             None,
             None,
+            None,
         );
         assert_eq!(snapshot.xr.as_ref(), Some(&injected));
         // Keyboard/mouse domains stay live alongside it.
@@ -4035,6 +4093,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert_eq!(plain.xr, None, "no XR domain without a device or injection");
 
@@ -4047,6 +4106,7 @@ mod tests {
             false,
             (800, 600),
             Some(&injected),
+            None,
             None,
             None,
         );
@@ -4071,6 +4131,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert_eq!(
             plain.gamepad, None,
@@ -4088,6 +4149,7 @@ mod tests {
             None,
             Some(&pad),
             None,
+            None,
         );
         assert_eq!(snapshot.gamepad.as_ref(), Some(&pad));
 
@@ -4101,6 +4163,7 @@ mod tests {
             None,
             Some(&pad),
             None,
+            None,
         );
         assert_eq!(snapshot.gamepad.as_ref(), Some(&pad));
         refresh_fixed_input_levels(
@@ -4108,6 +4171,7 @@ mod tests {
             &BTreeSet::new(),
             MouseButtons::default(),
             false,
+            None,
             None,
             None,
             None,
@@ -4132,6 +4196,7 @@ mod tests {
             None,
             Some(&pad),
             Some(&polled),
+            None,
         );
         assert_eq!(resolved.gamepad.as_ref(), Some(&pad));
         let polled_only = desktop_input_snapshot(
@@ -4145,6 +4210,7 @@ mod tests {
             None,
             None,
             Some(&polled),
+            None,
         );
         assert_eq!(polled_only.gamepad.as_ref(), Some(&polled));
     }
@@ -4163,6 +4229,7 @@ mod tests {
             Some(&injected),
             None,
             None,
+            None,
         );
         // Space would drive the EMULATOR's trigger to 1.0; the injected sample
         // owns the XR domain, so window keys must leave it alone.
@@ -4174,6 +4241,7 @@ mod tests {
             MouseButtons::default(),
             true,
             Some(&injected),
+            None,
             None,
             None,
         );

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -335,6 +335,12 @@ fn refresh_fixed_input_levels(
     snapshot.gamepad = gamepad_override.or(polled_gamepad).cloned();
     // Refresh touch LEVELS only — the snapshot's pressed/released lists are
     // owned by the separate edge application, exactly like keyboard edges.
+    // Deliberately add-only, unlike the wholesale xr/gamepad assignments:
+    // touch capability is sticky (no source ever un-declares a surface), so
+    // there is no None case to propagate. Today every injection also
+    // rebuilds the fixed snapshot wholesale (`sampled_input_changed`), so
+    // this refresh re-clones identical data — it exists so the level-refresh
+    // contract stays uniform across domains for any future polled source.
     if let Some(levels) = touch {
         snapshot
             .touch
@@ -1316,7 +1322,6 @@ fn service_debug_request(
                         edges,
                         phase,
                         functor_runtime_common::TouchPoint { id, x, y },
-                        true,
                     );
                     Ok(())
                 }
@@ -4213,6 +4218,68 @@ mod tests {
             None,
         );
         assert_eq!(polled_only.gamepad.as_ref(), Some(&polled));
+    }
+
+    #[test]
+    fn touch_levels_precede_edge_application_and_survive_refresh() {
+        use functor_runtime_common::{TouchPhase, TouchPoint, TouchSnapshot};
+        let point = |id, x, y| TouchPoint { id, x, y };
+
+        // Injection path: a begin folds into the shell-held levels + edges.
+        let mut touch_levels: Option<TouchSnapshot> = None;
+        let mut edges = InputEdges::default();
+        functor_runtime_common::apply_touch_transition(
+            &mut touch_levels,
+            &mut edges,
+            TouchPhase::Begin,
+            point(0, 40.0, 30.0),
+        );
+
+        // The builder sets levels BEFORE applying edges, so the same
+        // snapshot carries both the held contact and its press edge.
+        let snapshot = desktop_input_snapshot(
+            &BTreeSet::new(),
+            (0, 0),
+            MouseButtons::default(),
+            &edges,
+            false,
+            false,
+            (800, 600),
+            None,
+            None,
+            None,
+            touch_levels.as_ref(),
+        );
+        let touch = snapshot.touch.as_ref().unwrap();
+        assert_eq!(touch.touches, vec![point(0, 40.0, 30.0)]);
+        assert_eq!(touch.pressed, vec![point(0, 40.0, 30.0)]);
+
+        // The fixed-step refresh updates LEVELS while preserving the edge
+        // lists a separate edge application already placed.
+        let mut fixed = snapshot.clone();
+        functor_runtime_common::apply_touch_transition(
+            &mut touch_levels,
+            &mut edges,
+            TouchPhase::Move,
+            point(0, 60.0, 70.0),
+        );
+        refresh_fixed_input_levels(
+            &mut fixed,
+            &BTreeSet::new(),
+            MouseButtons::default(),
+            false,
+            None,
+            None,
+            None,
+            touch_levels.as_ref(),
+        );
+        let touch = fixed.touch.as_ref().unwrap();
+        assert_eq!(touch.touches, vec![point(0, 60.0, 70.0)]);
+        assert_eq!(
+            touch.pressed,
+            vec![point(0, 40.0, 30.0)],
+            "refresh must not clobber separately-applied edges"
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -757,6 +757,11 @@ tracking); use the desktop runtime's --headless/--debug-port path"
 desktop runtime's --headless/--debug-port path"
                         .to_string(),
                 ),
+                InputCommand::Touch { .. } => Err(
+                    "touch injection is unsupported on the device runtime; use the \
+desktop runtime's --headless/--debug-port path"
+                        .to_string(),
+                ),
             };
             if clock.is_paused() {
                 game.absorb_paused_input();

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -670,7 +670,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (28, 319));
+        assert_eq!(count(ApiGroup::Engine), (28, 321));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules

--- a/tools/functor-sdk/src/game.ts
+++ b/tools/functor-sdk/src/game.ts
@@ -11,6 +11,8 @@ import type {
   Scene,
   StepUntilOptions,
   WaitForOptions,
+  TouchPhaseName,
+  TouchSnapshot,
   XrInputSample,
   XrInputSnapshot,
 } from "./types.js";
@@ -75,6 +77,11 @@ export class FunctorClient {
    * injected). */
   async gamepadInput(): Promise<GamepadSnapshot | undefined> {
     return (await this.state()).input.gamepad;
+  }
+
+  /** Latest touch snapshot, or undefined on targets with no touch input. */
+  async touchInput(): Promise<TouchSnapshot | undefined> {
+    return (await this.state()).input.touch;
   }
 
   /** Capture the next rendered frame as PNG bytes. */
@@ -232,6 +239,15 @@ export class FunctorClient {
    * release half of {@link gamepad}'s held-key contract. */
   gamepadClear(): Promise<void> {
     return this.input({ type: "gamepad_clear" });
+  }
+
+  /** Inject one touch-contact transition (phases `begin`/`move`/`end`/
+   * `cancel`). Evented like {@link keyDown}, not whole-sample like
+   * {@link xr}: each call folds through the same reducer real touch events
+   * take, so a scripted tap or drag is recorded and replays identically.
+   * End every begun `id` to release the domain's contacts. */
+  touch(phase: TouchPhaseName, id: number, x: number, y: number): Promise<void> {
+    return this.input({ type: "touch", phase, id, x, y });
   }
 
   /** Click an interactive UI slot (`Clicked` in the runtime's UI protocol). */

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -63,6 +63,26 @@ export interface GamepadSnapshot {
   select: boolean;
 }
 
+/** One touch contact in the mouse's logical coordinate space. `id` is a
+ * small ordinal stable for the contact's lifetime. */
+export interface TouchPoint {
+  id: number;
+  x: number;
+  y: number;
+}
+
+/** Active touch contacts plus one step's de-duplicated transitions — the
+ * keyboard contract for fingers. A cancelled contact reports through
+ * `released`. */
+export interface TouchSnapshot {
+  touches: TouchPoint[];
+  pressed: TouchPoint[];
+  released: TouchPoint[];
+}
+
+/** Wire spelling of a touch transition phase for `POST /input`. */
+export type TouchPhaseName = "begin" | "move" | "end" | "cancel";
+
 /** Wire spelling of a mouse button for `POST /input`. */
 export type MouseButtonName = "left" | "right" | "middle";
 
@@ -111,6 +131,9 @@ export interface InputSnapshot {
    * polling — rest levels while unfocused/pinned) or a sample is injected;
    * absent on headless, which polls nothing. */
   gamepad?: GamepadSnapshot;
+  /** Present while a touch surface exists (or a touch was injected); empty
+   * lists while idle. Absent on targets with no touch input at all. */
+  touch?: TouchSnapshot;
 }
 
 export interface RuntimeViewport {
@@ -205,7 +228,8 @@ export type InputCommand =
   | ({ type: "xr" } & XrInputSample)
   | { type: "xr_clear" }
   | ({ type: "gamepad" } & GamepadInputSample)
-  | { type: "gamepad_clear" };
+  | { type: "gamepad_clear" }
+  | { type: "touch"; phase: TouchPhaseName; id: number; x: number; y: number };
 
 /** An injected gamepad sample for `POST /input` (desktop only) — the
  * {@link XrInputSample} contract for the pad domain: level state until

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -95,9 +95,9 @@ export interface MouseButtons {
 
 /** Runtime-owned input sampled independently of the game model.
  *
- * Typed device domains extend this record: XR and gamepad are available
- * today; a mobile-touch snapshot can be added without replacing
- * keyboard/mouse or introducing target-specific clients. */
+ * Typed device domains extend this record — XR, gamepad, and touch today;
+ * further devices join as sibling fields without replacing keyboard/mouse or
+ * introducing target-specific clients. */
 export interface InputSnapshot {
   /** Keys currently held, by canonical name. */
   held_keys: KeyName[];

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -510,6 +510,46 @@ test("gamepad() posts a flat, tagged partial sample; gamepadClear() releases it"
   ]);
 });
 
+test("touchInput returns the typed optional input domain", async () => {
+  const touch = {
+    touches: [{ id: 0, x: 120, y: 48 }],
+    pressed: [],
+    released: [{ id: 1, x: 10, y: 10 }],
+  };
+  const http = {
+    getJson: async () => ({
+      frame: 1,
+      tts: 0,
+      viewport: { width: 1, height: 1 },
+      views: [],
+      model: "{}",
+      input: { held_keys: [], mouse: { x: 0, y: 0 }, touch },
+    }),
+  } as unknown as HttpClient;
+  const client = new FunctorClient(http);
+
+  assert.deepEqual(await client.touchInput(), touch);
+});
+
+test("touch() posts one tagged transition per call", async () => {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const http = {
+    postText: async (path: string, body: unknown) => {
+      calls.push({ path, body });
+      return "ok";
+    },
+  } as HttpClient;
+  const client = new FunctorClient(http);
+
+  await client.touch("begin", 0, 40, 30);
+  await client.touch("end", 0, 41, 29);
+
+  assert.deepEqual(calls, [
+    { path: "/input", body: { type: "touch", phase: "begin", id: 0, x: 40, y: 30 } },
+    { path: "/input", body: { type: "touch", phase: "end", id: 0, x: 41, y: 29 } },
+  ]);
+});
+
 test("reloadAssets uploads binary envelopes then finalizes the manifest", async () => {
   const calls: Array<{ path: string; body: unknown }> = [];
   const http = {


### PR DESCRIPTION
Part 4 of the gamepad + touch input series, stacked on #656. The third typed device domain, and the first EVENTED one: touch needs real edges, so `TouchSnapshot` pairs active contacts (levels at current positions) with one-step `pressed`/`released` transition lists — the keyboard contract for fingers.

## Design

- **`touch: Option.t<touch>`** on the snapshot: `Some` = a touch surface EXISTS (empty lists while idle — the cue to show touch UI); `None` = no touch input. `touchPoint = { id, x, y }` in the mouse's logical coordinate space; ids are small shell-assigned ordinals.
- **One shared transition reducer** (`apply_touch_transition`, phases `begin`/`move`/`end`/`cancel`) folds every source — future web events, debug injection — through identical logic, so live input and replay cannot drift. A platform-`cancel` reports through `released`; a `begin` on an already-held id (a lost end — ids are reused) records an implicit release at the stale position plus a fresh press, so **a touch never leaks held and a relanding contact is never swallowed**. There is deliberately no silent-recovery mode: every removal is model-visible.
- **`InputEdges`** gains de-duplicated touch edge lists; `apply_to` materializes the domain for a tap landing entirely between fixed steps. **Replay needs zero new machinery**: levels + edges ride `RecordedInput::Snapshot`, and `clear_edges`/projection already do the right thing (reviewer-verified across zero-substep frames, catch-up substeps, `--fixed-time`, input scripts, and forward projection).
- **Injection is evented**, like `key`: `{"type":"touch","phase":"begin","id":0,"x":10,"y":20}` folds through the reducer (unknown phase → 400). MCP `run_script` gets a `touch()` arm **with restore bookkeeping**: a failed script's leaked contacts are cancelled and code-ended baseline contacts re-begun.
- Protocol v13 / debug protocol v11; SDK `touch()`/`touchInput()` + unit tests; the embedded typed test reads `snapshot.touch` (a `.funi` field drift fails a test). No shell produces the domain from hardware yet — the web touch-event wiring is the next slice, and every doc surface says so.

## Verification

`cargo test -p functor_runtime_common` (695 — reducer/lost-end/materialization/serde/golden tests) and `-p functor-runtime-desktop` (87 — threading + levels-before-edges + refresh-preserves-edges); wasm-target + CLI checks; SDK 22 unit tests; docs check; live headless e2e: begin lands exactly one press edge (consumed once across steps), move repositions the held level, end delivers one release and empties contacts, begin-on-held-id yields the implicit release + fresh press, bad phase 400s.

## xreview

Two-engine adversarial + de-dup pass; all findings addressed in the second commit: the lost-end High, the [AGREED] MCP restore gap, arg-helper/validation consistency, `upsert_touch_point` extraction, the two new coverage gaps, and doc honesty. The reviewers explicitly verified the edge/level machinery clean (no double-consumed or lost edges) and forward-projection semantics consistent with held keys.