### PR TITLE
feat(physics): linear and angular damping builder attributes

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1126,6 +1126,17 @@ docs/physics.md): dynamic/fixed bodies teleport the changed fields immediately,
 while a kinematic body receives the changed pose as its next-step target so it
 carries velocity into contacts.
 
+**Drag belongs on the body, not in `tick`.** Contact friction resists
+*sliding*, not *rolling*, so a sphere on a box coasts essentially forever —
+declare `|> Physics.linearDamping(f)` (and `|> Physics.angularDamping(f)` to
+bleed off spin) instead of reading `Physics.linearVelocity` and writing
+`Physics.setVelocityXZ` back every frame to fake it. Both default to `0.0`,
+both reject a negative value, both are `dynamic`-only (inert on a kinematic or
+fixed body), and changing the declared value writes it onto the live body from
+the next step without disturbing its pose or velocity — the same divergence
+rule as `friction`/`restitution`. Per-frame velocity commands are still right
+for *steering* (the controller recipe below); they are the wrong tool for *drag*.
+
 Physics **command effects** are returned beside the model like any effect
 — `(model, Physics.applyImpulse(ballTag, Vec3.make(0.0, 5.0, 0.0)))` — but carry no
 tagger: nothing folds back through `update`; observe outcomes via the

--- a/functor-prelude/prelude/physics.funi
+++ b/functor-prelude/prelude/physics.funi
@@ -116,6 +116,29 @@ let mass : (float, body) => body
 let friction : (float, body) => body
 /// Set a body's restitution; the body is last for piping.
 let restitution : (float, body) => body
+
+/// Damp a body's LINEAR velocity — drag, per second; the body is last for piping.
+///
+/// The default is `0.0` (no drag), so a rolling sphere on a box coasts almost
+/// forever: contact friction resists sliding, not rolling. A small value
+/// (`0.3`–`0.8`) is what makes a marble, a puck, or a thrown prop actually
+/// settle, and it belongs here rather than in a per-frame velocity command:
+/// damping is a property of the body, so declaring it keeps `tick` pure.
+/// Must not be negative. Only `dynamic` bodies integrate, so damping is inert
+/// on a `kinematic` or `fixed` one. Changing the value writes it onto the live
+/// body (the friction/restitution rule) — the new drag applies from the next
+/// step, with the body's current pose and velocity untouched.
+let linearDamping : (float, body) => body
+
+/// Damp a body's ANGULAR velocity — spin resistance, per second; the body is
+/// last for piping.
+///
+/// The default is `0.0`. Pair it with `linearDamping` for a ball that stops
+/// rolling instead of creeping, or use it alone to bleed off spin while linear
+/// motion is preserved. Must not be negative, `dynamic`-only, and reconciles
+/// onto a live body exactly like `linearDamping`.
+let angularDamping : (float, body) => body
+
 /// Make a body a non-solid sensor; the body is last for piping.
 let sensor : (body) => body
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -124,6 +124,7 @@
 //! Physics.at/velocity(v, body)                        -> Body
 //! Physics.rotateX/rotateY/rotateZ(angle, body)              -> Body
 //! Physics.mass/friction/restitution(n, body)                -> Body
+//! Physics.linearDamping/angularDamping(n, body)             -> Body
 //! Physics.sensor(body)                                      -> Body
 //! Physics.upright(body)                                     -> Body
 //! Physics.scene(Vec3.make(gx, gy, gz), [body, …])                      -> PhysicsScene
@@ -2760,6 +2761,24 @@ fn register_physics(reg: &mut crate::host_registry::Registry) {
             ))
         },
     );
+    reg.fn2(
+        "Physics.linearDamping",
+        "Physics.linearDamping(n, body)",
+        |n: f64, body: FunctorLangBody| {
+            Ok(FunctorLangBody(body.0.with_linear_damping(
+                non_negative(n, "Physics.linearDamping")? as f32,
+            )))
+        },
+    );
+    reg.fn2(
+        "Physics.angularDamping",
+        "Physics.angularDamping(n, body)",
+        |n: f64, body: FunctorLangBody| {
+            Ok(FunctorLangBody(body.0.with_angular_damping(
+                non_negative(n, "Physics.angularDamping")? as f32,
+            )))
+        },
+    );
     reg.fn1("Physics.sensor", "Physics.sensor(body)", |body: FunctorLangBody| {
         FunctorLangBody(body.0.as_sensor())
     });
@@ -4831,7 +4850,8 @@ fn positive(n: f64, what: &str) -> Result<f64, String> {
     }
 }
 
-/// Friction/restitution are coefficients: zero is meaningful, negative is not.
+/// Friction/restitution/damping are coefficients: zero is meaningful, negative
+/// is not (a negative damping would inject energy every step).
 fn non_negative(n: f64, what: &str) -> Result<f64, String> {
     if n >= 0.0 {
         Ok(n)
@@ -8575,6 +8595,8 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
              |> Physics.velocity(Vec3.make(1.0, 0.0, 0.0))\n\
              |> Physics.mass(2.0)\n\
              |> Physics.restitution(0.5)\n\
+             |> Physics.linearDamping(0.55)\n\
+             |> Physics.angularDamping(1.25)\n\
              let main = () => Physics.scene(Vec3.make(0.0, -9.81, 0.0), [\n\
                Physics.fixed(\"ground\", Physics.box(20.0, 0.2, 20.0)),\n\
                crate1,\n\
@@ -8589,6 +8611,11 @@ paths (+X, -X, +Y, -Y, +Z, -Z)"
         assert_eq!(scene.bodies[1].velocity, [1.0, 0.0, 0.0]);
         assert_eq!(scene.bodies[1].mass, Some(2.0));
         assert_eq!(scene.bodies[1].restitution, 0.5);
+        assert_eq!(scene.bodies[1].linear_damping, 0.55);
+        assert_eq!(scene.bodies[1].angular_damping, 1.25);
+        // Undeclared damping is 0.0 — no drag, the pre-existing behavior.
+        assert_eq!(scene.bodies[0].linear_damping, 0.0);
+        assert_eq!(scene.bodies[0].angular_damping, 0.0);
         assert!(scene.bodies[2].sensor);
     }
 
@@ -9141,6 +9168,14 @@ translation-only; use Physics.at with an unrotated Scene.terrain"
             (
                 "Physics.dynamic(\"x\", Physics.sphere(0.5)) |> Physics.friction(-1.0)",
                 "Physics.friction must not be negative",
+            ),
+            (
+                "Physics.dynamic(\"x\", Physics.sphere(0.5)) |> Physics.linearDamping(-0.1)",
+                "Physics.linearDamping must not be negative",
+            ),
+            (
+                "Physics.dynamic(\"x\", Physics.sphere(0.5)) |> Physics.angularDamping(-0.1)",
+                "Physics.angularDamping must not be negative",
             ),
         ] {
             let module =

--- a/runtime/functor-runtime-common/src/physics/scene.rs
+++ b/runtime/functor-runtime-common/src/physics/scene.rs
@@ -82,6 +82,17 @@ pub struct Body {
     pub mass: Option<f32>,
     pub friction: f32,
     pub restitution: f32,
+    /// Per-second linear velocity decay (rapier `linear_damping`). `0.0` — the
+    /// default — is no drag, so existing games are unchanged. Rapier integrates
+    /// damping only for `Dynamic` bodies; on a kinematic or fixed body it is
+    /// recorded and inert.
+    #[serde(default)]
+    pub linear_damping: f32,
+    /// Per-second angular velocity decay (rapier `angular_damping`). `0.0` —
+    /// the default — is no rolling resistance, so existing games are unchanged.
+    /// `Dynamic`-only, like `linear_damping`.
+    #[serde(default)]
+    pub angular_damping: f32,
     /// A sensor detects overlaps but produces no contact forces.
     pub sensor: bool,
     /// Rotation is locked on all three axes: the body translates but never
@@ -105,6 +116,8 @@ impl Body {
             // Rapier's collider defaults.
             friction: 0.5,
             restitution: 0.0,
+            linear_damping: 0.0,
+            angular_damping: 0.0,
             sensor: false,
             rotation_locked: false,
             authority: Authority::Local,
@@ -154,6 +167,16 @@ impl Body {
 
     pub fn with_restitution(mut self, restitution: f32) -> Body {
         self.restitution = restitution;
+        self
+    }
+
+    pub fn with_linear_damping(mut self, damping: f32) -> Body {
+        self.linear_damping = damping;
+        self
+    }
+
+    pub fn with_angular_damping(mut self, damping: f32) -> Body {
+        self.angular_damping = damping;
         self
     }
 

--- a/runtime/functor-runtime-common/src/physics/world.rs
+++ b/runtime/functor-runtime-common/src/physics/world.rs
@@ -754,7 +754,15 @@ impl World {
             BodyKind::Kinematic => RigidBodyBuilder::kinematic_position_based(),
             BodyKind::Fixed => RigidBodyBuilder::fixed(),
         };
-        let mut builder = builder.pose(pose_of(body)).linvel(vec3(body.velocity));
+        let mut builder = builder
+            .pose(pose_of(body))
+            .linvel(vec3(body.velocity))
+            // Damping lives on the RIGID BODY (unlike friction/restitution,
+            // which are collider material properties): it is a velocity decay
+            // the integrator applies, not a contact response. Rapier only
+            // integrates a dynamic body, so it is inert on kinematic/fixed.
+            .linear_damping(body.linear_damping)
+            .angular_damping(body.angular_damping);
         if body.rotation_locked {
             // An upright body translates but never tips (the character-capsule
             // case). This stops the solver from ACCUMULATING spin; a body that
@@ -936,6 +944,16 @@ impl World {
             if rb.linvel() != v {
                 rb.set_linvel(v, true);
             }
+        }
+        // Damping is a coefficient the integrator reads, so writing it does not
+        // wake the body (the friction/restitution rule) — a sleeping body has
+        // no velocity for the new value to act on, and it takes effect the
+        // moment something else wakes it.
+        if prev.linear_damping != next.linear_damping {
+            self.bodies[rb_handle].set_linear_damping(next.linear_damping);
+        }
+        if prev.angular_damping != next.angular_damping {
+            self.bodies[rb_handle].set_angular_damping(next.angular_damping);
         }
         if prev.friction != next.friction {
             self.colliders[col_handle].set_friction(next.friction);
@@ -1776,6 +1794,108 @@ mod tests {
         spin_up(&mut w, "a", [0.0, 4.0, 0.0]);
         w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0]).with_mass(2.0)]));
         assert!(spin_of(&w, "a") > 1.0);
+    }
+
+    // Damping is a RIGID-BODY property (friction/restitution are collider
+    // material properties), so it has to reach the body builder at spawn.
+    // Default 0.0 = no damping: existing games are unchanged.
+    #[test]
+    fn damping_is_applied_at_spawn_and_defaults_to_none() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("damped", [0.0, 5.0, 0.0])
+                .with_linear_damping(0.5)
+                .with_angular_damping(0.25),
+            crate_at("free", [5.0, 5.0, 0.0]),
+        ]));
+        assert_eq!(w.bodies[w.tags["damped"].0].linear_damping(), 0.5);
+        assert_eq!(w.bodies[w.tags["damped"].0].angular_damping(), 0.25);
+        assert_eq!(w.bodies[w.tags["free"].0].linear_damping(), 0.0);
+        assert_eq!(w.bodies[w.tags["free"].0].angular_damping(), 0.0);
+    }
+
+    // A body coasting with no gravity keeps its velocity forever without
+    // damping, and bleeds it off with damping — the marble-settles case.
+    #[test]
+    fn linear_damping_bleeds_off_velocity() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("damped", [0.0, 5.0, 0.0])
+                .with_velocity([4.0, 0.0, 0.0])
+                .with_linear_damping(2.0),
+            crate_at("free", [50.0, 5.0, 0.0]).with_velocity([4.0, 0.0, 0.0]),
+        ]));
+        for _ in 0..120 {
+            w.step_fixed();
+        }
+        let damped = w.body_velocity("damped").unwrap()[0];
+        let free = w.body_velocity("free").unwrap()[0];
+        assert!((free - 4.0).abs() < 1e-3, "undamped body slowed: {free}");
+        assert!(damped < 0.6, "damped body did not slow: {damped}");
+    }
+
+    // Angular damping is the other half: spin bleeds off.
+    #[test]
+    fn angular_damping_bleeds_off_spin() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("a", [0.0, 5.0, 0.0]).with_angular_damping(3.0)
+        ]));
+        spin_up(&mut w, "a", [0.0, 4.0, 0.0]);
+        for _ in 0..120 {
+            w.step_fixed();
+        }
+        assert!(spin_of(&w, "a") < 0.2, "spin held: {}", spin_of(&w, "a"));
+    }
+
+    // Changing a declared damping value writes it onto the LIVE body (the
+    // friction/restitution divergence rule) — no rebuild, no pose or velocity
+    // reset; the new drag simply applies from the next step. And a STRUCTURAL
+    // change (mass) respawns the body, which must re-derive damping from the
+    // new declaration rather than lose it.
+    #[test]
+    fn changing_damping_reconciles_onto_the_live_body() {
+        let mut w = World::new([0.0, 0.0, 0.0]);
+        w.reconcile(&scene(vec![
+            crate_at("a", [0.0, 5.0, 0.0]).with_velocity([4.0, 0.0, 0.0])
+        ]));
+        for _ in 0..30 {
+            w.step_fixed();
+        }
+        let moved = w.body_transform("a").unwrap().0;
+
+        // Re-declare the SAME body with damping: the ordinary reconcile path.
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])
+            .with_velocity([4.0, 0.0, 0.0])
+            .with_linear_damping(2.0)
+            .with_angular_damping(1.0)]));
+        assert_eq!(w.bodies[w.tags["a"].0].linear_damping(), 2.0);
+        assert_eq!(w.bodies[w.tags["a"].0].angular_damping(), 1.0);
+        // Neither pose nor velocity was disturbed by the attribute change.
+        assert_eq!(w.body_transform("a").unwrap().0, moved);
+        assert!((w.body_velocity("a").unwrap()[0] - 4.0).abs() < 1e-4);
+
+        for _ in 0..120 {
+            w.step_fixed();
+        }
+        assert!(w.body_velocity("a").unwrap()[0] < 0.6);
+
+        // A structural change (mass) despawns and respawns the body: damping
+        // must come back with it.
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])
+            .with_velocity([4.0, 0.0, 0.0])
+            .with_linear_damping(2.0)
+            .with_angular_damping(1.0)
+            .with_mass(3.0)]));
+        assert_eq!(w.bodies[w.tags["a"].0].linear_damping(), 2.0);
+        assert_eq!(w.bodies[w.tags["a"].0].angular_damping(), 1.0);
+
+        // …and taking the attribute back off restores the coast.
+        w.reconcile(&scene(vec![crate_at("a", [0.0, 5.0, 0.0])
+            .with_velocity([4.0, 0.0, 0.0])
+            .with_mass(3.0)]));
+        assert_eq!(w.bodies[w.tags["a"].0].linear_damping(), 0.0);
+        assert_eq!(w.bodies[w.tags["a"].0].angular_damping(), 0.0);
     }
 
     #[test]

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 306));
+        assert_eq!(count(ApiGroup::Engine), (27, 308));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
Rigid bodies exposed `mass` / `friction` / `restitution` / `upright` and nothing else — **no damping**. Contact friction resists *sliding*, not *rolling*, so a rapier sphere on a box coasts essentially forever.

## The gap (from the jam's `tweak-golf` marble-golf entry)

A putted marble **never settles** — still creeping at 0.22 u/s after 12 s. The entry worked around it by emulating drag in game code: a per-frame `Physics.linearVelocity` read feeding a per-frame `Physics.setVelocityXZ` command **inside `tick`** — ~12 lines with a two-tier coefficient hack, an imperative leak in what should be a pure model step.

## The fix

`Physics.linearDamping(f)` and `Physics.angularDamping(f)` — builder attributes that pass straight through to rapier's `RigidBodyBuilder::linear_damping` / `angular_damping`.

They follow the existing `friction`/`restitution` pattern end to end: a field on the declarative `Body`, applied at spawn, and **reconciled onto the live body when the declared value changes**.

**Divergence behavior on a live body** (documented in the `.funi`, the skill, and inline):
- Changing the declared value calls `set_linear_damping` / `set_angular_damping` on the live rigid body — no rebuild; **pose and velocity are untouched**, the new drag simply applies from the next step.
- It deliberately does **not wake** a sleeping body, matching `set_friction`/`set_restitution`. A sleeping body has no velocity for the value to act on, and the coefficient is already in place when something else wakes it.
- A **structural** change (mass/kind/shape) respawns the body, and `spawn` re-derives damping from the new declaration — pinned by a test.
- Default is **`0.0` on both axes**, so every existing game is unchanged.
- Rapier integrates only `Dynamic` bodies, so damping is inert on a `kinematic`/`fixed` one. Stated in both `.funi` docblocks and the skill (raised by review).

## Probe: absent-before / present-after

A scratch project outside the repo (`/tmp/functor-jam.YFADHZ/repro-damping/`): a 0.3-radius sphere pushed at 4 u/s across a flat box, friction 0.6 on both, **no game-code drag at all**. `tick` reads `Physics.linearVelocity` into the model; the debug runtime (`run native --debug-port --headless`) pins the clock and steps 1/60 s at a time; `/state.model.speed` is the horizontal speed.

| sim time | **before** (no damping) | **after** (`\|> Physics.linearDamping(0.55) \|> Physics.angularDamping(0.6)`) |
| --- | --- | --- |
| 2 s | 2.8534 u/s | 0.9210 u/s |
| 4 s | 2.8534 u/s | 0.2995 u/s |
| 6 s | 2.8534 u/s | 0.0974 u/s |
| 8 s | 2.8534 u/s | **0.0000 u/s** |
| 10 s | 2.8534 u/s | 0.0000 u/s |
| 12 s | **2.8534 u/s** | **0.0000 u/s** |

Without damping the speed is *exactly flat forever* — the marble is rolling, and rolling costs nothing. With damping it reaches a dead stop by 8.3 s.

## Tests

At the owning layer, in the existing physics test idioms.

`runtime/functor-runtime-common/src/physics/world.rs`:
- `damping_is_applied_at_spawn_and_defaults_to_none` — attribute reaches the `RigidBodyBuilder`; an undeclared body is 0.0/0.0.
- `linear_damping_bleeds_off_velocity` — with a **control body** in the same world: undamped holds 4.0 u/s after 2 s, damped is under 0.6.
- `angular_damping_bleeds_off_spin` — spin bleeds off.
- `changing_damping_reconciles_onto_the_live_body` — declared change writes onto the live body; **pose and velocity assert unchanged**; a later **structural (mass) rebuild** keeps damping; removing the attribute restores the coast.

`runtime/functor-runtime-common/src/functor_lang_prelude.rs`:
- `functor_lang_snippet_declares_a_physics_scene` — extended: the piped attributes land on the declaration, and an undeclared body defaults to 0.0/0.0.
- `non_positive_dimensions_are_rejected` — two rows added: negative damping is a teaching error on both axes (`Physics.linearDamping must not be negative, got -0.1`).

Registration goes through the **typed external registry** (`reg.fn2`), not a legacy `match path` arm, so arity/usage/conversion errors are derived — verified interactively (`|> Physics.angularDamping("lots")` → `expected a number, got a string`; over-application echoes the registered usage string `Physics.linearDamping(n, body)`). Per review these are framework-owned and not re-asserted in a damping-specific test.

Gate: `cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` — **19/19 suites ok**, 0 failed.

## Docs

- `functor-prelude/prelude/physics.funi` — both entries fully documented (the docgen gate requires it); the `.funi` ≡ registry drift test covers the wiring.
- `npm run generate:docs` + `npm run check:docs` — clean.
- **Docgen inventory pin moved** `(27, 305)` → `(27, 307)` in `tools/functor-docgen/src/lib.rs` for the two new entries. (Note for future fixers: `check:docs` does **not** cover this test — only `cargo test -p functor-docgen` does.)
- `.claude/skills/functor-lang/SKILL.md` — a short "drag belongs on the body, not in `tick`" paragraph in the physics section, distinguishing drag (declare damping) from steering (`setVelocityXZ`, still correct for the controller recipe).

## Perf — parity

`cargo run -q --release -p functor_runtime_common --example frame_bench`, release, back-to-back on the same machine, 3 runs each side, `min` column.

| grid | allocs/frame base → change | bytes/frame base → change | us/frame(min) base (3 runs) | us/frame(min) change (3 runs) |
| --- | --- | --- | --- | --- |
| 20x20 | 13877 → **13877** | 844497 → **844497** | 463.1 / 438.5 / 442.5 | 442.4 / 439.7 / 438.2 |
| 40x40 | 54717 → **54717** | 3308337 → **3308337** | 1743.8 / 1711.4 / 1727.5 | 1739.3 / 1717.2 / 1736.8 |
| 56x56 | 106973 → **106973** | 6461361 → **6461361** | 3374.6 / 3361.4 / 3379.8 | 3367.7 / 3339.6 / 3364.2 |

**Allocs and bytes are byte-identical** on all three sizes — the deterministic numbers, so this is exact parity. Wall-clock mins overlap run-to-run spread on both sides. Expected: the change adds two `f32` to a per-frame-declared struct and two comparisons in reconcile; `frame_bench`'s workload declares no physics bodies.

## Both shells

The physics code is shared in `functor-runtime-common`, so web gets it from the same seam with no wasm-side wiring. **Compile-checked, not smoke-run:** `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` passes. Native is the shell where the probe above actually ran.

## Review dispositions (`/xreview` — Claude subagent + Codex CLI + a dedicated de-dup pass)

| Severity | Finding | Engines | Disposition |
| --- | --- | --- | --- |
| **High** | A workspace-wide `cargo fmt` sweep was folded into the feature commit — 52 files, 1632 insertions, of which 46 files were pure reformatting (the base is not rustfmt-clean). | **[AGREED]** — Claude (High) + Codex (Low) | **Fixed.** Branch reset to base and the feature re-applied by hand. The diff is now **6 files / 215 insertions**, every line tracing to the goal. |
| **Medium** | Damping silently no-ops on `fixed`/`kinematic` bodies (rapier integrates only dynamic ones) and nothing said so. | Claude | **Fixed.** Caveat added to both `.funi` docblocks, both `Body` field docs, the spawn comment, and the skill. |
| Medium | The structural-rebuild path preserves damping but nothing pinned it. | Claude | **Fixed.** `changing_damping_reconciles_onto_the_live_body` now does a third reconcile that changes mass and asserts damping survives the respawn. |
| Low | `non_negative` admits `+inf`, so `linearDamping(1.0/0.0)` is an instant velocity kill rather than a teaching error. | Claude | **Not fixed — pre-existing and out of scope.** Shared with `friction`/`restitution` since they landed; not a regression. NaN is correctly rejected. Worth a separate PR that tightens `non_negative` for all three. |
| dedup `merge` [S3-index, S4-read] | `physics_damping_reports_arity_and_conversion_errors` re-asserts framework behavior `host_registry`'s own tests already own for every `reg.fnN`. | de-dup pass | **Fixed — test deleted.** Behavior verified interactively and reported above instead. |
| dedup `merge` [S4-read] | `physics_damping_attributes_default_to_zero` duplicates the shape of the existing "declared attributes reach the PhysicsScene" test. | de-dup pass | **Fixed — folded** into `functor_lang_snippet_declares_a_physics_scene` as four asserts. |
| dedup `merge` [S4-read] | `damping_is_applied_at_spawn_and_defaults_to_none` is behaviorally subsumed by the bleed-off tests. | de-dup pass | **Kept.** The bleed-off tests prove *effect*; this one pins the exact coefficient reaching the builder on both axes, which is the thing a future refactor would silently drop. Cheap and directly on the seam. |

De-dup coverage line, verbatim: *"All four strategies ran. S1: names report, 91 queries / 7346 candidates, one damping-relevant entry (the family pair). S2: clones report, 261 pairs, filtered to the 25 touching changed files — none overlap any line this change adds (nearest are `world.rs:1518-1560` and `:1910-2253`, pre-existing). S3: 3590-line API index, grepped for damping/drag/friction/restitution/non_negative/velocity-decay. S4: read the full diff."* — no actionable duplication in the implementation itself; the `with_linear_damping`/`with_angular_damping` pair is the intentional attribute family beside `with_friction`/`with_restitution`.

Both engines independently confirmed the correctness questions raised at them: structural rebuild preserves damping, not waking a sleeping body is right (and consistent with the neighbors), `#[serde(default)]` keeps old snapshots and recorded timelines readable, and replay determinism is intact (one `RigidBodyBuilder` site repo-wide; both live and declared damping are inside `snapshot()`).

**No visual change** — no GIF/PNG applies.

## Adoption (`tweak-golf`)

The entry deletes `dragFactor`, the `Physics.linearVelocity` read, and the `Physics.setVelocityXZ` command from `tick` — the non-firing branch becomes pure — and declares the ball `|> Physics.linearDamping(…) |> Physics.angularDamping(…)` instead. `scenario.mjs` must still report 21/21 including "max divergence 0" determinism and the hole-1 attract sink. Starting point: **`linearDamping(0.55)` + `angularDamping(0.6)`**, closest to the current two-tier feel in the probe above. Retuning hole pars is acceptable if the feel shifts.
