### PR TITLE
test(sdk): pin object-shaped (inline-module) entry-role launching

### DIFF
--- a/tools/functor-sdk/src/index.ts
+++ b/tools/functor-sdk/src/index.ts
@@ -1,10 +1,13 @@
 export { HttpClient, HttpError } from "./client.js";
 export { DEFAULT_STEP_DT, FunctorClient, stepAll, waitFor } from "./game.js";
 export {
+  entryRoleFile,
   findRepoRoot,
   formatCrashOutput,
   FunctorRunner,
   parseListeningPort,
+  resolveEntryArgs,
   waitForPort,
 } from "./server.js";
+export type { EntryRoleSpec } from "./server.js";
 export type * from "./types.js";

--- a/tools/functor-sdk/src/server.ts
+++ b/tools/functor-sdk/src/server.ts
@@ -64,6 +64,105 @@ export function findRepoRoot(startDir: string): string | undefined {
   }
 }
 
+/** A role in a project's `entries` map: either a bare path (roles-as-files) or
+ * an object naming the file plus the inline `module`/`prefix` its contract
+ * resolves in — two roles in ONE file, as in `examples/orbs`. (Named `…Spec`
+ * because it is the raw manifest VALUE, not the CLI's `EntryRole` binding
+ * scheme.) The object's fields are optional because a hand-written manifest is
+ * untrusted input, not because the CLI accepts a role without a file. */
+export type EntryRoleSpec = string | { file?: string; module?: string; prefix?: string };
+
+/** The `.fun` file a role points at (`""` when the object form has no usable
+ * `file`, which then matches no path and reports as a role/path disagreement).
+ * The role object must be READ, never stringified: `String({ file, module })`
+ * is `"[object Object]"` — the pre-#649 SDK did exactly that and could not
+ * launch any inline-module (same-file multiplayer) project at all. */
+export function entryRoleFile(role: EntryRoleSpec): string {
+  if (typeof role === "string") {
+    return role;
+  }
+  return typeof role?.file === "string" ? role.file : "";
+}
+
+/** Resolve the CLI args that select a project's entry role: `["--entry", name]`
+ * for a multi-entry project, `[]` otherwise. Throws when the request cannot be
+ * honoured (unknown role, ambiguous path, or a role/path disagreement) rather
+ * than silently launching a different game.
+ *
+ * `cfg` is the parsed `functor.json`, or `undefined` when the project has none.
+ * Relative `gameDir`/`gamePath` resolve against the current working directory.
+ */
+export function resolveEntryArgs(
+  cfg: { entry?: string; entries?: Record<string, EntryRoleSpec> } | undefined,
+  opts: { gameDir: string; gamePath: string; entry?: string },
+): string[] {
+  // Both sides of every comparison below are absolute, so a caller may pass
+  // either form (`launch` has already resolved its own).
+  const gameDir = resolve(opts.gameDir);
+  const gamePath = resolve(opts.gamePath);
+  const entries =
+    cfg?.entries && typeof cfg.entries === "object" ? cfg.entries : undefined;
+  if (!entries) {
+    // `entry` names a role out of an `entries` map. A project without one has
+    // no role to select, so honouring the request is impossible — say so
+    // rather than silently launching its sole entry.
+    if (opts.entry) {
+      throw new Error(
+        `the project in ${gameDir} declares no \`entries\` map, but launch ` +
+          `requested entry "${opts.entry}" — \`entry\` selects one of a ` +
+          "multi-entry project's roles.",
+      );
+    }
+    if (cfg === undefined) {
+      return [];
+    }
+    // Since the CLI launches the configured entry (not `functorLangPath`),
+    // verify they agree, or the SDK would silently run a DIFFERENT game.
+    const cfgEntry: string = cfg.entry ?? "game.fun";
+    if (resolve(gameDir, cfgEntry) !== gamePath) {
+      throw new Error(
+        `functor.json in ${gameDir} points at entry "${cfgEntry}", but launch ` +
+          `requested functorLangPath ${gamePath}. They must match — \`functor run native\` ` +
+          `launches the functor.json entry.`,
+      );
+    }
+    return [];
+  }
+
+  // Multi-entry project: select the role explicitly (the CLI's default would
+  // be `client`). Same-file roles are indistinguishable by path, so the caller
+  // must name one; otherwise the path picks it.
+  const matches = Object.keys(entries).filter(
+    (k) => resolve(gameDir, entryRoleFile(entries[k])) === gamePath,
+  );
+  if (!opts.entry && matches.length > 1) {
+    throw new Error(
+      `functor.json in ${gameDir} maps {${matches.join(", ")}} to the same ` +
+        `file ${gamePath} (roles as inline modules of one file), so the path ` +
+        "cannot say which you meant — pass `entry` to name the role.",
+    );
+  }
+  const name = opts.entry ?? matches[0];
+  if (!name || !Object.keys(entries).includes(name)) {
+    throw new Error(
+      `functor.json in ${gameDir} declares entries ` +
+        `{${Object.keys(entries).join(", ")}}, but launch requested ` +
+        `${opts.entry ? `entry "${opts.entry}"` : `functorLangPath ${gamePath}`}, ` +
+        `which matches none of them.`,
+    );
+  }
+  // Whichever way the role was chosen, it must be the file the caller asked
+  // for — otherwise the SDK would silently run a different source.
+  if (resolve(gameDir, entryRoleFile(entries[name])) !== gamePath) {
+    throw new Error(
+      `functor.json in ${gameDir} maps entry "${name}" to ` +
+        `"${entryRoleFile(entries[name])}", but launch requested functorLangPath ` +
+        `${gamePath}. They must match.`,
+    );
+  }
+  return ["--entry", name];
+}
+
 const MAX_LOG_LINES = 2000;
 const MAX_ERROR_LOG_LINES = 120;
 
@@ -175,79 +274,17 @@ export class FunctorRunner extends FunctorClient implements AsyncDisposable {
     // For a multi-entry project, the role selected out of `entries` via the
     // CLI's `--entry <name>` flag (placed before the subcommand, ahead of the
     // trailing runner args).
-    const entryArgs: string[] = [];
-    // `entry` names a role out of an `entries` map. A project without one has
-    // no role to select, so honouring the request is impossible — say so
-    // rather than silently launching its sole entry.
-    const noRoles = () => {
-      if (options.entry) {
-        throw new Error(
-          `the project in ${gameDir} declares no \`entries\` map, but launch ` +
-            `requested entry "${options.entry}" — \`entry\` selects one of a ` +
-            "multi-entry project's roles.",
-        );
-      }
-    };
-    if (existsSync(functorJson)) {
-      // Don't clobber a real project's config — but since the CLI launches its
-      // entry (not `functorLangPath`), verify they agree, or the SDK would silently run
-      // a DIFFERENT game than the caller asked for.
-      const cfg = JSON.parse(readFileSync(functorJson, "utf8"));
-      // A role is either a bare path (roles-as-files) or an object naming the
-      // file plus the inline `module`/`prefix` it resolves the contract in
-      // (two roles in ONE file — examples/orbs).
-      const entries =
-        cfg.entries && typeof cfg.entries === "object"
-          ? (cfg.entries as Record<string, string | { file?: string }>)
-          : undefined;
-      const fileOf = (role: string | { file?: string }): string =>
-        typeof role === "string" ? role : String(role?.file ?? "");
-      if (entries) {
-        // Multi-entry project: select the role explicitly (the CLI's default
-        // would be `client`). Same-file roles are indistinguishable by path,
-        // so the caller must name one; otherwise the path picks it.
-        const matches = Object.keys(entries).filter(
-          (k) => resolve(gameDir, fileOf(entries[k])) === gamePath,
-        );
-        if (!options.entry && matches.length > 1) {
-          throw new Error(
-            `functor.json in ${gameDir} maps {${matches.join(", ")}} to the same ` +
-              `file ${gamePath} (roles as inline modules of one file), so the path ` +
-              "cannot say which you meant — pass `entry` to name the role.",
-          );
-        }
-        const name = options.entry ?? matches[0];
-        if (!name || !Object.keys(entries).includes(name)) {
-          throw new Error(
-            `functor.json in ${gameDir} declares entries ` +
-              `{${Object.keys(entries).join(", ")}}, but launch requested ` +
-              `${options.entry ? `entry "${options.entry}"` : `functorLangPath ${gamePath}`}, ` +
-              `which matches none of them.`,
-          );
-        }
-        // Whichever way the role was chosen, it must be the file the caller
-        // asked for — otherwise the SDK would silently run a different source.
-        if (resolve(gameDir, fileOf(entries[name])) !== gamePath) {
-          throw new Error(
-            `functor.json in ${gameDir} maps entry "${name}" to ` +
-              `"${fileOf(entries[name])}", but launch requested functorLangPath ` +
-              `${gamePath}. They must match.`,
-          );
-        }
-        entryArgs.push("--entry", name);
-      } else {
-        noRoles();
-        const cfgEntry: string = cfg.entry ?? "game.fun";
-        if (resolve(gameDir, cfgEntry) !== gamePath) {
-          throw new Error(
-            `functor.json in ${gameDir} points at entry "${cfgEntry}", but launch ` +
-              `requested functorLangPath ${gamePath}. They must match — \`functor run native\` ` +
-              `launches the functor.json entry.`,
-          );
-        }
-      }
-    } else {
-      noRoles();
+    // Don't clobber a real project's config; a synthetic/temp game dir without
+    // one gets a minimal config pointing at the entry.
+    const cfg = existsSync(functorJson)
+      ? (JSON.parse(readFileSync(functorJson, "utf8")) ?? undefined)
+      : undefined;
+    const entryArgs = resolveEntryArgs(cfg, {
+      gameDir,
+      gamePath,
+      entry: options.entry,
+    });
+    if (cfg === undefined) {
       writeFileSync(functorJson, JSON.stringify({ language: "functor-lang", entry: wantEntry }));
     }
 

--- a/tools/functor-sdk/test/fixtures/same-file-roles/functor.json
+++ b/tools/functor-sdk/test/fixtures/same-file-roles/functor.json
@@ -1,0 +1,7 @@
+{
+  "language": "functor-lang",
+  "entries": {
+    "client": { "file": "game.fun", "module": "Client" },
+    "server": { "file": "game.fun", "module": "Server" }
+  }
+}

--- a/tools/functor-sdk/test/fixtures/same-file-roles/game.fun
+++ b/tools/functor-sdk/test/fixtures/same-file-roles/game.fun
@@ -1,0 +1,27 @@
+// Fixture for the SDK's entry resolution: TWO roles in ONE file, each an
+// inline module — the object-shaped `entries` form
+// (`{ "file": "game.fun", "module": "Client" }`) that `examples/orbs` uses.
+// The unit tests read the sibling functor.json; this file exists so the
+// fixture is a real, runnable project rather than a dangling manifest.
+
+let spin = (tts: float) => Angle.degrees(tts * 30.0)
+
+module Client {
+  let init = { role: "client" }
+  let tick = (m, dt: float, tts: float) => m
+  let draw = (m, tts: float) =>
+    Frame.create(
+      Camera3D.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
+      Scene.cube() |> Scene.rotateY(spin(tts)),
+    )
+}
+
+module Server {
+  let init = { role: "server" }
+  let tick = (m, dt: float, tts: float) => m
+  let draw = (m, tts: float) =>
+    Frame.create(
+      Camera3D.lookAt(Vec3.make(0.0, 1.5, -4.0), Vec3.make(0.0, 0.0, 0.0)),
+      Scene.sphere() |> Scene.rotateY(spin(tts)),
+    )
+}

--- a/tools/functor-sdk/test/unit.test.ts
+++ b/tools/functor-sdk/test/unit.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
+  entryRoleFile,
   findRepoRoot,
   formatCrashOutput,
   parseListeningPort,
   FunctorClient,
   HttpClient,
+  resolveEntryArgs,
   stepAll,
   waitFor,
 } from "../src/index.js";
@@ -26,6 +29,125 @@ test("findRepoRoot walks up to the cargo workspace root", () => {
 
 test("findRepoRoot returns undefined when there's no workspace above", () => {
   assert.equal(findRepoRoot("/"), undefined);
+});
+
+// Entry-role resolution, against a REAL manifest on disk: `test/fixtures/
+// same-file-roles` is the orbs shape — two roles pointing at ONE game.fun via
+// the object form `{ "file": …, "module": … }`. (Compiled tests run from
+// dist/test, so the fixture is located relative to this file, not the cwd.)
+const sdkDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const sameFileRolesDir = join(sdkDir, "test", "fixtures", "same-file-roles");
+const sameFileRolesCfg = JSON.parse(
+  readFileSync(join(sameFileRolesDir, "functor.json"), "utf8"),
+);
+const sameFileRolesGame = join(sameFileRolesDir, "game.fun");
+
+test("entryRoleFile reads the object form's file rather than stringifying it", () => {
+  // What this pins: the role object is READ, never stringified. The pre-#649
+  // SDK resolved `String(entries[k])` — "[object Object]" for the object form,
+  // a path no entry can match — so every inline-module (same-file multiplayer)
+  // project was unlaunchable. #649 fixed it with no test; this is that test.
+  assert.equal(entryRoleFile({ file: "game.fun", module: "Server" }), "game.fun");
+  assert.equal(entryRoleFile("server.fun"), "server.fun");
+});
+
+test("resolveEntryArgs selects an object-shaped (inline-module) role", () => {
+  for (const entry of ["client", "server"]) {
+    assert.deepEqual(
+      resolveEntryArgs(sameFileRolesCfg, {
+        gameDir: sameFileRolesDir,
+        gamePath: sameFileRolesGame,
+        entry,
+      }),
+      ["--entry", entry],
+      `${entry} should be forwarded as --entry ${entry}`,
+    );
+  }
+  // Paths may be relative to the cwd (launch resolves its own; a direct caller
+  // need not) — the comparison normalizes both sides.
+  assert.deepEqual(
+    resolveEntryArgs(sameFileRolesCfg, {
+      gameDir: relative(process.cwd(), sameFileRolesDir),
+      gamePath: relative(process.cwd(), sameFileRolesGame),
+      entry: "server",
+    }),
+    ["--entry", "server"],
+  );
+});
+
+test("resolveEntryArgs refuses to guess between two roles in one file", () => {
+  assert.throws(
+    () =>
+      resolveEntryArgs(sameFileRolesCfg, {
+        gameDir: sameFileRolesDir,
+        gamePath: sameFileRolesGame,
+      }),
+    /maps \{client, server\} to the same file .*pass `entry` to name the role/s,
+  );
+});
+
+test("resolveEntryArgs rejects a role that names a different file", () => {
+  assert.throws(
+    () =>
+      resolveEntryArgs(
+        { entries: { client: { file: "client.fun" }, server: "server.fun" } },
+        {
+          gameDir: "/proj",
+          gamePath: "/proj/client.fun",
+          entry: "server",
+        },
+      ),
+    /maps entry "server" to "server\.fun"/,
+  );
+});
+
+test("resolveEntryArgs picks a roles-as-files role by path, and rejects unknown names", () => {
+  const cfg = { entries: { client: "client.fun", server: "server.fun" } };
+  assert.deepEqual(
+    resolveEntryArgs(cfg, { gameDir: "/proj", gamePath: "/proj/server.fun" }),
+    ["--entry", "server"],
+  );
+  assert.throws(
+    () =>
+      resolveEntryArgs(cfg, {
+        gameDir: "/proj",
+        gamePath: "/proj/server.fun",
+        entry: "referee",
+      }),
+    /declares entries \{client, server\}.*entry "referee"/s,
+  );
+});
+
+test("resolveEntryArgs handles single-entry and config-less projects", () => {
+  assert.deepEqual(
+    resolveEntryArgs(
+      { entry: "game.fun" },
+      { gameDir: "/proj", gamePath: "/proj/game.fun" },
+    ),
+    [],
+  );
+  assert.throws(
+    () =>
+      resolveEntryArgs(
+        { entry: "other.fun" },
+        { gameDir: "/proj", gamePath: "/proj/game.fun" },
+      ),
+    /points at entry "other\.fun"/,
+  );
+  // No functor.json at all: nothing to select, and a role request is a lie.
+  assert.deepEqual(
+    resolveEntryArgs(undefined, { gameDir: "/proj", gamePath: "/proj/game.fun" }),
+    [],
+  );
+  assert.throws(
+    () =>
+      resolveEntryArgs(undefined, {
+        gameDir: "/proj",
+        gamePath: "/proj/game.fun",
+        entry: "server",
+      }),
+    /declares no `entries` map/,
+  );
 });
 
 test("formatCrashOutput keeps the panic and its context", () => {


### PR DESCRIPTION
## The blocker

The jam's **botball** entry (a same-file multiplayer game: one `game.fun`, `module Client` / `module Server`, the `examples/orbs` shape) could not drive its two roles with `@functor/sdk`. On the jam baseline `7955145`, `FunctorRunner.launch` resolved a manifest role with `String(entries[k])` — for the 1.2 object form `{ "file": "game.fun", "module": "Server" }` that is the string **`"[object Object]"`**, which matches no path, so every inline-module project failed with *"declares entries {client, server} … which matches none of them."*

The SDK's whole point is driving games headlessly, so botball hand-rolled ~100 lines of process spawn / port wait / HTTP polling as a workaround.

## What this PR does

**The resolution itself was already fixed on `main`** — #649 (`chore: remove examples/mp`) quietly rewrote it to read `role.file` while re-pointing the multiplayer e2e at `examples/orbs`. That fix landed **with no test**: the one line that decides whether same-file multiplayer is drivable at all lived inline inside `launch()`, unreachable without a GL binary and a spawned process. This PR makes it hold:

- **Extracts** the entry-role resolution out of `FunctorRunner.launch` into a pure, exported `resolveEntryArgs(cfg, { gameDir, gamePath, entry })` (+ `entryRoleFile`, `EntryRoleSpec`). `launch` now parses `functor.json` and calls it — behavior-preserving, verified branch by branch against the base.
- **Adds a fixture** — `tools/functor-sdk/test/fixtures/same-file-roles/` — two roles pointing at ONE `game.fun` via `{ file, module }`, the orbs/botball shape. It is a real project, not a dangling manifest: both roles typecheck (`functor -d … build native --entry client|server`).
- **Adds 6 unit tests** covering: object-form role selection, refusing to guess between two same-file roles, role/path disagreement, roles-as-files selection by path, unknown role names, single-entry and config-less projects.

No runtime/CLI change: object entries and `--entry` have been supported by the runtime since #423. Verified against the **jam baseline binary** (7955145) — it builds and runs both fixture roles — so this is purely SDK-side.

## Failing-then-passing proof

Restoring the pre-#649 stringification (`String(role)`) in `entryRoleFile` and running the new tests:

```
not ok 15 - entryRoleFile reads the object form's file rather than stringifying it
    actual: '[object Object]'
not ok 16 - resolveEntryArgs selects an object-shaped (inline-module) role
    error: 'functor.json in …/same-file-roles maps entry "client" to "[object Object]",
             but launch requested functorLangPath …/same-file-roles/game.fun. They must match.'
not ok 17 - resolveEntryArgs refuses to guess between two roles in one file
```

Restored, on this branch:

```
$ npm test                       # tools/functor-sdk
# pass 24   # fail 0             (all 6 new tests green)

$ FUNCTOR_E2E=1 FUNCTOR_E2E_HEADLESS=1 node --test dist/test/multiplayer.e2e.test.js \
      dist/test/functor-lang-hot-reload.e2e.test.js dist/test/launch-failure.e2e.test.js
ok 1 - editing a running .fun game preserves the model and rebinds behavior
ok 2 - launching against a missing game source rejects with an actionable error
ok 3 - two clients connect to a server and converge on a shared world
# pass 3   # fail 0
```

(e2e run against the jam's prebuilt `functor` binary, headless. The full `npm run test:e2e:headless` sweep also passed except for two tests that collided with an unrelated process already listening on the hardcoded port 8090 — `[debug-server] failed to bind 127.0.0.1:8090: Address already in use` — environmental, not caused by this change, and green when run without the squatter.)

**CI coverage:** `.github/workflows/e2e.yml` runs `npm run test:e2e:headless` in `tools/functor-sdk` on every PR, and that script runs `tsc` + `node --test dist/test/*.test.js` — so the new unit tests **are** exercised by CI (they are pure, no display needed). They were additionally run locally as shown above.

## Review dispositions (`/xreview`: Claude + Codex + a de-dup pass)

No Critical. Fixed:

- **(Claude, Medium) Docstring claimed a bug that isn't in the base.** True — the defect is *pre-#649*, i.e. the jam baseline botball ran on. Reworded the docstring and the test comment to say exactly that, and the commit is titled `test(sdk):`, not `fix(sdk):`.
- **(Codex, Medium) `resolveEntryArgs` rejected relative paths** that `launch` accepts (it resolves manifest paths but compared against the caller's raw `gamePath`). Now normalizes both inside the function; pinned by a test.
- **(Claude, Low) Dropping `String(...)` changed malformed-manifest behavior** (`{"file": 5}` → an opaque Node `ERR_INVALID_ARG_TYPE` instead of a domain error). Now `typeof role.file === "string"`, falling through to the existing role/path-disagreement error.
- **(Claude, Low) `functor.json` containing `null`** reached `cfg.entry` → TypeError. `?? undefined` routes it down the config-less path.
- **(De-dup, Low) `EntryRole` collided with the Rust `EntryRole`** (which means the *binding scheme*, `Prefix`/`Module` — not the manifest value). Renamed to `EntryRoleSpec`.

Justified, not changed:

- **(Claude, Low) exports for testability** — `formatCrashOutput`/`findRepoRoot` are already exported from `index.ts` and unit-tested the same way; this follows the file's convention.
- **(De-dup, Low) "use `examples/orbs` instead of a new fixture"** — deliberately not: the fixture is self-contained, named for the property under test, and immune to orbs' game design changing. Its `game.fun` is what makes it a real project (both roles typecheck) rather than a manifest pointing at nothing.
- **(De-dup) `resolveEntryArgs` vs the CLI's `FunctorLangConfig::select`/`pick_entry`** — judged a legitimate platform twin by the de-dup reviewer itself: the Rust side maps `--entry <name>` → a resolved role; the SDK maps a caller's path *back* to a role name to pass on the command line. No shared implementation is possible across the process boundary.
- **(Claude, Low) fixture path is `../..` from `dist/test`** — `npm test` / `npm run test:e2e*` are the documented runners and both compile to `dist/`.

De-dup coverage: all four strategies ran (S1 names — 4 queries / 7340 candidates / 12 above threshold; S2 clones — 261 pairs, **zero** touching the changed source; S3 index — 3589-line API index grepped for `entry`/`entries`/`role`; S4 — full diff read). Two Low findings, both above.

## Docs

`tools/functor-sdk/README.md` already documents `entry` with the orbs same-file shape (updated in #649) and `docs/debug-runtime.md` does not cover SDK launching — nothing describes the old behavior, so no doc change was needed.

## Adoption

Any worktree at the jam baseline gets the fix with:

```sh
git fetch origin fix/sdk-object-entries
git checkout origin/fix/sdk-object-entries -- tools/functor-sdk
(cd tools/functor-sdk && npm install && npm run build)
```

Verified on a scratch worktree at `7955145`: unit tests 24/24, and the two-role `examples/orbs` e2e converges against the prebuilt baseline binary.
