### PR TITLE
feat(examples): virtual-gamepad — touch thumbsticks in pure game code

### DIFF
--- a/examples/virtual-gamepad/functor.json
+++ b/examples/virtual-gamepad/functor.json
@@ -1,0 +1,1 @@
+{ "language": "functor-lang", "entry": "game.fun" }

--- a/examples/virtual-gamepad/functor.json
+++ b/examples/virtual-gamepad/functor.json
@@ -1,1 +1,1 @@
-{ "language": "functor-lang", "entry": "game.fun" }
+{ "language": "functor-lang", "entry": "game.fun", "cursor": "visible" }

--- a/examples/virtual-gamepad/game.fun
+++ b/examples/virtual-gamepad/game.fun
@@ -167,7 +167,7 @@ let hint = (m: Model) =>
     else "WASD: move    arrows: aim + fire    (touch a phone for thumbsticks)" in
   // Sprite.text is center-anchored, so the caption centers under the arena.
   Sprite.text(Color.rgb(0.65, 0.75, 0.9), 0.34, label)
-    |> Sprite.move(0.0, 0.0 - arenaHalfH - 0.36)
+    |> Sprite.move(0.0, 0.0 - arenaHalfH - 0.12)
 
 let arena = () =>
   Sprite.group([

--- a/examples/virtual-gamepad/game.fun
+++ b/examples/virtual-gamepad/game.fun
@@ -165,8 +165,9 @@ let hint = (m: Model) =>
   let label =
     if m.hasTouch then "left thumb: move    right thumb: aim + fire"
     else "WASD: move    arrows: aim + fire    (touch a phone for thumbsticks)" in
+  // Sprite.text is center-anchored, so the caption centers under the arena.
   Sprite.text(Color.rgb(0.65, 0.75, 0.9), 0.34, label)
-    |> Sprite.move(0.0 - 6.9, 0.0 - arenaHalfH - 0.12)
+    |> Sprite.move(0.0, 0.0 - arenaHalfH - 0.36)
 
 let arena = () =>
   Sprite.group([

--- a/examples/virtual-gamepad/game.fun
+++ b/examples/virtual-gamepad/game.fun
@@ -1,0 +1,218 @@
+// virtual-gamepad — twin-stick arena driven by TOUCH THUMBSTICKS built in
+// pure game code over the sampled touch domain (`snap.touch`), with a
+// keyboard fallback so desktop plays too.
+//
+//   functor -d examples/virtual-gamepad run wasm    # then open it on a phone
+//   functor -d examples/virtual-gamepad run native  # WASD moves, arrows aim/fire
+//
+// Left half of the screen: a floating MOVE stick (anchors where your thumb
+// lands). Right half: an AIM stick — deflect past half tilt to fire. The
+// stick math lives in the sibling `Pad` module as pure, `expect`-tested
+// functions; this file only folds touches in `sampledInput` and draws.
+//
+// Headless driving (docs/debug-runtime.md): touch is injectable —
+//   POST /input {"type":"touch","phase":"begin","id":0,"x":160,"y":400}
+//   POST /input {"type":"touch","phase":"move","id":0,"x":220,"y":400}
+// moves the player right, exactly as a real thumb would.
+
+// --- Tunables ---------------------------------------------------------------
+let stickRadius = 70.0    // px of thumb travel that reads as full tilt
+let moveSpeed = 9.0       // world units/s at full tilt
+let shotSpeed = 16.0      // projectile speed
+let fireTilt = 0.5        // right-stick deflection that starts firing
+let fireCooldown = 0.14   // seconds between shots
+let shotLife = 1.1        // seconds a shot lives
+
+// --- Model ------------------------------------------------------------------
+type Shot = { x: float, y: float, vx: float, vy: float, ttl: float }
+type Keys = { moveX: float, moveY: float, aimX: float, aimY: float }
+type Model = {
+  px: float,
+  py: float,
+  aimX: float,
+  aimY: float,
+  cooldown: float,
+  shots: List<Shot>,
+  left: Pad.Stick,
+  right: Pad.Stick,
+  keys: Keys,
+  surfaceW: float,
+  surfaceH: float,
+  hasTouch: bool
+}
+
+let init = {
+  px: 0.0,
+  py: 0.0,
+  aimX: 1.0,
+  aimY: 0.0,
+  cooldown: 0.0,
+  shots: [],
+  left: Pad.idle,
+  right: Pad.idle,
+  keys: { moveX: 0.0, moveY: 0.0, aimX: 0.0, aimY: 0.0 },
+  surfaceW: 800.0,
+  surfaceH: 600.0,
+  hasTouch: false
+}
+
+// --- Input: fold sticks and keyboard once per fixed step --------------------
+let axis = (heldKeys: List<Key.t>, minus: Key.t, plus: Key.t) =>
+  let held = (k: Key.t) => heldKeys |> List.any((h: Key.t) => h == k) in
+  (if held(plus) then 1.0 else 0.0) - (if held(minus) then 1.0 else 0.0)
+
+let sampledInput = (m: Model, snap: Input.snapshot) =>
+  let keys = {
+    moveX: axis(snap.heldKeys, Key.A, Key.D),
+    moveY: axis(snap.heldKeys, Key.S, Key.W),
+    aimX: axis(snap.heldKeys, Key.Left, Key.Right),
+    aimY: axis(snap.heldKeys, Key.Down, Key.Up)
+  } in
+  let sized = { m with
+    keys: keys,
+    surfaceW: Math.max(1.0, snap.mouse.surfaceWidth),
+    surfaceH: Math.max(1.0, snap.mouse.surfaceHeight) } in
+  match snap.touch with
+  | Option.Some(t) =>
+    let mid = sized.surfaceW / 2.0 in
+    { sized with
+      hasTouch: true,
+      left: Pad.update((p: Input.touchPoint) => p.x < mid, t, sized.left),
+      right: Pad.update((p: Input.touchPoint) => p.x >= mid, t, sized.right) }
+  | Option.None => sized
+
+// --- Simulation -------------------------------------------------------------
+// Stick vectors are surface-space (y down); the world is up-positive.
+let moveVec = (m: Model): Input.point2 =>
+  let pad = Pad.vector(stickRadius, m.left) in
+  if pad.x != 0.0 || pad.y != 0.0 then { x: pad.x, y: 0.0 - pad.y }
+  else { x: m.keys.moveX, y: m.keys.moveY }
+
+let aimVec = (m: Model): Input.point2 =>
+  let pad = Pad.vector(stickRadius, m.right) in
+  if pad.x != 0.0 || pad.y != 0.0 then { x: pad.x, y: 0.0 - pad.y }
+  else { x: m.keys.aimX, y: m.keys.aimY }
+
+let arenaHalfW = 7.6
+let arenaHalfH = 4.2
+
+let stepShot = (dt: float, s: Shot): Shot =>
+  { s with x: s.x + s.vx * dt, y: s.y + s.vy * dt, ttl: s.ttl - dt }
+
+let tick = (m: Model, dt, tts) =>
+  let mv = moveVec(m) in
+  let px = Math.clamp(0.0 - arenaHalfW, arenaHalfW, m.px + mv.x * moveSpeed * dt) in
+  let py = Math.clamp(0.0 - arenaHalfH, arenaHalfH, m.py + mv.y * moveSpeed * dt) in
+  let aim = aimVec(m) in
+  let tilt = Math.sqrt(aim.x * aim.x + aim.y * aim.y) in
+  let aimed =
+    if tilt > 0.0 then { m with px: px, py: py, aimX: aim.x / tilt, aimY: aim.y / tilt }
+    else { m with px: px, py: py } in
+  let flying =
+    aimed.shots
+    |> List.map((s: Shot) => stepShot(dt, s))
+    |> List.filter((s: Shot) => s.ttl > 0.0) in
+  if tilt >= fireTilt && aimed.cooldown <= 0.0 then
+    let shot = {
+      x: px,
+      y: py,
+      vx: aimed.aimX * shotSpeed,
+      vy: aimed.aimY * shotSpeed,
+      ttl: shotLife
+    } in
+    { aimed with shots: [shot, ..flying], cooldown: fireCooldown }
+  else
+    { aimed with shots: flying, cooldown: Math.max(0.0, aimed.cooldown - dt) }
+
+// --- Drawing ----------------------------------------------------------------
+let camW = 16.0
+let camH = 9.0
+
+// Surface CSS pixels (top-left origin) → world units (center origin, +Y up),
+// for drawing the stick overlays where the thumbs actually are.
+let toWorldX = (m: Model, sx: float) => (sx / m.surfaceW - 0.5) * camW
+let toWorldY = (m: Model, sy: float) => (0.5 - sy / m.surfaceH) * camH
+let pxToWorld = (m: Model, px: float) => px / m.surfaceW * camW
+
+let stickOverlay = (m: Model, stick: Pad.Stick) =>
+  if not stick.active then Sprite.blank()
+  else
+    let base = pxToWorld(m, stickRadius) in
+    Sprite.group([
+      Sprite.circle(Color.rgb(0.5, 0.75, 0.95), base)
+        |> Sprite.fade(0.18)
+        |> Sprite.move(toWorldX(m, stick.anchorX), toWorldY(m, stick.anchorY)),
+      Sprite.circle(Color.rgb(0.75, 0.9, 1.0), base * 0.35)
+        |> Sprite.fade(0.45)
+        |> Sprite.move(toWorldX(m, stick.x), toWorldY(m, stick.y)),
+    ])
+
+let shotSprite = (s: Shot) =>
+  Sprite.circle(Color.rgb(1.0, 0.85, 0.4), 0.09)
+    |> Sprite.fade(Math.min(1.0, s.ttl / 0.35))
+    |> Sprite.move(s.x, s.y)
+
+let player = (m: Model) =>
+  Sprite.group([
+    Sprite.circle(Color.rgb(0.35, 0.9, 0.7), 0.34),
+    // The barrel shows the aim without needing rotation math.
+    Sprite.circle(Color.rgb(0.9, 1.0, 0.95), 0.1)
+      |> Sprite.move(m.aimX * 0.4, m.aimY * 0.4),
+  ])
+  |> Sprite.move(m.px, m.py)
+
+let hint = (m: Model) =>
+  let label =
+    if m.hasTouch then "left thumb: move    right thumb: aim + fire"
+    else "WASD: move    arrows: aim + fire    (touch a phone for thumbsticks)" in
+  Sprite.text(Color.rgb(0.65, 0.75, 0.9), 0.34, label)
+    |> Sprite.move(0.0 - 6.9, 0.0 - arenaHalfH - 0.12)
+
+let arena = () =>
+  Sprite.group([
+    Sprite.rectangle(Color.rgb(0.10, 0.12, 0.2), arenaHalfW * 2.0 + 0.4, arenaHalfH * 2.0 + 0.4),
+    Sprite.rectangle(Color.rgb(0.05, 0.06, 0.11), arenaHalfW * 2.0, arenaHalfH * 2.0),
+  ])
+
+let draw = (m: Model, tts) =>
+  Frame.create2D(
+    Camera2D.create(camW, camH),
+    Sprite.group([
+      arena(),
+      Sprite.group(m.shots |> List.map(shotSprite)),
+      player(m),
+      hint(m),
+      stickOverlay(m, m.left),
+      stickOverlay(m, m.right),
+    ]),
+  )
+    |> Frame.withClearColor(Color.rgb(0.03, 0.04, 0.08))
+
+// --- Inline tests: the input → simulation seam ------------------------------
+
+// Full-left-stick tilt moves the player left at moveSpeed.
+expect (
+  let stick = { active: true, id: 0.0, anchorX: 200.0, anchorY: 300.0, x: 130.0, y: 300.0 } in
+  let m = tick({ init with left: stick }, 0.1, 0.1) in
+  Math.abs(m.px - (0.0 - 0.9)) < 0.0001 && m.py == 0.0
+)
+
+// A deflected right stick fires a shot along the aim; idle sticks fire none.
+expect (
+  let stick = { active: true, id: 0.0, anchorX: 600.0, anchorY: 300.0, x: 670.0, y: 300.0 } in
+  let m = tick({ init with right: stick }, 0.016, 0.016) in
+  (m.shots |> List.length) == 1.0 && m.aimX == 1.0 && m.aimY == 0.0
+)
+expect (tick(init, 0.016, 0.016).shots |> List.length) == 0.0
+
+// Keyboard fallback: surface-independent, up-positive.
+expect (
+  let keys = { moveX: 0.0, moveY: 1.0, aimX: 0.0, aimY: 0.0 } in
+  tick({ init with keys: keys }, 0.1, 0.1).py > 0.0
+)
+
+// The player clamps to the arena.
+expect (
+  let keys = { moveX: 1.0, moveY: 0.0, aimX: 0.0, aimY: 0.0 } in
+  tick({ init with keys: keys, px: arenaHalfW }, 0.5, 0.5).px == arenaHalfW
+)

--- a/examples/virtual-gamepad/game.fun
+++ b/examples/virtual-gamepad/game.fun
@@ -82,16 +82,19 @@ let sampledInput = (m: Model, snap: Input.snapshot) =>
   | Option.None => sized
 
 // --- Simulation -------------------------------------------------------------
-// Stick vectors are surface-space (y down); the world is up-positive.
-let moveVec = (m: Model): Input.point2 =>
-  let pad = Pad.vector(stickRadius, m.left) in
+// The one statement of the input-priority rule: the pad wins when deflected
+// (stick space is y-down surface px, negated ONCE into the up-positive
+// world); otherwise the keyboard axes, unit-clamped so a diagonal cannot
+// outrun a full stick tilt.
+let stickOr = (stick: Pad.Stick, kx: float, ky: float): Input.point2 =>
+  let pad = Pad.vector(stickRadius, stick) in
   if pad.x != 0.0 || pad.y != 0.0 then { x: pad.x, y: 0.0 - pad.y }
-  else { x: m.keys.moveX, y: m.keys.moveY }
+  else
+    let len = Math.sqrt(kx * kx + ky * ky) in
+    if len > 1.0 then { x: kx / len, y: ky / len } else { x: kx, y: ky }
 
-let aimVec = (m: Model): Input.point2 =>
-  let pad = Pad.vector(stickRadius, m.right) in
-  if pad.x != 0.0 || pad.y != 0.0 then { x: pad.x, y: 0.0 - pad.y }
-  else { x: m.keys.aimX, y: m.keys.aimY }
+let moveVec = (m: Model): Input.point2 => stickOr(m.left, m.keys.moveX, m.keys.moveY)
+let aimVec = (m: Model): Input.point2 => stickOr(m.right, m.keys.aimX, m.keys.aimY)
 
 let arenaHalfW = 7.6
 let arenaHalfH = 4.2
@@ -112,7 +115,10 @@ let tick = (m: Model, dt, tts) =>
     aimed.shots
     |> List.map((s: Shot) => stepShot(dt, s))
     |> List.filter((s: Shot) => s.ttl > 0.0) in
-  if tilt >= fireTilt && aimed.cooldown <= 0.0 then
+  // Cooldown drains BEFORE the eligibility check, so a dt at or above
+  // fireCooldown sustains one shot per tick rather than alternating.
+  let cool = Math.max(0.0, aimed.cooldown - dt) in
+  if tilt >= fireTilt && cool <= 0.0 then
     let shot = {
       x: px,
       y: py,
@@ -122,29 +128,30 @@ let tick = (m: Model, dt, tts) =>
     } in
     { aimed with shots: [shot, ..flying], cooldown: fireCooldown }
   else
-    { aimed with shots: flying, cooldown: Math.max(0.0, aimed.cooldown - dt) }
+    { aimed with shots: flying, cooldown: cool }
 
 // --- Drawing ----------------------------------------------------------------
 let camW = 16.0
 let camH = 9.0
 
-// Surface CSS pixels (top-left origin) → world units (center origin, +Y up),
-// for drawing the stick overlays where the thumbs actually are.
-let toWorldX = (m: Model, sx: float) => (sx / m.surfaceW - 0.5) * camW
-let toWorldY = (m: Model, sy: float) => (0.5 - sy / m.surfaceH) * camH
-let pxToWorld = (m: Model, px: float) => px / m.surfaceW * camW
+// The stick overlays draw in their OWN sprite layer whose camera IS the
+// surface (`Camera2D.create(surfaceW, surfaceH)`), so surface pixels map to
+// layer units exactly — no letterbox math. Mapping thumbs through the 16x9
+// GAME camera would drift off the finger on any non-16:9 screen, because
+// that camera aspect-fits with letterbox bars.
+let overlayX = (m: Model, sx: float) => sx - m.surfaceW / 2.0
+let overlayY = (m: Model, sy: float) => m.surfaceH / 2.0 - sy
 
 let stickOverlay = (m: Model, stick: Pad.Stick) =>
   if not stick.active then Sprite.blank()
   else
-    let base = pxToWorld(m, stickRadius) in
     Sprite.group([
-      Sprite.circle(Color.rgb(0.5, 0.75, 0.95), base)
+      Sprite.circle(Color.rgb(0.5, 0.75, 0.95), stickRadius)
         |> Sprite.fade(0.18)
-        |> Sprite.move(toWorldX(m, stick.anchorX), toWorldY(m, stick.anchorY)),
-      Sprite.circle(Color.rgb(0.75, 0.9, 1.0), base * 0.35)
+        |> Sprite.move(overlayX(m, stick.anchorX), overlayY(m, stick.anchorY)),
+      Sprite.circle(Color.rgb(0.75, 0.9, 1.0), stickRadius * 0.35)
         |> Sprite.fade(0.45)
-        |> Sprite.move(toWorldX(m, stick.x), toWorldY(m, stick.y)),
+        |> Sprite.move(overlayX(m, stick.x), overlayY(m, stick.y)),
     ])
 
 let shotSprite = (s: Shot) =>
@@ -183,10 +190,12 @@ let draw = (m: Model, tts) =>
       Sprite.group(m.shots |> List.map(shotSprite)),
       player(m),
       hint(m),
-      stickOverlay(m, m.left),
-      stickOverlay(m, m.right),
     ]),
   )
+    |> Frame.with2D(
+        Camera2D.create(m.surfaceW, m.surfaceH),
+        Sprite.group([stickOverlay(m, m.left), stickOverlay(m, m.right)]),
+      )
     |> Frame.withClearColor(Color.rgb(0.03, 0.04, 0.08))
 
 // --- Inline tests: the input → simulation seam ------------------------------
@@ -216,4 +225,20 @@ expect (
 expect (
   let keys = { moveX: 1.0, moveY: 0.0, aimX: 0.0, aimY: 0.0 } in
   tick({ init with keys: keys, px: arenaHalfW }, 0.5, 0.5).px == arenaHalfW
+)
+
+// A keyboard diagonal is unit-clamped — it cannot outrun a full stick tilt.
+expect (
+  let keys = { moveX: 1.0, moveY: 1.0, aimX: 0.0, aimY: 0.0 } in
+  let v = moveVec({ init with keys: keys }) in
+  Math.abs(Math.sqrt(v.x * v.x + v.y * v.y) - 1.0) < 0.0001
+)
+
+// Sustained fire at dt >= fireCooldown fires every tick, not every other:
+// the cooldown drains before the eligibility check.
+expect (
+  let stick = { active: true, id: 0.0, anchorX: 600.0, anchorY: 300.0, x: 670.0, y: 300.0 } in
+  let one = tick({ init with right: stick }, fireCooldown, fireCooldown) in
+  let two = tick(one, fireCooldown, fireCooldown * 2.0) in
+  (two.shots |> List.length) == 2.0
 )

--- a/examples/virtual-gamepad/pad.fun
+++ b/examples/virtual-gamepad/pad.fun
@@ -33,15 +33,25 @@ let track = (touch: Input.touch, stick: Stick): Stick =>
     |> Option.map((p: Input.touchPoint) => { stick with x: p.x, y: p.y })
     |> Option.defaultValue(idle)
 
-// Claim: an inactive stick anchors on the first press inside its zone.
+// Claim: an inactive stick anchors on the first press inside its zone. A
+// press whose release landed in the SAME snapshot (a quick tap) is skipped —
+// claiming a contact that is already gone would flash a phantom stick, and
+// worse, adopt the tap's recycled id if a new finger lands next sample. The
+// current position comes from the held list (a begin+move coalesced into one
+// snapshot deflects immediately), falling back to the press point.
 let claim = (inZone: (Input.touchPoint) => bool, touch: Input.touch, stick: Stick): Stick =>
   if stick.active then stick
   else
     touch.pressed
-    |> List.filter(inZone)
+    |> List.filter((p: Input.touchPoint) =>
+        inZone(p) && not (touch.released |> List.any((r: Input.touchPoint) => r.id == p.id)))
     |> List.head
     |> Option.map((p: Input.touchPoint) =>
-        { active: true, id: p.id, anchorX: p.x, anchorY: p.y, x: p.x, y: p.y })
+        let now =
+          touch.touches
+          |> List.find((h: Input.touchPoint) => h.id == p.id)
+          |> Option.defaultValue(p) in
+        { active: true, id: p.id, anchorX: p.x, anchorY: p.y, x: now.x, y: now.y })
     |> Option.defaultValue(stick)
 
 /// Fold one sampled touch record into the stick: existing contacts tracked
@@ -51,8 +61,8 @@ let update = (inZone: (Input.touchPoint) => bool, touch: Input.touch, stick: Sti
 
 /// The stick's deflection as a unit-clamped vector in STICK space (`x` right,
 /// `y` down — surface pixels; negate `y` for an up-positive world). `radius`
-/// is the pixel deflection that reads as full tilt; a radial dead zone keeps
-/// a resting thumb from drifting the player.
+/// is the POSITIVE pixel deflection that reads as full tilt; a radial dead
+/// zone keeps a resting thumb from drifting the player.
 let vector = (radius: float, stick: Stick): Input.point2 =>
   if not stick.active then { x: 0.0, y: 0.0 }
   else
@@ -129,4 +139,23 @@ expect (
                 touches: [{ id: 1.0, x: 100.0, y: 100.0 }],
                 pressed: [{ id: 1.0, x: 100.0, y: 100.0 }] } in
   not update(anywhere, noTouches, update(anywhere, press, idle)).active
+)
+
+// A quick tap — press AND release in one snapshot — never claims: the
+// contact is already gone, and its id may be recycled next sample.
+expect (
+  let tap = { touches: [],
+              pressed: [{ id: 0.0, x: 100.0, y: 100.0 }],
+              released: [{ id: 0.0, x: 100.0, y: 100.0 }] } in
+  not update(anywhere, tap, idle).active
+)
+
+// A begin+move coalesced into one snapshot deflects immediately: the anchor
+// is the press point, the position is the held contact's current one.
+expect (
+  let coalesced = { noTouches with
+                    touches: [{ id: 2.0, x: 160.0, y: 100.0 }],
+                    pressed: [{ id: 2.0, x: 100.0, y: 100.0 }] } in
+  let s = update(anywhere, coalesced, idle) in
+  s.anchorX == 100.0 && s.x == 160.0 && vector(60.0, s).x == 1.0
 )

--- a/examples/virtual-gamepad/pad.fun
+++ b/examples/virtual-gamepad/pad.fun
@@ -1,0 +1,132 @@
+// Pad — pure floating-thumbstick math over the sampled touch domain.
+//
+// A stick is CLAIMED by the first touch that begins inside its zone: the
+// stick's center anchors where the finger landed (the classic mobile
+// "floating stick"), deflection is the finger's offset from that anchor, and
+// lifting the finger releases the stick. All plain data and pure functions —
+// the `expect`s below run under `functor test` with no GPU, window, or real
+// touches, and the game folds one `Pad.update` per stick per sampled step.
+
+/// One floating stick: inactive, or anchored at the claim point and
+/// following contact `id`. Coordinates are surface CSS pixels, like the
+/// touch domain itself.
+type Stick = {
+  active: bool,
+  id: float,
+  anchorX: float,
+  anchorY: float,
+  x: float,
+  y: float
+}
+
+let idle = { active: false, id: 0.0, anchorX: 0.0, anchorY: 0.0, x: 0.0, y: 0.0 }
+
+// Follow the claimed contact: reposition with it, release when it lifts. A
+// contact that vanishes from the held list without a release edge (a swept
+// snapshot) also releases — a stick must never track a ghost.
+let track = (touch: Input.touch, stick: Stick): Stick =>
+  if not stick.active then stick
+  else if touch.released |> List.any((p: Input.touchPoint) => p.id == stick.id) then idle
+  else
+    touch.touches
+    |> List.find((p: Input.touchPoint) => p.id == stick.id)
+    |> Option.map((p: Input.touchPoint) => { stick with x: p.x, y: p.y })
+    |> Option.defaultValue(idle)
+
+// Claim: an inactive stick anchors on the first press inside its zone.
+let claim = (inZone: (Input.touchPoint) => bool, touch: Input.touch, stick: Stick): Stick =>
+  if stick.active then stick
+  else
+    touch.pressed
+    |> List.filter(inZone)
+    |> List.head
+    |> Option.map((p: Input.touchPoint) =>
+        { active: true, id: p.id, anchorX: p.x, anchorY: p.y, x: p.x, y: p.y })
+    |> Option.defaultValue(stick)
+
+/// Fold one sampled touch record into the stick: existing contacts tracked
+/// (and released) first, then a fresh press inside `inZone` may claim it.
+let update = (inZone: (Input.touchPoint) => bool, touch: Input.touch, stick: Stick): Stick =>
+  claim(inZone, touch, track(touch, stick))
+
+/// The stick's deflection as a unit-clamped vector in STICK space (`x` right,
+/// `y` down — surface pixels; negate `y` for an up-positive world). `radius`
+/// is the pixel deflection that reads as full tilt; a radial dead zone keeps
+/// a resting thumb from drifting the player.
+let vector = (radius: float, stick: Stick): Input.point2 =>
+  if not stick.active then { x: 0.0, y: 0.0 }
+  else
+    let dx = (stick.x - stick.anchorX) / radius in
+    let dy = (stick.y - stick.anchorY) / radius in
+    let len = Math.sqrt(dx * dx + dy * dy) in
+    if len < 0.15 then { x: 0.0, y: 0.0 }
+    else if len > 1.0 then { x: dx / len, y: dy / len }
+    else { x: dx, y: dy }
+
+// --- Inline tests (functor test) -------------------------------------------
+
+let noTouches: Input.touch = { touches: [], pressed: [], released: [] }
+let anywhere = (p: Input.touchPoint) => true
+let leftHalf = (p: Input.touchPoint) => p.x < 400.0
+
+// A press inside the zone claims the stick AT the press point.
+expect (
+  let press = { noTouches with
+                touches: [{ id: 3.0, x: 120.0, y: 300.0 }],
+                pressed: [{ id: 3.0, x: 120.0, y: 300.0 }] } in
+  let s = update(leftHalf, press, idle) in
+  s.active && s.id == 3.0 && s.anchorX == 120.0 && s.anchorY == 300.0
+)
+
+// A press OUTSIDE the zone is ignored.
+expect (
+  let press = { noTouches with
+                touches: [{ id: 0.0, x: 700.0, y: 300.0 }],
+                pressed: [{ id: 0.0, x: 700.0, y: 300.0 }] } in
+  not update(leftHalf, press, idle).active
+)
+
+// Movement deflects relative to the ANCHOR, and a release resets to idle.
+expect (
+  let press = { noTouches with
+                touches: [{ id: 1.0, x: 100.0, y: 100.0 }],
+                pressed: [{ id: 1.0, x: 100.0, y: 100.0 }] } in
+  let moved = { noTouches with touches: [{ id: 1.0, x: 160.0, y: 100.0 }] } in
+  let lifted = { noTouches with released: [{ id: 1.0, x: 160.0, y: 100.0 }] } in
+  let held = update(anywhere, moved, update(anywhere, press, idle)) in
+  let v = vector(60.0, held) in
+  v.x == 1.0 && v.y == 0.0 && not update(anywhere, lifted, held).active
+)
+
+// Deflection clamps to the unit circle beyond `radius`…
+expect (
+  let s = { active: true, id: 0.0, anchorX: 0.0, anchorY: 0.0, x: 120.0, y: 0.0 } in
+  vector(60.0, s).x == 1.0
+)
+
+// …and rests inside the dead zone.
+expect (
+  let s = { active: true, id: 0.0, anchorX: 0.0, anchorY: 0.0, x: 5.0, y: 3.0 } in
+  let v = vector(60.0, s) in
+  v.x == 0.0 && v.y == 0.0
+)
+
+// A second finger cannot steal an already-claimed stick.
+expect (
+  let press = { noTouches with
+                touches: [{ id: 1.0, x: 100.0, y: 100.0 }],
+                pressed: [{ id: 1.0, x: 100.0, y: 100.0 }] } in
+  let second = { noTouches with
+                 touches: [{ id: 1.0, x: 100.0, y: 100.0 }, { id: 2.0, x: 50.0, y: 50.0 }],
+                 pressed: [{ id: 2.0, x: 50.0, y: 50.0 }] } in
+  let s = update(anywhere, second, update(anywhere, press, idle)) in
+  s.id == 1.0 && s.anchorX == 100.0
+)
+
+// A contact that vanishes without a release edge still frees the stick.
+expect (
+  let press = { noTouches with
+                touches: [{ id: 1.0, x: 100.0, y: 100.0 }],
+                pressed: [{ id: 1.0, x: 100.0, y: 100.0 }] } in
+  not update(anywhere, noTouches, update(anywhere, press, idle)).active
+)


### PR DESCRIPTION
Part 6 (the finale) of the gamepad + touch input series, stacked on #659. The touch domain's worked reference and the twin-stick hole in the example corpus: floating touch thumbsticks built entirely as **pure game code** over `snap.touch` — deliberately not an engine feature.

- **`Pad`** (sibling module): claim/track/vector as pure, `expect`-tested functions — zone claiming with anchor-on-press, anchor-relative deflection, unit clamping, radial dead zone, second-finger no-steal, ghost-contact release.
- **`game.fun`**: one `Pad.update` per stick per sampled step; left thumb moves, right thumb aims and fires past half tilt; sticks drawn as translucent overlays where the thumbs are; keyboard fallback (WASD + arrows) with the hint line keyed off the touch capability signal.
- Headlessly drivable: the file header documents the touch-injection loop, and the acceptance run below used it.

## Visuals

![virtual-gamepad demo](https://gist.githubusercontent.com/tommy-xr/891454c068006c634693ab5b72fd0cd3/raw/vpad-demo.gif)

<sub>Two injected touch contacts drive the floating sticks: the left thumb wiggles the move stick (player orb glides), the right thumb holds a full-right deflection (aim nub + yellow shots streaming). Captured headlessly via the debug server's touch injection + paused-clock frame stepping.</sub>

![still](https://gist.githubusercontent.com/tommy-xr/891454c068006c634693ab5b72fd0cd3/raw/vpad-still.png)

## Verification

- `functor test`: 12 expects (stick math + the input→simulation seam).
- Live headless drive via `POST /input` touch transitions: move stick held right drove `px` to 4.8; aim stick up produced `aim (0, 1)` and fired shots; releases freed both sticks.
- Enters the `wasm-smoke` sample sweep automatically (`examples/*` scan).

## xreview

Two-engine adversarial + de-dup pass (both engines also verified the captures against the claims). All findings addressed:
- **[AGREED ×3, High]** the stick overlays mapped thumbs through the letterboxed 16:9 game camera and drifted off the finger on non-16:9 surfaces (measured 37px at the 4:3 default) → they now draw in their own **surface-sized HUD layer** (`Frame.with2D(Camera2D.create(surfaceW, surfaceH), …)`), pixel-exact on every aspect — post-fix captures measured the base centered on the anchor to the half-pixel.
- **[AGREED A+B]** same-snapshot tap claim guard (a released contact never claims; a coalesced begin+move deflects immediately) — under expects.
- Cooldown drains before the eligibility check (sustained fire at large dt); `stickOr` merges the two vector helpers and unit-clamps keyboard diagonals; `cursor: "visible"` per the 2D-example convention.
- Reviewers verified clean: same-snapshot finger swap, zone stability across resizes, division/NaN hazards, y-flip consistency, and full model plainness (hot-reload/time-travel safe).

Final state: **16 expects**, live headless drive re-verified after fixes, media re-captured post-fix.

