### PR TITLE
fix(render): transform lit normals with the inverse-transpose

### DIFF
--- a/runtime/functor-runtime-common/src/material/lit_material.rs
+++ b/runtime/functor-runtime-common/src/material/lit_material.rs
@@ -1,6 +1,8 @@
 use cgmath::Matrix4;
 use cgmath::Vector4;
 
+use crate::math::normal_matrix;
+
 use crate::fog::{FogUniforms, FOG_GLSL};
 use crate::light::{lighting_glsl, LightingUniforms};
 use crate::shader_program::ShaderProgram;
@@ -12,7 +14,8 @@ use super::Material;
 // Diffuse-lit surface: albedo (a color, optionally modulated by a texture) shaded
 // by a bounded array of lights (ambient / directional / point / spot) via Lambert
 // plus distance + cone falloff. Reads the frame's lights from `RenderContext`.
-// Needs the vertex normal (attribute location 2). The light loop + shadow
+// Needs the vertex normal (attribute location 2), which is transformed by the
+// normal matrix (inverse-transpose) so non-uniform scales shade correctly. The light loop + shadow
 // sampling live in the shared `lighting_glsl` snippet (also used by the skinned
 // lit shader).
 const VERTEX_SHADER_SOURCE: &str = r#"
@@ -22,6 +25,10 @@ const VERTEX_SHADER_SOURCE: &str = r#"
         layout (location = 3) in vec4 inTangent;
 
         uniform mat4 world;
+        // transpose(inverse(mat3(world))) — normals are covectors, so a
+        // non-uniform scale transforms them by the inverse-transpose. Tangents
+        // are ordinary directions and keep mat3(world).
+        uniform mat3 normalMatrix;
         uniform mat4 view;
         uniform mat4 projection;
 
@@ -33,7 +40,7 @@ const VERTEX_SHADER_SOURCE: &str = r#"
 
         void main() {
             texCoord = inTex;
-            vec3 n = mat3(world) * inNormal;
+            vec3 n = normalMatrix * inNormal;
             vec3 t = mat3(world) * inTangent.xyz;
             worldNormal = n;
             worldTangent = t;
@@ -90,6 +97,7 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
 
 struct Uniforms {
     world_loc: UniformLocation,
+    normal_matrix_loc: UniformLocation,
     view_loc: UniformLocation,
     projection_loc: UniformLocation,
     base_color_loc: UniformLocation,
@@ -137,6 +145,7 @@ impl Material for LitMaterial {
 
                 let uniforms = Uniforms {
                     world_loc: shader.get_uniform_location(ctx.gl, "world"),
+                    normal_matrix_loc: shader.get_uniform_location(ctx.gl, "normalMatrix"),
                     view_loc: shader.get_uniform_location(ctx.gl, "view"),
                     projection_loc: shader.get_uniform_location(ctx.gl, "projection"),
                     base_color_loc: shader.get_uniform_location(ctx.gl, "baseColor"),
@@ -168,6 +177,11 @@ impl Material for LitMaterial {
                 p.use_program(ctx.gl);
 
                 p.set_uniform_matrix4(ctx.gl, &uniforms.world_loc, world_matrix);
+                p.set_uniform_matrix3(
+                    ctx.gl,
+                    &uniforms.normal_matrix_loc,
+                    &normal_matrix(world_matrix),
+                );
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
 

--- a/runtime/functor-runtime-common/src/material/normal_debug_material.rs
+++ b/runtime/functor-runtime-common/src/material/normal_debug_material.rs
@@ -1,15 +1,17 @@
 use cgmath::Matrix4;
 
+use crate::math::normal_matrix;
+
 use crate::shader_program::ShaderProgram;
 use crate::shader_program::UniformLocation;
 use crate::RenderContext;
 
 use super::Material;
 
-// Visualizes world-space normals as color. `mat3(world)` rotates the
-// object-space normal into world space; for the uniform scales used by the
-// primitives that's adequate (a proper normal matrix would be the
-// inverse-transpose), and normalizing absorbs uniform scale. Used by
+// Visualizes world-space normals as color. The object-space normal goes to
+// world space through the normal matrix (the inverse-transpose of the world
+// transform), the same one the lit materials use — so this view shows exactly
+// the normals shading sees, including under a non-uniform scale. Used by
 // `DebugRenderMode::Normals` as a global override.
 const VERTEX_SHADER_SOURCE: &str = r#"
         layout (location = 0) in vec3 inPos;
@@ -17,13 +19,16 @@ const VERTEX_SHADER_SOURCE: &str = r#"
         layout (location = 2) in vec3 inNormal;
 
         uniform mat4 world;
+        // transpose(inverse(mat3(world))) — the same normal transform the lit
+        // materials use, so this debug view matches what shading sees.
+        uniform mat3 normalMatrix;
         uniform mat4 view;
         uniform mat4 projection;
 
         out vec3 worldNormal;
 
         void main() {
-            worldNormal = mat3(world) * inNormal;
+            worldNormal = normalMatrix * inNormal;
             gl_Position = projection * view * world * vec4(inPos, 1.0);
         }
 "#;
@@ -41,6 +46,7 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
 
 struct Uniforms {
     world_loc: UniformLocation,
+    normal_matrix_loc: UniformLocation,
     view_loc: UniformLocation,
     projection_loc: UniformLocation,
 }
@@ -79,6 +85,7 @@ impl Material for NormalDebugMaterial {
 
                 let uniforms = Uniforms {
                     world_loc: shader.get_uniform_location(ctx.gl, "world"),
+                    normal_matrix_loc: shader.get_uniform_location(ctx.gl, "normalMatrix"),
                     view_loc: shader.get_uniform_location(ctx.gl, "view"),
                     projection_loc: shader.get_uniform_location(ctx.gl, "projection"),
                 };
@@ -103,6 +110,11 @@ impl Material for NormalDebugMaterial {
                 p.use_program(ctx.gl);
 
                 p.set_uniform_matrix4(ctx.gl, &uniforms.world_loc, world_matrix);
+                p.set_uniform_matrix3(
+                    ctx.gl,
+                    &uniforms.normal_matrix_loc,
+                    &normal_matrix(world_matrix),
+                );
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
             }

--- a/runtime/functor-runtime-common/src/material/skinned_material.rs
+++ b/runtime/functor-runtime-common/src/material/skinned_material.rs
@@ -1,5 +1,7 @@
 use cgmath::Matrix4;
 
+use crate::math::normal_matrix;
+
 use crate::fog::{FogUniforms, FOG_GLSL};
 use crate::light::{lighting_glsl, LightingUniforms};
 use crate::shader_program::ShaderProgram;
@@ -9,8 +11,9 @@ use crate::RenderContext;
 use super::Material;
 
 // The skinned counterpart of `LitMaterial`: position AND normal deform by the
-// same joint blend (the normal rotation-only, via `mat3` — the
-// `SkinnedNormalDebugMaterial` convention), then the fragment shades with the
+// same joint blend (the normal by the world normal matrix composed with
+// `mat3(skinMatrix)` — the `SkinnedNormalDebugMaterial` convention), then the
+// fragment shades with the
 // shared lighting GLSL, so skinned glTF models are lit (and receive shadows)
 // exactly like lit static geometry. Albedo is the mesh's base-color texture
 // (unit 0, bound by the model draw path).
@@ -25,6 +28,11 @@ const VERTEX_SHADER_SOURCE: &str = r#"
 
         uniform mat4 jointTransforms[MAX_JOINTS];
         uniform mat4 world;
+        // transpose(inverse(mat3(world))) — see LitMaterial. The joint blend
+        // keeps its plain `mat3(skinMatrix)`, which ASSUMES the blended joint
+        // transform is rigid; a non-uniformly scaled joint (squash-and-stretch
+        // keyframes) still shades incorrectly — unchanged, pre-existing.
+        uniform mat3 normalMatrix;
         uniform mat4 view;
         uniform mat4 projection;
 
@@ -42,7 +50,7 @@ const VERTEX_SHADER_SOURCE: &str = r#"
                 inWeights.w * jointTransforms[int(inJointIndices.w)];
 
             texCoord = inTex;
-            worldNormal = mat3(world) * mat3(skinMatrix) * inNormal;
+            worldNormal = normalMatrix * mat3(skinMatrix) * inNormal;
 
             // Apply the skinning transformation
             vec4 skinnedPos = skinMatrix * vec4(inPos, 1.0);
@@ -77,6 +85,7 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
 
 struct Uniforms {
     world_loc: UniformLocation,
+    normal_matrix_loc: UniformLocation,
     view_loc: UniformLocation,
     projection_loc: UniformLocation,
     texture_loc: UniformLocation,
@@ -125,6 +134,7 @@ impl Material for SkinnedMaterial {
 
                 let uniforms = Uniforms {
                     world_loc: shader.get_uniform_location(ctx.gl, "world"),
+                    normal_matrix_loc: shader.get_uniform_location(ctx.gl, "normalMatrix"),
                     view_loc: shader.get_uniform_location(ctx.gl, "view"),
                     projection_loc: shader.get_uniform_location(ctx.gl, "projection"),
                     texture_loc: shader.get_uniform_location(ctx.gl, "texture1"),
@@ -154,6 +164,11 @@ impl Material for SkinnedMaterial {
                 p.use_program(ctx.gl);
 
                 p.set_uniform_matrix4(ctx.gl, &uniforms.world_loc, world_matrix);
+                p.set_uniform_matrix3(
+                    ctx.gl,
+                    &uniforms.normal_matrix_loc,
+                    &normal_matrix(world_matrix),
+                );
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
                 p.set_uniform_1i(ctx.gl, &uniforms.texture_loc, 0);

--- a/runtime/functor-runtime-common/src/material/skinned_normal_debug_material.rs
+++ b/runtime/functor-runtime-common/src/material/skinned_normal_debug_material.rs
@@ -1,5 +1,7 @@
 use cgmath::Matrix4;
 
+use crate::math::normal_matrix;
+
 use crate::shader_program::ShaderProgram;
 use crate::shader_program::UniformLocation;
 use crate::RenderContext;
@@ -21,6 +23,9 @@ const VERTEX_SHADER_SOURCE: &str = r#"
 
         uniform mat4 jointTransforms[MAX_JOINTS];
         uniform mat4 world;
+        // transpose(inverse(mat3(world))) — the same normal transform the lit
+        // materials use, so this debug view matches what shading sees.
+        uniform mat3 normalMatrix;
         uniform mat4 view;
         uniform mat4 projection;
 
@@ -33,7 +38,7 @@ const VERTEX_SHADER_SOURCE: &str = r#"
                 inWeights.z * jointTransforms[int(inJointIndices.z)] +
                 inWeights.w * jointTransforms[int(inJointIndices.w)];
 
-            worldNormal = mat3(world) * mat3(skinMatrix) * inNormal;
+            worldNormal = normalMatrix * mat3(skinMatrix) * inNormal;
 
             vec4 skinnedPos = skinMatrix * vec4(inPos, 1.0);
             gl_Position = projection * view * world * skinnedPos;
@@ -53,6 +58,7 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
 
 struct Uniforms {
     world_loc: UniformLocation,
+    normal_matrix_loc: UniformLocation,
     view_loc: UniformLocation,
     projection_loc: UniformLocation,
     joint_transforms_loc: UniformLocation,
@@ -92,6 +98,7 @@ impl Material for SkinnedNormalDebugMaterial {
 
                 let uniforms = Uniforms {
                     world_loc: shader.get_uniform_location(ctx.gl, "world"),
+                    normal_matrix_loc: shader.get_uniform_location(ctx.gl, "normalMatrix"),
                     view_loc: shader.get_uniform_location(ctx.gl, "view"),
                     projection_loc: shader.get_uniform_location(ctx.gl, "projection"),
                     joint_transforms_loc: shader.get_uniform_location(ctx.gl, "jointTransforms"),
@@ -117,6 +124,11 @@ impl Material for SkinnedNormalDebugMaterial {
                 p.use_program(ctx.gl);
 
                 p.set_uniform_matrix4(ctx.gl, &uniforms.world_loc, world_matrix);
+                p.set_uniform_matrix3(
+                    ctx.gl,
+                    &uniforms.normal_matrix_loc,
+                    &normal_matrix(world_matrix),
+                );
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
 

--- a/runtime/functor-runtime-common/src/math/mod.rs
+++ b/runtime/functor-runtime-common/src/math/mod.rs
@@ -1,2 +1,4 @@
 mod angle;
+mod normal;
 pub use angle::*;
+pub use normal::*;

--- a/runtime/functor-runtime-common/src/math/normal.rs
+++ b/runtime/functor-runtime-common/src/math/normal.rs
@@ -1,0 +1,77 @@
+use cgmath::{Matrix, Matrix3, Matrix4, SquareMatrix};
+
+/// The normal matrix for a world transform: `transpose(inverse(mat3(world)))`.
+///
+/// Normals are covectors — under a NON-UNIFORM scale, transforming them with
+/// the plain linear part tilts them the wrong way (a `scaleXYZ(240, 1, 240)`
+/// ground plane's gentle slopes come out nearly horizontal, which kills the
+/// key light and reads as ambient-only). The inverse-transpose is the correct
+/// transform; for rotations (and, after normalizing, uniform scales) it is the
+/// same matrix, so this is a no-op there.
+///
+/// A singular linear part (a zero scale on some axis) has no inverse; that
+/// degenerate transform falls back to the identity rather than producing NaNs
+/// — the geometry is flattened to a plane or a line either way. (The cofactor
+/// matrix would keep a meaningful normal for the rank-two case, but it also
+/// flips the sign under a mirroring scale, so it is a separate change.)
+pub fn normal_matrix(world: &Matrix4<f32>) -> Matrix3<f32> {
+    let linear = Matrix3::from_cols(world.x.truncate(), world.y.truncate(), world.z.truncate());
+    linear
+        .invert()
+        .map(|matrix| matrix.transpose())
+        .unwrap_or_else(Matrix3::identity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgmath::{Deg, InnerSpace, Vector3};
+
+    #[test]
+    fn non_uniform_scale_uses_the_inverse_transpose() {
+        // The reported bug: a unit-space slope under `scaleXYZ(240, 1, 240)`.
+        // The world-space normal must FLATTEN toward +Y (the slope gets 240x
+        // wider, not 240x steeper) — the plain linear part does the opposite.
+        let world = Matrix4::from_nonuniform_scale(240.0, 1.0, 240.0);
+        let local = Vector3::new(-0.2f32, 1.0, -0.1).normalize();
+
+        let actual = (normal_matrix(&world) * local).normalize();
+        let expected = Vector3::new(-0.2 / 240.0, 1.0, -0.1 / 240.0).normalize();
+        assert!((actual - expected).magnitude() < 1e-6, "got {actual:?}");
+
+        // And it really is different from the naive transform — the naive one
+        // tilts this normal ~90 degrees off, to a near-horizontal normal.
+        let naive = Vector3::new(-0.2 * 240.0, 1.0, -0.1 * 240.0).normalize();
+        assert!(
+            actual.dot(naive) < 0.1,
+            "the naive transform is not the bug"
+        );
+    }
+
+    #[test]
+    fn rotation_is_unchanged() {
+        let world = Matrix4::from_angle_y(Deg(37.0)) * Matrix4::from_angle_x(Deg(-19.0));
+        let local = Vector3::new(0.3f32, 0.5, -0.8).normalize();
+
+        let actual = normal_matrix(&world) * local;
+        let expected = (world * local.extend(0.0)).truncate();
+        assert!((actual - expected).magnitude() < 1e-5);
+    }
+
+    #[test]
+    fn uniform_scale_and_translation_only_rescale() {
+        let world =
+            Matrix4::from_translation(Vector3::new(4.0, -2.0, 9.0)) * Matrix4::from_scale(3.0);
+        let local = Vector3::new(0.0f32, 1.0, 0.0);
+
+        let actual = (normal_matrix(&world) * local).normalize();
+        assert!((actual - local).magnitude() < 1e-6);
+    }
+
+    #[test]
+    fn a_singular_transform_falls_back_to_identity() {
+        let world = Matrix4::from_nonuniform_scale(1.0, 0.0, 1.0);
+        let local = Vector3::new(0.0f32, 1.0, 0.0);
+        assert_eq!(normal_matrix(&world) * local, local);
+    }
+}

--- a/runtime/functor-runtime-common/src/terrain_renderer.rs
+++ b/runtime/functor-runtime-common/src/terrain_renderer.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use cgmath::{InnerSpace, Matrix, Matrix3, Matrix4, SquareMatrix, Vector3, Vector4};
+use cgmath::{InnerSpace, Matrix4, SquareMatrix, Vector3, Vector4};
 use glow::HasContext;
 
 use crate::{
@@ -630,7 +630,7 @@ impl TerrainRenderer {
         }
 
         let program = self.program.as_ref().expect("terrain program initialized");
-        let normal_matrix = terrain_normal_matrix(world);
+        let normal_matrix = crate::math::normal_matrix(world);
         unsafe {
             let p = &program.program;
             let u = &program.uniforms;
@@ -1915,14 +1915,6 @@ fn fit_heightmap(source: &HeightmapData, max_size: u32) -> (Vec<u16>, u32, u32) 
     (samples, width, height)
 }
 
-fn terrain_normal_matrix(world: &Matrix4<f32>) -> Matrix3<f32> {
-    let linear = Matrix3::from_cols(world.x.truncate(), world.y.truncate(), world.z.truncate());
-    linear
-        .invert()
-        .map(|matrix| matrix.transpose())
-        .unwrap_or_else(Matrix3::identity)
-}
-
 fn transformed_aabb_radius(world: &Matrix4<f32>, half_extents: Vector3<f32>) -> f32 {
     let x = world.x.truncate();
     let y = world.y.truncate();
@@ -2379,15 +2371,6 @@ mod tests {
             "test should exhaust the split budget, got {} patches",
             patches.len()
         );
-    }
-
-    #[test]
-    fn terrain_normals_use_inverse_transpose_for_non_uniform_scale() {
-        let world = Matrix4::from_nonuniform_scale(2.0, 1.0, 0.5);
-        let local = Vector3::new(1.0, 1.0, 0.0).normalize();
-        let actual = (terrain_normal_matrix(&world) * local).normalize();
-        let expected = Vector3::new(0.5, 1.0, 0.0).normalize();
-        assert!((actual - expected).magnitude() < 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
A lit surface under a **non-uniform scale** shaded as if it were ambient-only — silently. The lit vertex shaders transformed the object-space normal with plain `mat3(world)`, but normals are covectors: under `Scene.scaleXYZ(240, 1, 240)` a gentle heightmap slope comes out nearly *horizontal* (240x steeper, not 240x wider), so the key light's N·L collapses and the terrain goes black. Shadows cast onto it disappear with it.

This uploads `transpose(inverse(mat3(world)))` as a `normalMatrix` uniform and shades with it — the idiom the terrain renderer already used, hoisted to `crate::math::normal_matrix` and shared. Tangents deliberately keep `mat3(world)` (they are ordinary directions), which is what makes the TBN frame *orthogonal* for the first time: `(M⁻ᵀn)·(Mt) = n·t = 0`.

## Two-entry evidence

Found independently, and A/B-verified, by two game-jam entries:

- **code-garden** — `Scene.heightmap(unit grid) |> Scene.scaleXYZ(groundSize, 1, groundSize) |> Scene.lit(...)` rendered ambient-only; `Light.castShadows` produced nothing at all.
- **demiurge** — the same shape, confirmed with solar-noon A/B captures.

Both worked around it by pre-dividing heights by the scale factor and using a uniform `Scene.scale`. This is the natural shape to write, and it is exactly what `examples/synthwave` does — hidden there only because every surface in that scene is emissive.

## Before / after

Repro scene (headless `--capture-frame --fixed-time 0`): a lit heightmap ridge scaled 24x in XZ, and a lit sphere scaled `(6, 1.2, 6)`. Ambient is deliberately near-zero, so everything visible is the key light.

| before (`main`) | after |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/79547771314dcac23546b1fed2a84d9b/raw/before.png) | ![after](https://gist.githubusercontent.com/tommy-xr/79547771314dcac23546b1fed2a84d9b/raw/after.png) |

The same scene under `--debug-render normals` — the decisive view. Before: normals swing through the whole sphere (the rainbow) on geometry that is almost flat. After: near-uniform green (+Y), which is what a 24x-stretched terrain and a squashed dome actually have.

| before (`main`) | after |
| --- | --- |
| ![before-normals](https://gist.githubusercontent.com/tommy-xr/79547771314dcac23546b1fed2a84d9b/raw/before-normals.png) | ![after-normals](https://gist.githubusercontent.com/tommy-xr/79547771314dcac23546b1fed2a84d9b/raw/after-normals.png) |

**Web (WebGL2) — same fix, smoke-run, not just inspected.** The materials live in `functor-runtime-common`, so both shells share them. Rebuilt the wasm bundle and captured the same repro through `functor run wasm` in headless chromium, at the base ref and with the fix:

| before (`main`, wasm) | after (wasm) |
| --- | --- |
| ![before-web](https://gist.githubusercontent.com/tommy-xr/79547771314dcac23546b1fed2a84d9b/raw/before-web.png) | ![after-web](https://gist.githubusercontent.com/tommy-xr/79547771314dcac23546b1fed2a84d9b/raw/after-web.png) |

## What changed

- `math/normal.rs` (new) — `normal_matrix(&Matrix4) -> Matrix3`, the inverse-transpose, identity on a singular linear part. Four unit tests: the reported non-uniform case, rotation-unchanged (this one is what distinguishes inverse-**transpose** from a plain inverse — for a rotation `M⁻ᵀ = M`, `M⁻¹ ≠ M`), uniform scale + translation, singular fallback.
- `terrain_renderer.rs` — its private `terrain_normal_matrix` is deleted and rewired to the shared helper (identical math; its now-redundant test moved to live next to the implementation).
- `lit_material.rs` (covers `Scene.lit` / `litTexture` / `litNormalMapped`), `skinned_material.rs` — `normalMatrix` uniform, normal shaded through it.
- `normal_debug_material.rs`, `skinned_normal_debug_material.rs` — the same transform, so `DebugRenderMode::Normals` shows what shading actually sees. Not literally part of the P0, but a normals view that disagrees with shading is an active debugging trap — and it is what produced the second capture pair above.

Verified nothing else needs it: `depth`/`skinned_depth`/`basic`/`color`/`emissive` carry no normals, and the two *tangent* debug materials correctly keep `mat3(world)`.

## Perf (rendering internals gate)

`cargo run -q --release -p functor_runtime_common --example frame_bench`, 3 runs each, same machine, back to back. Allocations are **byte-identical**; wall-clock is inside run-to-run spread. The added work is one 3×3 invert per draw call, CPU-side, allocation-free — the same thing the terrain renderer already did per frame.

| grid | allocs/frame (base → change) | bytes/frame (base → change) | us/frame min, base (3 runs) | us/frame min, change (3 runs) |
| --- | --- | --- | --- | --- |
| 20x20 | 13877 → 13877 | 844497 → 844497 | 441.2 / 436.6 / 436.8 | 438.6 / 432.9 / 440.9 |
| 40x40 | 54717 → 54717 | 3308337 → 3308337 | 1720.8 / 1724.3 / 1715.1 | 1721.8 / 1703.9 / 1735.2 |
| 56x56 | 106973 → 106973 | 6461361 → 6461361 | 3357.9 / 3355.4 / 3348.0 | 3368.8 / 3317.0 / 3381.2 |

**No Quest was attached**, so there is no on-device number. The GPU-side delta is a `mat3` uniform upload replacing a `mat3` cast in the vertex shader — no extra texture sampling, no shader-complexity change — but per CLAUDE.md that gap is stated, not assumed absent.

## Tests

- `cargo test -p functor_runtime_common` — 693 + 31 pass (includes the 4 new normal-matrix tests).
- `npm run test:golden` (native, local GL) — all 12 scenarios pass, with **pixel diffs byte-identical to the base ref**. That is expected and worth stating: every current sample's non-uniform scales are on axis-aligned normals (the `lighting` fountain cylinder, `primitives`), which are eigenvectors of a diagonal scale, so nothing existing shifts. The corollary is the honest gap below.
- `npm run test:wasm-golden` (chromium/WebGL2) — passes, unchanged.

**Known coverage gap (accepted, not resolved):** no golden scenario has a non-uniformly-scaled lit surface with an off-axis normal, so nothing in the committed suite would catch this regressing. The unit tests pin the math and the captures pin the wiring, but the rendering-level regression test wants a sample with this shape — the natural carrier is one of the jam's terrain games as it lands in `examples/`, plus a `debugRender: "normals"` variant, which covers native and wasm from the one `golden-scenarios.json` entry.

## Review findings (`/xreview`: Claude subagent + Codex CLI + de-dup pass)

No Critical from either engine. Dispositions:

- **High (Claude) — "the TBN frame is now non-orthogonal; `n` and `t` come from different transforms."** *Rejected, with proof.* `(M⁻ᵀn)·(Mt) = nᵀM⁻¹Mt = n·t = 0`, so the frame is orthogonal *after* this change and was not before (both vectors previously went through `mat3(world)`, which is wrong for `n`). Codex reviewed the same code and explicitly cleared it for the same reason — the engines disagreed and the math settles it. Normal-mapping under non-uniform scale is improved, not regressed.
- **High (Claude) — no rendering-level regression test.** *Accepted, deferred, and documented above* (the coverage-gap paragraph). Adding a golden today means either a throwaway example or perturbing an existing sample's committed reference on my display; both are worse than an explicit, named gap.
- **High (Codex) — skinned normals are still wrong for a non-uniformly scaled joint** (`normalMatrix * mat3(skinMatrix)` assumes a rigid blend). *Correct, pre-existing, out of scope, now documented instead of hand-waved.* Fixing it means a per-vertex 3×3 inverse of the blended skin matrix — a real cost on Quest — and it is a distinct bug from the P0. The Claude reviewer independently flagged that my first comment asserted this was *impossible*; the comment now says the blend is **assumed** rigid and that a scaled joint still shades incorrectly.
- **Medium (Codex) — use the cofactor matrix as the singular fallback.** *Rejected for this PR, noted in the doc comment.* Identity preserves the pre-existing terrain behavior exactly, and the geometry is degenerate either way; cofactor also flips sign under a mirroring scale (det < 0), a separate behavioral change.
- **Medium (Claude) — the lit after-capture is bright enough to be a weak discriminator.** *Accepted.* That is why the `--debug-render normals` pair is in this PR body; it distinguishes "flattened correctly" from "flattened by accident".
- **Low (Claude) — `get_uniform_location` panics via `.expect()`.** No change. Safe at all four sites (every one of those fragment shaders reads `worldNormal`, so no driver can eliminate the uniform); noted as a latent trap for a future `Option`-returning sibling.
- **De-dup pass — `merge`: the terrain test now duplicated the new unit test.** *Accepted and applied* — the terrain copy is deleted; the assertion lives next to the implementation. The pass also cleared the repeated `normalMatrix` uniform wiring across four materials as the established per-material idiom (the repo only extracts a `*Uniforms` struct for multi-uniform concerns like `FogUniforms`/`LightingUniforms`), and confirmed exactly one inverse-transpose implementation now exists repo-wide.
- **De-dup coverage:** all four strategies ran, none unavailable. S1-names = 10 queries / 7342 candidates; S2-clones = 268-line whole-repo report, 26 pairs touching changed files after filtering (all pre-existing `Material` trait-impl family); S3-index = 948-fn API index grepped for normal matrix / inverse / transpose / mat3 / set_uniform_matrix3; S4-read = full diff plus candidate sources read at line.

## Adopting this

Games that pre-divided heights by their ground scale and used a uniform `Scene.scale` to dodge this can go back to the natural shape: author heights in world units and use `Scene.scaleXYZ(size, 1, size)` for the footprint. That reads the way the docs suggest, and lighting/shadows now work under it.
