### PR TITLE
feat(web): touch events into the sampled snapshot

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -383,9 +383,10 @@ let grab = (s) =>
   coordinate space, a quick tap can appear in both edge lists, and a
   platform-cancelled contact reports through `released`. `Option.Some` with
   empty lists = a touch surface exists but is idle (the cue to show touch
-  UI). No shell produces the domain from hardware yet on ANY target — debug
-  injection (`POST /input` `{"type":"touch","phase":"begin",…}`) is its only
-  source until the web touch-event wiring lands.
+  UI). The web runtime supplies the domain from real touch events
+  (capability declared up front on touch-capable devices); desktop has no
+  touch hardware, so there debug injection
+  (`POST /input` `{"type":"touch","phase":"begin",…}`) is its only source.
 - **Bundled modules use the ordinary module semantics.** The language-owned
   `Net.fun` / `Key.fun` / `Mouse.fun` builtins, `Random.funi` interface, and
   `Option.fun` / `Result.fun` standard-library implementations are in-memory

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -104,6 +104,12 @@ jobs:
       - name: Run gamepad wasm e2e
         run: npm run test:gamepad-wasm
 
+      # Real dispatched TouchEvents → the page bridge (ordinal remap,
+      # preventDefault, phase mapping) → the shared reducer → sampledInput:
+      # capability-before-contact plus a tap's press/release edges.
+      - name: Run touch wasm e2e
+        run: npm run test:touch-wasm
+
       # The multiplayer session hosted in the browser: a server + two client
       # panes, each its own `player.html?net=embedder` runtime, routed by the
       # host page's net coordinator over the embedder seam. Same "works native,

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -485,8 +485,9 @@ unfocused or the clock is pinned. `--headless` has no GLFW instance, so there
 injection is the domain's only source. `touch` carries active contacts plus
 one-step `pressed`/`released` transition lists (the keyboard contract for
 fingers); `Some` with empty lists means a touch surface exists but is idle.
-No shell produces the domain from hardware yet on ANY target — debug
-injection is its only source until the web touch-event wiring lands.
+The web runtime supplies the domain from real touch events (capability
+declared up front on touch-capable devices); desktop has no touch hardware,
+so there debug injection is its only source.
 Further devices
 should add typed sibling fields rather than target-specific endpoints or
 string-keyed capability bags.

--- a/e2e/fixtures/touch/functor.json
+++ b/e2e/fixtures/touch/functor.json
@@ -1,0 +1,1 @@
+{ "language": "functor-lang", "entry": "game.fun" }

--- a/e2e/fixtures/touch/game.fun
+++ b/e2e/fixtures/touch/game.fun
@@ -1,0 +1,41 @@
+// touch e2e fixture: logs "e2e-touch surface" once when the snapshot first
+// carries the touch domain (capability — Some with empty lists), then one
+// "e2e-touch tap …" line once a press AND a release edge have both been
+// sampled (a quick tap can put them in the same snapshot), echoing the press
+// position so the test can assert canvas-relative CSS coordinates.
+
+type Model = { surfaced: bool, taps: float, rels: float, x: float, y: float, logged: bool }
+
+let init = { surfaced: false, taps: 0.0, rels: 0.0, x: 0.0, y: 0.0, logged: false }
+
+let sampledInput = (m: Model, snap: Input.snapshot) =>
+  match snap.touch with
+  | Option.Some(t) =>
+    let surfaced =
+      if not m.surfaced then
+        // Text.length is only a sequencing device: binding the log's return
+        // forces it before the flag flips.
+        let line: string = Debug.log("e2e-touch", "surface") in
+        Text.length(line) > 0.0
+      else m.surfaced in
+    let pressed =
+      t.pressed
+      |> List.head
+      |> Option.map((p: Input.touchPoint) => { m with taps: m.taps + 1.0, x: p.x, y: p.y })
+      |> Option.defaultValue(m) in
+    let counted =
+      { pressed with surfaced: surfaced, rels: pressed.rels + List.length(t.released) } in
+    if not counted.logged && counted.taps > 0.0 && counted.rels > 0.0 then
+      let line: string =
+        Debug.log("e2e-touch", $"tap x={counted.x} y={counted.y} rels={counted.rels}") in
+      { counted with logged: Text.length(line) > 0.0 }
+    else counted
+  | Option.None => m
+
+let tick = (m: Model, dt, tts) => m
+
+let draw = (m: Model, tts) =>
+  Frame.create(
+    Camera3D.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.cube() |> Scene.translate(Vec3.make(m.x / 100.0, 0.0, 0.0)),
+  )

--- a/e2e/fixtures/touch/game.fun
+++ b/e2e/fixtures/touch/game.fun
@@ -4,9 +4,25 @@
 // sampled (a quick tap can put them in the same snapshot), echoing the press
 // position so the test can assert canvas-relative CSS coordinates.
 
-type Model = { surfaced: bool, taps: float, rels: float, x: float, y: float, logged: bool }
+type Model = {
+  surfaced: bool,
+  taps: float,
+  rels: float,
+  x: float,
+  y: float,
+  logged: bool,
+  multiLogged: bool
+}
 
-let init = { surfaced: false, taps: 0.0, rels: 0.0, x: 0.0, y: 0.0, logged: false }
+let init = {
+  surfaced: false,
+  taps: 0.0,
+  rels: 0.0,
+  x: 0.0,
+  y: 0.0,
+  logged: false,
+  multiLogged: false
+}
 
 let sampledInput = (m: Model, snap: Input.snapshot) =>
   match snap.touch with
@@ -25,11 +41,19 @@ let sampledInput = (m: Model, snap: Input.snapshot) =>
       |> Option.defaultValue(m) in
     let counted =
       { pressed with surfaced: surfaced, rels: pressed.rels + List.length(t.released) } in
-    if not counted.logged && counted.taps > 0.0 && counted.rels > 0.0 then
-      let line: string =
-        Debug.log("e2e-touch", $"tap x={counted.x} y={counted.y} rels={counted.rels}") in
-      { counted with logged: Text.length(line) > 0.0 }
-    else counted
+    let tapped =
+      if not counted.logged && counted.taps > 0.0 && counted.rels > 0.0 then
+        let line: string =
+          Debug.log("e2e-touch", $"tap x={counted.x} y={counted.y} rels={counted.rels}") in
+        { counted with logged: Text.length(line) > 0.0 }
+      else counted in
+    // Two simultaneous held contacts: log once, so the e2e can assert the
+    // page bridge assigned distinct ordinals (one shared ordinal would fold
+    // both fingers into a single contact).
+    if not tapped.multiLogged && List.length(t.touches) >= 2.0 then
+      let line: string = Debug.log("e2e-touch", "multi n=2") in
+      { tapped with multiLogged: Text.length(line) > 0.0 }
+    else tapped
   | Option.None => m
 
 let tick = (m: Model, dt, tts) => m

--- a/e2e/gamepad-wasm.mjs
+++ b/e2e/gamepad-wasm.mjs
@@ -18,58 +18,18 @@
 //
 //   npm run build:cli:debug   # once, so target/debug/functor embeds the runtime
 //   node e2e/gamepad-wasm.mjs
-import { execFileSync } from "node:child_process";
-import { createReadStream, statSync } from "node:fs";
-import http from "node:http";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { chromium } from "@playwright/test";
+import {
+  ROOT,
+  expect,
+  launchSoftwareGL,
+  serveExportedBundle,
+  waitFor,
+} from "./wasm-harness.mjs";
 
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DIR = path.join(ROOT, "e2e", "fixtures", "gamepad");
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-console.log(
-  execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", DIR, "build", "wasm"], {
-    encoding: "utf8",
-  })
-);
-
-const TYPES = {
-  ".html": "text/html",
-  ".js": "text/javascript",
-  ".wasm": "application/wasm",
-  ".fun": "text/plain",
-};
-const root = path.join(DIR, "dist", "web");
-const server = http.createServer((req, res) => {
-  let rel = decodeURIComponent(req.url.split("?")[0]);
-  if (rel === "/") rel = "/index.html";
-  const file = path.join(root, rel);
-  try {
-    statSync(file);
-  } catch {
-    res.writeHead(404).end("not found");
-    return;
-  }
-  res.writeHead(200, {
-    "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
-  });
-  createReadStream(file).pipe(res);
-});
-await new Promise((r) => server.listen(0, "127.0.0.1", r));
-const { port } = server.address();
-
-// Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
-// runner — no real GPU needed; this check compares no pixels.
-const browser = await chromium.launch({
-  args: [
-    "--use-gl=angle",
-    "--use-angle=swiftshader",
-    "--enable-unsafe-swiftshader",
-    "--ignore-gpu-blocklist",
-  ],
-});
+const { server, port } = await serveExportedBundle(DIR);
+const browser = await launchSoftwareGL();
 try {
   const page = await browser.newPage({ viewport: { width: 640, height: 480 } });
   const log = [];
@@ -107,23 +67,10 @@ try {
   });
 
   await page.goto(`http://127.0.0.1:${port}/`);
-  const waitFor = async (pattern, what) => {
-    const until = Date.now() + 30000;
-    while (Date.now() < until) {
-      if (log.some((line) => pattern.test(line))) return;
-      await sleep(200);
-    }
-    throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
-  };
-
-  await waitFor(/\[functor-lang\] loaded/, "the game to load");
-  await waitFor(/e2e-gamepad/, "the sampled pad to reach the game");
+  await waitFor(log, /\[functor-lang\] loaded/, "the game to load");
+  await waitFor(log, /e2e-gamepad/, "the sampled pad to reach the game");
 
   const line = log.find((l) => l.includes("e2e-gamepad"));
-  const expect = (cond, what) => {
-    console.log(`  ${cond ? "✓" : "✗"} ${what}`);
-    if (!cond) process.exitCode = 1;
-  };
   expect(line.includes("x=0.5"), `stick X crossed raw (${line})`);
   expect(line.includes("y=1"), "browser down-positive Y negated to up-positive");
   expect(line.includes("rt=0.25"), "analog trigger value (not the digital shadow)");

--- a/e2e/touch-wasm.mjs
+++ b/e2e/touch-wasm.mjs
@@ -1,70 +1,30 @@
 // touch wasm e2e: real browser TouchEvents reach a game's `sampledInput`
 // through the page's touch listeners and the shared transition reducer —
 // capability first (`Some` with empty lists on a touch-capable device before
-// any contact), then a tap's press+release edges with canvas-relative CSS
-// coordinates.
+// any contact), a tap's press+release edges with exact canvas-relative CSS
+// coordinates, distinct ordinals for a two-finger gesture, and the
+// compatibility mouse events staying ALIVE (no preventDefault — `Ui.*`
+// widgets must remain tappable on touch devices).
 //
 // Uses a touch-capable Playwright context (`hasTouch: true`, which also makes
-// `navigator.maxTouchPoints > 0`) and `page.touchscreen.tap` — real
-// dispatched TouchEvents, not synthetic wasm calls, so the whole page bridge
-// (ordinal remap, preventDefault, phase mapping) is exercised. The bundle is
-// exported with `build wasm` and served from an ephemeral port (the
-// e2e/module-role-wasm.mjs shape).
+// `navigator.maxTouchPoints > 0`); `page.touchscreen.tap` plus hand-dispatched
+// two-finger TouchEvents — real DOM events, so the whole page bridge
+// (ordinal remap, phase mapping, coordinates) is exercised.
 //
 //   npm run build:cli:debug   # once, so target/debug/functor embeds the runtime
 //   node e2e/touch-wasm.mjs
-import { execFileSync } from "node:child_process";
-import { createReadStream, statSync } from "node:fs";
-import http from "node:http";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { chromium } from "@playwright/test";
+import {
+  ROOT,
+  expect,
+  launchSoftwareGL,
+  serveExportedBundle,
+  waitFor,
+} from "./wasm-harness.mjs";
 
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const DIR = path.join(ROOT, "e2e", "fixtures", "touch");
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-
-console.log(
-  execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", DIR, "build", "wasm"], {
-    encoding: "utf8",
-  })
-);
-
-const TYPES = {
-  ".html": "text/html",
-  ".js": "text/javascript",
-  ".wasm": "application/wasm",
-  ".fun": "text/plain",
-};
-const root = path.join(DIR, "dist", "web");
-const server = http.createServer((req, res) => {
-  let rel = decodeURIComponent(req.url.split("?")[0]);
-  if (rel === "/") rel = "/index.html";
-  const file = path.join(root, rel);
-  try {
-    statSync(file);
-  } catch {
-    res.writeHead(404).end("not found");
-    return;
-  }
-  res.writeHead(200, {
-    "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
-  });
-  createReadStream(file).pipe(res);
-});
-await new Promise((r) => server.listen(0, "127.0.0.1", r));
-const { port } = server.address();
-
-// Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
-// runner — no real GPU needed; this check compares no pixels.
-const browser = await chromium.launch({
-  args: [
-    "--use-gl=angle",
-    "--use-angle=swiftshader",
-    "--enable-unsafe-swiftshader",
-    "--ignore-gpu-blocklist",
-  ],
-});
+const { server, port } = await serveExportedBundle(DIR);
+const browser = await launchSoftwareGL();
 try {
   const context = await browser.newContext({
     hasTouch: true,
@@ -76,32 +36,63 @@ try {
   page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
 
   await page.goto(`http://127.0.0.1:${port}/`);
-  const waitFor = async (pattern, what) => {
-    const until = Date.now() + 30000;
-    while (Date.now() < until) {
-      if (log.some((line) => pattern.test(line))) return;
-      await sleep(200);
-    }
-    throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
-  };
-
-  await waitFor(/\[functor-lang\] loaded/, "the game to load");
+  await waitFor(log, /\[functor-lang\] loaded/, "the game to load");
   // Capability is declared BEFORE any contact.
-  await waitFor(/e2e-touch.*surface/, "the touch capability to reach the game");
+  await waitFor(log, /e2e-touch.*surface/, "the touch capability to reach the game");
+
+  // Record whether the browser's compatibility mouse events survive the
+  // touch listeners (they must — the Ui.* widget bridge runs on them).
+  await page.evaluate(() => {
+    window.__compatMouse = 0;
+    document
+      .getElementById("canvas")
+      .addEventListener("mousedown", () => (window.__compatMouse += 1));
+  });
 
   await page.touchscreen.tap(200, 150);
-  await waitFor(/e2e-touch.*tap/, "the tap's edges to reach the game");
+  await waitFor(log, /e2e-touch.*tap/, "the tap's edges to reach the game");
 
   const line = log.find((l) => l.includes("e2e-touch") && l.includes("tap"));
-  const expect = (cond, what) => {
-    console.log(`  ${cond ? "✓" : "✗"} ${what}`);
-    if (!cond) process.exitCode = 1;
-  };
-  // X is canvas-relative CSS pixels and unaffected by the scrubber's vertical
-  // offset; Y just needs to be a positive in-canvas coordinate.
-  expect(line.includes("x=200"), `press X in canvas CSS pixels (${line})`);
-  expect(/y=\d/.test(line) && !line.includes("y=-"), "press Y positive");
+  // The canvas sits below the scrubber bar (margin-top), so Y is the axis a
+  // rect-vs-client mistake shows up on — assert it exactly.
+  const canvasTop = await page.evaluate(
+    () => document.getElementById("canvas").getBoundingClientRect().top,
+  );
+  const expectedY = 150 - canvasTop;
+  expect(/\btap x=200 y=/.test(line), `press X in canvas CSS pixels (${line})`);
+  const y = Number((line.match(/y=([\d.]+)/) ?? [])[1]);
+  expect(
+    Math.abs(y - expectedY) <= 1,
+    `press Y is canvas-relative (${y} ≈ ${expectedY})`,
+  );
   expect(/rels=[1-9]/.test(line), "the release edge arrived");
+
+  const compat = await page.evaluate(() => window.__compatMouse);
+  expect(compat > 0, "compatibility mouse events still fire (Ui.* stays tappable)");
+
+  // Two simultaneous contacts get DISTINCT ordinals.
+  await page.evaluate(() => {
+    const canvas = document.getElementById("canvas");
+    const rect = canvas.getBoundingClientRect();
+    const touch = (id, x, y) =>
+      new Touch({
+        identifier: id,
+        target: canvas,
+        clientX: rect.left + x,
+        clientY: rect.top + y,
+      });
+    const pair = [touch(101, 100, 100), touch(202, 300, 100)];
+    canvas.dispatchEvent(
+      new TouchEvent("touchstart", {
+        touches: pair,
+        targetTouches: pair,
+        changedTouches: pair,
+        bubbles: true,
+      }),
+    );
+  });
+  await waitFor(log, /e2e-touch.*multi n=2/, "two simultaneous contacts to sample");
+
   expect(
     !log.some((l) => /\[functor-lang\].*error/.test(l)),
     "no [functor-lang] errors during the run",

--- a/e2e/touch-wasm.mjs
+++ b/e2e/touch-wasm.mjs
@@ -1,0 +1,114 @@
+// touch wasm e2e: real browser TouchEvents reach a game's `sampledInput`
+// through the page's touch listeners and the shared transition reducer —
+// capability first (`Some` with empty lists on a touch-capable device before
+// any contact), then a tap's press+release edges with canvas-relative CSS
+// coordinates.
+//
+// Uses a touch-capable Playwright context (`hasTouch: true`, which also makes
+// `navigator.maxTouchPoints > 0`) and `page.touchscreen.tap` — real
+// dispatched TouchEvents, not synthetic wasm calls, so the whole page bridge
+// (ordinal remap, preventDefault, phase mapping) is exercised. The bundle is
+// exported with `build wasm` and served from an ephemeral port (the
+// e2e/module-role-wasm.mjs shape).
+//
+//   npm run build:cli:debug   # once, so target/debug/functor embeds the runtime
+//   node e2e/touch-wasm.mjs
+import { execFileSync } from "node:child_process";
+import { createReadStream, statSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DIR = path.join(ROOT, "e2e", "fixtures", "touch");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+console.log(
+  execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", DIR, "build", "wasm"], {
+    encoding: "utf8",
+  })
+);
+
+const TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".wasm": "application/wasm",
+  ".fun": "text/plain",
+};
+const root = path.join(DIR, "dist", "web");
+const server = http.createServer((req, res) => {
+  let rel = decodeURIComponent(req.url.split("?")[0]);
+  if (rel === "/") rel = "/index.html";
+  const file = path.join(root, rel);
+  try {
+    statSync(file);
+  } catch {
+    res.writeHead(404).end("not found");
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
+  });
+  createReadStream(file).pipe(res);
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const { port } = server.address();
+
+// Software WebGL2 (swiftshader) so the runtime's GL context comes up on any
+// runner — no real GPU needed; this check compares no pixels.
+const browser = await chromium.launch({
+  args: [
+    "--use-gl=angle",
+    "--use-angle=swiftshader",
+    "--enable-unsafe-swiftshader",
+    "--ignore-gpu-blocklist",
+  ],
+});
+try {
+  const context = await browser.newContext({
+    hasTouch: true,
+    viewport: { width: 640, height: 480 },
+  });
+  const page = await context.newPage();
+  const log = [];
+  page.on("console", (m) => log.push(m.text()));
+  page.on("pageerror", (e) => log.push(`pageerror: ${e}`));
+
+  await page.goto(`http://127.0.0.1:${port}/`);
+  const waitFor = async (pattern, what) => {
+    const until = Date.now() + 30000;
+    while (Date.now() < until) {
+      if (log.some((line) => pattern.test(line))) return;
+      await sleep(200);
+    }
+    throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
+  };
+
+  await waitFor(/\[functor-lang\] loaded/, "the game to load");
+  // Capability is declared BEFORE any contact.
+  await waitFor(/e2e-touch.*surface/, "the touch capability to reach the game");
+
+  await page.touchscreen.tap(200, 150);
+  await waitFor(/e2e-touch.*tap/, "the tap's edges to reach the game");
+
+  const line = log.find((l) => l.includes("e2e-touch") && l.includes("tap"));
+  const expect = (cond, what) => {
+    console.log(`  ${cond ? "✓" : "✗"} ${what}`);
+    if (!cond) process.exitCode = 1;
+  };
+  // X is canvas-relative CSS pixels and unaffected by the scrubber's vertical
+  // offset; Y just needs to be a positive in-canvas coordinate.
+  expect(line.includes("x=200"), `press X in canvas CSS pixels (${line})`);
+  expect(/y=\d/.test(line) && !line.includes("y=-"), "press Y positive");
+  expect(/rels=[1-9]/.test(line), "the release edge arrived");
+  expect(
+    !log.some((l) => /\[functor-lang\].*error/.test(l)),
+    "no [functor-lang] errors during the run",
+  );
+} finally {
+  await browser.close();
+  server.close();
+}
+
+console.log(process.exitCode ? "✗ touch wasm e2e FAILED" : "✓ touch wasm e2e passed");

--- a/e2e/wasm-harness.mjs
+++ b/e2e/wasm-harness.mjs
@@ -1,0 +1,77 @@
+// Shared boot for the exported-bundle wasm e2es (module-role, gamepad,
+// touch): `build wasm` the fixture with the built CLI, serve `dist/web` from
+// an ephemeral port (hermetic next to anyone's dev server on :8080), and
+// launch software-WebGL2 chromium (no real GPU needed; these checks compare
+// no pixels).
+import { execFileSync } from "node:child_process";
+import { createReadStream, statSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+export const ROOT = fileURLToPath(new URL("..", import.meta.url));
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const TYPES = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".wasm": "application/wasm",
+  ".fun": "text/plain",
+};
+
+/** Export `dir` with `build wasm` and serve its dist/web on an ephemeral
+ * port. Returns `{ server, port }`; `server.close()` when done. */
+export async function serveExportedBundle(dir) {
+  console.log(
+    execFileSync(path.join(ROOT, "target/debug/functor"), ["-d", dir, "build", "wasm"], {
+      encoding: "utf8",
+    }),
+  );
+  const root = path.join(dir, "dist", "web");
+  const server = http.createServer((req, res) => {
+    let rel = decodeURIComponent(req.url.split("?")[0]);
+    if (rel === "/") rel = "/index.html";
+    const file = path.join(root, rel);
+    try {
+      statSync(file);
+    } catch {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": TYPES[path.extname(file)] ?? "application/octet-stream",
+    });
+    createReadStream(file).pipe(res);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  return { server, port: server.address().port };
+}
+
+/** Software-WebGL2 chromium (swiftshader) that comes up on GPU-less CI. */
+export function launchSoftwareGL() {
+  return chromium.launch({
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+    ],
+  });
+}
+
+/** Poll `log` until a line matches `pattern`, else throw with the console. */
+export async function waitFor(log, pattern, what, timeoutMs = 30000) {
+  const until = Date.now() + timeoutMs;
+  while (Date.now() < until) {
+    if (log.some((line) => pattern.test(line))) return;
+    await sleep(200);
+  }
+  throw new Error(`timed out waiting for ${what}\n--- console ---\n${log.join("\n")}`);
+}
+
+/** Print a ✓/✗ line; a failure sets the process exit code. */
+export function expect(cond, what) {
+  console.log(`  ${cond ? "✓" : "✗"} ${what}`);
+  if (!cond) process.exitCode = 1;
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:wasm-golden:update": "playwright test --update-snapshots",
     "test:wasm-smoke": "node e2e/wasm-smoke.mjs",
     "test:gamepad-wasm": "node e2e/gamepad-wasm.mjs",
+    "test:touch-wasm": "node e2e/touch-wasm.mjs",
     "test:wasm-remote-assets": "node e2e/remote-assets.mjs",
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1150,19 +1150,12 @@ impl FrameCtx<'_> {
                                     );
                                 }
                             }
-                            RecordedInput::Touch { phase, id, x, y } => {
-                                let sample = sampled_input.get_or_insert_with(Default::default);
-                                crate::apply_touch_transition(
-                                    &mut sample.touch,
-                                    &mut projected_edges,
-                                    *phase,
-                                    crate::TouchPoint {
-                                        id: *id,
-                                        x: *x,
-                                        y: *y,
-                                    },
-                                );
-                            }
+                            // `Touch` is never recorded as a sparse event —
+                            // the web queue merely reuses this enum as its
+                            // transport, and touch reaches the recorded log
+                            // only inside `Snapshot` (which replaces the
+                            // carried sample wholesale). Folding it here too
+                            // would be a latent double-apply.
                             _ => {}
                         }
                         self.replay_input(event.clone(), &ui_handlers, &webview_handlers);
@@ -1266,9 +1259,9 @@ impl FrameCtx<'_> {
                 self.deliver_sampled_input(&snapshot, false);
                 return;
             }
-            // Touch has no event entry point — it reaches games only through
-            // the sampled snapshot, which the projection fold above already
-            // rebuilt from this event.
+            // Touch has no event entry point and is never recorded as a
+            // sparse event (it reaches the log only inside `Snapshot`); the
+            // variant exists as the web input queue's transport.
             RecordedInput::Touch { .. } => return,
             RecordedInput::UiEvent(event) => {
                 self.deliver_ui_event(ui_handlers, &event);

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -1150,6 +1150,19 @@ impl FrameCtx<'_> {
                                     );
                                 }
                             }
+                            RecordedInput::Touch { phase, id, x, y } => {
+                                let sample = sampled_input.get_or_insert_with(Default::default);
+                                crate::apply_touch_transition(
+                                    &mut sample.touch,
+                                    &mut projected_edges,
+                                    *phase,
+                                    crate::TouchPoint {
+                                        id: *id,
+                                        x: *x,
+                                        y: *y,
+                                    },
+                                );
+                            }
                             _ => {}
                         }
                         self.replay_input(event.clone(), &ui_handlers, &webview_handlers);
@@ -1253,6 +1266,10 @@ impl FrameCtx<'_> {
                 self.deliver_sampled_input(&snapshot, false);
                 return;
             }
+            // Touch has no event entry point — it reaches games only through
+            // the sampled snapshot, which the projection fold above already
+            // rebuilt from this event.
+            RecordedInput::Touch { .. } => return,
             RecordedInput::UiEvent(event) => {
                 self.deliver_ui_event(ui_handlers, &event);
                 return;

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -41,9 +41,11 @@ pub struct InputSnapshot {
     /// Live touch contacts when the target supplies them. `Some` signals
     /// touch CAPABILITY (a touch surface exists), so a game can decide to
     /// show touch UI; an idle touchscreen is `Some` with empty lists, and
-    /// `None` means no touch surface at all. Today the domain's only source
-    /// is debug injection — the web shell's touch-event wiring (which will
-    /// set `Some` on touch-capable devices before any contact) lands next.
+    /// `None` means no touch surface at all. The web shell declares
+    /// capability up front on touch-capable devices (`maxTouchPoints > 0`)
+    /// and folds the page's touch events through the shared reducer; desktop
+    /// has no touch hardware source, so there the domain exists only while
+    /// debug-injected.
     ///
     /// Omitted rather than serialized as `null` when absent, like `xr`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -736,6 +738,15 @@ pub enum RecordedInput {
     /// A mouse-button edge carrying the raw `MouseButton as i32` code, so
     /// replay re-runs `MouseButton::from_i32` exactly as the live path does.
     MouseButton { button: i32, is_down: bool },
+    /// A touch-contact transition carrying its raw scalars, so a shell input
+    /// bridge (the web page's touch listeners) and replay run the same
+    /// reducer path ([`apply_touch_transition`]).
+    Touch {
+        phase: TouchPhase,
+        id: u32,
+        x: f32,
+        y: f32,
+    },
     /// The continuously sampled input delivered before one simulation tick.
     ///
     /// Unlike edge events above, this is recorded every tick whose game

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -98,6 +98,22 @@ pub enum TouchPhase {
     Cancel,
 }
 
+impl TouchPhase {
+    /// The phase for a wire scalar — the ONE decoder for the numeric encoding
+    /// page input bridges use (0 begin, 1 move, 2 end, 3 cancel), pinned by
+    /// `touch_phase_from_i32_round_trips` so reordering the enum cannot
+    /// silently remap a bridge. `None` for anything else — the event drops.
+    pub fn from_i32(value: i32) -> Option<TouchPhase> {
+        match value {
+            0 => Some(TouchPhase::Begin),
+            1 => Some(TouchPhase::Move),
+            2 => Some(TouchPhase::End),
+            3 => Some(TouchPhase::Cancel),
+            _ => None,
+        }
+    }
+}
+
 /// Last known mouse position in logical shell coordinates, the matching
 /// surface extent, held buttons, and this step's button transitions.
 ///
@@ -359,28 +375,34 @@ fn upsert_touch_point(points: &mut Vec<TouchPoint>, point: TouchPoint) -> bool {
 /// `Cancel` reporting through `released` so a stolen gesture never leaks a
 /// held contact. A `Begin` on an id already held means a release was lost
 /// (ids are reused ordinals): it records an implicit release at the stale
-/// position and a fresh press, so neither contact is swallowed. Unlike the
-/// keyboard reducers there is no silent-recovery mode — a touch removal is
-/// always model-visible, which is the never-leaks-held guarantee. Returns
-/// whether the level state actually changed.
+/// position and a fresh press, so neither contact is swallowed.
+/// `record_edge` follows [`apply_key_transition_to_snapshot`]'s recovery-only
+/// semantics: shells pass `false` when clearing suppressed input's physical
+/// levels (a release during a paused scrub) without inventing an edge the
+/// game never received. Returns whether the level state actually changed.
 pub fn apply_touch_transition(
     touch: &mut Option<TouchSnapshot>,
     edges: &mut InputEdges,
     phase: TouchPhase,
     point: TouchPoint,
+    record_edge: bool,
 ) -> bool {
     match phase {
         TouchPhase::Begin => {
             let touch = touch.get_or_insert_with(TouchSnapshot::default);
             match touch.touches.iter_mut().find(|p| p.id == point.id) {
                 Some(existing) => {
-                    edges.touch_transition(*existing, false);
-                    edges.touch_transition(point, true);
+                    if record_edge {
+                        edges.touch_transition(*existing, false);
+                        edges.touch_transition(point, true);
+                    }
                     *existing = point;
                 }
                 None => {
                     touch.touches.push(point);
-                    edges.touch_transition(point, true);
+                    if record_edge {
+                        edges.touch_transition(point, true);
+                    }
                 }
             }
             true
@@ -403,7 +425,9 @@ pub fn apply_touch_transition(
                 return false;
             };
             levels.touches.remove(index);
-            edges.touch_transition(point, false);
+            if record_edge {
+                edges.touch_transition(point, false);
+            }
             true
         }
     }
@@ -1537,6 +1561,45 @@ mod tests {
     }
 
     #[test]
+    fn touch_phase_from_i32_round_trips() {
+        // The numeric encoding page input bridges use — pinned so reordering
+        // the enum cannot silently remap a bridge.
+        assert_eq!(TouchPhase::from_i32(0), Some(TouchPhase::Begin));
+        assert_eq!(TouchPhase::from_i32(1), Some(TouchPhase::Move));
+        assert_eq!(TouchPhase::from_i32(2), Some(TouchPhase::End));
+        assert_eq!(TouchPhase::from_i32(3), Some(TouchPhase::Cancel));
+        assert_eq!(TouchPhase::from_i32(4), None);
+        assert_eq!(TouchPhase::from_i32(-1), None);
+    }
+
+    #[test]
+    fn touch_recovery_clears_levels_without_model_visible_edges() {
+        // The key/mouse recovery contract: a release folded with
+        // `record_edge: false` unsticks the physical level while inventing no
+        // edge the game never received.
+        let mut touch: Option<TouchSnapshot> = None;
+        let mut edges = InputEdges::default();
+        let point = TouchPoint {
+            id: 0,
+            x: 5.0,
+            y: 5.0,
+        };
+        apply_touch_transition(&mut touch, &mut edges, TouchPhase::Begin, point, true);
+        edges.clear();
+        assert!(apply_touch_transition(
+            &mut touch,
+            &mut edges,
+            TouchPhase::Cancel,
+            point,
+            false,
+        ));
+        assert!(touch.as_ref().unwrap().touches.is_empty());
+        let mut snapshot = InputSnapshot::default();
+        edges.apply_to(&mut snapshot);
+        assert!(snapshot.touch.is_none(), "no edges → no materialization");
+    }
+
+    #[test]
     fn touch_transitions_fold_like_keyboard_edges() {
         let mut touch: Option<TouchSnapshot> = None;
         let mut edges = InputEdges::default();
@@ -1548,6 +1611,7 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(0, 10.0, 20.0),
+            true,
         ));
         // Move repositions the level without a new edge; moving an unknown
         // contact is a no-op.
@@ -1556,12 +1620,14 @@ mod tests {
             &mut edges,
             TouchPhase::Move,
             point(0, 15.0, 25.0),
+            true,
         ));
         assert!(!apply_touch_transition(
             &mut touch,
             &mut edges,
             TouchPhase::Move,
             point(7, 0.0, 0.0),
+            true,
         ));
         // A second contact, then a quick tap of it before the step: both its
         // edges survive while the level is already gone.
@@ -1570,12 +1636,14 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(1, 100.0, 100.0),
+            true,
         ));
         assert!(apply_touch_transition(
             &mut touch,
             &mut edges,
             TouchPhase::End,
             point(1, 101.0, 99.0),
+            true,
         ));
 
         let mut snapshot = InputSnapshot {
@@ -1606,6 +1674,7 @@ mod tests {
             &mut edges,
             TouchPhase::Cancel,
             point(0, 15.0, 25.0),
+            true,
         ));
         let mut cancelled = InputSnapshot {
             touch: touch.clone(),
@@ -1621,6 +1690,7 @@ mod tests {
             &mut edges,
             TouchPhase::End,
             point(0, 15.0, 25.0),
+            true,
         ));
 
         // A Begin on an id already held means an End was lost (ids are
@@ -1633,6 +1703,7 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(0, 10.0, 10.0),
+            true,
         );
         edges.clear();
         apply_touch_transition(
@@ -1640,6 +1711,7 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(0, 90.0, 90.0),
+            true,
         );
         let mut relanded = InputSnapshot::default();
         edges.apply_to(&mut relanded);
@@ -1660,12 +1732,14 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(3, 5.0, 5.0),
+            true,
         );
         apply_touch_transition(
             &mut fresh,
             &mut edges,
             TouchPhase::End,
             point(3, 5.0, 5.0),
+            true,
         );
         let mut bare = InputSnapshot::default();
         edges.apply_to(&mut bare);

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1324,6 +1324,7 @@ fn service_debug_request(
                         edges,
                         phase,
                         functor_runtime_common::TouchPoint { id, x, y },
+                        true,
                     );
                     Ok(())
                 }
@@ -4235,6 +4236,7 @@ mod tests {
             &mut edges,
             TouchPhase::Begin,
             point(0, 40.0, 30.0),
+            true,
         );
 
         // The builder sets levels BEFORE applying edges, so the same
@@ -4264,6 +4266,7 @@ mod tests {
             &mut edges,
             TouchPhase::Move,
             point(0, 60.0, 70.0),
+            true,
         );
         refresh_fixed_input_levels(
             &mut fixed,

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -406,8 +406,10 @@ fn apply_scripted_events(
             }
             // Listed rather than `_`, so adding a scriptable line shape (e.g.
             // wheel motion) has to be wired here instead of compiling to a
-            // silent no-op.
+            // silent no-op. `parse_input_script` has no touch line shape yet,
+            // so `Touch` is unreachable here.
             RecordedInput::MouseWheel { .. }
+            | RecordedInput::Touch { .. }
             | RecordedInput::Snapshot(_)
             | RecordedInput::UiEvent(_)
             | RecordedInput::WebviewEvent(_) => {}

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -6,11 +6,12 @@
        this page only wires input into the runtime's `functor_lang_*` exports. -->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
     <style>
       html, body { margin: 0; height: 100%; overflow: hidden; }
       /* Fill the window; the runtime sizes the drawable buffer (and GL
          viewport) to match this displayed size each frame, scaled for HiDPI. */
-      #canvas { display: block; width: 100%; height: calc(100% - var(--functor-scrubber-h, 0px)); margin-top: var(--functor-scrubber-h, 0px); }
+      #canvas { display: block; width: 100%; height: calc(100% - var(--functor-scrubber-h, 0px)); margin-top: var(--functor-scrubber-h, 0px); touch-action: none; overscroll-behavior: none; }
       /* Explicit mouse-capture toggle. The cursor stays FREE by default so the
          time-travel scrubber is usable without the pointer being grabbed on
          every click; press this (or Esc to release) to control the camera. */
@@ -72,6 +73,7 @@
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
         functor_lang_mouse_button,
+        functor_lang_touch_event,
         functor_lang_uses_captured_mouse_input,
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
@@ -482,6 +484,41 @@
           gameButtons.clear();
         };
         window.addEventListener("blur", releaseGameButtons);
+
+        // Touch contacts (mobile): forwarded into the sampled-input touch
+        // domain with page-assigned small ordinals (browsers hand out
+        // arbitrary Touch.identifiers). CSS pixels relative to the canvas,
+        // like the visible-pointer path. preventDefault keeps a game drag
+        // from scrolling/zooming and suppresses the synthesized
+        // compatibility mouse events.
+        const touchOrdinals = new Map(); // Touch.identifier -> small ordinal
+        const touchOrdinal = (identifier) => {
+          if (touchOrdinals.has(identifier)) return touchOrdinals.get(identifier);
+          const used = new Set(touchOrdinals.values());
+          let ordinal = 0;
+          while (used.has(ordinal)) ordinal++;
+          touchOrdinals.set(identifier, ordinal);
+          return ordinal;
+        };
+        // Phases mirror functor_lang_touch_event: 0 begin, 1 move, 2 end, 3 cancel.
+        const forwardTouches = (e, phase, release) => {
+          e.preventDefault();
+          const rect = canvas.getBoundingClientRect();
+          for (const touch of e.changedTouches) {
+            const ordinal = touchOrdinal(touch.identifier);
+            functor_lang_touch_event(
+              phase,
+              ordinal,
+              touch.clientX - rect.left,
+              touch.clientY - rect.top,
+            );
+            if (release) touchOrdinals.delete(touch.identifier);
+          }
+        };
+        canvas.addEventListener("touchstart", (e) => forwardTouches(e, 0, false), { passive: false });
+        canvas.addEventListener("touchmove", (e) => forwardTouches(e, 1, false), { passive: false });
+        canvas.addEventListener("touchend", (e) => forwardTouches(e, 2, true), { passive: false });
+        canvas.addEventListener("touchcancel", (e) => forwardTouches(e, 3, true), { passive: false });
 
         // Interactive game UI (docs/ui-interaction.md U3): while the pointer
         // is FREE (not look mode), its canvas position + primary button drive

--- a/runtime/functor-runtime-web/index-functor-lang.html
+++ b/runtime/functor-runtime-web/index-functor-lang.html
@@ -6,7 +6,7 @@
        this page only wires input into the runtime's `functor_lang_*` exports. -->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       html, body { margin: 0; height: 100%; overflow: hidden; }
       /* Fill the window; the runtime sizes the drawable buffer (and GL
@@ -488,37 +488,52 @@
         // Touch contacts (mobile): forwarded into the sampled-input touch
         // domain with page-assigned small ordinals (browsers hand out
         // arbitrary Touch.identifiers). CSS pixels relative to the canvas,
-        // like the visible-pointer path. preventDefault keeps a game drag
-        // from scrolling/zooming and suppresses the synthesized
-        // compatibility mouse events.
-        const touchOrdinals = new Map(); // Touch.identifier -> small ordinal
-        const touchOrdinal = (identifier) => {
+        // like the visible-pointer path. No preventDefault: the canvas's
+        // `touch-action: none` already stops scrolling/zooming, while the
+        // browser's compatibility mouse events stay alive so `Ui.*` widgets
+        // and mouse-driven games remain tappable on touch devices (a
+        // touch-aware game simply ignores the synthesized mouse input).
+        const touchOrdinals = new Map(); // Touch.identifier -> { ordinal, x, y }
+        const touchEntry = (identifier) => {
           if (touchOrdinals.has(identifier)) return touchOrdinals.get(identifier);
-          const used = new Set(touchOrdinals.values());
+          const used = new Set([...touchOrdinals.values()].map((e) => e.ordinal));
           let ordinal = 0;
           while (used.has(ordinal)) ordinal++;
-          touchOrdinals.set(identifier, ordinal);
-          return ordinal;
+          const entry = { ordinal, x: 0, y: 0 };
+          touchOrdinals.set(identifier, entry);
+          return entry;
         };
-        // Phases mirror functor_lang_touch_event: 0 begin, 1 move, 2 end, 3 cancel.
+        // Phases mirror TouchPhase::from_i32: 0 begin, 1 move, 2 end, 3 cancel.
         const forwardTouches = (e, phase, release) => {
-          e.preventDefault();
+          if (debugCameraOwnsInput()) return;
           const rect = canvas.getBoundingClientRect();
           for (const touch of e.changedTouches) {
-            const ordinal = touchOrdinal(touch.identifier);
-            functor_lang_touch_event(
-              phase,
-              ordinal,
-              touch.clientX - rect.left,
-              touch.clientY - rect.top,
-            );
+            const entry = touchEntry(touch.identifier);
+            entry.x = touch.clientX - rect.left;
+            entry.y = touch.clientY - rect.top;
+            functor_lang_touch_event(phase, entry.ordinal, entry.x, entry.y);
             if (release) touchOrdinals.delete(touch.identifier);
           }
         };
-        canvas.addEventListener("touchstart", (e) => forwardTouches(e, 0, false), { passive: false });
-        canvas.addEventListener("touchmove", (e) => forwardTouches(e, 1, false), { passive: false });
-        canvas.addEventListener("touchend", (e) => forwardTouches(e, 2, true), { passive: false });
-        canvas.addEventListener("touchcancel", (e) => forwardTouches(e, 3, true), { passive: false });
+        canvas.addEventListener("touchstart", (e) => forwardTouches(e, 0, false));
+        canvas.addEventListener("touchmove", (e) => forwardTouches(e, 1, false));
+        canvas.addEventListener("touchend", (e) => forwardTouches(e, 2, true));
+        canvas.addEventListener("touchcancel", (e) => forwardTouches(e, 3, true));
+        // The touch twin of releaseGameButtons: a contact whose touchend the
+        // page never sees (tab switch, system gesture, incoming call) must
+        // not stay held forever — sweep every active contact as CANCELLED
+        // (the platform stole it) and free its ordinal.
+        const releaseTouches = () => {
+          for (const entry of touchOrdinals.values()) {
+            functor_lang_touch_event(3, entry.ordinal, entry.x, entry.y);
+          }
+          touchOrdinals.clear();
+        };
+        window.addEventListener("blur", releaseTouches);
+        window.addEventListener("pagehide", releaseTouches);
+        document.addEventListener("visibilitychange", () => {
+          if (document.hidden) releaseTouches();
+        });
 
         // Interactive game UI (docs/ui-interaction.md U3): while the pointer
         // is FREE (not look mode), its canvas position + primary button drive

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -284,6 +284,22 @@ pub fn functor_lang_mouse_button(button: i32, is_down: bool) {
     push_input(InputEvent::MouseButton { button, is_down });
 }
 
+/// One touch-contact transition from the page's touch listeners. `phase` is
+/// 0=begin, 1=move, 2=end, 3=cancel (anything else is dropped); `id` is the
+/// page-assigned small ordinal (the page remaps the browser's arbitrary
+/// `Touch.identifier`s); `x`/`y` are CSS pixels relative to the canvas.
+#[wasm_bindgen]
+pub fn functor_lang_touch_event(phase: u32, id: u32, x: f32, y: f32) {
+    let phase = match phase {
+        0 => functor_runtime_common::TouchPhase::Begin,
+        1 => functor_runtime_common::TouchPhase::Move,
+        2 => functor_runtime_common::TouchPhase::End,
+        3 => functor_runtime_common::TouchPhase::Cancel,
+        _ => return,
+    };
+    push_input(InputEvent::Touch { phase, id, x, y });
+}
+
 thread_local! {
     /// The page's UNLOCKED pointer over the canvas — `(pos in CSS px,
     /// primary button down, press latched since last sample)` — for the
@@ -501,6 +517,44 @@ pub fn drain_input(
                 }
                 if deliver {
                     game.mouse_button(button, is_down);
+                }
+            }
+            InputEvent::Touch { phase, id, x, y } => {
+                let point = functor_runtime_common::TouchPoint { id, x, y };
+                match phase {
+                    functor_runtime_common::TouchPhase::Begin
+                    | functor_runtime_common::TouchPhase::Move => {
+                        if deliver {
+                            functor_runtime_common::apply_touch_transition(
+                                &mut snapshot.touch,
+                                edges,
+                                phase,
+                                point,
+                            );
+                        }
+                    }
+                    functor_runtime_common::TouchPhase::End
+                    | functor_runtime_common::TouchPhase::Cancel => {
+                        if deliver {
+                            functor_runtime_common::apply_touch_transition(
+                                &mut snapshot.touch,
+                                edges,
+                                phase,
+                                point,
+                            );
+                        } else if recover_releases {
+                            // Physical recovery while input is suppressed
+                            // (paused/pinned): the level must clear so a
+                            // contact lifted during a scrub can't stick, but
+                            // no model-visible edge — the game never saw the
+                            // suppressed press either. The key/mouse
+                            // recovery rule, applied at the shell (the
+                            // reducer itself has no silent mode).
+                            if let Some(touch) = snapshot.touch.as_mut() {
+                                touch.touches.retain(|p| p.id != id);
+                            }
+                        }
+                    }
                 }
             }
             // Only the time-travel recorder creates snapshots; the page input
@@ -726,6 +780,15 @@ fn input_marker(input: &InputEvent) -> Option<(&'static str, String)> {
                 format!("mouse {name} {edge}"),
             ))
         }
+        InputEvent::Touch { phase, id, .. } => Some((
+            match phase {
+                functor_runtime_common::TouchPhase::Begin => "touch-begin",
+                functor_runtime_common::TouchPhase::Move => "touch-move",
+                functor_runtime_common::TouchPhase::End
+                | functor_runtime_common::TouchPhase::Cancel => "touch-end",
+            },
+            format!("touch {id} {phase:?}"),
+        )),
         InputEvent::Snapshot(_) => None,
         InputEvent::UiEvent(event) => Some(("ui-input", format!("UI {event:?}"))),
         InputEvent::WebviewEvent(event) => Some(("webview-input", format!("webview {event:?}"))),

--- a/runtime/functor-runtime-web/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-web/src/functor_lang_game.rs
@@ -289,13 +289,9 @@ pub fn functor_lang_mouse_button(button: i32, is_down: bool) {
 /// page-assigned small ordinal (the page remaps the browser's arbitrary
 /// `Touch.identifier`s); `x`/`y` are CSS pixels relative to the canvas.
 #[wasm_bindgen]
-pub fn functor_lang_touch_event(phase: u32, id: u32, x: f32, y: f32) {
-    let phase = match phase {
-        0 => functor_runtime_common::TouchPhase::Begin,
-        1 => functor_runtime_common::TouchPhase::Move,
-        2 => functor_runtime_common::TouchPhase::End,
-        3 => functor_runtime_common::TouchPhase::Cancel,
-        _ => return,
+pub fn functor_lang_touch_event(phase: i32, id: u32, x: f32, y: f32) {
+    let Some(phase) = functor_runtime_common::TouchPhase::from_i32(phase) else {
+        return;
     };
     push_input(InputEvent::Touch { phase, id, x, y });
 }
@@ -520,41 +516,23 @@ pub fn drain_input(
                 }
             }
             InputEvent::Touch { phase, id, x, y } => {
-                let point = functor_runtime_common::TouchPoint { id, x, y };
-                match phase {
-                    functor_runtime_common::TouchPhase::Begin
-                    | functor_runtime_common::TouchPhase::Move => {
-                        if deliver {
-                            functor_runtime_common::apply_touch_transition(
-                                &mut snapshot.touch,
-                                edges,
-                                phase,
-                                point,
-                            );
-                        }
-                    }
+                // The key/mouse level/edge split: presses and moves only when
+                // delivering; releases also as recovery while suppressed
+                // (level cleared, no model-visible edge — `record_edge` is
+                // `deliver`, the shared reducers' recovery contract).
+                let is_release = matches!(
+                    phase,
                     functor_runtime_common::TouchPhase::End
-                    | functor_runtime_common::TouchPhase::Cancel => {
-                        if deliver {
-                            functor_runtime_common::apply_touch_transition(
-                                &mut snapshot.touch,
-                                edges,
-                                phase,
-                                point,
-                            );
-                        } else if recover_releases {
-                            // Physical recovery while input is suppressed
-                            // (paused/pinned): the level must clear so a
-                            // contact lifted during a scrub can't stick, but
-                            // no model-visible edge — the game never saw the
-                            // suppressed press either. The key/mouse
-                            // recovery rule, applied at the shell (the
-                            // reducer itself has no silent mode).
-                            if let Some(touch) = snapshot.touch.as_mut() {
-                                touch.touches.retain(|p| p.id != id);
-                            }
-                        }
-                    }
+                        | functor_runtime_common::TouchPhase::Cancel
+                );
+                if deliver || (is_release && recover_releases) {
+                    functor_runtime_common::apply_touch_transition(
+                        &mut snapshot.touch,
+                        edges,
+                        phase,
+                        functor_runtime_common::TouchPoint { id, x, y },
+                        deliver,
+                    );
                 }
             }
             // Only the time-travel recorder creates snapshots; the page input
@@ -780,15 +758,11 @@ fn input_marker(input: &InputEvent) -> Option<(&'static str, String)> {
                 format!("mouse {name} {edge}"),
             ))
         }
-        InputEvent::Touch { phase, id, .. } => Some((
-            match phase {
-                functor_runtime_common::TouchPhase::Begin => "touch-begin",
-                functor_runtime_common::TouchPhase::Move => "touch-move",
-                functor_runtime_common::TouchPhase::End
-                | functor_runtime_common::TouchPhase::Cancel => "touch-end",
-            },
-            format!("touch {id} {phase:?}"),
-        )),
+        // Touch is never recorded as a sparse event (only inside `Snapshot`,
+        // which this marker log doesn't unpack), so no timeline marker can
+        // fire for it — returning a label here would advertise a feature
+        // that cannot appear.
+        InputEvent::Touch { .. } => None,
         InputEvent::Snapshot(_) => None,
         InputEvent::UiEvent(event) => Some(("ui-input", format!("UI {event:?}"))),
         InputEvent::WebviewEvent(event) => Some(("webview-input", format!("webview {event:?}"))),

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1391,6 +1391,13 @@ async fn run_async() -> Result<(), JsValue> {
         let initial_time = performance.now() as f32;
         let mut last_time = initial_time;
         let mut input_snapshot = InputSnapshot::default();
+        // Touch CAPABILITY is declared up front on touch-capable devices —
+        // `Some` with empty lists — so a game can decide to show touch UI
+        // before the first contact. (Touch events themselves would also
+        // materialize the domain; this makes the idle state honest too.)
+        if window.navigator().max_touch_points() > 0 {
+            input_snapshot.touch = Some(functor_runtime_common::TouchSnapshot::default());
+        }
         // rAF can produce zero or several fixed steps. Keep transitions until
         // the first step, then clear them before any catch-up step.
         let mut input_edges = InputEdges::default();

--- a/site/index.html
+++ b/site/index.html
@@ -73,7 +73,7 @@
           </div>
           <iframe
             class="hero-scene"
-            src="player.html?game=examples%2Fplatformer.fun&amp;file=examples%2Fplatformer.fun&amp;file=examples%2Fassets.fun"
+            src="player.html?game=examples%2Fplatformer.fun&amp;file=examples%2Fplatformer.fun&amp;file=examples%2Fassets.fun&amp;touch=passive"
             title="live platformer with time-travel extrapolation rendered by functor"
             allow="pointer-lock"
           ></iframe>

--- a/site/player.html
+++ b/site/player.html
@@ -8,6 +8,7 @@
        sync when the runtime's functor_lang_* exports change. -->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
@@ -27,7 +28,7 @@
       html, body { margin: 0; height: 100%; overflow: hidden; background: #0d0221; }
       /* Fill the frame; the runtime sizes the drawable buffer (and GL
          viewport) to match this displayed size each frame, scaled for HiDPI. */
-      #canvas { display: block; width: 100%; height: calc(100% - var(--functor-scrubber-h, 0px)); margin-top: var(--functor-scrubber-h, 0px); }
+      #canvas { display: block; width: 100%; height: calc(100% - var(--functor-scrubber-h, 0px)); margin-top: var(--functor-scrubber-h, 0px); touch-action: none; overscroll-behavior: none; }
       /* Explicit mouse-capture toggle. The cursor stays FREE by default so the
          time-travel scrubber (and the sandbox editor) is usable without the
          pointer being grabbed on every canvas click; press this (or Esc to
@@ -135,6 +136,7 @@
         functor_lang_mouse_move,
         functor_lang_mouse_wheel,
         functor_lang_mouse_button,
+        functor_lang_touch_event,
         functor_lang_uses_captured_mouse_input,
         functor_lang_ui_pointer,
         functor_lang_ui_pointer_leave,
@@ -551,6 +553,41 @@
           gameButtons.clear();
         };
         window.addEventListener("blur", releaseGameButtons);
+
+        // Touch contacts (mobile): forwarded into the sampled-input touch
+        // domain with page-assigned small ordinals (browsers hand out
+        // arbitrary Touch.identifiers). CSS pixels relative to the canvas,
+        // like the visible-pointer path. preventDefault keeps a game drag
+        // from scrolling/zooming and suppresses the synthesized
+        // compatibility mouse events.
+        const touchOrdinals = new Map(); // Touch.identifier -> small ordinal
+        const touchOrdinal = (identifier) => {
+          if (touchOrdinals.has(identifier)) return touchOrdinals.get(identifier);
+          const used = new Set(touchOrdinals.values());
+          let ordinal = 0;
+          while (used.has(ordinal)) ordinal++;
+          touchOrdinals.set(identifier, ordinal);
+          return ordinal;
+        };
+        // Phases mirror functor_lang_touch_event: 0 begin, 1 move, 2 end, 3 cancel.
+        const forwardTouches = (e, phase, release) => {
+          e.preventDefault();
+          const rect = canvas.getBoundingClientRect();
+          for (const touch of e.changedTouches) {
+            const ordinal = touchOrdinal(touch.identifier);
+            functor_lang_touch_event(
+              phase,
+              ordinal,
+              touch.clientX - rect.left,
+              touch.clientY - rect.top,
+            );
+            if (release) touchOrdinals.delete(touch.identifier);
+          }
+        };
+        canvas.addEventListener("touchstart", (e) => forwardTouches(e, 0, false), { passive: false });
+        canvas.addEventListener("touchmove", (e) => forwardTouches(e, 1, false), { passive: false });
+        canvas.addEventListener("touchend", (e) => forwardTouches(e, 2, true), { passive: false });
+        canvas.addEventListener("touchcancel", (e) => forwardTouches(e, 3, true), { passive: false });
 
         // Interactive game UI (docs/ui-interaction.md U3): while the pointer
         // is FREE (not look mode), its canvas position + primary button drive

--- a/site/player.html
+++ b/site/player.html
@@ -8,7 +8,7 @@
        sync when the runtime's functor_lang_* exports change. -->
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
@@ -557,37 +557,63 @@
         // Touch contacts (mobile): forwarded into the sampled-input touch
         // domain with page-assigned small ordinals (browsers hand out
         // arbitrary Touch.identifiers). CSS pixels relative to the canvas,
-        // like the visible-pointer path. preventDefault keeps a game drag
-        // from scrolling/zooming and suppresses the synthesized
-        // compatibility mouse events.
-        const touchOrdinals = new Map(); // Touch.identifier -> small ordinal
-        const touchOrdinal = (identifier) => {
+        // like the visible-pointer path. No preventDefault: the canvas's
+        // `touch-action: none` already stops scrolling/zooming, while the
+        // browser's compatibility mouse events stay alive so `Ui.*` widgets
+        // and mouse-driven games remain tappable on touch devices (a
+        // touch-aware game simply ignores the synthesized mouse input).
+        const touchOrdinals = new Map(); // Touch.identifier -> { ordinal, x, y }
+        const touchEntry = (identifier) => {
           if (touchOrdinals.has(identifier)) return touchOrdinals.get(identifier);
-          const used = new Set(touchOrdinals.values());
+          const used = new Set([...touchOrdinals.values()].map((e) => e.ordinal));
           let ordinal = 0;
           while (used.has(ordinal)) ordinal++;
-          touchOrdinals.set(identifier, ordinal);
-          return ordinal;
+          const entry = { ordinal, x: 0, y: 0 };
+          touchOrdinals.set(identifier, entry);
+          return entry;
         };
-        // Phases mirror functor_lang_touch_event: 0 begin, 1 move, 2 end, 3 cancel.
+        // Phases mirror TouchPhase::from_i32: 0 begin, 1 move, 2 end, 3 cancel.
         const forwardTouches = (e, phase, release) => {
-          e.preventDefault();
+          if (debugCameraOwnsInput()) return;
           const rect = canvas.getBoundingClientRect();
           for (const touch of e.changedTouches) {
-            const ordinal = touchOrdinal(touch.identifier);
-            functor_lang_touch_event(
-              phase,
-              ordinal,
-              touch.clientX - rect.left,
-              touch.clientY - rect.top,
-            );
+            const entry = touchEntry(touch.identifier);
+            entry.x = touch.clientX - rect.left;
+            entry.y = touch.clientY - rect.top;
+            functor_lang_touch_event(phase, entry.ordinal, entry.x, entry.y);
             if (release) touchOrdinals.delete(touch.identifier);
           }
         };
-        canvas.addEventListener("touchstart", (e) => forwardTouches(e, 0, false), { passive: false });
-        canvas.addEventListener("touchmove", (e) => forwardTouches(e, 1, false), { passive: false });
-        canvas.addEventListener("touchend", (e) => forwardTouches(e, 2, true), { passive: false });
-        canvas.addEventListener("touchcancel", (e) => forwardTouches(e, 3, true), { passive: false });
+        // `?touch=passive` opts a decorative embed out of the game touch
+        // domain entirely: the landing page's hero iframe sits where a
+        // phone's first scroll swipe lands, and `touch-action: none` there
+        // would turn it into a scroll trap. Passive embeds keep native
+        // scrolling and receive no touch domain.
+        const passiveTouch = params.get("touch") === "passive";
+        if (passiveTouch) {
+          canvas.style.touchAction = "pan-y";
+          canvas.style.overscrollBehavior = "auto";
+        } else {
+          canvas.addEventListener("touchstart", (e) => forwardTouches(e, 0, false));
+          canvas.addEventListener("touchmove", (e) => forwardTouches(e, 1, false));
+          canvas.addEventListener("touchend", (e) => forwardTouches(e, 2, true));
+          canvas.addEventListener("touchcancel", (e) => forwardTouches(e, 3, true));
+        }
+        // The touch twin of releaseGameButtons: a contact whose touchend the
+        // page never sees (tab switch, system gesture, incoming call) must
+        // not stay held forever — sweep every active contact as CANCELLED
+        // (the platform stole it) and free its ordinal.
+        const releaseTouches = () => {
+          for (const entry of touchOrdinals.values()) {
+            functor_lang_touch_event(3, entry.ordinal, entry.x, entry.y);
+          }
+          touchOrdinals.clear();
+        };
+        window.addEventListener("blur", releaseTouches);
+        window.addEventListener("pagehide", releaseTouches);
+        document.addEventListener("visibilitychange", () => {
+          if (document.hidden) releaseTouches();
+        });
 
         // Interactive game UI (docs/ui-interaction.md U3): while the pointer
         // is FREE (not look mode), its canvas position + primary button drive

--- a/tools/functor-sdk/src/types.ts
+++ b/tools/functor-sdk/src/types.ts
@@ -131,8 +131,9 @@ export interface InputSnapshot {
    * polling — rest levels while unfocused/pinned) or a sample is injected;
    * absent on headless, which polls nothing. */
   gamepad?: GamepadSnapshot;
-  /** Present while a touch surface exists (or a touch was injected); empty
-   * lists while idle. Absent on targets with no touch input at all. */
+  /** Present while a touch surface exists (web declares it up front on
+   * touch-capable devices; desktop only while injected); empty lists while
+   * idle. Absent on targets with no touch input at all. */
   touch?: TouchSnapshot;
 }
 


### PR DESCRIPTION
Part 5 of the gamepad + touch input series, stacked on #658. The touch domain's first hardware source: both player pages forward real browser touch events through a new `functor_lang_touch_event` export into the shared transition reducer, with mobile page plumbing (viewport meta, `touch-action: none` canvas CSS).

## What's here

- **Page bridge** (both templates + the exported bundle): `touchstart/move/end/cancel` listeners remap the browser's arbitrary `Touch.identifier`s to small stable ordinals (last position tracked) and forward canvas-relative CSS coordinates. **No `preventDefault`** — `touch-action: none` alone stops scroll/zoom while the browser's compatibility mouse events stay alive, so `Ui.*` widgets and mouse-driven games remain tappable on phones (pinned by an e2e assertion). A blur/pagehide/visibilitychange sweep cancels every active contact — a tab switch mid-touch can't hold a contact forever. Forwarding is gated off while the debug camera owns input.
- **Capability up front**: `maxTouchPoints > 0` → `Some` with empty lists at boot, so a game can show touch UI before the first contact.
- **Drain arm** = the three-line key/mouse shape: deliver → shared reducer; suppressed releases fold with `record_edge: false` (reinstated on `apply_touch_transition` with a real caller + test — levels unstick, no invented edge). `TouchPhase::from_i32` is the one pinned decoder for the bridge's numeric phases.
- **`RecordedInput::Touch`** exists as the web queue's transport only; the producer deliberately does NOT fold it in projection (touch reaches the recorded log only inside `Snapshot` — folding both would be a latent double-apply) and the timeline marker honestly returns `None`.
- **Hero embed protected**: `player.html?touch=passive` opts a decorative embed out of the touch domain and keeps native scroll chaining; the landing page's hero iframe sets it, so a phone's first swipe still scrolls.
- **e2e** (`npm run test:touch-wasm`, in `wasm-smoke.yml`): a `hasTouch` Playwright context dispatches a REAL tap + a two-finger gesture — asserts capability-before-contact, exact canvas-relative Y, the release edge, distinct ordinals, live compat mouse events, no `[functor-lang]` errors. The exported-bundle harness is extracted to `e2e/wasm-harness.mjs` (gamepad + touch converted).

## Verification

`cargo test -p functor_runtime_common` (697) and `-p functor-runtime-desktop` (87); wasm build; **both** touch and gamepad e2es green against the fresh bundle; docs check; SDK build.

## xreview

Two-engine adversarial + de-dup pass; all findings addressed in the second commit — the two [AGREED] items (compat-mouse regression, lost-touchend sweep), the hero scroll trap, single-reducer consolidation, dead-arm honesty, phase-decoder pinning, `user-scalable` removal, e2e depth, and the harness extraction. Deliberately deferred (pre-existing, flagged by the de-dup pass as out of scope): consolidating the two pages' ~475 identical input-bridge lines into a shared `input-bridge.js` on the `scrubber.js` distribution rails.