### PR TITLE
feat(mcp): the native coordinator — session groups, socketless transport, wire_log

### DIFF
--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -46,10 +46,19 @@ use super::mcp_net::NetCoordinator;
 /// localhost endpoints, not per-frame runtime work.
 const PUMP_INTERVAL: Duration = Duration::from_millis(8);
 
+/// Largest delivery body the pump will post, comfortably under the debug
+/// server's own 64 KB command limit. A backlog larger than this is split across
+/// rounds rather than posted whole (which would 413 forever).
+const MAX_DELIVERY_BYTES: usize = 32 * 1024;
+
 /// Rows `wire_log` returns when the caller names no limit, and the ceiling it
 /// will return at all.
 const WIRE_LOG_DEFAULT_ROWS: usize = 100;
 const WIRE_LOG_MAX_ROWS: usize = 2_000;
+
+/// Total `payload_text` bytes one `wire_log` answer will carry. The row cap
+/// bounds the count; this bounds the SIZE, which the rows themselves do not.
+const MAX_WIRE_PAYLOAD_BYTES: usize = 256 * 1024;
 
 /// How long `launch_game` waits for a spawned runtime to answer discovery.
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -217,6 +226,33 @@ struct GroupMember {
 struct Group {
     members: Vec<GroupMember>,
     net: NetCoordinator,
+    /// Members whose last pump round failed, so the report is printed once per
+    /// outage instead of 125 times a second.
+    unreachable: BTreeSet<String>,
+}
+
+impl Group {
+    /// Report a member the pump could not reach — once, until it recovers.
+    fn note_unreachable(&mut self, label: &str, what: String) {
+        if self.unreachable.insert(label.to_string()) {
+            eprintln!("[coordinator] {label} unreachable — {what}");
+        }
+    }
+
+    fn note_reachable(&mut self, label: &str) {
+        if self.unreachable.remove(label) {
+            eprintln!("[coordinator] {label} is reachable again");
+        }
+    }
+}
+
+/// Whether a `/net/deliver` batch is safe to keep and retry.
+enum DeliveryOutcome {
+    Applied,
+    /// The runtime provably did not fold it — requeue.
+    NotApplied(String),
+    /// It may or may not have folded — report, and do NOT retry.
+    Ambiguous(String),
 }
 
 /// What `spawn_runtime` hands back to the two launch tools.
@@ -1242,9 +1278,10 @@ files writes the inline project to a scratch directory this server owns",
     /// the background pump held off for the whole round. So a packet a client
     /// sends in round N reaches the authority before the authority steps.
     ///
-    /// Delivery in v1 is IMMEDIATE, in order, and never dropped (a perfect,
-    /// reliable link). Latency, jitter, and step-time scheduling arrive with
-    /// barrier stepping.
+    /// Delivery in v1 is IMMEDIATE and in order (a perfect, reliable link):
+    /// the router never drops or reorders, and a failed delivery is re-queued
+    /// at the front and retried. Latency, jitter, and step-time scheduling
+    /// arrive with barrier stepping.
     #[tool]
     async fn launch_session_group(
         &self,
@@ -1298,10 +1335,17 @@ files writes the inline project to a scratch directory this server owns",
                     // A half-launched group is a half-wired network: tear the
                     // launched roles down rather than leave the caller to guess
                     // which ones exist.
-                    self.abandon_group_members(&members).await;
-                    return tool_error(format!(
-                        "launch_session_group stopped at role {role:?}: {message}"
-                    ));
+                    let orphaned = self.abandon_group_members(&members).await;
+                    let mut error =
+                        format!("launch_session_group stopped at role {role:?}: {message}");
+                    if !orphaned.is_empty() {
+                        error.push_str(&format!(
+                            "\n\nWARNING: could not confirm termination of {} — those runtimes \
+may still be running, and this server no longer tracks them.",
+                            orphaned.join(", ")
+                        ));
+                    }
+                    return tool_error(error);
                 }
             }
         }
@@ -1313,6 +1357,7 @@ files writes the inline project to a scratch directory this server owns",
         let group = Arc::new(tokio::sync::Mutex::new(Group {
             members: members.clone(),
             net,
+            unreachable: BTreeSet::new(),
         }));
         {
             let mut registry = self.sessions.lock().expect("mcp registry poisoned");
@@ -1385,10 +1430,31 @@ files writes the inline project to a scratch directory this server owns",
             .filter(|packet| filter.matches(packet))
             .collect();
         let total = matched.len();
-        let rows: Vec<Value> = matched
+        // A row cap alone is not an output bound — a game chooses how big a
+        // message is, and 2000 rows of a chatty protocol is megabytes straight
+        // into a model's context. So payloads also share a byte budget, spent
+        // NEWEST-first (a reader asking for a window wants its tail); an
+        // elided row keeps every other field and says so.
+        let mut payload_budget = MAX_WIRE_PAYLOAD_BYTES;
+        let mut elided = 0usize;
+        let mut rows: Vec<Value> = matched
             .into_iter()
             .skip(total.saturating_sub(limit))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
             .map(|packet| {
+                let payload = match &packet.payload_text {
+                    Some(text) if text.len() <= payload_budget => {
+                        payload_budget -= text.len();
+                        Value::String(text.clone())
+                    }
+                    Some(_) => {
+                        elided += 1;
+                        Value::Null
+                    }
+                    None => Value::Null,
+                };
                 serde_json::json!({
                     "seq": packet.seq,
                     // Always null in v1 — delivery is immediate and
@@ -1400,10 +1466,12 @@ files writes the inline project to a scratch directory this server owns",
                     "conn": packet.conn,
                     "kind": packet.kind,
                     "size": packet.size,
-                    "payload_text": packet.payload_text,
+                    "payload_text": payload,
+                    "payload_elided": packet.payload_text.is_some() && payload.is_null(),
                 })
             })
             .collect();
+        rows.reverse();
         ok_text(
             serde_json::json!({
                 "group": group_id,
@@ -1412,6 +1480,9 @@ files writes the inline project to a scratch directory this server owns",
                 "oldest_seq": guard.net.oldest_seq(),
                 "matched": total,
                 "returned": rows.len(),
+                // How many returned rows dropped their payload to stay inside
+                // the byte budget — narrow the window or the `link` to see them.
+                "payloads_elided": elided,
                 "connections": guard.net.connection_counts(),
                 "rows": rows,
             })
@@ -1519,6 +1590,16 @@ files writes the inline project to a scratch directory this server owns",
             .lock()
             .expect("mcp registry poisoned")
             .begin_stop(&args.session));
+        // De-route BEFORE taking the session gate, for two reasons. It removes
+        // a lock-order inversion: `step_all` takes a group lock and THEN the
+        // per-session gates, so a stop holding a gate while waiting for the
+        // group lock could hang both for the life of the process (neither
+        // tokio mutex has a timeout). And it runs on every exit from here,
+        // including the unconfirmed-termination error return below — otherwise
+        // a group could outlive its last member and its pump would poll a dead
+        // runtime forever. `begin_stop` has already marked the session closing,
+        // so nothing new can start on it either way.
+        self.forget_group_member(&args.session).await;
         // Stop is a lifecycle boundary: after `closing` is visible it must
         // drain the current operation and finish cleanup even if its own MCP
         // request is subsequently cancelled.
@@ -1573,10 +1654,6 @@ MCP server before reconnecting or reusing that runtime URL.",
                 args.session, target.url
             ));
         }
-        // The coordinator must forget a stopped role, or its peers keep a
-        // connection to a runtime that no longer exists. A group with no
-        // members left disappears, which is also what ends its pump task.
-        self.forget_group_member(&args.session).await;
         ok_text(format!(
             "stopped session {} ({})",
             args.session,
@@ -1841,14 +1918,15 @@ a session that must step twice per round is two rounds, not one list",
                 coordinated.insert(id, group);
             }
         }
+        // ONE deadline for the call, not one per session: N sessions must not
+        // multiply how long a single tool call can block. Started BEFORE the
+        // group locks, since waiting for a concurrent round to finish is time
+        // this call spends like any other.
+        let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
         let mut groups: Vec<tokio::sync::OwnedMutexGuard<Group>> = Vec::new();
         for group in coordinated.into_values() {
             groups.push(group.lock_owned().await);
         }
-
-        // ONE deadline for the call, not one per session: N sessions must not
-        // multiply how long a single tool call can block.
-        let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
         let mut stepped: Vec<Value> = Vec::with_capacity(targets.len());
         for (session, target) in targets {
             let desync = |message: String| {
@@ -2223,10 +2301,12 @@ impl FunctorMcp {
         })
     }
 
-    /// Tear down the roles a failed group launch already started. Best effort
-    /// by construction: the caller is already reporting a failure, and a child
-    /// this server cannot kill is reported by `list_sessions` either way.
-    async fn abandon_group_members(&self, members: &[GroupMember]) {
+    /// Tear down the roles a failed group launch already started, returning
+    /// the ones whose termination could NOT be confirmed. The caller is already
+    /// reporting a failure; an orphaned runtime has to be named in it, since
+    /// the session record is gone and `list_sessions` will not show it.
+    async fn abandon_group_members(&self, members: &[GroupMember]) -> Vec<String> {
+        let mut orphaned = Vec::new();
         for member in members {
             let child = {
                 let mut registry = self.sessions.lock().expect("mcp registry poisoned");
@@ -2235,14 +2315,19 @@ impl FunctorMcp {
                 child
             };
             if let Some(mut child) = child {
-                let _ = terminate_child(
+                if terminate_child(
                     &mut child,
                     "owned runtime child",
                     RUNTIME_CHILD_SHUTDOWN_TIMEOUT,
                 )
-                .await;
+                .await
+                .is_err()
+                {
+                    orphaned.push(member.url.clone());
+                }
             }
         }
+        orphaned
     }
 
     /// Remove a session from its group's routing table, dropping the group
@@ -2253,15 +2338,17 @@ impl FunctorMcp {
         };
         {
             let mut guard = group.lock().await;
-            let Some(index) = guard
+            // Not `else { return }`: the registry cleanup below must run even
+            // when the member is already gone, or `session_groups` keeps a
+            // stale row and the group can never empty (so its pump never ends).
+            if let Some(index) = guard
                 .members
                 .iter()
                 .position(|member| member.session == session)
-            else {
-                return;
-            };
-            let label = guard.members.remove(index).label;
-            guard.net.remove_session(&label);
+            {
+                let label = guard.members.remove(index).label;
+                guard.net.remove_session(&label);
+            }
         }
         let mut registry = self.sessions.lock().expect("mcp registry poisoned");
         registry.session_groups.remove(session);
@@ -2346,8 +2433,18 @@ wired to each other by this process, with no sockets)"
         for member in &members {
             let json = match self.get(&member.url, "/net/outbound").await {
                 Ok(json) => json,
-                Err(_) => continue,
+                // A member that cannot be drained is skipped for the round, but
+                // never SILENTLY: the failure includes a 409 from a runtime
+                // that is not on the embedder transport, which is the exact
+                // misconfiguration `EMBEDDER_TRANSPORT_REQUIRED` exists to make
+                // loud. Reported once per member until it succeeds again, so a
+                // dead child does not print 125 lines a second.
+                Err(error) => {
+                    guard.note_unreachable(&member.label, format!("drain failed: {error}"));
+                    continue;
+                }
             };
+            guard.note_reachable(&member.label);
             if json == "[]" {
                 continue;
             }
@@ -2358,8 +2455,8 @@ wired to each other by this process, with no sockets)"
                     }
                 }
                 // A runtime whose outbound JSON does not parse is a protocol
-                // break, not a game bug — say so once per round on stderr,
-                // which is this server's log channel (stdout is JSON-RPC).
+                // break, not a game bug — say so on stderr, which is this
+                // server's log channel (stdout is JSON-RPC).
                 Err(error) => eprintln!(
                     "[coordinator] {} sent unparseable outbound commands: {error}",
                     member.label
@@ -2367,14 +2464,48 @@ wired to each other by this process, with no sockets)"
             }
         }
         guard.net.retry_pending();
+        for (label, shed) in guard.net.take_drops() {
+            eprintln!(
+                "[coordinator] {label}'s queue overflowed — dropped {shed} undelivered event(s); \
+that session is not consuming its traffic"
+            );
+        }
         for member in &members {
-            let events = guard.net.take_outbox(&member.label);
-            if events.is_empty() {
-                continue;
-            }
-            let body = serde_json::to_string(&events).expect("delivered events serialize");
-            if self.post(&member.url, "/net/deliver", body).await.is_err() {
-                guard.net.requeue(&member.label, events);
+            let mut events = guard.net.take_outbox(&member.label);
+            while !events.is_empty() {
+                // CHUNKED, because `/net/deliver` caps its body: posting a
+                // whole backlog as one request would 413, be re-queued whole,
+                // and 413 again every round — a session's inbound dead for the
+                // rest of the run, silently. Splitting means a backlog drains
+                // over several rounds instead.
+                let rest = events.split_off(deliverable_prefix(&events));
+                let body = serde_json::to_string(&events).expect("delivered events serialize");
+                match self.post_delivery(&member.url, body).await {
+                    DeliveryOutcome::Applied => events = rest,
+                    DeliveryOutcome::NotApplied(error) => {
+                        // In order: the un-posted tail first, then this batch in
+                        // front of it. A reliable channel must not reorder.
+                        guard.net.requeue(&member.label, rest);
+                        guard.net.requeue(&member.label, events);
+                        guard.note_unreachable(&member.label, format!("delivery failed: {error}"));
+                        break;
+                    }
+                    // Ambiguous: the runtime may already have folded it, so
+                    // this batch is NOT retried (see `post_delivery`). The tail
+                    // goes back, and the loss is loud.
+                    DeliveryOutcome::Ambiguous(error) => {
+                        guard.net.requeue(&member.label, rest);
+                        guard.note_unreachable(
+                            &member.label,
+                            format!(
+                                "delivery outcome unknown, so {} event(s) were NOT retried \
+(retrying could double-fold them): {error}",
+                                events.len()
+                            ),
+                        );
+                        break;
+                    }
+                }
             }
         }
     }
@@ -2445,6 +2576,43 @@ wired to each other by this process, with no sockets)"
             .await
             .map_err(|error| format!("POST {path} on {url} failed: {error}"))?;
         read_body(path, response).await
+    }
+
+    /// `POST /net/deliver`, classified by whether the batch can be SAFELY
+    /// retried.
+    ///
+    /// `/net/deliver` applies its events before answering, so a blind retry on
+    /// any failure would re-fold a batch the runtime may already have absorbed
+    /// — duplicating messages on a channel `Sub.connect` promises is reliable
+    /// and ordered, which is worse for a game than losing them. So only a
+    /// failure that provably did NOT apply is re-queued: a refused connection
+    /// (nothing was sent) or a status the runtime chose (it rejected the body).
+    /// An ambiguous failure — a timeout, a truncated response — is reported and
+    /// dropped rather than risked twice. A transactional batch id belongs with
+    /// the barrier-stepping protocol, not with a v1 that talks to a child
+    /// process over loopback.
+    async fn post_delivery(&self, url: &str, body: String) -> DeliveryOutcome {
+        let response = match self
+            .http
+            .post(format!("{url}/net/deliver"))
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) if error.is_connect() => {
+                return DeliveryOutcome::NotApplied(format!("connection refused: {error}"))
+            }
+            Err(error) => return DeliveryOutcome::Ambiguous(format!("request failed: {error}")),
+        };
+        let rejected = response.status().is_client_error() || response.status().is_server_error();
+        match read_body("/net/deliver", response).await {
+            Ok(_) => DeliveryOutcome::Applied,
+            // The runtime answered, and its answer was a refusal: nothing was
+            // folded, so the batch is safe to keep.
+            Err(message) if rejected => DeliveryOutcome::NotApplied(message),
+            Err(message) => DeliveryOutcome::Ambiguous(message),
+        }
     }
 
     async fn post_binary(&self, url: &str, path: &str, body: Vec<u8>) -> Result<String, String> {
@@ -3500,19 +3668,28 @@ Rebuild that runtime from this version of Functor."
     }
 }
 
-/// The roles a project's `functor.json` declares, in manifest order.
+/// The roles a project's `functor.json` declares, sorted — `manifest_entries`'
+/// pairs with their files dropped. `entries` is a map, so its declaration order
+/// is not part of what the manifest means; a group's launch order comes from
+/// [`group_roles`] instead.
 fn declared_entries(manifest: &str) -> Result<Vec<String>, String> {
-    let value: Value = serde_json::from_str(manifest)
-        .map_err(|error| format!("functor.json is not valid JSON: {error}"))?;
-    match value.get("entries").and_then(Value::as_object) {
-        Some(entries) if !entries.is_empty() => Ok(entries.keys().cloned().collect()),
-        // A single-entry project has exactly one role, so a "group" of it is
-        // one game — say what is missing rather than launch a lonely session.
-        _ => Err(
-            "this project declares no `entries`, so it has no roles to group — a multiplayer project's functor.json looks like {\"entries\": {\"client\": …, \"server\": …}}"
+    // A single-`entry` manifest parses as ONE NAMELESS role, which is exactly
+    // the case to refuse: a "group" of a single-entry project is one game. So
+    // is a manifest `manifest_entries` cannot reason about at all.
+    let roles: Vec<String> = manifest_entries(manifest)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(role, _)| role)
+        .filter(|role| !role.is_empty())
+        .collect();
+    if roles.is_empty() {
+        return Err(
+            "this project declares no `entries`, so it has no roles to group — a multiplayer \
+project's functor.json looks like {\"entries\": {\"client\": …, \"server\": …}}"
                 .to_string(),
-        ),
+        );
     }
+    Ok(roles)
 }
 
 /// The roles to launch, in order. Explicit `roles` wins verbatim (repeats are
@@ -3638,6 +3815,20 @@ ends; pass a single label instead"
             },
         }
     }
+}
+
+/// How many leading events fit in one `/net/deliver` body. At least one always
+/// does: a single event over the budget is posted alone and lets the runtime's
+/// own 413 be the (loud) answer, rather than being silently stuck forever.
+fn deliverable_prefix(events: &[functor_runtime_common::net::DeliveredEvent]) -> usize {
+    let mut bytes = 2; // the enclosing `[]`
+    for (index, event) in events.iter().enumerate() {
+        bytes += serde_json::to_string(event).map_or(0, |json| json.len() + 1);
+        if bytes > MAX_DELIVERY_BYTES {
+            return index.max(1);
+        }
+    }
+    events.len()
 }
 
 fn node_executable() -> String {
@@ -5098,7 +5289,7 @@ fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
 mod tests {
     use super::{
         acquire_target_operation, base64_encoded_len, checked_output_total, declared_entries,
-        encoded_capture_total, group_labels, group_roles,
+        deliverable_prefix, encoded_capture_total, group_labels, group_roles, MAX_DELIVERY_BYTES,
         ensure_operation_active, extend_bounded, find_guide_section, guide_sections,
         json_encoded_len, node_code_call_result, node_code_summary, read_body,
         read_bounded_response, render_api_hits, render_guide_contents, render_guide_section,
@@ -6366,7 +6557,7 @@ mod tests {
         let error = declared_entries(r#"{"entry":"game.fun"}"#).unwrap_err();
         assert!(error.contains("no `entries`"), "{error}");
         assert_eq!(
-            declared_entries(r#"{"entries":{"client":{},"server":{}}}"#).unwrap(),
+            declared_entries(r#"{"entries":{"client":{"file":"game.fun","module":"Client"},"server":{"file":"game.fun","module":"Server"}}}"#).unwrap(),
             ["client", "server"]
         );
     }
@@ -6414,5 +6605,38 @@ mod tests {
             matching(WireFilter::parse(Some("server:client2"), None, &known).unwrap()),
             [2]
         );
+    }
+
+    /// `/net/deliver` caps its body, so a backlog must be SPLIT rather than
+    /// posted whole: posting whole would 413, be re-queued whole, and 413 again
+    /// every round — that session's inbound dead for the rest of the run.
+    #[test]
+    fn a_delivery_batch_is_split_below_the_endpoint_limit() {
+        use functor_runtime_common::net::DeliveredEvent;
+        let event = |index: usize| DeliveredEvent::Message {
+            key: "ws://127.0.0.1:9101/orbs".into(),
+            conn: 1,
+            text: format!("{index}").repeat(400),
+        };
+        let events: Vec<DeliveredEvent> = (0..200).map(event).collect();
+        let prefix = deliverable_prefix(&events);
+        assert!(prefix > 0 && prefix < events.len(), "split at {prefix}");
+        assert!(
+            serde_json::to_string(&events[..prefix]).unwrap().len() <= MAX_DELIVERY_BYTES + 4096,
+            "the chosen prefix stays near the budget"
+        );
+
+        // A small backlog is one body.
+        let small: Vec<DeliveredEvent> = (0..3).map(event).collect();
+        assert_eq!(deliverable_prefix(&small), 3);
+
+        // A SINGLE event over the budget still goes alone: the runtime's own
+        // 413 is then the loud answer, rather than a batch stuck forever.
+        let huge = vec![DeliveredEvent::Message {
+            key: "k".into(),
+            conn: 1,
+            text: "x".repeat(MAX_DELIVERY_BYTES * 2),
+        }];
+        assert_eq!(deliverable_prefix(&huge), 1);
     }
 }

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 
 use base64::Engine as _;
 use functor_docgen::{ApiItem, ApiReference};
+use functor_runtime_common::net::ConnCommand;
 use functor_runtime_common::{debug_protocol::DEBUG_PROTOCOL_SERVICE, Key};
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, ContentBlock};
@@ -35,6 +36,20 @@ use tokio::io::{
     AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader,
 };
 use tokio::process::{Child, Command};
+
+use super::mcp_net::NetCoordinator;
+
+/// How often the background routing pump drains and delivers a live group's
+/// traffic. Between `step_all` rounds a group still runs on wall-clock time,
+/// and its packets must move without a tool call to push them — this is the
+/// coordinator standing in for the kernel. It is a HOST-side poll of two tiny
+/// localhost endpoints, not per-frame runtime work.
+const PUMP_INTERVAL: Duration = Duration::from_millis(8);
+
+/// Rows `wire_log` returns when the caller names no limit, and the ceiling it
+/// will return at all.
+const WIRE_LOG_DEFAULT_ROWS: usize = 100;
+const WIRE_LOG_MAX_ROWS: usize = 2_000;
 
 /// How long `launch_game` waits for a spawned runtime to answer discovery.
 const LAUNCH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -178,6 +193,38 @@ struct Session {
     /// ATTACHED session: the manifest of a runtime someone else started is not
     /// knowable over the wire.
     manifest: Option<String>,
+}
+
+/// One role of a session GROUP: a runtime launched on the embedder transport,
+/// whose network is this process.
+#[derive(Clone, Debug)]
+struct GroupMember {
+    /// Registry session id (`s3`).
+    session: String,
+    /// The routing identity in the wire log — the role name, disambiguated
+    /// when a role is launched more than once (`server`, `client1`, `client2`).
+    label: String,
+    /// The functor.json entry this member runs.
+    role: String,
+    url: String,
+}
+
+/// A set of runtimes wired to each other by this process.
+///
+/// One `tokio::sync::Mutex` per group covers BOTH the coordinator and the
+/// pump's HTTP round-trips, so a background pump and a `step_all` round can
+/// never interleave halfway through routing a batch.
+struct Group {
+    members: Vec<GroupMember>,
+    net: NetCoordinator,
+}
+
+/// What `spawn_runtime` hands back to the two launch tools.
+struct SpawnedRuntime {
+    session: String,
+    url: String,
+    port: u16,
+    discovery: Value,
 }
 
 /// The await-safe part of a registry session.
@@ -409,6 +456,11 @@ struct Registry {
     /// window between `free_port` and the child's own bind — and MCP tool calls
     /// can overlap, which is exactly the two-game case sessions exist for.
     reserved: BTreeSet<u16>,
+    /// Coordinated groups by id (`g1`), and the reverse index a `step_all`
+    /// uses to find the group a session belongs to.
+    groups: BTreeMap<String, Arc<tokio::sync::Mutex<Group>>>,
+    session_groups: BTreeMap<String, String>,
+    next_group: u32,
 }
 
 impl Registry {
@@ -892,6 +944,45 @@ pub struct StepAllArgs {
 }
 
 #[derive(Deserialize, JsonSchema)]
+pub struct LaunchGroupArgs {
+    /// Project directory (the one holding `functor.json`), absolute or
+    /// relative to the MCP server's working directory. A group launches from a
+    /// directory only: its roles come from that manifest's `entries`.
+    pub dir: String,
+    /// The roles to launch, IN ORDER — the launch order and the order to pass
+    /// to `step_all`, so put the authority where the protocol needs it.
+    /// Repeats are allowed and are how a group gets two clients:
+    /// `["server", "client", "client"]`. Omit it for one session per declared
+    /// entry, with a role named `server` first.
+    pub roles: Option<Vec<String>>,
+    /// `"headless"` (default here — a group is usually driven, not watched)
+    /// creates no GL context at all; `"hidden"` renders into an invisible
+    /// window so `capture_frame` returns pixels.
+    pub mode: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct WireLogArgs {
+    /// Group id from `launch_session_group`. Omit it when only one group is
+    /// running.
+    pub group: Option<String>,
+    /// Return only rows with a HIGHER `seq` than this — read the last row's
+    /// `seq` before a `step_all` round and pass it after to get exactly that
+    /// round's traffic.
+    pub since: Option<u64>,
+    /// Newest-first row cap (default 100, maximum 2000). Rows are returned
+    /// oldest-first within that window.
+    pub limit: Option<usize>,
+    /// One session label (`"server"`, `"client2"`), or an unordered pair
+    /// (`"client1:server"`) — only traffic touching it, or between them.
+    pub link: Option<String>,
+    /// With a single-label `link`: `"sent"` (rows FROM it) or `"received"`
+    /// (rows TO it). Without one it is an error, since there is no reference
+    /// point for a direction.
+    pub direction: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
 pub struct RewindArgs {
     pub session: String,
     /// The recorded rendered frame to restore.
@@ -1103,71 +1194,15 @@ files writes the inline project to a scratch directory this server owns",
         // unreadable manifest is not this tool's error to raise — the launch
         // below fails on it with the runtime's own message.
         let manifest = std::fs::read_to_string(dir.join("functor.json")).ok();
-        let port = resolve!(self
-            .sessions
-            .lock()
-            .expect("mcp registry poisoned")
-            .reserve_port());
-        let exe = resolve!(std::env::current_exe()
-            .map_err(|error| format!("cannot locate the functor executable: {error}")));
-
-        let mut command = Command::new(exe);
-        command.arg("-d").arg(&dir);
-        if let Some(entry) = &args.entry {
-            command.arg("--entry").arg(entry);
-        }
-        command
-            .args(["run", "native", "--debug-port"])
-            .arg(port.to_string())
-            .arg(mode_flag)
-            // stdout is this server's JSON-RPC channel — a child must never
-            // inherit it, or its logs would corrupt the protocol stream.
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .kill_on_drop(true);
-
-        let mut child = match command.spawn() {
-            Ok(child) => child,
-            Err(error) => {
-                self.release_port(port);
-                return tool_error(format!("failed to spawn the runtime: {error}"));
-            }
-        };
-        let log = Arc::new(Mutex::new(Vec::new()));
-        let mut drains = Vec::new();
-        if let Some(stream) = child.stdout.take() {
-            drains.push(drain_into(stream, log.clone()));
-        }
-        if let Some(stream) = child.stderr.take() {
-            drains.push(drain_into(stream, log.clone()));
-        }
-
-        let url = format!("http://127.0.0.1:{port}");
-        let discovery = match self.await_runtime(&url, &mut child).await {
-            Ok(discovery) => discovery,
-            Err(message) => {
-                let _ = child.start_kill();
-                self.release_port(port);
-                // The output that explains a failed launch — a bind error, a
-                // typecheck diagnostic — is written just before the child exits,
-                // so let the drain tasks reach EOF before reading the tail.
-                let _ = tokio::time::timeout(Duration::from_millis(500), async {
-                    for drain in drains {
-                        let _ = drain.await;
-                    }
-                })
-                .await;
-                return tool_error(format!("{message}\n\nruntime output:\n{}", tail(&log)));
-            }
-        };
-
-        let id = self.sessions.lock().expect("mcp registry poisoned").insert(
-            url.clone(),
-            Some(port),
-            Some(child),
-            scratch,
-            manifest,
+        let spawned = resolve!(
+            self.spawn_runtime(&dir, args.entry.as_deref(), mode_flag, scratch, manifest, false)
+                .await
+        );
+        let (id, url, port, discovery) = (
+            spawned.session,
+            spawned.url,
+            spawned.port,
+            spawned.discovery,
         );
         let mut response = serde_json::json!({
             "session": id,
@@ -1187,6 +1222,201 @@ files writes the inline project to a scratch directory this server owns",
             response["discovery"] = discovery;
         }
         ok_text(response.to_string())
+    }
+
+    /// Launch a whole MULTIPLAYER session at once, with THIS PROCESS as the
+    /// network. Every role starts on the embedder transport, so no socket is
+    /// ever opened: each runtime's `Sub.listen` / `Sub.connect` / `Effect.send`
+    /// traffic is drained by this server, routed by authority (a client url's
+    /// `host:port` matching a server's bind), and delivered back — and every
+    /// routed packet is readable as data through `wire_log`.
+    ///
+    /// Roles come from the project's `functor.json` `entries`. `roles` is the
+    /// launch order AND the order to hand `step_all`; repeats give a group two
+    /// clients. Returns the group id and one session per role, labelled the way
+    /// the wire log names them.
+    ///
+    /// Routing runs on this server's own loop: continuously in the background
+    /// (~8 ms) while the group runs live, and — the part that matters for
+    /// evaluation — at every session boundary INSIDE a `step_all` round, with
+    /// the background pump held off for the whole round. So a packet a client
+    /// sends in round N reaches the authority before the authority steps.
+    ///
+    /// Delivery in v1 is IMMEDIATE, in order, and never dropped (a perfect,
+    /// reliable link). Latency, jitter, and step-time scheduling arrive with
+    /// barrier stepping.
+    #[tool]
+    async fn launch_session_group(
+        &self,
+        Parameters(args): Parameters<LaunchGroupArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mode = args.mode.as_deref().unwrap_or("headless");
+        let mode_flag = match mode {
+            "hidden" => "--hidden",
+            "headless" => "--headless",
+            other => {
+                return tool_error(format!(
+                    "unknown mode {other:?}: expected \"headless\" (default; no GL) or \
+\"hidden\" (an invisible window, so capture_frame works)"
+                ))
+            }
+        };
+        let dir = std::path::PathBuf::from(&args.dir);
+        let manifest_text = resolve!(std::fs::read_to_string(dir.join("functor.json")).map_err(
+            |error| format!("cannot read {}/functor.json: {error}", absolute(&dir))
+        ));
+        let declared = resolve!(declared_entries(&manifest_text));
+        let roles = resolve!(group_roles(args.roles.as_deref(), &declared));
+        let labels = group_labels(&roles);
+
+        let group_id = {
+            let mut registry = self.sessions.lock().expect("mcp registry poisoned");
+            registry.next_group += 1;
+            format!("g{}", registry.next_group)
+        };
+
+        let mut members: Vec<GroupMember> = Vec::with_capacity(roles.len());
+        for (role, label) in roles.iter().zip(&labels) {
+            match self
+                .spawn_runtime(
+                    &dir,
+                    Some(role),
+                    mode_flag,
+                    None,
+                    Some(manifest_text.clone()),
+                    true,
+                )
+                .await
+            {
+                Ok(spawned) => members.push(GroupMember {
+                    session: spawned.session,
+                    label: label.clone(),
+                    role: role.clone(),
+                    url: spawned.url,
+                }),
+                Err(message) => {
+                    // A half-launched group is a half-wired network: tear the
+                    // launched roles down rather than leave the caller to guess
+                    // which ones exist.
+                    self.abandon_group_members(&members).await;
+                    return tool_error(format!(
+                        "launch_session_group stopped at role {role:?}: {message}"
+                    ));
+                }
+            }
+        }
+
+        let mut net = NetCoordinator::new();
+        for member in &members {
+            net.add_session(&member.label);
+        }
+        let group = Arc::new(tokio::sync::Mutex::new(Group {
+            members: members.clone(),
+            net,
+        }));
+        {
+            let mut registry = self.sessions.lock().expect("mcp registry poisoned");
+            for member in &members {
+                registry
+                    .session_groups
+                    .insert(member.session.clone(), group_id.clone());
+            }
+            registry.groups.insert(group_id.clone(), group.clone());
+        }
+        self.spawn_pump(group_id.clone(), group);
+
+        ok_text(
+            serde_json::json!({
+                "group": group_id,
+                "dir": absolute(&dir),
+                "mode": mode,
+                "transport": "embedder (this process is the network; no sockets)",
+                "sessions": members
+                    .iter()
+                    .map(|member| serde_json::json!({
+                        "session": member.session,
+                        "label": member.label,
+                        "role": member.role,
+                        "url": member.url,
+                    }))
+                    .collect::<Vec<_>>(),
+                "step_order": members.iter().map(|m| m.session.clone()).collect::<Vec<_>>(),
+            })
+            .to_string(),
+        )
+    }
+
+    /// The WIRE, as data: every packet this process routed for a group, in
+    /// order. One row per delivery — `{seq, frame, at_ms, from, to, conn, kind,
+    /// size, payload_text}`.
+    ///
+    /// `payload_text` is the message exactly as the receiving runtime sees it,
+    /// undecoded on purpose: the framing belongs to the game (`Effect.sendMsg`
+    /// writes JSON), so YOU decode it — a coordinator that parsed payloads
+    /// would be inventing a protocol it does not own.
+    ///
+    /// `frame` is `null` in v1: delivery is immediate and unscheduled, so there
+    /// is no step to name it with. `seq` is the stable cursor — read the last
+    /// row's `seq`, run a `step_all` round, then pass it as `since` to get
+    /// exactly that round's traffic.
+    #[tool]
+    async fn wire_log(
+        &self,
+        Parameters(args): Parameters<WireLogArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (group_id, group) = resolve!(self.group_by_id(args.group.as_deref()));
+        let limit = args.limit.unwrap_or(WIRE_LOG_DEFAULT_ROWS);
+        if limit == 0 || limit > WIRE_LOG_MAX_ROWS {
+            return tool_error(format!(
+                "limit must be between 1 and {WIRE_LOG_MAX_ROWS} (got {limit})"
+            ));
+        }
+        let guard = group.lock().await;
+        let known: Vec<String> = guard.net.labels().to_vec();
+        let filter = resolve!(WireFilter::parse(
+            args.link.as_deref(),
+            args.direction.as_deref(),
+            &known
+        ));
+        let matched: Vec<&crate::commands::mcp_net::Packet> = guard
+            .net
+            .packets()
+            .filter(|packet| args.since.is_none_or(|since| packet.seq > since))
+            .filter(|packet| filter.matches(packet))
+            .collect();
+        let total = matched.len();
+        let rows: Vec<Value> = matched
+            .into_iter()
+            .skip(total.saturating_sub(limit))
+            .map(|packet| {
+                serde_json::json!({
+                    "seq": packet.seq,
+                    // Always null in v1 — delivery is immediate and
+                    // unscheduled, so there is no step to name it with.
+                    "frame": packet.frame,
+                    "at_ms": (packet.at_ms * 1000.0).round() / 1000.0,
+                    "from": packet.from,
+                    "to": packet.to,
+                    "conn": packet.conn,
+                    "kind": packet.kind,
+                    "size": packet.size,
+                    "payload_text": packet.payload_text,
+                })
+            })
+            .collect();
+        ok_text(
+            serde_json::json!({
+                "group": group_id,
+                "sessions": known,
+                "routed": guard.net.routed(),
+                "oldest_seq": guard.net.oldest_seq(),
+                "matched": total,
+                "returned": rows.len(),
+                "connections": guard.net.connection_counts(),
+                "rows": rows,
+            })
+            .to_string(),
+        )
     }
 
     /// Attach to a debug server this process does NOT own — a runtime someone
@@ -1343,6 +1573,10 @@ MCP server before reconnecting or reusing that runtime URL.",
                 args.session, target.url
             ));
         }
+        // The coordinator must forget a stopped role, or its peers keep a
+        // connection to a runtime that no longer exists. A group with no
+        // members left disappears, which is also what ends its pump task.
+        self.forget_group_member(&args.session).await;
         ok_text(format!(
             "stopped session {} ({})",
             args.session,
@@ -1595,6 +1829,23 @@ a session that must step twice per round is two rounds, not one list",
             targets.push((session.clone(), target));
         }
 
+        // Coordinated groups among the listed sessions: their locks are held
+        // for the WHOLE round, which suspends the background routing pump.
+        // Routing then happens only where this loop puts it — at each session
+        // boundary — so a packet lands before its receiver's step rather than
+        // wherever an 8 ms timer fired. Locked in group-id order, and no other
+        // path ever holds two, so this cannot deadlock.
+        let mut coordinated: BTreeMap<String, Arc<tokio::sync::Mutex<Group>>> = BTreeMap::new();
+        for (session, _) in &targets {
+            if let Some((id, group)) = self.group_of(session) {
+                coordinated.insert(id, group);
+            }
+        }
+        let mut groups: Vec<tokio::sync::OwnedMutexGuard<Group>> = Vec::new();
+        for group in coordinated.into_values() {
+            groups.push(group.lock_owned().await);
+        }
+
         // ONE deadline for the call, not one per session: N sessions must not
         // multiply how long a single tool call can block.
         let operation_deadline = Instant::now() + OPERATION_TOTAL_TIMEOUT;
@@ -1616,6 +1867,14 @@ in the list have already advanced; the group is no longer in lockstep."
                 Ok(operation) => operation,
                 Err(message) => return tool_error(desync(message)),
             };
+            // Route first: whatever the previous session in this round emitted
+            // becomes this one's inbound BEFORE it steps. `POST /net/deliver`
+            // folds each event through `update` before answering, so by the
+            // time this returns the model has already absorbed the round's
+            // traffic.
+            for group in groups.iter_mut() {
+                self.pump_locked(group).await;
+            }
             // Drain what this session has ALREADY received before it steps, so
             // the round folds it in rather than carrying it to the next one.
             if let Err(message) = self.settle_net(&target, operation_deadline).await {
@@ -1628,6 +1887,12 @@ in the list have already advanced; the group is no longer in lockstep."
             let mut summary = summarize_state(&state);
             summary["session"] = Value::String(session);
             stepped.push(summary);
+        }
+        // One final round so the LAST session's emissions are routed before the
+        // call returns: a `wire_log` taken straight afterwards then shows the
+        // whole round rather than all-but-the-tail.
+        for group in groups.iter_mut() {
+            self.pump_locked(group).await;
         }
         ok_text(
             serde_json::json!({ "dts": dts, "frames": frames, "sessions": stepped }).to_string(),
@@ -1863,6 +2128,277 @@ impl FunctorMcp {
             .lock()
             .expect("mcp registry poisoned")
             .target(session)
+    }
+
+    /// Spawn one runtime child, wait for it to answer discovery, and register
+    /// it. The shared body of `launch_game` and `launch_session_group` — the
+    /// only difference between them is `embedder_net`, which decides whether
+    /// the child opens real sockets or hands its traffic to this process.
+    async fn spawn_runtime(
+        &self,
+        dir: &Path,
+        entry: Option<&str>,
+        mode_flag: &str,
+        scratch: Option<ScratchDir>,
+        manifest: Option<String>,
+        embedder_net: bool,
+    ) -> Result<SpawnedRuntime, String> {
+        let port = self
+            .sessions
+            .lock()
+            .expect("mcp registry poisoned")
+            .reserve_port()?;
+        let exe = std::env::current_exe()
+            .map_err(|error| format!("cannot locate the functor executable: {error}"))?;
+
+        let mut command = Command::new(exe);
+        command.arg("-d").arg(dir);
+        if let Some(entry) = entry {
+            command.arg("--entry").arg(entry);
+        }
+        command
+            .args(["run", "native", "--debug-port"])
+            .arg(port.to_string())
+            .arg(mode_flag);
+        if embedder_net {
+            // The runner arg the CLI forwards verbatim: no socket is opened,
+            // and the drained ConnCommands wait for `GET /net/outbound`.
+            command.args(["--net-transport", "embedder"]);
+        }
+        command
+            // stdout is this server's JSON-RPC channel — a child must never
+            // inherit it, or its logs would corrupt the protocol stream.
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                self.release_port(port);
+                return Err(format!("failed to spawn the runtime: {error}"));
+            }
+        };
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut drains = Vec::new();
+        if let Some(stream) = child.stdout.take() {
+            drains.push(drain_into(stream, log.clone()));
+        }
+        if let Some(stream) = child.stderr.take() {
+            drains.push(drain_into(stream, log.clone()));
+        }
+
+        let url = format!("http://127.0.0.1:{port}");
+        let discovery = match self.await_runtime(&url, &mut child).await {
+            Ok(discovery) => discovery,
+            Err(message) => {
+                let _ = child.start_kill();
+                self.release_port(port);
+                // The output that explains a failed launch — a bind error, a
+                // typecheck diagnostic — is written just before the child exits,
+                // so let the drain tasks reach EOF before reading the tail.
+                let _ = tokio::time::timeout(Duration::from_millis(500), async {
+                    for drain in drains {
+                        let _ = drain.await;
+                    }
+                })
+                .await;
+                return Err(format!("{message}\n\nruntime output:\n{}", tail(&log)));
+            }
+        };
+
+        let session = self.sessions.lock().expect("mcp registry poisoned").insert(
+            url.clone(),
+            Some(port),
+            Some(child),
+            scratch,
+            manifest,
+        );
+        Ok(SpawnedRuntime {
+            session,
+            url,
+            port,
+            discovery,
+        })
+    }
+
+    /// Tear down the roles a failed group launch already started. Best effort
+    /// by construction: the caller is already reporting a failure, and a child
+    /// this server cannot kill is reported by `list_sessions` either way.
+    async fn abandon_group_members(&self, members: &[GroupMember]) {
+        for member in members {
+            let child = {
+                let mut registry = self.sessions.lock().expect("mcp registry poisoned");
+                let child = registry.take_child(&member.session).ok().flatten();
+                let _ = registry.remove(&member.session);
+                child
+            };
+            if let Some(mut child) = child {
+                let _ = terminate_child(
+                    &mut child,
+                    "owned runtime child",
+                    RUNTIME_CHILD_SHUTDOWN_TIMEOUT,
+                )
+                .await;
+            }
+        }
+    }
+
+    /// Remove a session from its group's routing table, dropping the group
+    /// (and so ending its pump) once it is empty.
+    async fn forget_group_member(&self, session: &str) {
+        let Some((group_id, group)) = self.group_of(session) else {
+            return;
+        };
+        {
+            let mut guard = group.lock().await;
+            let Some(index) = guard
+                .members
+                .iter()
+                .position(|member| member.session == session)
+            else {
+                return;
+            };
+            let label = guard.members.remove(index).label;
+            guard.net.remove_session(&label);
+        }
+        let mut registry = self.sessions.lock().expect("mcp registry poisoned");
+        registry.session_groups.remove(session);
+        let empty = registry
+            .groups
+            .get(&group_id)
+            .is_some_and(|_| !registry.session_groups.values().any(|id| *id == group_id));
+        if empty {
+            registry.groups.remove(&group_id);
+        }
+    }
+
+    /// The group a session belongs to, if any.
+    fn group_of(&self, session: &str) -> Option<(String, Arc<tokio::sync::Mutex<Group>>)> {
+        let registry = self.sessions.lock().expect("mcp registry poisoned");
+        let id = registry.session_groups.get(session)?.clone();
+        let group = registry.groups.get(&id)?.clone();
+        Some((id, group))
+    }
+
+    fn group_by_id(&self, id: Option<&str>) -> Result<(String, Arc<tokio::sync::Mutex<Group>>), String> {
+        let registry = self.sessions.lock().expect("mcp registry poisoned");
+        match id {
+            Some(id) => registry
+                .groups
+                .get(id)
+                .cloned()
+                .map(|group| (id.to_string(), group))
+                .ok_or_else(|| {
+                    if registry.groups.is_empty() {
+                        format!(
+                            "unknown group {id:?}: no groups yet — start one with \
+launch_session_group"
+                        )
+                    } else {
+                        format!(
+                            "unknown group {id:?}: known groups are {}",
+                            registry.groups.keys().cloned().collect::<Vec<_>>().join(", ")
+                        )
+                    }
+                }),
+            None if registry.groups.len() == 1 => {
+                let (id, group) = registry.groups.iter().next().expect("one group");
+                Ok((id.clone(), group.clone()))
+            }
+            None if registry.groups.is_empty() => Err(
+                "no session group is running — launch_session_group starts one (its roles are \
+wired to each other by this process, with no sockets)"
+                    .to_string(),
+            ),
+            None => Err(format!(
+                "several groups are running ({}) — name one with `group`",
+                registry.groups.keys().cloned().collect::<Vec<_>>().join(", ")
+            )),
+        }
+    }
+
+    /// ONE routing round: take every member's queued `ConnCommand`s, route
+    /// them, and hand each member what it is owed.
+    ///
+    /// The pump deliberately does NOT take a session's operation gate. It is
+    /// the TRANSPORT — the thing a kernel does behind every other operation —
+    /// so gating it would both deadlock against a `step_all` holding a gate and
+    /// misrepresent what it models. `/net/outbound` and `/net/deliver` are the
+    /// only endpoints it touches, and neither races the clock.
+    ///
+    /// A member that cannot be reached (it stopped, it is mid-reload) is
+    /// skipped for the round rather than failing the group, and an undelivered
+    /// batch is re-queued in order for the next one.
+    async fn pump_group(&self, group: &Arc<tokio::sync::Mutex<Group>>) {
+        let mut guard = group.lock().await;
+        self.pump_locked(&mut guard).await;
+    }
+
+    /// [`Self::pump_group`] against a group lock the caller already holds — how
+    /// `step_all` pumps at each session boundary while KEEPING the background
+    /// pump out for the whole round. Holding the lock is what makes a round's
+    /// deliveries fall on the boundaries the caller declared instead of
+    /// wherever an 8 ms timer happened to fire.
+    async fn pump_locked(&self, guard: &mut Group) {
+        let members = guard.members.clone();
+        for member in &members {
+            let json = match self.get(&member.url, "/net/outbound").await {
+                Ok(json) => json,
+                Err(_) => continue,
+            };
+            if json == "[]" {
+                continue;
+            }
+            match serde_json::from_str::<Vec<ConnCommand>>(&json) {
+                Ok(commands) => {
+                    for command in commands {
+                        guard.net.perform(&member.label, command);
+                    }
+                }
+                // A runtime whose outbound JSON does not parse is a protocol
+                // break, not a game bug — say so once per round on stderr,
+                // which is this server's log channel (stdout is JSON-RPC).
+                Err(error) => eprintln!(
+                    "[coordinator] {} sent unparseable outbound commands: {error}",
+                    member.label
+                ),
+            }
+        }
+        guard.net.retry_pending();
+        for member in &members {
+            let events = guard.net.take_outbox(&member.label);
+            if events.is_empty() {
+                continue;
+            }
+            let body = serde_json::to_string(&events).expect("delivered events serialize");
+            if self.post(&member.url, "/net/deliver", body).await.is_err() {
+                guard.net.requeue(&member.label, events);
+            }
+        }
+    }
+
+    /// The background half of the cadence: while a group's sessions run live
+    /// (between tool calls, on wall-clock time), its packets still have to
+    /// move. One task per group, ending when the group does.
+    fn spawn_pump(&self, group_id: String, group: Arc<tokio::sync::Mutex<Group>>) {
+        let server = self.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(PUMP_INTERVAL).await;
+                let alive = server
+                    .sessions
+                    .lock()
+                    .expect("mcp registry poisoned")
+                    .groups
+                    .contains_key(&group_id);
+                if !alive {
+                    return;
+                }
+                server.pump_group(&group).await;
+            }
+        });
     }
 
     async fn acquire_operation(
@@ -2960,6 +3496,146 @@ Rebuild that runtime from this version of Functor."
                 ));
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+
+/// The roles a project's `functor.json` declares, in manifest order.
+fn declared_entries(manifest: &str) -> Result<Vec<String>, String> {
+    let value: Value = serde_json::from_str(manifest)
+        .map_err(|error| format!("functor.json is not valid JSON: {error}"))?;
+    match value.get("entries").and_then(Value::as_object) {
+        Some(entries) if !entries.is_empty() => Ok(entries.keys().cloned().collect()),
+        // A single-entry project has exactly one role, so a "group" of it is
+        // one game — say what is missing rather than launch a lonely session.
+        _ => Err(
+            "this project declares no `entries`, so it has no roles to group — a multiplayer project's functor.json looks like {\"entries\": {\"client\": …, \"server\": …}}"
+                .to_string(),
+        ),
+    }
+}
+
+/// The roles to launch, in order. Explicit `roles` wins verbatim (repeats are
+/// how a group gets two clients); the default is one session per declared
+/// entry, with `server` first because a client's `Connect` has nothing to
+/// resolve until its authority exists.
+fn group_roles(requested: Option<&[String]>, declared: &[String]) -> Result<Vec<String>, String> {
+    if let Some(roles) = requested {
+        if roles.is_empty() {
+            return Err(format!(
+                "roles must name at least one entry; this project declares {}",
+                declared.join(", ")
+            ));
+        }
+        if let Some(unknown) = roles.iter().find(|role| !declared.contains(role)) {
+            return Err(format!(
+                "unknown role {unknown:?}: this project declares {}",
+                declared.join(", ")
+            ));
+        }
+        return Ok(roles.to_vec());
+    }
+    let mut roles: Vec<String> = declared.to_vec();
+    if let Some(index) = roles.iter().position(|role| role == "server") {
+        let server = roles.remove(index);
+        roles.insert(0, server);
+    }
+    Ok(roles)
+}
+
+/// Wire-log labels for a role list: the plain role name when it appears once,
+/// and `client1` / `client2` when it repeats.
+fn group_labels(roles: &[String]) -> Vec<String> {
+    let mut seen: BTreeMap<&str, usize> = BTreeMap::new();
+    for role in roles {
+        *seen.entry(role.as_str()).or_insert(0) += 1;
+    }
+    let mut used: BTreeMap<&str, usize> = BTreeMap::new();
+    roles
+        .iter()
+        .map(|role| {
+            if seen[role.as_str()] == 1 {
+                role.clone()
+            } else {
+                let index = used.entry(role.as_str()).or_insert(0);
+                *index += 1;
+                format!("{role}{index}")
+            }
+        })
+        .collect()
+}
+
+/// `wire_log`'s `link` + `direction`, resolved against the group's labels so a
+/// typo is an error rather than an empty result a caller would read as "no
+/// traffic".
+#[derive(Debug)]
+enum WireFilter {
+    All,
+    /// Rows between these two labels, in either direction.
+    Pair(String, String),
+    /// Rows touching one label, optionally narrowed to one direction.
+    One {
+        label: String,
+        sent: Option<bool>,
+    },
+}
+
+impl WireFilter {
+    fn parse(link: Option<&str>, direction: Option<&str>, known: &[String]) -> Result<Self, String> {
+        let sent = match direction {
+            None => None,
+            Some("sent") => Some(true),
+            Some("received") => Some(false),
+            Some(other) => {
+                return Err(format!(
+                    "unknown direction {other:?}: expected \"sent\" or \"received\""
+                ))
+            }
+        };
+        let check = |label: &str| -> Result<String, String> {
+            if known.iter().any(|k| k == label) {
+                Ok(label.to_string())
+            } else {
+                Err(format!(
+                    "unknown session label {label:?}: this group has {}",
+                    known.join(", ")
+                ))
+            }
+        };
+        match link {
+            None if sent.is_some() => Err(
+                "direction needs a single-label `link` to be relative to — \"sent\" from what?"
+                    .to_string(),
+            ),
+            None => Ok(WireFilter::All),
+            Some(link) => match link.split_once(':') {
+                Some((a, b)) if sent.is_some() => {
+                    let _ = (check(a.trim())?, check(b.trim())?);
+                    Err(format!(
+                        "direction does not apply to the pair {link:?} — it already names both \
+ends; pass a single label instead"
+                    ))
+                }
+                Some((a, b)) => Ok(WireFilter::Pair(check(a.trim())?, check(b.trim())?)),
+                None => Ok(WireFilter::One {
+                    label: check(link.trim())?,
+                    sent,
+                }),
+            },
+        }
+    }
+
+    fn matches(&self, packet: &crate::commands::mcp_net::Packet) -> bool {
+        match self {
+            WireFilter::All => true,
+            WireFilter::Pair(a, b) => {
+                (packet.from == *a && packet.to == *b) || (packet.from == *b && packet.to == *a)
+            }
+            WireFilter::One { label, sent } => match sent {
+                Some(true) => packet.from == *label,
+                Some(false) => packet.to == *label,
+                None => packet.from == *label || packet.to == *label,
+            },
         }
     }
 }
@@ -4421,13 +5097,15 @@ fn tail(log: &Arc<Mutex<Vec<u8>>>) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        acquire_target_operation, base64_encoded_len, checked_output_total, encoded_capture_total,
+        acquire_target_operation, base64_encoded_len, checked_output_total, declared_entries,
+        encoded_capture_total, group_labels, group_roles,
         ensure_operation_active, extend_bounded, find_guide_section, guide_sections,
         json_encoded_len, node_code_call_result, node_code_summary, read_body,
         read_bounded_response, render_api_hits, render_guide_contents, render_guide_section,
         retain_final_snapshot, search_api, serialize_json_bounded, spawn_node_child,
         strip_front_matter, truncate_code_error, CodeInputRestore, CodeOutputBudget, FunctorMcp,
-        NodeCodeOutput, Registry, RunGameCodeUnsafeArgs, SessionTarget, LANGUAGE_GUIDE,
+        NodeCodeOutput, Registry, RunGameCodeUnsafeArgs, SessionTarget, WireFilter,
+        LANGUAGE_GUIDE,
         MAX_CODE_CAPTURE_BYTES, MAX_CODE_TEXT_BYTES, QUICK_FACTS_SLUG,
     };
     use functor_docgen::ApiReference;
@@ -5630,5 +6308,111 @@ mod tests {
             panic!("a removed id must not resolve again");
         };
         assert!(message.contains("unknown session"), "{message}");
+    }
+
+    // ---------------------------------------------------- session groups
+
+    fn packet(from: &str, to: &str, seq: u64) -> crate::commands::mcp_net::Packet {
+        crate::commands::mcp_net::Packet {
+            seq,
+            at_ms: 0.0,
+            frame: None,
+            from: from.into(),
+            to: to.into(),
+            conn: 1,
+            kind: "message",
+            size: 1,
+            payload_text: Some("x".into()),
+        }
+    }
+
+    /// A group's default order puts the AUTHORITY first: a client's `Connect`
+    /// has nothing to resolve until something is listening, and the same order
+    /// is what `step_all` wants.
+    #[test]
+    fn the_default_role_order_launches_the_server_first() {
+        let declared = vec!["client".to_string(), "server".to_string()];
+        assert_eq!(group_roles(None, &declared).unwrap(), ["server", "client"]);
+    }
+
+    /// Explicit roles are verbatim — including repeats, which is the only way
+    /// to ask for two clients — and an unknown one is refused before anything
+    /// launches.
+    #[test]
+    fn explicit_roles_are_taken_verbatim_and_checked() {
+        let declared = vec!["client".to_string(), "server".to_string()];
+        let asked = ["server".to_string(), "client".to_string(), "client".to_string()];
+        assert_eq!(group_roles(Some(&asked), &declared).unwrap(), asked);
+
+        let typo = ["sevrer".to_string()];
+        let error = group_roles(Some(&typo), &declared).unwrap_err();
+        assert!(error.contains("unknown role"), "{error}");
+        assert!(group_roles(Some(&[]), &declared).is_err());
+    }
+
+    /// Labels are what the wire log reads by, so a repeated role has to become
+    /// two distinguishable names while a unique one stays plain.
+    #[test]
+    fn repeated_roles_get_numbered_labels() {
+        let roles: Vec<String> = ["server", "client", "client"]
+            .iter()
+            .map(|r| r.to_string())
+            .collect();
+        assert_eq!(group_labels(&roles), ["server", "client1", "client2"]);
+    }
+
+    #[test]
+    fn a_project_with_no_entries_is_not_a_group() {
+        let error = declared_entries(r#"{"entry":"game.fun"}"#).unwrap_err();
+        assert!(error.contains("no `entries`"), "{error}");
+        assert_eq!(
+            declared_entries(r#"{"entries":{"client":{},"server":{}}}"#).unwrap(),
+            ["client", "server"]
+        );
+    }
+
+    /// The wire filter resolves against the group's real labels, so a typo is
+    /// an ERROR rather than an empty result a caller reads as "no traffic".
+    #[test]
+    fn the_wire_filter_refuses_labels_the_group_does_not_have() {
+        let known = vec!["server".to_string(), "client1".to_string()];
+        let error = WireFilter::parse(Some("cleint1"), None, &known).unwrap_err();
+        assert!(error.contains("unknown session label"), "{error}");
+        let error = WireFilter::parse(Some("server"), Some("upward"), &known).unwrap_err();
+        assert!(error.contains("unknown direction"), "{error}");
+        // A direction with nothing to be relative to is a mistake, not a
+        // silently-ignored argument.
+        assert!(WireFilter::parse(None, Some("sent"), &known).is_err());
+        assert!(WireFilter::parse(Some("server:client1"), Some("sent"), &known).is_err());
+    }
+
+    #[test]
+    fn the_wire_filter_selects_by_link_and_direction() {
+        let known = vec!["server".to_string(), "client1".to_string(), "client2".to_string()];
+        let rows = [
+            packet("client1", "server", 0),
+            packet("server", "client1", 1),
+            packet("server", "client2", 2),
+        ];
+        let matching = |filter: WireFilter| -> Vec<u64> {
+            rows.iter().filter(|p| filter.matches(p)).map(|p| p.seq).collect()
+        };
+        assert_eq!(matching(WireFilter::parse(None, None, &known).unwrap()), [0, 1, 2]);
+        assert_eq!(
+            matching(WireFilter::parse(Some("client1"), None, &known).unwrap()),
+            [0, 1]
+        );
+        assert_eq!(
+            matching(WireFilter::parse(Some("client1"), Some("sent"), &known).unwrap()),
+            [0]
+        );
+        assert_eq!(
+            matching(WireFilter::parse(Some("client1"), Some("received"), &known).unwrap()),
+            [1]
+        );
+        assert_eq!(
+            matching(WireFilter::parse(Some("server:client2"), None, &known).unwrap()),
+            [2]
+        );
     }
 }

--- a/cli/src/commands/mcp_net.rs
+++ b/cli/src/commands/mcp_net.rs
@@ -26,7 +26,9 @@
 //!     batch.
 //!
 //! PERFECT LINKS ONLY, and delivery is IMMEDIATE: a routed packet is handed to
-//! its destination on the coordinator's next pump, in order, never dropped.
+//! its destination on the coordinator's next pump, in order. The ROUTER never
+//! drops or reorders one — a delivery the pump could not complete comes back
+//! to the front of its queue ([`NetCoordinator::requeue`]).
 //! Everything a link profile would add — latency, jitter, partitions — and
 //! step-TIME scheduling ("departs step 610, deliver at 618") arrive with
 //! barrier stepping, which is the PR that also gives [`Packet::frame`] a
@@ -47,6 +49,16 @@ const PACKET_LOG_CAP: usize = 10_000;
 /// …and a second bound, on the payload TEXT the log retains: a count alone is
 /// not a memory bound, because a game chooses how big a message is.
 const PACKET_LOG_BYTES: usize = 8 << 20;
+
+/// Bound on a single session's undelivered queue.
+///
+/// The log is capped but the OUTBOX was not: a member that stops answering
+/// (its child died without a `stop_game`) keeps having packets routed TO it by
+/// peers that are still running, forever. Past this, the oldest queued events
+/// are dropped and COUNTED — a coordinator that advertises a perfect link must
+/// not discard traffic silently, and a queue that has grown this far belongs
+/// to a session that is not coming back.
+const OUTBOX_CAP: usize = 4_096;
 
 /// How long a `Connect` with no listener waits for its server session before it
 /// errors.
@@ -116,7 +128,6 @@ fn authority_of(endpoint: &str) -> &str {
     after_scheme.split('/').next().unwrap_or(after_scheme)
 }
 
-#[derive(Default)]
 pub struct NetCoordinator {
     /// Registered sessions, in launch order (the order the log reads best in).
     sessions: Vec<String>,
@@ -130,17 +141,29 @@ pub struct NetCoordinator {
     pending: Vec<PendingConnect>,
     log: VecDeque<Packet>,
     log_bytes: usize,
+    /// Events shed from an over-full outbox, per session, awaiting a report.
+    dropped: BTreeMap<String, usize>,
     next_conn: i32,
     next_seq: u64,
-    started: Option<Instant>,
+    started: Instant,
 }
 
 impl NetCoordinator {
     pub fn new() -> Self {
         Self {
+            sessions: Vec::new(),
+            outbox: BTreeMap::new(),
+            listeners: BTreeMap::new(),
+            conns: BTreeMap::new(),
+            pending: Vec::new(),
+            log: VecDeque::new(),
+            log_bytes: 0,
+            dropped: BTreeMap::new(),
+            // Ids start at 1: 0 is the "no connection" id an unroutable-connect
+            // error carries, so there is no valid `Default` for this type.
             next_conn: 1,
-            started: Some(Instant::now()),
-            ..Default::default()
+            next_seq: 0,
+            started: Instant::now(),
         }
     }
 
@@ -223,7 +246,13 @@ impl NetCoordinator {
                 }
             }
             ConnCommand::Send { conn, payload } => {
-                let conn = conn as i32;
+                // A `ConnectionId` is a u64 while the delivery side is an i32:
+                // truncating would let a bogus id (a stale one a model carried
+                // across a reload) ALIAS a live connection and be delivered
+                // instead of dropped. Refuse it the way `peer_of` would.
+                let Ok(conn) = i32::try_from(conn) else {
+                    return;
+                };
                 // A send on a connection this session is not an end of (a
                 // closed one, or a stale id a model carried across a reload) is
                 // DROPPED, not misrouted — `VirtualNet::send` refuses the same
@@ -245,7 +274,9 @@ impl NetCoordinator {
                 );
             }
             ConnCommand::CloseConn { conn } => {
-                let conn = conn as i32;
+                let Ok(conn) = i32::try_from(conn) else {
+                    return;
+                };
                 // Same ownership rule: only an end may close it.
                 if self.peer_of(conn, session).is_some() {
                     self.close(conn, session);
@@ -332,6 +363,12 @@ Sub.listen(\"{authority}\", …) before a client can connect"
         for event in events.into_iter().rev() {
             queue.push_front(event);
         }
+    }
+
+    /// Take the per-session drop counts accumulated since the last call, so
+    /// the pump can report them once rather than per packet.
+    pub fn take_drops(&mut self) -> BTreeMap<String, usize> {
+        std::mem::take(&mut self.dropped)
     }
 
     /// Every packet routed so far, oldest first (capped).
@@ -483,15 +520,17 @@ Sub.listen(\"{authority}\", …) before a client can connect"
         };
         let conn = event.conn();
         queue.push_back(event);
+        if queue.len() > OUTBOX_CAP {
+            let shed = queue.len() - OUTBOX_CAP;
+            queue.drain(..shed);
+            *self.dropped.entry(to.session.clone()).or_insert(0) += shed;
+        }
 
         let seq = self.next_seq;
         self.next_seq += 1;
         let packet = Packet {
             seq,
-            at_ms: self
-                .started
-                .map(|start| start.elapsed().as_secs_f64() * 1000.0)
-                .unwrap_or(0.0),
+            at_ms: self.started.elapsed().as_secs_f64() * 1000.0,
             frame: None,
             from: from.to_string(),
             to: to.session.clone(),
@@ -760,5 +799,69 @@ mod tests {
         let seqs: Vec<u64> = net.packets().map(|p| p.seq).collect();
         assert_eq!(seqs, vec![0, 1, 2, 3, 4]);
         assert_eq!(net.routed(), 5);
+    }
+
+    /// A member that stops consuming must not grow its queue forever: past the
+    /// cap the OLDEST events are shed and COUNTED, because a coordinator that
+    /// advertises a perfect link may not discard traffic silently.
+    #[test]
+    fn an_unconsumed_outbox_is_bounded_and_reports_what_it_shed() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.take_outbox("server");
+        // client1 never drains again.
+        for index in 0..(OUTBOX_CAP + 50) {
+            net.perform(
+                "server",
+                ConnCommand::Send {
+                    conn: 1,
+                    payload: format!("{index}").into_bytes(),
+                },
+            );
+        }
+        // 51: the handshake's `connected` row was still queued too.
+        let drops = net.take_drops();
+        assert_eq!(drops.get("client1"), Some(&51), "{drops:?}");
+        assert!(net.take_drops().is_empty(), "drops are reported once");
+        let queued = net.take_outbox("client1");
+        assert_eq!(queued.len(), OUTBOX_CAP);
+        // The NEWEST survive: the `connected` row and the first 50 sends were
+        // shed, so the oldest kept is send #50.
+        assert_eq!(
+            queued.first(),
+            Some(&DeliveredEvent::Message {
+                key: "ws://127.0.0.1:9101/orbs".into(),
+                conn: 1,
+                text: "50".into()
+            })
+        );
+    }
+
+    /// A `conn` that does not fit the delivery side's i32 must be REFUSED, not
+    /// truncated: `4_294_967_297` would alias live connection 1 and be
+    /// delivered against it.
+    #[test]
+    fn an_out_of_range_conn_is_refused_rather_than_truncated() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.take_outbox("server");
+        net.take_outbox("client1");
+
+        net.perform(
+            "client1",
+            ConnCommand::Send {
+                conn: (1u64 << 32) + 1,
+                payload: b"alias".to_vec(),
+            },
+        );
+        assert!(net.take_outbox("server").is_empty());
+        net.perform("client1", ConnCommand::CloseConn { conn: (1u64 << 32) + 1 });
+        assert_eq!(
+            net.connection_counts().get("client1"),
+            Some(&1),
+            "the live connection survived a forged close"
+        );
     }
 }

--- a/cli/src/commands/mcp_net.rs
+++ b/cli/src/commands/mcp_net.rs
@@ -1,0 +1,764 @@
+//! The NATIVE net coordinator: the MCP host process as a multiplayer game's
+//! network.
+//!
+//! Design note: `~/notes` Addendum 7 — "the embedder is the MCP host process".
+//! The web runtime already routes its networking to the page embedding it
+//! (`runtime/functor-runtime-web/src/lib.rs`, and the host-page coordinator in
+//! `site/src/net-coordinator.ts`). That seam is not browser-specific: a native
+//! runtime started with `--net-transport embedder` opens no socket, queues its
+//! drained [`ConnCommand`]s for `GET /net/outbound`, and takes events back
+//! over `POST /net/deliver`. This module is the thing in between — one
+//! coordinator protocol, of which MCP is the headless frontend.
+//!
+//! The ROUTING MODEL is `site/src/net-coordinator.ts`'s, and through it
+//! `functor_runtime_common::net::VirtualNet`'s:
+//!
+//!   * a listener registry keyed by AUTHORITY (host:port, scheme and path
+//!     ignored), so a client url `ws://127.0.0.1:9101/orbs` matches a server
+//!     bind `127.0.0.1:9101`;
+//!   * ONE connection id per PAIR, shared by both ends, so a send from either
+//!     end routes to the other by looking up the same row;
+//!   * both ends are told `connected`, each under ITS OWN routing key — the
+//!     client under the url it dialled, the server under its bind — because
+//!     that key is how each runtime routes the event back to the right
+//!     `Sub.connect` / `Sub.listen` tagger;
+//!   * FIFO per session: deliveries queue in arrival order and flush as one
+//!     batch.
+//!
+//! PERFECT LINKS ONLY, and delivery is IMMEDIATE: a routed packet is handed to
+//! its destination on the coordinator's next pump, in order, never dropped.
+//! Everything a link profile would add — latency, jitter, partitions — and
+//! step-TIME scheduling ("departs step 610, deliver at 618") arrive with
+//! barrier stepping, which is the PR that also gives [`Packet::frame`] a
+//! meaning; until then it is `None` rather than a measurement dressed up as a
+//! schedule.
+//!
+//! This module is pure: it performs no I/O and knows nothing about HTTP. The
+//! pump that drains and delivers lives in `mcp.rs`.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::time::Instant;
+
+use functor_runtime_common::net::{ConnCommand, DeliveredEvent};
+
+/// Newest entries win: a long session must not grow without bound.
+const PACKET_LOG_CAP: usize = 10_000;
+
+/// …and a second bound, on the payload TEXT the log retains: a count alone is
+/// not a memory bound, because a game chooses how big a message is.
+const PACKET_LOG_BYTES: usize = 8 << 20;
+
+/// How long a `Connect` with no listener waits for its server session before it
+/// errors.
+///
+/// It cannot fail fast: a runtime reconciles `Sub.connect` against its DECLARED
+/// keys, so a key emitted once is never re-emitted
+/// (`functor_lang_producer::reconcile_connections`). An error delivered to a
+/// client whose server has not bound yet would therefore be permanent — and so
+/// would one delivered while the server session is RELOADING (which is why
+/// `close` re-queues the client end, see there).
+const CONNECT_GRACE: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// One routed packet — the wire, as data.
+#[derive(Clone, Debug)]
+pub struct Packet {
+    /// Monotonic within a group, and never reused: `wire_log`'s `since` cursor,
+    /// which is what lets a caller ask for exactly the rows a `step_all` round
+    /// produced.
+    pub seq: u64,
+    /// Milliseconds since the coordinator started, for ordering against
+    /// wall-clock events. NOT game time.
+    pub at_ms: f64,
+    /// The session frame this packet belongs to. Always `None` in v1:
+    /// delivery is immediate and unscheduled, so there is no step to name.
+    /// Barrier stepping fills it in by construction.
+    pub frame: Option<u64>,
+    /// Session label the packet came from.
+    pub from: String,
+    /// Session label it was delivered to.
+    pub to: String,
+    pub conn: i32,
+    pub kind: &'static str,
+    /// Payload bytes for a message; 0 for the lifecycle kinds.
+    pub size: usize,
+    /// The message's wire TEXT, exactly as the receiving runtime sees it.
+    /// Decoding is deliberately NOT done here: the framing is the game's
+    /// (`Effect.sendMsg`'s JSON), and an agent reading the log decodes it —
+    /// a coordinator that parsed payloads would be inventing a protocol it
+    /// does not own.
+    pub payload_text: Option<String>,
+}
+
+/// One end of a connection: the session, and the key ITS runtime routes by.
+#[derive(Clone, Debug)]
+struct Side {
+    session: String,
+    key: String,
+}
+
+#[derive(Clone, Debug)]
+struct Conn {
+    client: Side,
+    server: Side,
+}
+
+struct PendingConnect {
+    session: String,
+    key: String,
+    since: Instant,
+}
+
+/// The authority (host:port) of an endpoint, ignoring scheme and path — the
+/// same rule `VirtualNet` and the TS coordinator apply, so all three agree on
+/// what matches.
+fn authority_of(endpoint: &str) -> &str {
+    let after_scheme = endpoint.rsplit("://").next().unwrap_or(endpoint);
+    after_scheme.split('/').next().unwrap_or(after_scheme)
+}
+
+#[derive(Default)]
+pub struct NetCoordinator {
+    /// Registered sessions, in launch order (the order the log reads best in).
+    sessions: Vec<String>,
+    /// Events queued for each session, flushed in order by the pump.
+    outbox: BTreeMap<String, VecDeque<DeliveredEvent>>,
+    /// authority -> the listening side.
+    listeners: BTreeMap<String, Side>,
+    /// Shared connection id -> its two ends. Ids start at 1: 0 is the "no
+    /// connection" id an unroutable-connect error carries.
+    conns: BTreeMap<i32, Conn>,
+    pending: Vec<PendingConnect>,
+    log: VecDeque<Packet>,
+    log_bytes: usize,
+    next_conn: i32,
+    next_seq: u64,
+    started: Option<Instant>,
+}
+
+impl NetCoordinator {
+    pub fn new() -> Self {
+        Self {
+            next_conn: 1,
+            started: Some(Instant::now()),
+            ..Default::default()
+        }
+    }
+
+    /// Register a session under the label the wire log shows ("server",
+    /// "client1").
+    pub fn add_session(&mut self, label: &str) {
+        if !self.sessions.iter().any(|s| s == label) {
+            self.sessions.push(label.to_string());
+        }
+        self.outbox.entry(label.to_string()).or_default();
+    }
+
+    /// Drop a session and close every connection it held (both ends notified).
+    pub fn remove_session(&mut self, label: &str) {
+        self.reset_session(label);
+        self.sessions.retain(|s| s != label);
+        self.outbox.remove(label);
+    }
+
+    pub fn labels(&self) -> &[String] {
+        &self.sessions
+    }
+
+    /// Close everything a session owns without deregistering it — what a
+    /// RELOAD of that role means to the network. The peers are told
+    /// `disconnected`, and a client whose server went away is re-queued (see
+    /// [`Self::close`]) so the role's next `Listen` re-opens it.
+    pub fn reset_session(&mut self, label: &str) {
+        let owned: Vec<i32> = self
+            .conns
+            .iter()
+            .filter(|(_, row)| row.client.session == label || row.server.session == label)
+            .map(|(id, _)| *id)
+            .collect();
+        for conn in owned {
+            self.close(conn, label);
+        }
+        self.listeners.retain(|_, side| side.session != label);
+        self.pending.retain(|p| p.session != label);
+        if let Some(outbox) = self.outbox.get_mut(label) {
+            outbox.clear();
+        }
+    }
+
+    /// Route one command a session's runtime emitted.
+    pub fn perform(&mut self, session: &str, command: ConnCommand) {
+        match command {
+            ConnCommand::Listen { key, .. } => {
+                // Idempotent by authority, like every host treats `Listen` (a
+                // hot reload re-declares it every time). The newest wins.
+                self.listeners.insert(
+                    authority_of(&key).to_string(),
+                    Side {
+                        session: session.to_string(),
+                        key,
+                    },
+                );
+                // A client that dialled before this role booted is waiting.
+                self.retry_pending();
+            }
+            ConnCommand::Connect { key, .. } => {
+                // Idempotent by key: a re-declare while the connection is
+                // already up must not open a second one.
+                if self.conn_for(session, &key).is_some() {
+                    return;
+                }
+                if self
+                    .pending
+                    .iter()
+                    .any(|p| p.session == session && p.key == key)
+                {
+                    return;
+                }
+                if !self.open(session, &key) {
+                    self.pending.push(PendingConnect {
+                        session: session.to_string(),
+                        key,
+                        since: Instant::now(),
+                    });
+                }
+            }
+            ConnCommand::Send { conn, payload } => {
+                let conn = conn as i32;
+                // A send on a connection this session is not an end of (a
+                // closed one, or a stale id a model carried across a reload) is
+                // DROPPED, not misrouted — `VirtualNet::send` refuses the same
+                // case via `peer_of`.
+                let Some(peer) = self.peer_of(conn, session) else {
+                    return;
+                };
+                let size = payload.len();
+                let text = String::from_utf8_lossy(&payload).into_owned();
+                self.deliver(
+                    session,
+                    &peer,
+                    DeliveredEvent::Message {
+                        key: peer.key.clone(),
+                        conn,
+                        text,
+                    },
+                    size,
+                );
+            }
+            ConnCommand::CloseConn { conn } => {
+                let conn = conn as i32;
+                // Same ownership rule: only an end may close it.
+                if self.peer_of(conn, session).is_some() {
+                    self.close(conn, session);
+                }
+            }
+            ConnCommand::CloseKey { key } => {
+                let authority = authority_of(&key).to_string();
+                if self
+                    .listeners
+                    .get(&authority)
+                    .is_some_and(|side| side.session == session && side.key == key)
+                {
+                    self.listeners.remove(&authority);
+                }
+                let owned: Vec<i32> = self
+                    .conns
+                    .iter()
+                    .filter(|(_, row)| {
+                        (row.client.session == session && row.client.key == key)
+                            || (row.server.session == session && row.server.key == key)
+                    })
+                    .map(|(id, _)| *id)
+                    .collect();
+                for conn in owned {
+                    self.close(conn, session);
+                }
+                self.pending
+                    .retain(|p| !(p.session == session && p.key == key));
+            }
+        }
+    }
+
+    /// Retry connects whose listener had not booted yet; give up after the
+    /// grace window with a teaching error on the CALLER's key.
+    ///
+    /// In ARRIVAL order, so connection ids (and therefore the server's player
+    /// order) follow the order the clients asked, not the reverse.
+    pub fn retry_pending(&mut self) {
+        let now = Instant::now();
+        let requests: Vec<PendingConnect> = self.pending.drain(..).collect();
+        for request in requests {
+            if now.duration_since(request.since) > CONNECT_GRACE {
+                let authority = authority_of(&request.key).to_string();
+                let side = Side {
+                    session: request.session.clone(),
+                    key: request.key.clone(),
+                };
+                self.deliver(
+                    &request.session,
+                    &side,
+                    DeliveredEvent::Error {
+                        key: request.key,
+                        conn: 0,
+                        message: format!(
+                            "no session is listening on {authority} — a role must declare \
+Sub.listen(\"{authority}\", …) before a client can connect"
+                        ),
+                    },
+                    0,
+                );
+                continue;
+            }
+            if !self.open(&request.session, &request.key) {
+                self.pending.push(request);
+            }
+        }
+    }
+
+    /// Take everything queued for a session, in arrival order.
+    pub fn take_outbox(&mut self, label: &str) -> Vec<DeliveredEvent> {
+        self.outbox
+            .get_mut(label)
+            .map(|queue| queue.drain(..).collect())
+            .unwrap_or_default()
+    }
+
+    /// Put an undelivered batch back at the FRONT, so a transport hiccup
+    /// retries in order rather than losing the packets. The log already
+    /// recorded them: the log is what the coordinator ROUTED.
+    pub fn requeue(&mut self, label: &str, events: Vec<DeliveredEvent>) {
+        let Some(queue) = self.outbox.get_mut(label) else {
+            return;
+        };
+        for event in events.into_iter().rev() {
+            queue.push_front(event);
+        }
+    }
+
+    /// Every packet routed so far, oldest first (capped).
+    pub fn packets(&self) -> impl Iterator<Item = &Packet> {
+        self.log.iter()
+    }
+
+    /// The oldest sequence number the log still holds — how a reader learns its
+    /// `since` cursor fell off the end rather than silently seeing a gap.
+    pub fn oldest_seq(&self) -> Option<u64> {
+        self.log.front().map(|packet| packet.seq)
+    }
+
+    /// How many packets have EVER been routed, including trimmed ones.
+    pub fn routed(&self) -> u64 {
+        self.next_seq
+    }
+
+    /// Live connections per session — the only place that knows who is
+    /// actually talking to whom.
+    pub fn connection_counts(&self) -> BTreeMap<String, usize> {
+        let mut counts = BTreeMap::new();
+        for row in self.conns.values() {
+            for side in [&row.client, &row.server] {
+                *counts.entry(side.session.clone()).or_insert(0) += 1;
+            }
+        }
+        counts
+    }
+
+    // ------------------------------------------------------------------ routing
+
+    /// Resolve a client key to its listening session and wire the pair up.
+    /// False when nobody is listening on that authority (the caller waits).
+    ///
+    /// KNOWN, inherited from `VirtualNet` (whose `peer_of` has the same
+    /// degeneracy): a session that both listens on and connects to its OWN
+    /// authority — a host that also plays — gets both ends of one row.
+    fn open(&mut self, session: &str, key: &str) -> bool {
+        let Some(server) = self.listeners.get(authority_of(key)).cloned() else {
+            return false;
+        };
+        if !self.sessions.iter().any(|s| *s == server.session) {
+            return false;
+        }
+        let conn = self.next_conn;
+        self.next_conn += 1;
+        let client = Side {
+            session: session.to_string(),
+            key: key.to_string(),
+        };
+        self.conns.insert(
+            conn,
+            Conn {
+                client: client.clone(),
+                server: server.clone(),
+            },
+        );
+        // BOTH ends learn about the connection, each under its own routing key.
+        // Each is logged as coming FROM its peer, so the log reads as traffic
+        // between two sessions rather than as one talking to itself.
+        self.deliver(
+            &server.session,
+            &client,
+            DeliveredEvent::Connected {
+                key: key.to_string(),
+                conn,
+            },
+            0,
+        );
+        self.deliver(
+            session,
+            &server,
+            DeliveredEvent::Connected {
+                key: server.key.clone(),
+                conn,
+            },
+            0,
+        );
+        true
+    }
+
+    fn close(&mut self, conn: i32, by_session: &str) {
+        let Some(row) = self.conns.remove(&conn) else {
+            return;
+        };
+        for side in [row.client.clone(), row.server.clone()] {
+            self.deliver(
+                by_session,
+                &side,
+                DeliveredEvent::Disconnected {
+                    key: side.key.clone(),
+                    conn,
+                },
+                0,
+            );
+        }
+        // A client whose peer went away (the server role reloaded, or closed
+        // the connection) can never ask again: its runtime only emits `Connect`
+        // for a key it has not already declared, and a `disconnected` does not
+        // clear that. So the coordinator re-queues the client end on its
+        // behalf, and the server's next `Listen` re-opens it. Without this,
+        // reloading the authority kills every client for the rest of the run.
+        if by_session != row.client.session
+            && self.sessions.iter().any(|s| *s == row.client.session)
+            && !self
+                .pending
+                .iter()
+                .any(|p| p.session == row.client.session && p.key == row.client.key)
+        {
+            self.pending.push(PendingConnect {
+                session: row.client.session,
+                key: row.client.key,
+                since: Instant::now(),
+            });
+        }
+    }
+
+    /// The peer end of `conn` as seen from `session`, or `None` when that
+    /// session is not on the connection.
+    fn peer_of(&self, conn: i32, session: &str) -> Option<Side> {
+        let row = self.conns.get(&conn)?;
+        if row.client.session == session {
+            return Some(row.server.clone());
+        }
+        if row.server.session == session {
+            return Some(row.client.clone());
+        }
+        None
+    }
+
+    /// The live connection this session holds for `key`, if any.
+    fn conn_for(&self, session: &str, key: &str) -> Option<i32> {
+        self.conns
+            .iter()
+            .find(|(_, row)| row.client.session == session && row.client.key == key)
+            .map(|(id, _)| *id)
+    }
+
+    fn deliver(&mut self, from: &str, to: &Side, event: DeliveredEvent, size: usize) {
+        let Some(queue) = self.outbox.get_mut(&to.session) else {
+            return;
+        };
+        let (kind, payload_text) = match &event {
+            DeliveredEvent::Connected { .. } => ("connected", None),
+            DeliveredEvent::Message { text, .. } => ("message", Some(text.clone())),
+            DeliveredEvent::Disconnected { .. } => ("disconnected", None),
+            DeliveredEvent::Error { .. } => ("error", None),
+        };
+        let conn = event.conn();
+        queue.push_back(event);
+
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        let packet = Packet {
+            seq,
+            at_ms: self
+                .started
+                .map(|start| start.elapsed().as_secs_f64() * 1000.0)
+                .unwrap_or(0.0),
+            frame: None,
+            from: from.to_string(),
+            to: to.session.clone(),
+            conn,
+            kind,
+            size,
+            payload_text,
+        };
+        self.log_bytes += packet.payload_text.as_ref().map_or(0, String::len);
+        self.log.push_back(packet);
+        while self.log.len() > PACKET_LOG_CAP {
+            if let Some(dropped) = self.log.pop_front() {
+                self.log_bytes -= dropped.payload_text.as_ref().map_or(0, String::len);
+            }
+        }
+        // The byte bound sheds one packet at a time: it only bites for a
+        // protocol whose messages are large, and there the newest few are what
+        // a reader is looking at anyway.
+        while self.log_bytes > PACKET_LOG_BYTES && self.log.len() > 1 {
+            if let Some(dropped) = self.log.pop_front() {
+                self.log_bytes -= dropped.payload_text.as_ref().map_or(0, String::len);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn listen(key: &str) -> ConnCommand {
+        ConnCommand::Listen {
+            key: key.to_string(),
+            addr: key.to_string(),
+        }
+    }
+
+    fn connect(key: &str) -> ConnCommand {
+        ConnCommand::Connect {
+            key: key.to_string(),
+            url: key.to_string(),
+        }
+    }
+
+    fn group(labels: &[&str]) -> NetCoordinator {
+        let mut net = NetCoordinator::new();
+        for label in labels {
+            net.add_session(label);
+        }
+        net
+    }
+
+    /// The routing rule the whole design rests on: a client's URL matches a
+    /// server's bind by AUTHORITY, and both ends are told about the connection
+    /// under their OWN key — the key each runtime routes the event back by.
+    #[test]
+    fn a_connect_matches_a_listen_by_authority_and_tells_both_ends() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+
+        assert_eq!(
+            net.take_outbox("server"),
+            vec![DeliveredEvent::Connected {
+                key: "127.0.0.1:9101".into(),
+                conn: 1
+            }],
+            "the server hears the event under its own LISTEN key"
+        );
+        assert_eq!(
+            net.take_outbox("client1"),
+            vec![DeliveredEvent::Connected {
+                key: "ws://127.0.0.1:9101/orbs".into(),
+                conn: 1
+            }],
+            "the client hears it under the url it dialled"
+        );
+    }
+
+    /// One connection id per PAIR: a send from either end routes to the other
+    /// through the same row, and the payload crosses as TEXT.
+    #[test]
+    fn a_send_routes_to_the_peer_and_lands_in_the_log_as_text() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.take_outbox("server");
+        net.take_outbox("client1");
+
+        net.perform(
+            "client1",
+            ConnCommand::Send {
+                conn: 1,
+                payload: b"{\"Move\":[1,0]}".to_vec(),
+            },
+        );
+        assert_eq!(
+            net.take_outbox("server"),
+            vec![DeliveredEvent::Message {
+                key: "127.0.0.1:9101".into(),
+                conn: 1,
+                text: "{\"Move\":[1,0]}".into()
+            }]
+        );
+        assert!(net.take_outbox("client1").is_empty(), "no echo to the sender");
+
+        let last = net.packets().last().expect("a routed packet");
+        assert_eq!((last.from.as_str(), last.to.as_str()), ("client1", "server"));
+        assert_eq!(last.kind, "message");
+        assert_eq!(last.size, 14);
+        assert_eq!(last.payload_text.as_deref(), Some("{\"Move\":[1,0]}"));
+        assert_eq!(last.frame, None, "v1 delivery is unscheduled");
+    }
+
+    /// A send on a connection the sender is not an end of is DROPPED, never
+    /// misrouted — the stale-id case a model carries across a reload.
+    #[test]
+    fn a_send_on_a_foreign_connection_is_dropped() {
+        let mut net = group(&["server", "client1", "client2"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.take_outbox("server");
+        net.take_outbox("client1");
+
+        net.perform(
+            "client2",
+            ConnCommand::Send {
+                conn: 1,
+                payload: b"spoof".to_vec(),
+            },
+        );
+        assert!(net.take_outbox("server").is_empty());
+        assert!(net.take_outbox("client1").is_empty());
+    }
+
+    /// A client that dials before its authority exists WAITS, and connects the
+    /// moment the listener appears — the launch race a group cannot avoid.
+    /// Ids follow ARRIVAL order, so the server seats players in dial order.
+    #[test]
+    fn a_connect_with_no_listener_waits_and_opens_in_arrival_order() {
+        let mut net = group(&["server", "client1", "client2"]);
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.perform("client2", connect("ws://127.0.0.1:9101/orbs"));
+        assert!(net.take_outbox("client1").is_empty(), "nothing to connect to yet");
+
+        net.perform("server", listen("127.0.0.1:9101"));
+        assert_eq!(
+            net.take_outbox("client1")
+                .into_iter()
+                .map(|e| e.conn())
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+        assert_eq!(
+            net.take_outbox("client2")
+                .into_iter()
+                .map(|e| e.conn())
+                .collect::<Vec<_>>(),
+            vec![2]
+        );
+    }
+
+    /// Re-declaring a connect (every frame's reconciliation, or a hot reload)
+    /// must not open a second connection.
+    #[test]
+    fn connect_and_listen_are_idempotent() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        assert_eq!(net.take_outbox("client1").len(), 1);
+        assert_eq!(net.connection_counts().get("client1"), Some(&1));
+    }
+
+    /// Reloading the AUTHORITY must not kill the session: both ends see the
+    /// disconnect, and the client end is re-queued so the role's next `Listen`
+    /// re-opens it (its runtime will never re-emit `Connect` on its own).
+    #[test]
+    fn reloading_the_authority_reconnects_its_clients() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        net.take_outbox("server");
+        net.take_outbox("client1");
+
+        net.reset_session("server");
+        assert_eq!(
+            net.take_outbox("client1"),
+            vec![DeliveredEvent::Disconnected {
+                key: "ws://127.0.0.1:9101/orbs".into(),
+                conn: 1
+            }]
+        );
+
+        // The reloaded role re-declares its listen — and the client is back,
+        // on a NEW connection id, without having asked again.
+        net.perform("server", listen("127.0.0.1:9101"));
+        assert_eq!(
+            net.take_outbox("client1"),
+            vec![DeliveredEvent::Connected {
+                key: "ws://127.0.0.1:9101/orbs".into(),
+                conn: 2
+            }]
+        );
+    }
+
+    /// An undelivered batch goes back at the FRONT: a transport hiccup must not
+    /// reorder a reliable channel.
+    #[test]
+    fn a_requeued_batch_keeps_its_place_at_the_front() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        let first = net.take_outbox("client1");
+        assert_eq!(first.len(), 1);
+        net.requeue("client1", first);
+        net.reset_session("client1");
+        // reset clears the outbox, so re-open and check ordering directly.
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        let batch = net.take_outbox("client1");
+        net.requeue("client1", batch);
+        net.perform(
+            "server",
+            ConnCommand::Send {
+                conn: 2,
+                payload: b"after".to_vec(),
+            },
+        );
+        let kinds: Vec<&'static str> = net
+            .take_outbox("client1")
+            .iter()
+            .map(|e| match e {
+                DeliveredEvent::Connected { .. } => "connected",
+                DeliveredEvent::Message { .. } => "message",
+                DeliveredEvent::Disconnected { .. } => "disconnected",
+                DeliveredEvent::Error { .. } => "error",
+            })
+            .collect();
+        assert_eq!(kinds, vec!["connected", "message"]);
+    }
+
+    #[test]
+    fn authority_ignores_scheme_and_path() {
+        assert_eq!(authority_of("ws://127.0.0.1:9101/orbs"), "127.0.0.1:9101");
+        assert_eq!(authority_of("127.0.0.1:9101"), "127.0.0.1:9101");
+        assert_eq!(authority_of("wss://example.test/a/b"), "example.test");
+    }
+
+    /// `seq` is the cursor `wire_log`'s `since` filter reads, so it must be
+    /// strictly increasing and never reused.
+    #[test]
+    fn sequence_numbers_are_monotonic_across_the_whole_group() {
+        let mut net = group(&["server", "client1"]);
+        net.perform("server", listen("127.0.0.1:9101"));
+        net.perform("client1", connect("ws://127.0.0.1:9101/orbs"));
+        for _ in 0..3 {
+            net.perform(
+                "client1",
+                ConnCommand::Send {
+                    conn: 1,
+                    payload: b"x".to_vec(),
+                },
+            );
+        }
+        let seqs: Vec<u64> = net.packets().map(|p| p.seq).collect();
+        assert_eq!(seqs, vec![0, 1, 2, 3, 4]);
+        assert_eq!(net.routed(), 5);
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod import;
 pub mod init;
 pub mod inspect;
 pub mod mcp;
+pub mod mcp_net;

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -563,6 +563,10 @@ what lets a driver route a packet and then step, and know the step saw it.
 `pending_net` therefore stays 0 on this transport — nothing waits in a shell
 channel.
 
+`--net-transport embedder` without `--debug-port` is refused at startup: with no
+client there is nothing to drain the queue or deliver into it, so the game's
+network would silently be a black hole with an unbounded backlog behind it.
+
 The device runtime answers 409 for both: a Quest session's network is a real
 socket to a real peer, with no coordinator behind adb.
 

--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -126,6 +126,8 @@ screenshot run has no reason to grab your mouse.
 | `POST /reload-asset` | upload one project-relative texture/model/audio asset as a binary path+bytes envelope |
 | `POST /sync-assets` | finish a sync from a JSON array of current asset paths; uploaded paths absent from the manifest are removed |
 | `POST /rewind` | restore recorded model + physics to `{"frame":42}` (pin the clock first) |
+| `GET /net/outbound` | **embedder transport only** — take-and-consume the game's queued `ConnCommand`s (see below) |
+| `POST /net/deliver` | **embedder transport only** — deliver inbound network events into the game (see below) |
 
 ### `model` in `GET /state`
 
@@ -508,6 +510,61 @@ are excluded — by file name. A producer whose logic is not source-shaped
 (`--replay`) answers **501**, and a pre-v5 runtime answers **404**.
 
 `functor mcp`'s `save_project` tool is built on it (docs/mcp.md).
+
+### The embedder transport (protocol v11)
+
+A runtime started with `--net-transport embedder` opens **no socket**. Its
+persistent-connection traffic — everything `Sub.listen`, `Sub.connect`,
+`Effect.send` and `Effect.close` produce — stays queued for the debug client,
+and inbound events arrive from it. **The client is the network.** The default is
+unchanged (`--net-transport sockets`): the runner dispatches to the real
+tungstenite host exactly as before, and both endpoints below answer **409**,
+because draining there would steal the real dispatcher's commands and
+delivering there would inject events no peer sent.
+
+This is the native half of the seam the web runtime already has
+(`window.__functorNetTransport = "embedder"`, and the browser coordinator in
+`site/src/net-coordinator.ts`). Natively, "the embedder" is whatever process
+drives the debug server — for `functor mcp`'s session groups, that is the MCP
+host itself (docs/mcp.md).
+
+**`GET /net/outbound`** returns and CONSUMES the queued commands, as the
+versioned `ConnCommand` JSON every host consumes (serde's externally-tagged
+representation, byte payloads included):
+
+```jsonc
+[ {"Listen":  {"key":"127.0.0.1:9101","addr":"127.0.0.1:9101"}},
+  {"Connect": {"key":"ws://127.0.0.1:9101/orbs","url":"ws://127.0.0.1:9101/orbs"}},
+  {"Send":    {"conn":1,"payload":[102,117,110,58]}},
+  {"CloseConn": {"conn":1}},
+  {"CloseKey":  {"key":"127.0.0.1:9101"}} ]
+```
+
+**`POST /net/deliver`** takes a JSON array of events, the shape mirroring the
+four producer push methods one-for-one (`key` is the routing key of the
+`connect`/`listen` the event belongs to; a message is TEXT, as a real WebSocket
+hands it over):
+
+```jsonc
+[ {"kind":"connected",    "key":"ws://127.0.0.1:9101/orbs","conn":1},
+  {"kind":"message",      "key":"ws://127.0.0.1:9101/orbs","conn":1,"text":"hi"},
+  {"kind":"disconnected", "key":"ws://127.0.0.1:9101/orbs","conn":1},
+  {"kind":"error",        "key":"ws://127.0.0.1:9101/orbs","conn":1,"message":"…"} ]
+```
+
+The two directions use different shapes on purpose: egress is the already
+versioned logic↔shell type, and ingress mirrors the push methods it feeds. A
+negative `conn` is a **400** (it would reach the game as `u64::MAX`), and so is
+a malformed batch — neither reaches the runtime loop.
+
+Delivery is **synchronous**: each event folds through `update` before the
+response, so a `200` means the model has already absorbed the batch. That is
+what lets a driver route a packet and then step, and know the step saw it.
+`pending_net` therefore stays 0 on this transport — nothing waits in a shell
+channel.
+
+The device runtime answers 409 for both: a Quest session's network is a real
+socket to a real peer, with no coordinator behind adb.
 
 ### Project asset sync
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -480,13 +480,18 @@ registry keyed by **authority** (`host:port` — so a client's
 connection id per pair** shared by both ends, both ends told `connected` under
 their own routing key, and **FIFO per session**. A client that dials before its
 authority exists waits and connects the moment the listener appears (15 s
-grace), and reloading the authority re-queues its clients — their runtimes can
-never re-dial on their own.
+grace). A client whose peer is REMOVED from the group (its session stopped) is
+re-queued, because a runtime never re-dials on its own; a plain hot RELOAD of
+the authority is not that case — the model, and with it the connection ids,
+survives, so the group keeps routing straight across it.
 
 **Cadence.** Routing runs on this server's own loop, in two places:
 
-- **continuously in the background**, every ~8 ms, so a group running live on
-  wall-clock time still moves its packets between tool calls;
+- **continuously in the background** — a round is scheduled every 8 ms, though
+  its real period is the round trip to each member (a headless runtime services
+  the debug channel once per ~16 ms loop, so a three-role group settles nearer
+  50–100 ms) — so a group running live on wall-clock time still moves its
+  packets between tool calls;
 - **at every session boundary inside a `step_all` round**, with the background
   pump held off for the whole round. So a packet client 1 sends in round *N*
   is delivered — and folded through `update`, since `POST /net/deliver` answers
@@ -496,10 +501,17 @@ That second half is what `step_all` could not do over sockets. It is still not
 a *barrier*: the group runs freely between rounds, and nothing schedules a
 packet into a named step.
 
-**Delivery in v1 is IMMEDIATE, in order, and never dropped** — a perfect,
-reliable link. Latency, jitter, and step-time scheduling ("departs step 610,
-deliver at 618") arrive with barrier stepping, which is also what will give
-`wire_log`'s `frame` a value; today it is always `null` rather than a
+**Delivery in v1 is IMMEDIATE and in order** — a perfect, reliable link: the
+router never drops or reorders a packet, and a delivery that fails in transit
+is re-queued at the front of its queue and retried. The one honest gap is that
+`GET /net/outbound` is take-and-consume, so a drain whose RESPONSE is lost
+takes those commands with it, and a delivery whose outcome is UNKNOWN (a
+timeout) is reported and not retried rather than risked twice — on a reliable
+ordered channel, a duplicate is worse than a gap. A session that stops
+consuming has its queue bounded and the shed count reported. All of these land
+on stderr, which is where this server logs; none of them are silent. Latency, jitter, and step-time scheduling ("departs step
+610, deliver at 618") arrive with barrier stepping, which is also what will
+give `wire_log`'s `frame` a value; today it is always `null` rather than a
 measurement dressed up as a schedule.
 
 **Reading the wire.** `wire_log` returns rows oldest-first:
@@ -519,7 +531,10 @@ cursor — read the last row's `seq`, run a round, pass it back as `since`, and
 you have exactly that round's traffic. `link` narrows to one label
 (`"client1"`) or an unordered pair (`"client1:server"`), and `direction`
 (`"sent"` / `"received"`) narrows a single label further. A label the group does
-not have is an error, not an empty result.
+not have is an error, not an empty result. Rows share a payload byte budget
+spent newest-first, so a chatty protocol's oldest rows come back with
+`payload_elided: true` (and `payloads_elided` counted) rather than flooding the
+answer — narrow the window or the `link` to read them.
 
 **What reproduces, and what does not.** With immediate in-order delivery and
 `step_all`'s boundary pumping, a steady-state round routes the same packets, in

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -106,6 +106,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 | `get_scene` | The camera, scene graph, and lights `draw` produced. Pure data, so it works headlessly. |
 | `get_trace` | The paused inspector trace: every entry point's binder and variable values for the last real frame. Pause first. |
 | `capture_frame` | A PNG of the next rendered frame, returned as an MCP image block. |
+| `wire_log` | Every packet the coordinator routed for a session group, as data: `{seq, frame, at_ms, from, to, conn, kind, size, payload_text}`, with `since` / `limit` / `link` / `direction` filters. Group sessions only. |
 
 **Driving.**
 
@@ -114,6 +115,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 | `pause` | Pin the clock (defaults to the current `tts`), so nothing advances on its own. |
 | `step` | Run 1–10,000 `frames` of finite positive `dts` each, **wait for them to land**, and return the fresh state. |
 | `step_all` | Step several sessions one round, strictly sequentially, in the order given — the multiplayer lockstep primitive. See [Running a multiplayer session](#running-a-multiplayer-session). |
+| `launch_session_group` | Launch every role of a multi-entry project at once, wired to each other by **this process** — no sockets. See [The coordinator: this process is the network](#the-coordinator-this-process-is-the-network). |
 | `resume` | Follow wall-clock time again. |
 | `send_input` | Inject one `POST /input` command verbatim — key, mouse move/wheel/button, `ui_event`, or an `xr` sample. |
 | `rewind` | Restore model + physics to a recorded frame (it pins the clock first, as `/rewind` requires). |
@@ -439,6 +441,102 @@ an orbs client connects once and does not retry.
 `examples/orbs` twice from scratch and asserts the ordered lockstep produces
 the identical world trace both times.
 
+## The coordinator: this process is the network
+
+Everything above runs the roles over **real localhost sockets**, which is why
+`step_all` cannot promise anything about delivery: the packets are the kernel's.
+`launch_session_group` runs the same project the other way round — every role
+starts on the **embedder transport** (`--net-transport embedder`,
+`docs/debug-runtime.md`), so **no runtime opens a socket at all**. Each one's
+`Sub.listen` / `Sub.connect` / `Effect.send` traffic is drained by this server,
+routed, and delivered back. The MCP host *is* the network.
+
+```jsonc
+launch_session_group { "dir": "examples/orbs",
+                       "roles": ["server", "client", "client"],
+                       "mode": "headless" }
+// → { "group": "g1",
+//     "sessions": [ {"session":"s1","label":"server","role":"server", …},
+//                   {"session":"s2","label":"client1","role":"client", …},
+//                   {"session":"s3","label":"client2","role":"client", …} ],
+//     "step_order": ["s1","s2","s3"] }
+
+pause    { "session": "s2" }                          // pin every role
+pause    { "session": "s1" }
+pause    { "session": "s3" }
+step_all { "sessions": ["s2", "s1", "s3"] }           // one lockstep round
+wire_log { "group": "g1", "since": 41 }               // …and what crossed in it
+```
+
+`roles` is the launch order **and** the order to hand `step_all`; repeats are
+how a group gets two clients. Omit it for one session per declared entry, with
+a role named `server` first. Labels (`server`, `client1`, `client2`) are the
+routing identities the wire log reads by.
+
+**Routing (what the coordinator does).** It mirrors the browser coordinator
+(`site/src/net-coordinator.ts`) and, through it, `VirtualNet`: a listener
+registry keyed by **authority** (`host:port` — so a client's
+`ws://127.0.0.1:9101/orbs` matches a server's `127.0.0.1:9101` bind), **one
+connection id per pair** shared by both ends, both ends told `connected` under
+their own routing key, and **FIFO per session**. A client that dials before its
+authority exists waits and connects the moment the listener appears (15 s
+grace), and reloading the authority re-queues its clients — their runtimes can
+never re-dial on their own.
+
+**Cadence.** Routing runs on this server's own loop, in two places:
+
+- **continuously in the background**, every ~8 ms, so a group running live on
+  wall-clock time still moves its packets between tool calls;
+- **at every session boundary inside a `step_all` round**, with the background
+  pump held off for the whole round. So a packet client 1 sends in round *N*
+  is delivered — and folded through `update`, since `POST /net/deliver` answers
+  only after the fold — before the authority steps.
+
+That second half is what `step_all` could not do over sockets. It is still not
+a *barrier*: the group runs freely between rounds, and nothing schedules a
+packet into a named step.
+
+**Delivery in v1 is IMMEDIATE, in order, and never dropped** — a perfect,
+reliable link. Latency, jitter, and step-time scheduling ("departs step 610,
+deliver at 618") arrive with barrier stepping, which is also what will give
+`wire_log`'s `frame` a value; today it is always `null` rather than a
+measurement dressed up as a schedule.
+
+**Reading the wire.** `wire_log` returns rows oldest-first:
+
+```jsonc
+{ "seq": 42, "frame": null, "at_ms": 8123.44,
+  "from": "client1", "to": "server", "conn": 1,
+  "kind": "message", "size": 118,
+  "payload_text": "\u0001fun:{\"Variant\":[\"Steer\",[…]]}" }
+```
+
+`payload_text` is the message **exactly as the receiving runtime sees it**, and
+is deliberately **not** decoded server-side: the framing belongs to the game
+(`Effect.sendMsg` writes U+0001 + `fun:` + the payload as JSON; plain
+`Effect.send` text is unframed), so the reader decodes it. `seq` is the stable
+cursor — read the last row's `seq`, run a round, pass it back as `since`, and
+you have exactly that round's traffic. `link` narrows to one label
+(`"client1"`) or an unordered pair (`"client1:server"`), and `direction`
+(`"sent"` / `"received"`) narrows a single label further. A label the group does
+not have is an error, not an empty result.
+
+**What reproduces, and what does not.** With immediate in-order delivery and
+`step_all`'s boundary pumping, a steady-state round routes the same packets, in
+the same direction, every time. Absolute frame numbers do not: a group runs on
+wall-clock time between rounds, so how many frames elapse before you pause is
+not controlled. Whole-environment reproducibility waits on barrier stepping.
+
+Groups are launched from a **directory** (`dir`), because the roles come from
+that project's `functor.json` `entries`; use `launch_game` for an inline
+`files` project. Stopping a group's last session retires its coordinator, and
+`wire_log` then reports the group as unknown.
+
+`e2e/mcp-session-group.mjs` is the proof: orbs as a group, clients converging
+with **nothing ever listening on `127.0.0.1:9101`**, `wire_log` rows that decode
+agent-side, `step_all` + `wire_log` composing per round, and a mid-group reload
+of the authority.
+
 ## Debugging a human's live session
 
 `functor develop` serves the debug runtime on **http://127.0.0.1:8077** by default
@@ -490,8 +588,10 @@ tracking every frame).
 - [`docs/debug-runtime.md`](debug-runtime.md) — the HTTP surface these tools wrap,
   with the exact request/response shapes.
 - `e2e/mcp-server.mjs` — the end-to-end proof, speaking raw JSON-RPC to the server.
-- `e2e/mcp-step-all.mjs` — the multiplayer proof: three roles of
-  `examples/orbs`, stepped in order, run twice, asserted identical.
+- `e2e/mcp-step-all.mjs` — the multiplayer proof over real sockets: three roles
+  of `examples/orbs`, stepped in order, run twice, asserted identical.
+- `e2e/mcp-session-group.mjs` — the coordinator proof: the same roles wired to
+  each other by the MCP process, with zero sockets, and their wire read back.
 - `.claude/skills/functor-lang/SKILL.md` — the language guide `language_guide`
   serves, and the file to edit when the language changes.
 - [`docs/functor-lang.md`](functor-lang.md) — the language roadmap behind it.

--- a/e2e/mcp-rpc.mjs
+++ b/e2e/mcp-rpc.mjs
@@ -6,6 +6,7 @@
 // is it, imported by `mcp-server.mjs` and `mcp-step-all.mjs`.
 //
 // Plain ESM with node builtins only, like every other file in `e2e/`.
+import { connect } from "node:net";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -109,4 +110,43 @@ export async function startMcp(clientName) {
   });
   rpc.notify("notifications/initialized", {});
   return { proc, rpc };
+}
+
+/** Poll `get_state` until `predicate` holds, or fail loudly with the last model.
+ *
+ * Shared by every multiplayer script: a networked assertion is always "wait for
+ * a game-level fact", never "step and hope". */
+export async function waitForState(rpc, session, predicate, what, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  for (;;) {
+    last = await rpc.call("get_state", { session });
+    if (predicate(last)) return last;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${what}; last model: ${JSON.stringify(last.model)}`);
+    }
+    await sleep(100);
+  }
+}
+
+/** Is something listening on a localhost TCP port? */
+export async function portIsBound(port) {
+  return new Promise((resolve) => {
+    const socket = connect({ host: "127.0.0.1", port });
+    socket.once("connect", () => (socket.destroy(), resolve(true)));
+    socket.once("error", () => (socket.destroy(), resolve(false)));
+  });
+}
+
+/** Wait until something IS listening on a localhost TCP port.
+ *
+ * An orbs client dials ONCE with no retry, so a client launched before the
+ * server's `Sub.listen` has bound lands in "error" and never converges. */
+export async function waitForPort(port, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await portIsBound(port)) return;
+    if (Date.now() > deadline) throw new Error(`nothing listening on 127.0.0.1:${port}`);
+    await sleep(100);
+  }
 }

--- a/e2e/mcp-session-group.mjs
+++ b/e2e/mcp-session-group.mjs
@@ -1,0 +1,279 @@
+// `functor mcp` E2E: the NATIVE COORDINATOR — the host process IS the network.
+//
+// It runs `examples/orbs` as a session GROUP: one `server` role and two
+// `client` roles, each launched on the embedder transport
+// (`--net-transport embedder`), so no runtime opens a socket at all. Every
+// `Sub.listen` / `Sub.connect` / `Effect.send` crosses THIS process, which
+// routes it and records it.
+//
+// What it proves (docs/mcp.md, "Running a multiplayer session"; Addendum 7):
+//
+//   1. ZERO REAL SOCKETS. `examples/orbs` binds `127.0.0.1:9101` over a real
+//      transport; under the coordinator nothing ever listens there, checked
+//      repeatedly — before the group converges, after it converges, and after
+//      a dozen lockstep rounds. The clients still converge, which is the
+//      point: the routing is real, the sockets are not.
+//   2. `wire_log` is the wire AS DATA, and its `payload_text` is undecoded on
+//      purpose — this test decodes the `fun:`-framed JSON itself, which is
+//      exactly what an agent does.
+//   3. `step_all` and `wire_log` COMPOSE: take the last `seq`, step a round,
+//      and the new rows are that round's traffic (client→server intents and
+//      server→client snapshots), in both directions.
+//   4. Reloading the AUTHORITY mid-group is survivable: the group keeps
+//      routing and the clients keep tracking the world.
+//
+// Determinism, honestly: delivery is immediate and in-order, and `step_all`
+// pumps at each session boundary with the background pump held off — so the
+// COUNT and DIRECTION of a round's packets is what this asserts, per round.
+// Absolute frame numbers are not: the group runs on wall-clock time between
+// tool calls, so how many frames elapse before the pause is not controlled.
+// Whole-environment reproducibility waits on barrier stepping.
+//
+// Run manually (needs the CLI built; the wasm bundle is not required):
+//
+//   cargo build -p functor-cli --no-default-features
+//   node e2e/mcp-session-group.mjs
+//
+// Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
+import { connect } from "node:net";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { check, failures, ROOT, sleep, startMcp } from "./mcp-rpc.mjs";
+
+const DIR = "examples/orbs";
+/** The ws port `examples/orbs` declares (`let bind = "127.0.0.1:9101"`). Under
+ * the embedder transport it must NEVER be bound. */
+const WS_PORT = 9101;
+const ROUNDS = 12;
+const DTS = 0.016;
+
+/** True when something is listening on a localhost TCP port. */
+async function portIsBound(port) {
+  return new Promise((resolve) => {
+    const socket = connect({ host: "127.0.0.1", port });
+    socket.once("connect", () => (socket.destroy(), resolve(true)));
+    socket.once("error", () => (socket.destroy(), resolve(false)));
+  });
+}
+
+async function waitForState(rpc, session, predicate, what, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  for (;;) {
+    last = await rpc.call("get_state", { session });
+    if (predicate(last)) return last;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${what}; last model: ${JSON.stringify(last.model)}`);
+    }
+    await sleep(100);
+  }
+}
+
+const { proc, rpc } = await startMcp("functor-e2e-session-group");
+let group = null;
+
+try {
+  check(!(await portIsBound(WS_PORT)), `nothing is on 127.0.0.1:${WS_PORT} before the run`);
+
+  console.log("▸ launch_session_group wires three orbs roles to each other");
+  const launched = await rpc.call("launch_session_group", {
+    dir: DIR,
+    roles: ["server", "client", "client"],
+    mode: "headless",
+  });
+  group = launched.group;
+  const [server, c1, c2] = launched.sessions.map((s) => s.session);
+  check(
+    launched.sessions.map((s) => s.label).join(",") === "server,client1,client2",
+    `the group labels its roles for the wire log (${launched.sessions.map((s) => s.label)})`,
+  );
+  check(
+    launched.step_order.join(",") === [server, c1, c2].join(","),
+    "the group reports the step order the roles were launched in",
+  );
+
+  console.log("\n▸ the clients converge over the coordinator — with no socket anywhere");
+  await waitForState(rpc, c1, (s) => s.model.myPid === 0, "client 1 to be seated as P0");
+  await waitForState(rpc, c2, (s) => s.model.myPid === 1, "client 2 to be seated as P1");
+  for (const [name, session] of [["1", c1], ["2", c2]]) {
+    await waitForState(
+      rpc,
+      session,
+      (s) => s.model.ships.length === 2,
+      `client ${name} to see both ships`,
+    );
+  }
+  check(
+    !(await portIsBound(WS_PORT)),
+    `the group converged with NOTHING listening on 127.0.0.1:${WS_PORT}`,
+  );
+
+  console.log("\n▸ wire_log is the wire as data");
+  const log = await rpc.call("wire_log", { group, limit: 500 });
+  check(log.rows.length > 0, `the coordinator routed ${log.routed} packet(s)`);
+  check(
+    log.sessions.join(",") === "server,client1,client2",
+    `wire_log names the group's sessions (${log.sessions})`,
+  );
+  const connectRow = log.rows.find((r) => r.kind === "connected");
+  check(connectRow !== undefined, "the handshake is in the log as a `connected` row");
+  const messages = log.rows.filter((r) => r.kind === "message");
+  check(messages.length > 0, `${messages.length} message row(s) carry payload_text`);
+  // The framing belongs to the GAME: `Effect.sendMsg` prefixes U+0001 + "fun:"
+  // and then serde's EffectValue JSON (site/src/wire-value.ts documents the
+  // shape). The coordinator deliberately does not decode any of it, so this
+  // test does — which is exactly what an agent reading the log does.
+  const TYPED_MSG_PREFIX = "\u0001fun:";
+  const decodable = messages.filter((row) => {
+    const text = row.payload_text ?? "";
+    if (!text.startsWith(TYPED_MSG_PREFIX)) return false;
+    const body = text.slice(TYPED_MSG_PREFIX.length);
+    try {
+      JSON.parse(body);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  check(
+    decodable.length === messages.length,
+    `every payload_text decodes agent-side (${decodable.length}/${messages.length}); ` +
+      `sample: ${JSON.stringify(messages[0]?.payload_text?.slice(0, 80))}`,
+  );
+  check(
+    messages.every((row) => row.size > 0 && row.from !== row.to),
+    "message rows carry a byte size and route between two distinct sessions",
+  );
+  check(
+    log.rows.every((row) => row.frame === null),
+    "v1 delivery is unscheduled, so every row's frame is null (barrier stepping fills it in)",
+  );
+
+  console.log("\n▸ a filtered wire_log narrows by link and direction");
+  const fromC1 = await rpc.call("wire_log", { group, link: "client1", direction: "sent", limit: 200 });
+  check(
+    fromC1.rows.length > 0 && fromC1.rows.every((row) => row.from === "client1"),
+    `link+direction returns only client1's sends (${fromC1.rows.length} rows)`,
+  );
+  const pair = await rpc.call("wire_log", { group, link: "client2:server", limit: 200 });
+  check(
+    pair.rows.every((row) => new Set([row.from, row.to]).size === 2
+      && ["client2", "server"].includes(row.from)
+      && ["client2", "server"].includes(row.to)),
+    "a pair link returns only traffic between those two ends",
+  );
+  let badLabel = null;
+  try {
+    await rpc.call("wire_log", { group, link: "cleint1" });
+  } catch (error) {
+    badLabel = error.message;
+  }
+  check(
+    badLabel !== null && /unknown session label/.test(badLabel),
+    "a mistyped label is a teaching error, not an empty result",
+  );
+
+  console.log("\n▸ step_all and wire_log compose");
+  // Nothing in orbs moves on its own — hold thrust on client 1 so each round
+  // has real client→server traffic to route.
+  await rpc.call("send_input", { session: c1, command: { type: "key", key: "w", down: true } });
+  await waitForState(
+    rpc,
+    server,
+    (s) => s.model.world.pilots.some((p) => p.ship.pid === 0 && p.intent.thrust === true),
+    "the server to see P0 thrusting",
+  );
+  for (const session of [c1, server, c2]) await rpc.call("pause", { session });
+
+  const perRound = [];
+  let cursor = (await rpc.call("wire_log", { group, limit: 1 })).rows.at(-1)?.seq ?? null;
+  for (let round = 0; round < ROUNDS; round += 1) {
+    await rpc.call("step_all", { sessions: [c1, server, c2], dts: DTS });
+    const window = await rpc.call("wire_log", {
+      group,
+      ...(cursor === null ? {} : { since: cursor }),
+      limit: 500,
+    });
+    perRound.push(window.rows);
+    if (window.rows.length > 0) cursor = window.rows.at(-1).seq;
+  }
+  check(
+    perRound.every((rows) => rows.every((row) => row.seq > 0)),
+    "every windowed row falls after the cursor taken before its round",
+  );
+  const steady = perRound.slice(2);
+  check(
+    steady.every((rows) => rows.length > 0),
+    `each stepped round routed traffic (${perRound.map((r) => r.length).join(",")})`,
+  );
+  check(
+    steady.every((rows) => rows.some((r) => r.from === "client1" && r.to === "server")),
+    "each round carries client1's intent to the authority",
+  );
+  check(
+    steady.every((rows) => rows.some((r) => r.from === "server" && r.to === "client2")),
+    "…and the authority's broadcast back out to client2",
+  );
+  const counts = new Set(steady.map((rows) => rows.length));
+  check(
+    counts.size === 1,
+    `an ordered round routes the same packet count every time (${[...counts].join(",")})`,
+  );
+  check(
+    !(await portIsBound(WS_PORT)),
+    `still NOTHING listening on 127.0.0.1:${WS_PORT} after ${ROUNDS} rounds`,
+  );
+
+  console.log("\n▸ reloading the authority mid-group");
+  // A model-preserving push of the SAME source. The connections belong to the
+  // COORDINATOR, not to the game, so a reload of the authority does not tear
+  // them down: the model (and with it the seats and connection ids) survives,
+  // and routing continues across it. That is the documented behaviour this
+  // pins — a client that is dropped can never re-dial on its own, so silently
+  // losing the group here would be invisible until a session went quiet.
+  const before = (await rpc.call("get_state", { session: server })).model_revision;
+  await rpc.call("reload_project", {
+    session: server,
+    files: [["game.fun", readFileSync(join(ROOT, DIR, "game.fun"), "utf8")]],
+  });
+  for (const session of [c1, server, c2]) await rpc.call("resume", { session });
+  const after = await waitForState(
+    rpc,
+    server,
+    (s) => s.model_revision > before && s.model.world.pilots.length === 2,
+    "the reloaded authority to keep both pilots seated",
+  );
+  check(after.model.world.pilots.length === 2, "the group survived a reload of its authority");
+  const post = await rpc.call("wire_log", { group, since: cursor, limit: 200 });
+  check(
+    post.rows.some((r) => r.from === "server"),
+    "the reloaded authority is still sending on the coordinator's connections",
+  );
+  check(
+    !(await portIsBound(WS_PORT)),
+    `no socket appeared across the reload either (127.0.0.1:${WS_PORT})`,
+  );
+
+  console.log("\n▸ stopping the group's sessions retires the coordinator");
+  await rpc.call("send_input", { session: c1, command: { type: "key", key: "w", down: false } });
+  for (const session of [c1, c2, server]) await rpc.call("stop_game", { session });
+  let gone = null;
+  try {
+    await rpc.call("wire_log", { group });
+  } catch (error) {
+    gone = error.message;
+  }
+  check(gone !== null, "the group is gone once its last session stops");
+} catch (error) {
+  failures.push(String(error?.stack ?? error));
+  console.error(error);
+} finally {
+  proc.stdin.end();
+}
+
+console.log(
+  failures.length === 0 ? "\nAll coordinator MCP checks passed." : `\n${failures.length} failure(s):`,
+);
+for (const failure of failures) console.log(`  - ${failure}`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/e2e/mcp-session-group.mjs
+++ b/e2e/mcp-session-group.mjs
@@ -35,11 +35,10 @@
 //   node e2e/mcp-session-group.mjs
 //
 // Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
-import { connect } from "node:net";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { check, failures, ROOT, sleep, startMcp } from "./mcp-rpc.mjs";
+import { check, failures, portIsBound, ROOT, startMcp, waitForState } from "./mcp-rpc.mjs";
 
 const DIR = "examples/orbs";
 /** The ws port `examples/orbs` declares (`let bind = "127.0.0.1:9101"`). Under
@@ -47,28 +46,6 @@ const DIR = "examples/orbs";
 const WS_PORT = 9101;
 const ROUNDS = 12;
 const DTS = 0.016;
-
-/** True when something is listening on a localhost TCP port. */
-async function portIsBound(port) {
-  return new Promise((resolve) => {
-    const socket = connect({ host: "127.0.0.1", port });
-    socket.once("connect", () => (socket.destroy(), resolve(true)));
-    socket.once("error", () => (socket.destroy(), resolve(false)));
-  });
-}
-
-async function waitForState(rpc, session, predicate, what, timeoutMs = 30000) {
-  const deadline = Date.now() + timeoutMs;
-  let last;
-  for (;;) {
-    last = await rpc.call("get_state", { session });
-    if (predicate(last)) return last;
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${what}; last model: ${JSON.stringify(last.model)}`);
-    }
-    await sleep(100);
-  }
-}
 
 const { proc, rpc } = await startMcp("functor-e2e-session-group");
 let group = null;

--- a/e2e/mcp-step-all.mjs
+++ b/e2e/mcp-step-all.mjs
@@ -28,13 +28,12 @@
 //   node e2e/mcp-step-all.mjs
 //
 // Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
-import { connect } from "node:net";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 // The raw JSON-RPC client is shared with e2e/mcp-server.mjs.
-import { check, failures, ROOT, sleep, startMcp } from "./mcp-rpc.mjs";
+import { check, failures, ROOT, sleep, startMcp, waitForPort, waitForState } from "./mcp-rpc.mjs";
 
 const DIR = "examples/orbs";
 /** The ws port `examples/orbs` binds (`let bind = "127.0.0.1:9101"`). */
@@ -42,39 +41,6 @@ const WS_PORT = 9101;
 /** Lockstep rounds per run. Enough to see the world move, short enough to run twice. */
 const ROUNDS = 12;
 const DTS = 0.016;
-
-/** Poll `get_state` until `predicate` holds, or fail loudly with the last state. */
-async function waitForState(rpc, session, predicate, what, timeoutMs = 20000) {
-  const deadline = Date.now() + timeoutMs;
-  let last;
-  for (;;) {
-    last = await rpc.call("get_state", { session });
-    if (predicate(last)) return last;
-    if (Date.now() > deadline) {
-      throw new Error(`timed out waiting for ${what}; last state: ${JSON.stringify(last.model)}`);
-    }
-    await sleep(100);
-  }
-}
-
-/** Wait until something is listening on a localhost TCP port.
- *
- * An orbs client dials ONCE with no retry, so a client launched before the
- * server's `Sub.listen` has bound lands in "error" and never converges. The
- * SDK's own multiplayer test gates on the same port for the same reason. */
-async function waitForPort(port, timeoutMs = 30000) {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    const open = await new Promise((resolve) => {
-      const socket = connect({ host: "127.0.0.1", port });
-      socket.once("connect", () => (socket.destroy(), resolve(true)));
-      socket.once("error", () => (socket.destroy(), resolve(false)));
-    });
-    if (open) return;
-    if (Date.now() > deadline) throw new Error(`nothing listening on 127.0.0.1:${port}`);
-    await sleep(100);
-  }
-}
 
 /** The authority's ships: `world.pilots` is a list of `{ ship, intent }`. */
 const shipsOf = (state) => state.model.world.pilots.map((p) => p.ship);

--- a/runtime/functor-runtime-common/src/debug_http.rs
+++ b/runtime/functor-runtime-common/src/debug_http.rs
@@ -405,6 +405,88 @@ fn handle(mut stream: TcpStream, tx: &mpsc::Sender<DebugRequest>) -> Option<()> 
             }
             respond_result(&mut stream, cors_origin, recv(resp_rx), "rewind")
         }
+        ("GET", "/net/outbound") => {
+            let (resp_tx, resp_rx) = mpsc::channel();
+            if tx.send(DebugRequest::NetOutbound(resp_tx)).is_err() {
+                return runtime_gone(&mut stream, cors_origin);
+            }
+            match recv(resp_rx) {
+                Ok(Ok(json)) => respond_bytes(
+                    &mut stream,
+                    cors_origin,
+                    200,
+                    "OK",
+                    "application/json",
+                    json.as_bytes(),
+                ),
+                // The same 409 discipline `/time` uses: a runtime that cannot
+                // honor the request in its current mode says so loudly, rather
+                // than answering an empty `[]` a coordinator would read as
+                // "the game sent nothing" forever.
+                Ok(Err(message)) => {
+                    respond_text(&mut stream, cors_origin, 409, "Conflict", &message)
+                }
+                Err(_) => respond_text(
+                    &mut stream,
+                    cors_origin,
+                    500,
+                    "Internal Server Error",
+                    "net outbound failed",
+                ),
+            }
+        }
+        ("POST", "/net/deliver") => {
+            let body = match read_body(&mut reader, content_length, MAX_COMMAND_BYTES) {
+                Ok(body) => body,
+                Err(BodyError::MissingLength | BodyError::TooLarge) => {
+                    respond_text(
+                        &mut stream,
+                        cors_origin,
+                        413,
+                        "Payload Too Large",
+                        "delivery too large (or missing Content-Length); limit is 64KB",
+                    );
+                    return Some(());
+                }
+                Err(BodyError::Invalid) => {
+                    respond_text(&mut stream, cors_origin, 400, "Bad Request", "bad body");
+                    return Some(());
+                }
+            };
+            let events = match std::str::from_utf8(&body)
+                .map_err(|error| error.to_string())
+                .and_then(crate::net::parse_delivered_events)
+            {
+                Ok(events) => events,
+                Err(error) => {
+                    respond_text(
+                        &mut stream,
+                        cors_origin,
+                        400,
+                        "Bad Request",
+                        &format!("bad net delivery: {error}"),
+                    );
+                    return Some(());
+                }
+            };
+            let (resp_tx, resp_rx) = mpsc::channel();
+            if tx.send(DebugRequest::NetDeliver(events, resp_tx)).is_err() {
+                return runtime_gone(&mut stream, cors_origin);
+            }
+            match recv(resp_rx) {
+                Ok(Ok(status)) => respond_text(&mut stream, cors_origin, 200, "OK", &status),
+                Ok(Err(message)) => {
+                    respond_text(&mut stream, cors_origin, 409, "Conflict", &message)
+                }
+                Err(_) => respond_text(
+                    &mut stream,
+                    cors_origin,
+                    500,
+                    "Internal Server Error",
+                    "net delivery failed",
+                ),
+            }
+        }
         ("POST", "/reload-asset") => {
             let body = match read_body(
                 &mut reader,
@@ -930,6 +1012,85 @@ Content-Length: {}\r\n\r\n{body}",
             "{response}"
         );
         assert!(response.ends_with("pinned by --fixed-time"));
+    }
+
+    /// The embedder transport's egress: the runtime's answer is the drained
+    /// `ConnCommand` JSON verbatim, and a runtime on the socket transport
+    /// REFUSES with 409 rather than answering an empty array — a coordinator
+    /// must be able to tell "nothing was sent" from "you asked the wrong
+    /// runtime".
+    #[test]
+    fn net_outbound_returns_the_drained_commands_and_409s_off_transport() {
+        let drain = |answer: Result<String, String>| {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let client = connect(
+                &listener,
+                "GET /net/outbound HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+            );
+            let (tx, rx) = mpsc::channel();
+            let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+            match rx.recv().unwrap() {
+                DebugRequest::NetOutbound(response) => response.send(answer).unwrap(),
+                _ => panic!("expected a net outbound request"),
+            }
+            server.join().unwrap();
+            client.join().unwrap()
+        };
+
+        let commands = r#"[{"Listen":{"key":"127.0.0.1:9101","addr":"127.0.0.1:9101"}}]"#;
+        let response = drain(Ok(commands.to_string()));
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response}");
+        assert!(response.contains("Content-Type: application/json\r\n"));
+        assert!(response.ends_with(commands), "{response}");
+
+        let response = drain(Err("on the socket transport".into()));
+        assert!(response.starts_with("HTTP/1.1 409 Conflict\r\n"), "{response}");
+    }
+
+    /// Ingress parses through the SHARED `DeliveredEvent` type (the same one
+    /// the web embedder posts), so a malformed batch is a 400 that never
+    /// reaches the runtime loop.
+    #[test]
+    fn net_deliver_parses_the_shared_event_shape_and_rejects_malformed_batches() {
+        use crate::net::DeliveredEvent;
+        let deliver = |body: &str| {
+            let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+            let request = format!(
+                "POST /net/deliver HTTP/1.1\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            let client = connect(&listener, request);
+            let (tx, rx) = mpsc::channel();
+            let server = std::thread::spawn(move || handle(listener.accept().unwrap().0, &tx));
+            let events = match rx.recv_timeout(Duration::from_secs(5)) {
+                Ok(DebugRequest::NetDeliver(events, response)) => {
+                    response.send(Ok("delivered".into())).unwrap();
+                    Some(events)
+                }
+                Ok(_) => panic!("expected a net deliver request"),
+                Err(_) => None,
+            };
+            server.join().unwrap();
+            (events, client.join().unwrap())
+        };
+
+        let (events, response) =
+            deliver(r#"[{"kind":"message","key":"ws://x/","conn":3,"text":"hi"}]"#);
+        assert_eq!(
+            events,
+            Some(vec![DeliveredEvent::Message {
+                key: "ws://x/".into(),
+                conn: 3,
+                text: "hi".into()
+            }])
+        );
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response}");
+
+        // A negative conn would reach the game as u64::MAX; the shared parser
+        // rejects it, and so this never reaches the runtime loop.
+        let (events, response) = deliver(r#"[{"kind":"connected","key":"k","conn":-1}]"#);
+        assert_eq!(events, None);
+        assert!(response.starts_with("HTTP/1.1 400 Bad Request\r\n"), "{response}");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -62,7 +62,16 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// events. Additive — a pre-v10 runtime simply omits both, which deserializes
 /// as `0`; a client that waits on either must gate on the version rather than
 /// read a constant zero as "quiescent".
-pub const DEBUG_PROTOCOL_VERSION: u32 = 10;
+///
+/// 11 added the EMBEDDER TRANSPORT's two endpoints — `GET /net/outbound` and
+/// `POST /net/deliver` — through which a host process IS the network for a
+/// runtime started with `--net-transport embedder` (no socket is ever opened).
+/// Additive, and inert unless that argument was passed: under the default
+/// socket transport both routes answer 409, because draining the game's
+/// outbound commands there would steal them from the real dispatcher and
+/// delivering into it would inject events no peer sent. A pre-v11 runtime
+/// answers 404.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 11;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -172,6 +181,16 @@ pub const DEBUG_ROUTES: &[DebugRoute] = &[
         method: "POST",
         path: "/rewind",
         description: "coupled scene rewind — {\"frame\":42} restores model + physics to that rendered frame (pin the clock first); 400 if unrecorded/pruned",
+    },
+    DebugRoute {
+        method: "GET",
+        path: "/net/outbound",
+        description: "embedder transport (--net-transport embedder): take-and-consume the game's queued ConnCommands as JSON — the host process is this runtime's network; 409 under the default socket transport",
+    },
+    DebugRoute {
+        method: "POST",
+        path: "/net/deliver",
+        description: "embedder transport (--net-transport embedder): deliver inbound network events, a JSON array of {kind:\"connected\"|\"message\"|\"disconnected\"|\"error\", key, conn, text?/message?}; folded through update before the response; 409 under the default socket transport",
     },
 ];
 
@@ -566,6 +585,16 @@ pub enum DebugRequest {
     ReloadAsset(ProjectAsset, Sender<Result<String, String>>),
     SyncAssets(ProjectAssetPaths, Sender<Result<String, String>>),
     Rewind(u64, Sender<Result<String, String>>),
+    /// Embedder transport: take-and-consume the game's queued `ConnCommand`s.
+    /// `Err` when the runtime is on the default socket transport, where the
+    /// real dispatcher owns that queue.
+    NetOutbound(Sender<Result<String, String>>),
+    /// Embedder transport: push inbound events into the game. `Err` for the
+    /// same reason as [`DebugRequest::NetOutbound`].
+    NetDeliver(
+        Vec<crate::net::DeliveredEvent>,
+        Sender<Result<String, String>>,
+    ),
 }
 
 #[cfg(test)]
@@ -877,6 +906,8 @@ mod tests {
             "POST /reload-asset",
             "POST /sync-assets",
             "POST /rewind",
+            "GET /net/outbound",
+            "POST /net/deliver",
         ]
         .into_iter()
         .map(str::to_owned)
@@ -899,7 +930,7 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 10);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 11);
     }
 
     /// The v10 fields are ADDITIVE: a pre-v10 payload (which carries neither)

--- a/runtime/functor-runtime-common/src/net/embedder.rs
+++ b/runtime/functor-runtime-common/src/net/embedder.rs
@@ -22,10 +22,14 @@
 //! which take the routing `key` beside each event and a message as TEXT — so
 //! this type mirrors those signatures one-for-one instead.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// One inbound network event handed to the runtime by its embedder.
-#[derive(Debug, PartialEq, Eq, Deserialize)]
+///
+/// `Serialize` because the embedder is not always JavaScript: the native
+/// coordinator (`functor mcp`) BUILDS these and posts them to a runtime's
+/// `POST /net/deliver`, so both ends of the seam speak the one type.
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum DeliveredEvent {
     /// The connection identified by `key` became usable as `conn`.

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1479,6 +1479,22 @@ then restart the runner"
         .debug_port
         .and_then(|port| debug_server::spawn(&args.debug_bind, port, args.debug_port_optional));
 
+    // The embedder transport is only half a network without a debug client:
+    // the drained commands accumulate in an unbounded queue nobody takes, and
+    // no event can ever be delivered. Refusing here turns a silent leak (and a
+    // game whose networking quietly does nothing) into a startup error — and
+    // it deliberately keys on the SERVER, not the flag, so an optional port
+    // that was already taken fails just as loudly.
+    if args.net_transport == NetTransportArg::Embedder && debug_requests.is_none() {
+        eprintln!(
+            "error: --net-transport embedder needs a debug server — the embedder IS the client \
+of `GET /net/outbound` / `POST /net/deliver`, so without one this game's network can never be \
+drained or delivered. Pass --debug-port <PORT> (or drop --net-transport embedder to use real \
+sockets)."
+        );
+        std::process::exit(1);
+    }
+
     // Headless: drive the game + debug server with no GL window, and return.
     if args.headless {
         if args.capture_frame.is_some() {

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use functor_runtime_common::asset::AssetCache;
+use functor_runtime_common::net::DeliveredEvent;
 use functor_runtime_common::viewer::{camera_frustum_lines, DebugCamera, DebugPresentation};
 use functor_runtime_common::{
     Frame, FrameTime, GameClock, InputEdges, InputSnapshot, MouseButtons, MouseSnapshot,
@@ -549,6 +550,22 @@ pub enum CursorPolicyArg {
     Visible,
 }
 
+/// Where this runtime's persistent-connection networking goes.
+///
+/// The desktop analog of the web runtime's `window.__functorNetTransport`
+/// (`runtime/functor-runtime-web/src/lib.rs`): natively, "the embedder" is the
+/// process driving the debug server — `functor mcp`'s coordinator.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum NetTransportArg {
+    /// Real sockets, via the tungstenite host (`ws_host`). The default.
+    #[default]
+    Sockets,
+    /// No socket is ever opened. The game's drained `ConnCommand`s stay queued
+    /// for `GET /net/outbound`, and inbound events arrive over
+    /// `POST /net/deliver` — so the debug-server CLIENT is the network.
+    Embedder,
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -620,6 +637,15 @@ pub struct Args {
     /// Pointer policy selected by the project's `functor.json`.
     #[arg(long, value_enum, default_value_t = CursorPolicyArg::Captured)]
     cursor: CursorPolicyArg,
+
+    /// Where `Sub.connect` / `Sub.listen` traffic goes: real `sockets`
+    /// (default) or the `embedder` — the process on the other side of the
+    /// debug server, which then drains `GET /net/outbound` and delivers over
+    /// `POST /net/deliver`. `embedder` opens NO socket, which is how
+    /// `functor mcp`'s coordinator runs a whole client/server session inside
+    /// one host process with a readable wire log.
+    #[arg(long, value_enum, default_value_t = NetTransportArg::Sockets)]
+    net_transport: NetTransportArg,
 
     /// Write a PNG of the rendered frame to this path, then exit. The capture
     /// happens on the first frame after --capture-time seconds of wall-clock
@@ -873,11 +899,19 @@ fn deliver_net_ws(
 
 /// Perform the HTTP + WebSocket commands this frame's tick queued. HTTP requests
 /// run on tokio tasks (results return via `net_tx`); WS commands go to the manager.
+///
+/// Under [`NetTransportArg::Embedder`] the connection half is SKIPPED entirely:
+/// the commands stay in the shared queue until the debug server's
+/// `GET /net/outbound` takes them, which is what makes the embedder path cost
+/// nothing per frame beyond the branch — and, more importantly, means no
+/// socket is ever opened. The HTTP half is untouched either way: `Effect.http`
+/// is not connection traffic and has no coordinator to route it.
 fn dispatch_net_ws(
     game: &mut dyn Game,
     net_tx: &std::sync::mpsc::Sender<net_dispatch::NetResult>,
     http_client: &reqwest::Client,
     ws_manager: &mut ws_host::WsManager,
+    net_transport: NetTransportArg,
 ) {
     let commands_json = game.net_drain_commands();
     if commands_json != "[]" {
@@ -898,6 +932,10 @@ fn dispatch_net_ws(
         }
     }
 
+    if net_transport == NetTransportArg::Embedder {
+        return;
+    }
+
     let conn_json = game.net_drain_conn_commands();
     if conn_json != "[]" {
         match serde_json::from_str::<Vec<functor_runtime_common::net::ConnCommand>>(&conn_json) {
@@ -910,6 +948,14 @@ fn dispatch_net_ws(
         }
     }
 }
+
+/// Refusal both embedder-transport endpoints answer under the default socket
+/// transport. Draining there would steal the real dispatcher's commands and
+/// delivering there would inject events no peer sent — so this is a 409, not a
+/// quiet empty answer a coordinator would read as "the game sent nothing".
+const EMBEDDER_TRANSPORT_REQUIRED: &str =
+    "this runtime is on the socket transport — start it with `--net-transport embedder` \
+for the host process to be its network";
 
 /// Service one debug-server request. `capture` produces the PNG (or a
 /// `CaptureError`) for `POST /capture` — a framebuffer readback in the windowed
@@ -945,6 +991,9 @@ fn service_debug_request(
     // instead of reaching the game. Always `None` in the headless loop, which
     // has no webview overlay.
     mut webview_keyboard: Option<&mut Vec<crate::webview_keys::WebviewKey>>,
+    // Which transport owns the game's connection queues, so `/net/outbound`
+    // and `/net/deliver` refuse rather than fight the real dispatcher.
+    net_transport: NetTransportArg,
     capture: &dyn Fn() -> Result<Vec<u8>, debug_server::CaptureError>,
 ) -> bool {
     let mut sampled_input_changed = false;
@@ -1038,6 +1087,39 @@ fn service_debug_request(
                 }
             }
             let _ = resp.send(result);
+        }
+        debug_server::DebugRequest::NetOutbound(resp) => {
+            let _ = resp.send(if net_transport == NetTransportArg::Embedder {
+                Ok(game.net_drain_conn_commands())
+            } else {
+                Err(EMBEDDER_TRANSPORT_REQUIRED.to_string())
+            });
+        }
+        debug_server::DebugRequest::NetDeliver(events, resp) => {
+            let _ = resp.send(if net_transport == NetTransportArg::Embedder {
+                let count = events.len();
+                // Each push folds the event through `update` synchronously
+                // (`deliver_net_event`), so a 200 means the model has already
+                // absorbed the batch — the property the coordinator's
+                // step-ordering relies on.
+                for event in events {
+                    match event {
+                        DeliveredEvent::Connected { key, conn } => game.net_push_connected(key, conn),
+                        DeliveredEvent::Message { key, conn, text } => {
+                            game.net_push_conn_message(key, conn, text)
+                        }
+                        DeliveredEvent::Disconnected { key, conn } => {
+                            game.net_push_disconnected(key, conn)
+                        }
+                        DeliveredEvent::Error { key, conn, message } => {
+                            game.net_push_conn_error(key, conn, message)
+                        }
+                    }
+                }
+                Ok(format!("delivered {count} net event(s)"))
+            } else {
+                Err(EMBEDDER_TRANSPORT_REQUIRED.to_string())
+            });
         }
         debug_server::DebugRequest::Input(cmd, resp) => {
             sampled_input_changed = matches!(
@@ -1163,6 +1245,7 @@ fn run_headless(
     emulate_xr: bool,
     input_script: Option<HashMap<u64, Vec<RecordedInput>>>,
     script_dt: f32,
+    net_transport: NetTransportArg,
 ) {
     // Stderr, not stdout: keep the CLI's `--json` ndjson stream (stdout) clean
     // even under `--headless`. This is an out-of-band notice, not an event.
@@ -1254,7 +1337,7 @@ fn run_headless(
             game.tick(sub.clone());
             frame_count += 1;
         }
-        dispatch_net_ws(&mut *game, &net_tx, &http_client, &mut ws_manager);
+        dispatch_net_ws(&mut *game, &net_tx, &http_client, &mut ws_manager, net_transport);
 
         // The frame is pure data (no GL); it powers GET /scene. Drain and drop
         // audio commands so they do not pile up. Preloads and physics terrain
@@ -1294,6 +1377,7 @@ fn run_headless(
                     &scene_context,
                     None,
                     None, // no webview overlay in headless
+                    net_transport,
                     &|| {
                         Err(debug_server::CaptureError::Unavailable(
                             "capture is unavailable in --headless mode".to_string(),
@@ -1415,6 +1499,7 @@ then restart the runner"
             args.emulate_xr,
             input_script,
             args.script_dt,
+            args.net_transport,
         );
         return;
     }
@@ -2491,7 +2576,13 @@ Escape again to quit"
 
             // Perform the HTTP + WebSocket commands this frame's tick queued
             // (shared with the headless loop).
-            dispatch_net_ws(&mut *game, &net_tx, &http_client, &mut ws_manager);
+            dispatch_net_ws(
+                &mut *game,
+                &net_tx,
+                &http_client,
+                &mut ws_manager,
+                args.net_transport,
+            );
 
             // Follow window resizes: query the drawable size each frame.
             // Framebuffer size is in pixels, so this handles HiDPI/retina.
@@ -3292,6 +3383,7 @@ Escape again to quit"
                         } else {
                             None
                         },
+                        args.net_transport,
                         // GL readback on the render thread (a real Failed on error).
                         &|| {
                             functor_runtime_common::frame_capture::encode_bound_framebuffer_png(

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -811,6 +811,17 @@ tracking); use the desktop runtime's --headless/--debug-port path"
             }
             let _ = response.send(result);
         }
+        // The embedder transport is a NATIVE-HOST facility: a device session's
+        // network is a real socket to a real peer, and there is no coordinator
+        // on the other side of adb. Refusing keeps the protocol honest instead
+        // of letting a driver drain the queue the device's own dispatcher owns.
+        DebugRequest::NetOutbound(response) | DebugRequest::NetDeliver(_, response) => {
+            let _ = response.send(Err(
+                "the embedder transport is not available on the device runtime — \
+its networking is real sockets"
+                    .to_string(),
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
**MCP Phase 2 — the native coordinator** (design doc Addendum 7, stacked on #650): the embedder seam was never browser-specific. Natively, *the MCP host process is the network* — an agent runs a multiplayer session with zero real sockets and reads the wire as data.

**The transport**: `--net-transport embedder` (default `sockets`, unchanged; refused without `--debug-port` so the outbox can't grow undrainable). At the native dispatch seam (`dispatch_net_ws`), the connection half early-returns and commands queue for the debug server: `GET /net/outbound` drains them (409 off-transport — a coordinator must distinguish "nothing sent" from "wrong runtime"), `POST /net/deliver` accepts the shared `DeliveredEvent` shape (#591's type, now `Serialize`) and folds through `update` before answering. Protocol v11. **Cost story**: mode off = one enum compare; mode on = draining *replaces* the socket write, all new work on the HTTP thread — nothing per-frame, no frame_bench owed.

**The coordinator**: `launch_session_group {dir, roles?}` boots a functor.json's roles (server first) on the embedder transport and returns the step order; the host routes by the same semantics as the browser coordinator (listener registry, one conn id per pair, FIFO; delivery immediate in v1 — step-time scheduling arrives with barrier stepping and reuses #657's discipline, and delegating the table to `VirtualNet` is deferred with reasons until that PR needs its `deliver_tick`). Pumping is two-part and documented: a background task plus a pump at every session boundary inside a `step_all` round, group-locked so the background can't fire mid-round — the pump is the transport, so it never takes a session's operation gate.

**`wire_log`** (MCP tool): the routed-packet log as data — `{seq, frame(null until barrier), at_ms, from, to, conn, kind, size, payload_text}` with link/direction/since filters, cursors that compose with `step_all`, and a payload byte budget with elision flags. Payloads carry the `fun:` framing verbatim; agents decode.

**The proof** (`e2e/mcp-session-group.mjs`): orbs' declared bind `127.0.0.1:9101` is asserted **unbound before, during, and after** — while both clients seat as P0/P1 and see both ships. Steady-state `step_all` rounds route exactly 4 packets, both runs. An authority reload is survived. Run twice, green both.

**Cross-engine review (Claude + Codex + dedup)** — both engines' two Highs fixed: 64KB delivery bodies wedged a session forever (chunked in order); non-transactional retries could double-fold a batch (failures classified: provably-not-applied requeues, ambiguous reports-and-stops — the docs no longer claim "never dropped"). Plus a self-found **lock-order inversion** between `stop_game` and `step_all` (also closing the pump leak both engines flagged), bounded outbox with shed reporting, deadline covering lock waits, checked conn casts. Dedup: `declared_entries` reuses `manifest_entries`; the e2es share their wait helpers.

**Verification**: functor_runtime_common 694; desktop 86; functor-cli 120/121 (1 pre-existing on base, stash-verified); strict build clean; `build:cli:debug`; the group e2e ×2; `mcp-step-all` green; `mcp-server` at its one pre-existing failure.

With this, Addendum 7's Phase 2 is real: **launch group → step_all → wire_log → assert** — deterministic-where-promised, wire-visible, socketless. Phase 3 (barrier stepping + whole-environment seek natively) is next, and it restores the seek regression coverage relinquished at the netsim removal — against the real architecture this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
