### PR TITLE
docs(site): the manual teaches the stored-closure hot-reload contract

### DIFF
--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -480,6 +480,52 @@ functor -d . run native --entry server  # the same world, seen from the authorit
             see the previous frame's — so on the very first frame declared bodies don't exist
             yet. Keep physics reads in <code>draw</code>.
           </p>
+
+          <h3 id="stored-closures">Closures in the model across a reload</h3>
+          <p>
+            MVU invites you to put <em>functions</em> in the model — a spell's behavior, an
+            enemy's steering, a per-entity callback made by a factory. Hot reload keeps those
+            closures alive under three rules:
+          </p>
+          <ul>
+            <li>
+              <strong>A stored closure adopts the edited code.</strong> Its identity is the name
+              of the <em>enclosing definition</em> it was made in, not where it sits in the model,
+              so closures nested in records, lists, tuples, variants, and maps all rebind. The
+              reload log says how many: <code>4 stored closure(s) rebound</code>.
+            </li>
+            <li>
+              <strong>Its captured values carry over.</strong> The saved environment is
+              re-attached to the new body — new code, old data. A closure made as
+              <code>firebolt(10.0)</code> keeps <code>power = 10</code> and runs your edited
+              formula with it.
+            </li>
+            <li>
+              <strong>A renamed or deleted definition keeps its old body, loudly.</strong>
+              <code>[functor-lang] reload: stored closure `firebolt/fn` has no match after the
+              edit (renamed, deleted, or moved); keeping its old body</code> — the same happens
+              when the edited body captures a name the saved environment doesn't have. Nothing
+              breaks; that value simply stops tracking your edits until it is remade.
+            </li>
+          </ul>
+          <p>
+            <strong>The edge to know first: editing the creation site does nothing to closures
+            that already exist.</strong> Captured arguments were evaluated when the closure was
+            made, and a reload does not re-evaluate them — nor does it re-run <code>init</code>.
+            Edit the <em>body</em> to change live behavior; to change a captured value, rebuild
+            the closures from the current factory (an explicit "reforge" the game can run):
+          </p>
+          <pre class="functor-lang">let firebolt = (power: float) => (charge: float) => power * charge
+
+let init = { spells: [firebolt(10.0)] }   // this 10.0 changes on RESTART only
+
+// Editing the body above re-aims every stored spell; editing the 10.0 does not.
+// Reforging does: it makes new closures from the current factory.
+let reforge = (model) => { model with spells: [firebolt(10.0)] }</pre>
+          <p>
+            Closures created fresh each frame store nothing, so they always run current code —
+            this contract only concerns functions the model holds between frames.
+          </p>
         </section>
 
         <section id="debug-camera">
@@ -895,6 +941,13 @@ functor docs --format json         # the machine-readable shape</pre>
               <code>1.5s &lt; 2000ms</code>, and physics tags, all fine.
               (<code>Sprite.t</code> is the other deliberate exception: it is plain data
               underneath.)
+            </li>
+            <li>
+              <strong>A closure in the model adopts edited code, but not edited captures.</strong>
+              On reload a stored closure re-points at the new body of the definition it came from
+              and keeps the values it captured — so changing <code>firebolt(10.0)</code> to
+              <code>firebolt(25.0)</code> leaves every spell already in the model at 10. See
+              <a href="#stored-closures">closures in the model across a reload</a>.
             </li>
           </ul>
           <p class="docs-footnote">

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -489,10 +489,11 @@ functor -d . run native --entry server  # the same world, seen from the authorit
           </p>
           <ul>
             <li>
-              <strong>A stored closure adopts the edited code.</strong> Its identity is the name
-              of the <em>enclosing definition</em> it was made in, not where it sits in the model,
-              so closures nested in records, lists, tuples, variants, and maps all rebind. The
-              reload log says how many: <code>4 stored closure(s) rebound</code>.
+              <strong>A stored closure adopts the edited code.</strong> Its identity is the
+              <em>enclosing definition</em>'s name plus where the lambda sits in that
+              definition's source — hence <code>firebolt/fn</code> — never where it sits in the
+              model, so closures nested in records, lists, tuples, variants, and maps all rebind.
+              The reload log counts them: <code>model preserved; 1 stored closure(s) rebound</code>.
             </li>
             <li>
               <strong>Its captured values carry over.</strong> The saved environment is
@@ -501,11 +502,12 @@ functor -d . run native --entry server  # the same world, seen from the authorit
               formula with it.
             </li>
             <li>
-              <strong>A renamed or deleted definition keeps its old body, loudly.</strong>
+              <strong>An edit it can't be matched to keeps its old body, loudly.</strong>
               <code>[functor-lang] reload: stored closure `firebolt/fn` has no match after the
-              edit (renamed, deleted, or moved); keeping its old body</code> — the same happens
-              when the edited body captures a name the saved environment doesn't have. Nothing
-              breaks; that value simply stops tracking your edits until it is remade.
+              edit (renamed, deleted, or moved); keeping its old body</code>. Changing the
+              lambda's parameter count, or making it capture names the old one didn't, gets its
+              own warning and the same treatment. Nothing breaks; that value simply stops
+              tracking your edits until the code remakes it.
             </li>
           </ul>
           <p>
@@ -523,8 +525,8 @@ let init = { spells: [firebolt(10.0)] }   // this 10.0 changes on RESTART only
 // Reforging does: it makes new closures from the current factory.
 let reforge = (model) => { model with spells: [firebolt(10.0)] }</pre>
           <p>
-            Closures created fresh each frame store nothing, so they always run current code —
-            this contract only concerns functions the model holds between frames.
+            A closure built and used inside one frame never crosses a reload, so it always runs
+            current code — this contract only concerns functions the model holds between frames.
           </p>
         </section>
 


### PR DESCRIPTION
## What

The manual's hot-reload prose covered model preservation, `init`-on-restart, and top-level late binding — but never the **stored-closure contract**. This adds it: a new subsection in **The game contract**, `#stored-closures` ("Closures in the model across a reload"), plus one cross-linked bullet in **Sharp edges**. Additive prose only; no restructuring, no nav change (the nav lists `h2` anchors).

Published rules:

1. **A stored closure adopts the edited code** — identity is the enclosing definition's name plus where the lambda sits in that definition's source (`firebolt/fn`), never where it sits in the model; records, lists, tuples, variants, and maps all rebind. The reload log counts them (`model preserved; 1 stored closure(s) rebound`).
2. **Its captured values carry over** — new code, old data.
3. **An edit it can't be matched to keeps its old body, loudly** — the verbatim `[functor-lang] reload: stored closure \`firebolt/fn\` has no match after the edit (renamed, deleted, or moved); keeping its old body`, plus arity/capture-shape changes, which warn and get the same treatment.

…and the sharp edge users hit first: **editing the creation site does nothing to closures that already exist** — captured arguments are not re-evaluated on reload and `init` is not re-run, so changing a captured value needs an explicit "reforge" that rebuilds the closures from the current factory. One tight worked example shows the factory, the `init` creation site, and the reforge.

## Why — the evidence

The jam entry **spellsmith** (a wave-defense game whose spells are closures stored in the model) characterized all of this live with a `proof.mjs` harness: reading the damage each stored closure deals across saves, it confirmed rebind of list-nested and directly-held closures, the carried captures, the rename warning, and — the trap that cost it real time — that editing `firebolt(10.0)` at the creation site left every live spell at the old power, which is why the game grew an explicit **F = reforge** key. Its notes name this the top docs gap: "closures in the model, edit and save" is the engine's marquee demo, yet the contract was published nowhere on functor.games.

## Source of truth

The wording mirrors the repo-internal `.claude/skills/functor-lang/SKILL.md` hot-reload section (the accuracy source), and every claim was cross-checked against the pinned tests:

- `functor-lang/tests/rebind.rs` — `stored_closure_adopts_edited_body_and_keeps_env` (:53), `closures_rebind_inside_containers` (:71), `closures_nested_in_maps_rebind…` (:217), `closures_rebind_inside_tuples` (:420), `deleted_def_keeps_old_body_with_warning` (:119), `unresolvable_new_capture_keeps_old_body_with_warning` (:142), `arity_change_keeps_old_body_with_warning` (:354), `capture_kind_change…` (:377)
- `functor-lang/src/rebind.rs:242` — the exact warning string quoted in the manual
- `runtime/functor-runtime-desktop/src/functor_lang_game.rs:806` — the `(model preserved; N stored closure(s) rebound; …)` log line
- `tools/functor-sdk/test/functor-lang-closure-rebind.e2e.test.ts` — the same contract end to end, including the `1 stored closure(s) rebound` log assertion

The worked snippet typechecks: `cargo run -q -p functor-lang -- check` exits 0.

## Screenshots (rendered `/manual/`)

New section, desktop and mobile:

| desktop | mobile |
| --- | --- |
| ![new section desktop](https://gist.githubusercontent.com/tommy-xr/7ca58ac6ab6f24386858353415b6b483/raw/after-desktop-stored-closures.png) | ![new section mobile](https://gist.githubusercontent.com/tommy-xr/7ca58ac6ab6f24386858353415b6b483/raw/after-mobile-stored-closures.png) |

Before/after of the whole **The game contract** section (base `d5634cc` build vs this change), desktop 1440px and mobile 390px:

- before: [desktop](https://gist.githubusercontent.com/tommy-xr/7ca58ac6ab6f24386858353415b6b483/raw/before-desktop-contract.png) · [mobile](https://gist.githubusercontent.com/tommy-xr/7ca58ac6ab6f24386858353415b6b483/raw/before-mobile-contract.png)
- after: [desktop](https://gist.githubusercontent.com/tommy-xr/7ca58ac6ab6f24386858353415b6b483/raw/after-desktop-contract.png) · [mobile](https://gist.githubusercontent.com/tommy-xr/7ca58ac6ab6f24386858353415b6b483/raw/after-mobile-contract.png)

## Review dispositions (`/xreview`: Claude subagent + Codex, both read-only over `d5634cc...HEAD`)

No Critical or High findings from either engine; every published log string and behavioral claim verified against the code and tests.

| # | Engine | Severity | Finding | Disposition |
| --- | --- | --- | --- | --- |
| 1 | Claude | Medium | Exception set incomplete — arity change, capture-kind change, and removed shadow also keep the old body | **Fixed**: bullet 3 now covers parameter-count and capture-shape changes |
| 2 | Claude | Low | "the same happens when the edited body captures a name the environment lacks" implied the same warning text; the real trigger is the new body capturing something the old didn't | **Fixed**: reworded to "gets its own warning and the same treatment" |
| 3 | Claude | Low/Med | Identity is def name **plus a source path**, not just the name | **Fixed**: bullet 1 now says "the enclosing definition's name plus where the lambda sits in that definition's source — hence `firebolt/fn`" |
| 4 | Claude | Low | Illustrative count `4` didn't match the section's one-spell example | **Fixed**: quotes the real log fragment `model preserved; 1 stored closure(s) rebound` |
| 5 | Codex | Minor | "fresh closures store nothing" is loose — closures always capture | **Fixed**: "A closure built and used inside one frame never crosses a reload" |
| 6 | Claude | Low | `init`-on-restart restates the Get-started paragraph | **Accepted as-is** — local reinforcement of the mechanism at the point of use |
| 7 | Claude | Low | Stored closures also make time-travel snapshots reload-unsafe | **Out of scope** — the manual doesn't cover time travel; noted as deliberate |

De-dup pass: not applicable — the change adds no functions or types, only prose (no `dupfinder` strategies run).

Re-verified after the fixes: site rebuilds clean (`npm run site:build`), screenshots above are the post-fix render, snippet still typechecks.
