### PR TITLE
feat(prelude): Camera3D.toGroundPoint — pointer to ground-plane point

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -965,7 +965,7 @@ The generated modules:
 | --- | --- |
 | `Scene` | 3D scene nodes: primitives, models, terrain, materials, transforms |
 | `Sprite` | pure 2D picture values: shapes, text, images, transforms |
-| `Camera3D` | 3D cameras (`lookAt`, `firstPerson`), clip planes, screen→world rays |
+| `Camera3D` | 3D cameras (`lookAt`, `firstPerson`), clip planes, screen→world rays and ground-plane picks (`toWorldRay`, `toGroundPoint`) |
 | `Camera2D` | center-origin 2D camera: pan, zoom, screen→world |
 | `Frame` | what `draw` returns: 3D / lit / 2D frames, fog, skybox, clear color, render targets, 2D layers |
 | `Light` | ambient / directional / point / spot lights and shadow casting |

--- a/functor-prelude/prelude/camera3d.funi
+++ b/functor-prelude/prelude/camera3d.funi
@@ -28,10 +28,11 @@ let toWorldRay : (Input.mouse, t) => Option.t<ray>
 /// The "what did I click on the ground" primitive: the same mapping as
 /// `toWorldRay` (one top-left-origin logical space, so Retina/device-pixel
 /// ratio scales out), intersected with the ground plane for you. The camera is
-/// last for piping. Returns `Option.None` when the ray never reaches the
-/// plane — parallel to it, or hitting behind the eye — as well as whenever
-/// `toWorldRay` itself declines. Quantizing the point into tiles or cells
-/// stays game-owned.
+/// last for piping. Returns `Option.None` when the ray never usefully reaches
+/// the plane — grazing or parallel to it, or meeting it at or behind the eye —
+/// as well as whenever `toWorldRay` itself declines. A non-finite `groundY` is
+/// a teaching error rather than a miss. Quantizing the point into tiles or
+/// cells stays game-owned.
 let toGroundPoint : (Input.mouse, float, t) => Option.t<Vec3.t>
 /// A tracked pose mapped into world space through an authored camera.
 type mappedPose = { position: Input.point3, forward: Input.point3, up: Input.point3 }

--- a/functor-prelude/prelude/camera3d.funi
+++ b/functor-prelude/prelude/camera3d.funi
@@ -23,6 +23,16 @@ type ray = { origin: Vec3.t, direction: Vec3.t }
 /// into `Physics.cast` / `Physics.raycast`. Returns `Option.None` while the
 /// pointer is outside the surface or the camera is degenerate.
 let toWorldRay : (Input.mouse, t) => Option.t<ray>
+/// Intersect the pointer ray with the horizontal plane `y = groundY`.
+///
+/// The "what did I click on the ground" primitive: the same mapping as
+/// `toWorldRay` (one top-left-origin logical space, so Retina/device-pixel
+/// ratio scales out), intersected with the ground plane for you. The camera is
+/// last for piping. Returns `Option.None` when the ray never reaches the
+/// plane — parallel to it, or hitting behind the eye — as well as whenever
+/// `toWorldRay` itself declines. Quantizing the point into tiles or cells
+/// stays game-owned.
+let toGroundPoint : (Input.mouse, float, t) => Option.t<Vec3.t>
 /// A tracked pose mapped into world space through an authored camera.
 type mappedPose = { position: Input.point3, forward: Input.point3, up: Input.point3 }
 /// Map a rig-local tracked pose through the authored camera.

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -386,9 +386,10 @@ impl Camera {
     /// Shares every coordinate and degeneracy rule with
     /// [`to_world_ray`](Self::to_world_ray) — position and surface extent live
     /// in one top-left-origin logical space, so a device-pixel ratio scales
-    /// out. Returns `None` when the ray misses the plane: a parallel (or
-    /// near-parallel) ray, an intersection behind the eye, a non-finite
-    /// `ground_y`, or any case where `to_world_ray` itself declines.
+    /// out. Returns `None` when the ray misses the plane: a grazing or parallel
+    /// ray, an intersection at or behind the eye, or any case where
+    /// `to_world_ray` itself declines. A non-finite `ground_y` also yields
+    /// `None`; the prelude rejects that at the boundary as a usage error.
     pub fn to_ground_point(
         &self,
         x: f32,
@@ -397,14 +398,12 @@ impl Camera {
         surface_height: f32,
         ground_y: f32,
     ) -> Option<[f32; 3]> {
-        if !ground_y.is_finite() {
-            return None;
-        }
         let ray = self.to_world_ray(x, y, surface_width, surface_height)?;
+        // `to_world_ray` already guarantees a finite, normalized direction.
         let dir_y = ray.direction[1];
-        // A near-parallel ray would place the hit arbitrarily far away; treat it
-        // as a miss rather than emitting a huge (or infinite) coordinate.
-        if !dir_y.is_finite() || dir_y.abs() < 1e-6 {
+        // A grazing ray puts the hit a million eye-heights away, well past
+        // anything the game meant to pick; cut it off rather than report it.
+        if dir_y.abs() < 1e-6 {
             return None;
         }
         let distance = (ground_y - ray.origin[1]) / dir_y;

--- a/runtime/functor-runtime-common/src/camera.rs
+++ b/runtime/functor-runtime-common/src/camera.rs
@@ -380,6 +380,49 @@ impl Camera {
             })
     }
 
+    /// Intersect the ray through a logical surface point with the horizontal
+    /// plane `y = ground_y`.
+    ///
+    /// Shares every coordinate and degeneracy rule with
+    /// [`to_world_ray`](Self::to_world_ray) — position and surface extent live
+    /// in one top-left-origin logical space, so a device-pixel ratio scales
+    /// out. Returns `None` when the ray misses the plane: a parallel (or
+    /// near-parallel) ray, an intersection behind the eye, a non-finite
+    /// `ground_y`, or any case where `to_world_ray` itself declines.
+    pub fn to_ground_point(
+        &self,
+        x: f32,
+        y: f32,
+        surface_width: f32,
+        surface_height: f32,
+        ground_y: f32,
+    ) -> Option<[f32; 3]> {
+        if !ground_y.is_finite() {
+            return None;
+        }
+        let ray = self.to_world_ray(x, y, surface_width, surface_height)?;
+        let dir_y = ray.direction[1];
+        // A near-parallel ray would place the hit arbitrarily far away; treat it
+        // as a miss rather than emitting a huge (or infinite) coordinate.
+        if !dir_y.is_finite() || dir_y.abs() < 1e-6 {
+            return None;
+        }
+        let distance = (ground_y - ray.origin[1]) / dir_y;
+        // Strictly in front of the eye: the eye exactly on the plane, or the
+        // plane behind the camera, is a miss.
+        if !(distance.is_finite() && distance > 0.0) {
+            return None;
+        }
+        let hit = [
+            ray.origin[0] + ray.direction[0] * distance,
+            // Pinned rather than recomputed so the result lies exactly on the
+            // authored plane regardless of floating-point drift.
+            ground_y,
+            ray.origin[2] + ray.direction[2] * distance,
+        ];
+        (hit[0].is_finite() && hit[2].is_finite()).then_some(hit)
+    }
+
     /// Build an asymmetric perspective projection from four view-space field-
     /// of-view angles. This is the projection form supplied per eye by XR
     /// runtimes, where the optical center usually does not sit at the middle
@@ -593,6 +636,104 @@ mod tests {
                 .to_world_ray(50.0, 50.0, 100.0, 100.0)
                 .is_none());
         }
+    }
+
+    // The camera the ground-point tests share: 10 up, 10 back, gazing at the
+    // world origin, so the center surface point hits the ground exactly there.
+    fn overhead_camera() -> Camera {
+        Camera::look_at(
+            [0.0, 10.0, -10.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        )
+    }
+
+    #[test]
+    fn ground_point_hits_the_plane_under_the_gaze() {
+        let hit = overhead_camera()
+            .to_ground_point(800.0, 450.0, 1600.0, 900.0, 0.0)
+            .unwrap();
+        assert!(approx(hit[0], 0.0));
+        assert!(approx(hit[1], 0.0));
+        assert!(approx(hit[2], 0.0));
+    }
+
+    // Every hit must lie on the world ray through the same surface point:
+    // toGroundPoint is exactly toWorldRay plus the plane intersection.
+    #[test]
+    fn ground_point_lies_on_the_world_ray_through_the_same_point() {
+        let camera = overhead_camera();
+        for (x, y) in [(120.0, 90.0), (800.0, 450.0), (1490.0, 700.0)] {
+            let ray = camera.to_world_ray(x, y, 1600.0, 900.0).unwrap();
+            let hit = camera.to_ground_point(x, y, 1600.0, 900.0, 0.0).unwrap();
+            let offset = Vector3::from(hit) - Vector3::from(ray.origin);
+            let distance = offset.magnitude();
+            assert!(distance > 0.0);
+            assert!(offset.normalize().dot(Vector3::from(ray.direction)) > 0.99999);
+        }
+    }
+
+    #[test]
+    fn ground_point_honors_a_nonzero_ground_plane() {
+        let camera = overhead_camera();
+        // The eye is 10 up and 10 back gazing at the origin, so the plane 4
+        // units up is crossed 6/10ths of the way along that span.
+        let hit = camera
+            .to_ground_point(800.0, 450.0, 1600.0, 900.0, 4.0)
+            .unwrap();
+        assert!(approx(hit[0], 0.0));
+        assert_eq!(hit[1], 4.0, "the hit is pinned exactly onto the plane");
+        assert!(approx(hit[2], -4.0), "hit: {hit:?}");
+    }
+
+    #[test]
+    fn ground_point_is_logical_scale_invariant() {
+        let camera = overhead_camera();
+        let one_x = camera.to_ground_point(300.0, 200.0, 900.0, 1000.0, 0.0).unwrap();
+        let retina = camera
+            .to_ground_point(600.0, 400.0, 1800.0, 2000.0, 0.0)
+            .unwrap();
+        for i in 0..3 {
+            assert!(approx(one_x[i], retina[i]));
+        }
+    }
+
+    #[test]
+    fn ground_point_rejects_parallel_behind_and_degenerate_rays() {
+        // A level gaze never reaches the ground plane.
+        let level = Camera::look_at(
+            [0.0, 5.0, 0.0],
+            [0.0, 5.0, 10.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        assert!(level.to_ground_point(800.0, 450.0, 1600.0, 900.0, 0.0).is_none());
+
+        // Gazing up from above the plane puts the intersection behind the eye.
+        let upward = Camera::look_at(
+            [0.0, 5.0, 0.0],
+            [0.0, 15.0, 5.0],
+            [0.0, 1.0, 0.0],
+            Angle::from_degrees(45.0),
+        );
+        assert!(upward.to_ground_point(800.0, 450.0, 1600.0, 900.0, 0.0).is_none());
+
+        let camera = overhead_camera();
+        // The eye exactly on the plane is a zero-distance miss, not the eye.
+        assert!(camera
+            .to_ground_point(800.0, 450.0, 1600.0, 900.0, 10.0)
+            .is_none());
+        assert!(camera
+            .to_ground_point(800.0, 450.0, 1600.0, 900.0, f32::NAN)
+            .is_none());
+        assert!(camera
+            .to_ground_point(800.0, 450.0, 1600.0, 900.0, f32::INFINITY)
+            .is_none());
+        // Everything toWorldRay declines is declined here too.
+        assert!(camera.to_ground_point(-1.0, 450.0, 1600.0, 900.0, 0.0).is_none());
+        assert!(camera.to_ground_point(800.0, 900.0, 1600.0, 900.0, 0.0).is_none());
+        assert!(camera.to_ground_point(800.0, 450.0, 0.0, 900.0, 0.0).is_none());
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2312,7 +2312,9 @@ fn register_camera(reg: &mut crate::host_registry::Registry) {
     );
     reg.fn3(
         "Camera3D.toGroundPoint",
-        "Camera3D.toGroundPoint(mouse, groundY, camera)",
+        "Camera3D.toGroundPoint(mouse, groundY, camera) — a finite ground-plane height",
+        // A NaN/infinite plane is rejected by the `f64` argument conversion
+        // before the body runs, so the body handles only real geometry.
         |mouse: FunctorLangMouse, ground_y: f64, camera: FunctorLangCamera| {
             crate::input::option_value(
                 camera
@@ -6072,21 +6074,24 @@ forward: { x: 0, y: 0, z: 1 }, up: { x: 0, y: 1, z: 0 } }"
         ));
     }
 
+    // The plane height is game data, so a nonsense one is taught by the shared
+    // number conversion, not silently reported as "the pointer isn't over the
+    // ground" — a NaN plane is game math gone wrong, not a pointer miss.
     #[test]
-    fn camera_ground_point_honors_a_raised_plane() {
-        let value = eval(
-            "let main = () => Camera3D.toGroundPoint(\n\
-               { x: 400.0, y: 300.0, surfaceWidth: 800.0, surfaceHeight: 600.0 }, 4.0,\n\
-               Camera3D.lookAt(Vec3.make(0.0, 10.0, -10.0), Vec3.make(0.0, 0.0, 0.0)))",
-        );
-        let Value::Variant { ctor, args } = value else {
-            panic!("the ground point should return an Option");
-        };
-        assert_eq!(ctor.as_ref(), "Option.Some");
-        let (x, y, z) = vec3_of(&args[0], "ground hit", Span::new(0, 0)).unwrap();
-        // 6/10ths of the way along the eye→origin span, pinned onto the plane.
-        assert_eq!(y, 4.0);
-        assert!(x.abs() < 1e-5 && (z + 4.0).abs() < 1e-5, "{x} {z}");
+    fn camera_ground_point_rejects_a_non_finite_plane() {
+        let module = functor_lang::lower(
+            functor_lang::parse(
+                "let main = () => Camera3D.toGroundPoint(\n\
+                   { x: 400.0, y: 300.0, surfaceWidth: 800.0, surfaceHeight: 600.0 }, 0.0 / 0.0,\n\
+                   Camera3D.lookAt(Vec3.make(0.0, 10.0, -10.0), Vec3.make(0.0, 0.0, 0.0)))",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let failure = functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("a non-finite ground plane should fail");
+        assert_eq!(failure.error.message, "expected a finite number, got NaN");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -44,6 +44,9 @@
 //! Camera3D.toWorldRay(mouse, camera)                         -> Option<{ origin, direction }>
 //!   (top-left logical mouse coordinates through the authored perspective;
 //!    both fields are Vec3 values and direction is normalized)
+//! Camera3D.toGroundPoint(mouse, groundY, camera)             -> Option<Vec3>
+//!   (that ray intersected with the horizontal plane y = groundY; None when
+//!    the ray is parallel to it or would hit behind the eye)
 //! Anim.lookAt(joint, target, maxDeflection, weight, anim)  -> Anim
 //!   (post-pass aim of local +Z at a model-space Vec3 target)
 //! Anim.reach(root, middle, end, target, weight, anim)      -> Anim
@@ -2304,6 +2307,24 @@ fn register_camera(reg: &mut crate::host_registry::Registry) {
                             ("direction".to_string(), vec3(ray.direction)),
                         ]))
                     }),
+            )
+        },
+    );
+    reg.fn3(
+        "Camera3D.toGroundPoint",
+        "Camera3D.toGroundPoint(mouse, groundY, camera)",
+        |mouse: FunctorLangMouse, ground_y: f64, camera: FunctorLangCamera| {
+            crate::input::option_value(
+                camera
+                    .0
+                    .to_ground_point(
+                        mouse.x,
+                        mouse.y,
+                        mouse.surface_width,
+                        mouse.surface_height,
+                        ground_y as f32,
+                    )
+                    .map(|[x, y, z]| Value::HostData(Rc::new(FunctorLangVec3((x, y, z))))),
             )
         },
     );
@@ -6013,6 +6034,59 @@ forward: { x: 0, y: 0, z: 1 }, up: { x: 0, y: 1, z: 0 } }"
             Value::Variant { ref ctor, ref args }
                 if ctor.as_ref() == "Option.None" && args.is_empty()
         ));
+    }
+
+    // The ground pick a top-down/tactics game reaches for: the center of the
+    // surface under an overhead camera lands exactly under the gaze, as a Vec3
+    // that pipes straight back into Vec3.x / Vec3.z.
+    #[test]
+    fn camera_ground_point_intersects_the_authored_plane() {
+        let value = eval(
+            "let main = () => Camera3D.toGroundPoint(\n\
+               { x: 400.0, y: 300.0, surfaceWidth: 800.0, surfaceHeight: 600.0 }, 0.0,\n\
+               Camera3D.lookAt(Vec3.make(0.0, 10.0, -10.0), Vec3.make(0.0, 0.0, 0.0)))",
+        );
+        let Value::Variant { ctor, args } = value else {
+            panic!("the ground point should return an Option");
+        };
+        assert_eq!(ctor.as_ref(), "Option.Some");
+        let [hit] = args.as_slice() else {
+            panic!("Some should carry the hit");
+        };
+        let (x, y, z) = vec3_of(hit, "ground hit", Span::new(0, 0)).unwrap();
+        assert!(x.abs() < 1e-5 && y.abs() < 1e-5 && z.abs() < 1e-5, "{x} {y} {z}");
+    }
+
+    // A level gaze never reaches the ground, and the plane is game-chosen.
+    #[test]
+    fn camera_ground_point_returns_none_for_a_parallel_ray() {
+        let value = eval(
+            "let main = () => Camera3D.toGroundPoint(\n\
+               { x: 400.0, y: 300.0, surfaceWidth: 800.0, surfaceHeight: 600.0 }, 0.0,\n\
+               Camera3D.lookAt(Vec3.make(0.0, 5.0, 0.0), Vec3.make(0.0, 5.0, 10.0)))",
+        );
+        assert!(matches!(
+            value,
+            Value::Variant { ref ctor, ref args }
+                if ctor.as_ref() == "Option.None" && args.is_empty()
+        ));
+    }
+
+    #[test]
+    fn camera_ground_point_honors_a_raised_plane() {
+        let value = eval(
+            "let main = () => Camera3D.toGroundPoint(\n\
+               { x: 400.0, y: 300.0, surfaceWidth: 800.0, surfaceHeight: 600.0 }, 4.0,\n\
+               Camera3D.lookAt(Vec3.make(0.0, 10.0, -10.0), Vec3.make(0.0, 0.0, 0.0)))",
+        );
+        let Value::Variant { ctor, args } = value else {
+            panic!("the ground point should return an Option");
+        };
+        assert_eq!(ctor.as_ref(), "Option.Some");
+        let (x, y, z) = vec3_of(&args[0], "ground hit", Span::new(0, 0)).unwrap();
+        // 6/10ths of the way along the eye→origin span, pinned onto the plane.
+        assert_eq!(y, 4.0);
+        assert!(x.abs() < 1e-5 && (z + 4.0).abs() < 1e-5, "{x} {z}");
     }
 
     #[test]

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -83,6 +83,26 @@ fn camera_world_ray_checks_as_physics_cast_input() {
     );
 }
 
+/// The ground pick is one call: a grid game quantizes the returned Vec3 into
+/// tiles itself, with no hand-rolled ray/plane intersection in between.
+#[test]
+fn camera_ground_point_checks_as_a_tile_pick() {
+    let diags = check(
+        "let camera = Camera3D.lookAt(\n\
+           Vec3.make(0.0, 10.0, -10.0), Vec3.make(0.0, 0.0, 0.0))\n\
+         type Tile = { gx: float, gz: float }\n\
+         let pickTile = (mouse: Input.mouse): Option.t<Tile> =>\n\
+           match Camera3D.toGroundPoint(mouse, 0.08, camera) with\n\
+           | Option.Some(hit) =>\n\
+             Option.Some({ gx: Math.floor(Vec3.x(hit) + 3.5), gz: Math.floor(Vec3.z(hit) + 3.5) })\n\
+           | Option.None => Option.None",
+    );
+    assert!(
+        diags.is_empty(),
+        "Camera3D.toGroundPoint should quantize into tiles directly: {diags:?}"
+    );
+}
+
 /// Cursor rays can become model-space targets for the pure animation
 /// post-pass without unpacking the Vec3 at the animation boundary.
 #[test]

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 305));
+        assert_eq!(count(ApiGroup::Engine), (27, 306));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
## The gap

`Camera3D.toWorldRay` hands a game a world ray. Every game that actually wants
**"what point on the ground did I click"** then hand-rolls the same ray/plane
intersection: reject by direction-Y, `t = (groundY - origin.y) / dir.y`, scale,
add. Three call sites re-derive it today — each with its own epsilon, its own
sign convention, and its own degeneracy rules:

| Call site | Shape | Adopts? |
| --- | --- | --- |
| `tactics` jam entry — `pickTile` | y = 0.08 grid plane, `dy >= -0.0001` guard, no behind-eye test | **yes** |
| `twin-stick` jam entry — `groundHit` | y = 0 arena floor, `dy > -0.00001` guard, no behind-eye test | **yes** |
| `examples/animation` — `pointerTarget` | a *vertical* z = -0.28 interaction plane | no — see follow-up |

Two of the three are literally ground picks. The third is the same math on a
different axis, which is exactly why the divergence is worth removing from the
game layer: every copy invents a slightly different miss rule.

## The fix

```
let toGroundPoint : (Input.mouse, float, t) => Option.t<Vec3.t>
```

`Camera3D.toGroundPoint(mouse, groundY, camera)` — camera last, matching
`toWorldRay(mouse, camera)` and `clip(near, far, camera)` for thread-last
piping. It composes `Camera::to_world_ray` rather than re-deriving the
unprojection, so it inherits **one top-left-origin logical coordinate space** —
scaling position and extent by a device-pixel ratio leaves the result
unchanged (pinned by `ground_point_is_logical_scale_invariant`).

`Option.None` for a grazing/parallel ray, an intersection at or behind the eye
(including the eye exactly on the plane), and anything `toWorldRay` itself
declines. A non-finite `groundY` is a teaching error from the shared number
conversion, not a silent miss. The hit's `y` is pinned exactly onto the authored
plane rather than recomputed, so float drift can't put it just off. **Tile
quantization stays game-owned.**

Registered as one typed closure in the shared external registry
(`register_camera` → `reg.fn3`), not a legacy `match path` arm — so **both
producers resolve it**: the desktop and wasm shells run the same
`FunctorLangEmbeddedGame` over `FunctorHost`, which is built from that registry.
Verified with `cargo check -p functor-runtime-web --target wasm32-unknown-unknown`.

## Adoption (verified end-to-end)

`tactics`' `pickTile` loses its whole intersection block:

```diff
 let pickTile = (mouse: Input.mouse): Option.t<GridPoint> =>
-  match Camera3D.toWorldRay(mouse, camera) with
+  match Camera3D.toGroundPoint(mouse, 0.08, camera) with
   | Option.None => Option.None
-  | Option.Some(ray) =>
-      let dy = Vec3.y(ray.direction) in
-      if dy >= -0.0001 then Option.None else
-      let distance = (0.08 - Vec3.y(ray.origin)) / dy in
-      let hit = ray.origin |> Vec3.add(ray.direction |> Vec3.scale(distance)) in
+  | Option.Some(hit) =>
       let x = Math.floor(Vec3.x(hit) + 3.5) in
       let z = Math.floor(Vec3.z(hit) + 3.5) in
       if x >= 0.0 && x < 7.0 && z >= 0.0 && z < 7.0
       then Option.Some({ gx: x, gz: z })
       else Option.None
```

Applied to a scratch copy of the entry and run against its own `proof.sh` with
the CLI built from this branch: the ground picks still select (5,1), move to
(5,3), and attack (5,5) — byte-identical model assertions to the unmodified
baseline, both jq gates passing (`TANK HIT // 2 DAMAGE`, tank at (5,3), enemy 5
at hp 5 then (5,4), turn 2 `PlayerTurn`). The entry's own tuning constant
(`0.08`) and grid bounds are untouched.

## Tests

- **Pure math** (`camera.rs`) — hit under the gaze; the hit lies on the world ray
  through the *same* surface point (so this is provably `toWorldRay` + a plane);
  `groundY = 4` on an eye-10-up camera lands at z = -4 with `y` exactly 4;
  Retina/logical scale invariance (300,200,900x1000 ≡ 600,400,1800x2000);
  rejection of a level gaze, an upward gaze from above the plane, the eye
  exactly on the plane, NaN/inf `groundY`, and every case `toWorldRay` declines.
- **Prelude eval** (`functor_lang_prelude.rs`) — the external returns
  `Option.Some(<Vec3>)` at the right point, `Option.None` for a parallel ray,
  and a NaN plane fails with `expected a finite number, got NaN`.
- **Typecheck** (`prelude_typecheck.rs`) — the tactics-shaped `pickTile`
  typechecks: the returned Vec3 flows straight into `Vec3.x` / `Vec3.z` /
  `Math.floor` with no unpacking.
- `cargo test -p functor_runtime_common` — **698 + 32 pass, 0 fail**, including
  the `.funi` ≡ registry drift test.
- `npm run generate:docs` + `npm run check:docs` — clean; `Camera3D.toGroundPoint`
  renders into the API reference from its `///` docs.

## Perf (`frame_bench`, release, back-to-back)

Nothing existing calls the new external, so the expectation is exact parity — and
the deterministic columns confirm it.

| | allocs/frame | bytes/frame | us/frame (min, 3 runs) |
| --- | --- | --- | --- |
| base `d5634cc` — 20x20 | 13877 | 844497 | 442.2 / 434.8 / 441.8 |
| **change** — 20x20 | **13877** | **844497** | 440.0 / 438.4 / 442.5 |
| base `d5634cc` — 40x40 | 54717 | 3308337 | 1737.0 / 1702.5 / 1743.1 |
| **change** — 40x40 | **54717** | **3308337** | 1727.6 / 1748.0 / 1736.2 |
| base `d5634cc` — 56x56 | 106973 | 6461361 | 3385.1 / 3316.2 / 3392.5 |
| **change** — 56x56 | **106973** | **6461361** | 3370.8 / 3366.1 / 3409.1 |

`allocs/frame` and `bytes/frame` are **byte-identical** at every size. Wall clock
overlaps run-to-run spread in both directions — noise. No GPU/rendering path is
touched (this is a pure CPU math external, no shader/material/sampler change), so
no device profile is required; none was run.

## xreview dispositions

Two engines (Claude subagent + Codex CLI) plus a dedicated de-dup pass, over
`d5634cc...HEAD`. **Zero Critical, zero High.** Both engines independently
confirmed the math, the arg order, the `.funi`↔registry match, and the pinned
`y`.

| Finding | Severity | Engine | Disposition |
| --- | --- | --- | --- |
| Docs said `None` only for "behind the eye", but `distance > 0.0` also rejects `t == 0` (eye on plane) | Low | **[AGREED]** Codex + Claude | **Fixed** — kept the strict test (a pick at the eye is degenerate) and documented "at or behind the eye" in the `.funi` and the Rust doc |
| `!ground_y.is_finite()` guard is dead — a non-finite plane already yields a non-finite `distance` | Low | Claude | **Fixed** — removed; the NaN/inf tests still pass unchanged |
| `!dir_y.is_finite()` is dead — `to_world_ray` guarantees a finite normalized direction | Low | Claude | **Fixed** — removed, with a comment naming the guarantee |
| The 1e-6 epsilon's comment claimed an infinity guard, which the finiteness gates actually provide | Low | Claude | **Fixed** — kept the epsilon (a normalized `dir_y` of 1e-20 yields a finite but absurd 1e21 coordinate) and reworded it as the grazing-ray cutoff it is |
| A non-finite `groundY` should teach like `Camera3D.clip` rather than return `None` | Medium | Claude | **Already true** — the registry's shared `f64` conversion rejects it first (`expected a finite number, got NaN`). I briefly added a redundant explicit check; the test proved it unreachable, so it was removed and the framework behavior is now pinned by a test instead |
| Eval-layer raised-plane test re-derived arithmetic the pure-layer test already pins | Low | Claude | **Fixed** — dropped; the eval layer now proves only wiring (one `Some`, one `None`, one teaching error) |
| `diverged` [S3-index, S4-read]: y-plane-only, so `examples/animation`'s vertical-plane `pointerTarget` can't adopt and its differing miss rules persist | — | de-dup pass | **Accepted, scoped out.** A general `toPlanePoint` needs a plane *value* type — a real API design, not a parameter. The two true ground picks (tactics, twin-stick) are the evidenced demand; noted as a follow-up |

De-dup coverage: S1-names ran (2 queries / 7349 candidates — no prior art);
S2-clones ran (whole-repo, **zero** pairs touching any changed file after
filtering); S3-index ran (403 KB index grepped for ground/plane/unproject/
screen_to_world/toWorld/raycast/intersect/pick across `.rs`/`.fun`/`.funi`/`.ts`);
S4-read ran (full diff plus `to_world_ray` and `examples/animation/game.fun` at
source). No strategy unavailable. `to_ground_point` **composes** `to_world_ray`
rather than re-deriving the unprojection; `Camera2D.toWorld` is the intentional
2D sibling; `Physics.cast` picks live colliders, a different operation.

## Not visual

No rendering, shader, material, or example output changes — this adds a pure math
external with no visible surface, so there is no GIF/PNG to embed.

## CI fix

The first push failed `build-native` on all three OSes: `cargo test -p
functor-docgen`'s `embedded_api_is_a_complete_documented_surface` pins the
embedded API inventory (`Engine == (27, 305)`) so a declaration can never
silently leave the reference. Adding one documented declaration moves it to
`(27, 306)` — exactly the deliberate edit that pin asks for. Bumped in
`b07f57e`. Worth noting for future prelude PRs: `npm run check:docs` does **not**
cover this test, so the local gate for a prelude addition is
`cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` (the
exact CI command), which now passes locally across all 19 test binaries.
