### PR TITLE
feat(scene): Scene.opacity — a translucent pass for the 3D scene

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1034,6 +1034,15 @@ is the exception in shape only (the light is its sole argument).
 `s |> Scene.rotateY(r) |> Scene.translate(v)` rotates in place, then moves (the
 order the source reads). `Physics.rotateX/Y/Z` follows the same rule.
 
+**Translucency is a subtree modifier, not a color channel** — `Color.rgb` has no
+alpha; `s |> Scene.opacity(0.35)` makes a whole subtree see-through, whatever
+materials are under it. Nested opacities multiply, an alpha outside `0..1` is an
+error, and `Scene.opacity(1.0, s)` is exactly `s` (so it does not perturb
+`Scene.equals`). Translucent subtrees draw after all opaque geometry, sorted
+back-to-front by the average world position of their leaves, with depth writing
+off and no shadow — see the `Scene.opacity` reference for what that granularity
+does and does not fix. The 2D analogue is `Sprite.fade`.
+
 **Zero-argument constructors take their parens** — `Scene.cube()`,
 `Sprite.blank()`, `Anim.rest()`, `Effect.none()`, `Map.empty()`,
 `Ui.topLeft()`. The arity is enforced.

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -63,6 +63,30 @@ let litNormalMapped : (Color.t, 'texture, t) => t
 /// feed reads mirrored.
 let screen : (RenderTarget.t, t) => t
 
+/// Make a subtree TRANSLUCENT — alpha from 0 (invisible) to 1 (unchanged); the
+/// scene is last for piping.
+///
+/// The alpha applies uniformly to everything below it, whatever material each
+/// node uses — solid colors, textures, lit models, terrain — so a ghost copy of
+/// a craft is `craftScene(...) |> Scene.opacity(0.35)`. Nested opacities
+/// multiply. An alpha outside `0..1` is an error, not a clamp.
+///
+/// HOW IT RENDERS, so the caveats are predictable:
+///
+/// - Translucent subtrees draw in a pass AFTER all opaque geometry, with depth
+///   testing on and depth WRITING off — opaque things in front hide them; they
+///   never hide each other.
+/// - They are sorted back-to-front by the average world position of the leaves
+///   under each `Scene.opacity` node. That is the whole sorting granularity:
+///   there is no per-triangle sort, so within ONE translucent subtree
+///   overlapping surfaces (including the back faces of a closed mesh) read
+///   denser where they overlap, and two INTERPENETRATING translucent objects
+///   sort by their averages, which is wrong for the overlapping sliver.
+/// - A translucent subtree casts no shadow.
+/// - `Scene.opacity(1.0, scene)` is exactly `scene` — the identity. Nothing
+///   that never calls this changes in cost or appearance.
+let opacity : (float, t) => t
+
 /// Attach an animation pose to model nodes; the scene is last for piping.
 ///
 /// Without an attached pose, a skinned model plays its FIRST clip on the game

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -76,15 +76,21 @@ let screen : (RenderTarget.t, t) => t
 /// - Translucent subtrees draw in a pass AFTER all opaque geometry, with depth
 ///   testing on and depth WRITING off — opaque things in front hide them; they
 ///   never hide each other.
-/// - They are sorted back-to-front by the average world position of the leaves
-///   under each `Scene.opacity` node. That is the whole sorting granularity:
+/// - They are sorted back-to-front by the VIEW-SPACE depth of the average world
+///   position of the leaves under each `Scene.opacity` node. That is the whole
+///   sorting granularity:
 ///   there is no per-triangle sort, so within ONE translucent subtree
 ///   overlapping surfaces (including the back faces of a closed mesh) read
 ///   denser where they overlap, and two INTERPENETRATING translucent objects
 ///   sort by their averages, which is wrong for the overlapping sliver.
 /// - A translucent subtree casts no shadow.
 /// - `Scene.opacity(1.0, scene)` is exactly `scene` — the identity. Nothing
-///   that never calls this changes in cost or appearance.
+///   that never calls this changes in cost or appearance. The flip side is a
+///   STEP at that boundary: the instant alpha drops below 1 the subtree leaves
+///   the opaque pass, stops writing depth AND stops casting a shadow, so a fade
+///   beginning at exactly 1.0 pops on its first frame rather than easing.
+/// - An alpha of 0 draws nothing at all — the subtree is skipped rather than
+///   rasterized — so fading fully out costs nothing.
 let opacity : (float, t) => t
 
 /// Attach an animation pose to model nodes; the scene is last for piping.

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2158,6 +2158,30 @@ row 0 has {cols} heights, row {r} has {}",
             )
         },
     );
+    // Translucency (scene-last, so it pipes). At alpha 1 this is the IDENTITY —
+    // it returns the scene untouched rather than wrapping it — so a game that
+    // never asks for translucency (or asks for none this frame) produces the
+    // exact same scene value, and the renderer's transparent pass never arms.
+    // Out of range is an error, matching `Sprite.fade`: silently clamping a
+    // computed fade hides the bug that produced 1.4.
+    reg.fn2(
+        "Scene.opacity",
+        "Scene.opacity(alpha, scene)",
+        |alpha: f64, scene: FunctorLangScene| {
+            if !(0.0..=1.0).contains(&alpha) {
+                return Err(format!(
+                    "Scene.opacity alpha must be between 0 and 1, got {alpha}"
+                ));
+            }
+            if alpha == 1.0 {
+                return Ok(scene);
+            }
+            Ok(FunctorLangScene(Scene3D {
+                obj: SceneObject::Opacity(alpha as f32, vec![scene.0]),
+                xform: Matrix4::from_scale(1.0),
+            }))
+        },
+    );
     // Attach an animation expression to the Model node(s) in a scene
     // (scene-last, so it pipes right after `Scene.model`). Without it a
     // skinned model keeps the zero-config default: its first clip auto-plays
@@ -6652,6 +6676,14 @@ forward: { x: 0, y: 0, z: 1 }, up: { x: 0, y: 1, z: 0 } }"
                 "Sprite.fade alpha must be between 0 and 1",
             ),
             (
+                "Scene.cube() |> Scene.opacity(1.5)",
+                "Scene.opacity alpha must be between 0 and 1",
+            ),
+            (
+                "Scene.cube() |> Scene.opacity(-0.1)",
+                "Scene.opacity alpha must be between 0 and 1",
+            ),
+            (
                 "Camera2D.create(16.0, 0.0)",
                 "Camera2D.create width and height must be positive",
             ),
@@ -7670,6 +7702,52 @@ Vec3.make(x, y, z)"
 
     // Scene.animate pipes after Scene.model and lands the expression on the
     // Model node — the declarative "what pose" seam the renderer evaluates.
+    #[test]
+    fn scene_opacity_wraps_the_subtree_and_nested_opacities_stay_nested() {
+        let value = eval(
+            "let main = () => Scene.cube() |> Scene.opacity(0.5) |> Scene.opacity(0.5)",
+        );
+        let scene = scene_of(&value).expect("a Scene");
+        let SceneObject::Opacity(outer, outer_items) = &scene.obj else {
+            panic!("expected an Opacity node, got {:?}", scene.obj);
+        };
+        assert_eq!(*outer, 0.5);
+        let SceneObject::Opacity(inner, inner_items) = &outer_items[0].obj else {
+            panic!("expected a nested Opacity node, got {:?}", outer_items[0].obj);
+        };
+        assert_eq!(*inner, 0.5);
+        // The multiplication is the RENDERER's (0.25 at the leaf); the scene
+        // value keeps both nodes so `Scene.equals` and `/scene` show what the
+        // game actually said.
+        assert!(matches!(
+            inner_items[0].obj,
+            SceneObject::Geometry(Shape::Cube)
+        ));
+    }
+
+    /// Full opacity is the IDENTITY, not a wrapper: this is what makes the
+    /// feature free for every scene that does not use it, and it is the
+    /// property `Scene.equals` and the golden images both depend on.
+    #[test]
+    fn scene_opacity_of_one_is_the_identity() {
+        let with = eval("let main = () => Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0)) |> Scene.opacity(1.0)");
+        let without =
+            eval("let main = () => Scene.cube() |> Scene.color(Color.rgb(1.0, 0.0, 0.0))");
+        assert_eq!(
+            scene_of(&with).expect("a Scene"),
+            scene_of(&without).expect("a Scene")
+        );
+    }
+
+    /// Zero is legal and distinct from "not drawn" — it is an invisible node,
+    /// so a fade to nothing does not have to branch in game code.
+    #[test]
+    fn scene_opacity_of_zero_is_a_node() {
+        let value = eval("let main = () => Scene.cube() |> Scene.opacity(0.0)");
+        let scene = scene_of(&value).expect("a Scene");
+        assert!(matches!(scene.obj, SceneObject::Opacity(a, _) if a == 0.0));
+    }
+
     #[test]
     fn scene_animate_sets_clip_on_model() {
         let value = eval(

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2173,11 +2173,17 @@ row 0 has {cols} heights, row {r} has {}",
                     "Scene.opacity alpha must be between 0 and 1, got {alpha}"
                 ));
             }
+            // Narrow FIRST, then test for the identity: an alpha of
+            // 0.999_999_999 narrows to exactly 1.0 at 32-bit precision, and
+            // wrapping it would build an `Opacity` node whose alpha is 1 —
+            // contradicting the variant's invariant and paying for a
+            // transparent pass that changes no pixel.
+            let alpha = alpha as f32;
             if alpha == 1.0 {
                 return Ok(scene);
             }
             Ok(FunctorLangScene(Scene3D {
-                obj: SceneObject::Opacity(alpha as f32, vec![scene.0]),
+                obj: SceneObject::Opacity(alpha, vec![scene.0]),
                 xform: Matrix4::from_scale(1.0),
             }))
         },
@@ -7736,6 +7742,18 @@ Vec3.make(x, y, z)"
         assert_eq!(
             scene_of(&with).expect("a Scene"),
             scene_of(&without).expect("a Scene")
+        );
+    }
+
+    /// The identity test happens AFTER narrowing to 32-bit, so an alpha that
+    /// rounds to 1 is the identity too — the `Opacity` variant's invariant is
+    /// "alpha is strictly below 1", and nothing may build a counterexample.
+    #[test]
+    fn an_alpha_that_narrows_to_one_is_also_the_identity() {
+        let value = eval("let main = () => Scene.cube() |> Scene.opacity(0.999999999)");
+        assert_eq!(
+            scene_of(&value).expect("a Scene"),
+            scene_of(&eval("let main = () => Scene.cube()")).expect("a Scene")
         );
     }
 

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -71,6 +71,11 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v12: translucent subtrees — the `SceneObject::Opacity` variant (a v11 reader
+/// cannot decode a frame carrying one). Only scenes that call `Scene.opacity`
+/// produce it: full opacity is the identity, so every other frame keeps its
+/// v11 shape.
+///
 /// v11: the `AnimExpr::Reach` two-bone IK variant nested in
 /// `ModelDescription.animation`.
 ///
@@ -106,7 +111,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 11;
+pub const PROTOCOL_VERSION: u32 = 12;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -603,7 +608,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 11);
+        assert_eq!(PROTOCOL_VERSION, 12);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -630,7 +635,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 11);
+        assert_eq!(PROTOCOL_VERSION, 12);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],
@@ -646,11 +651,35 @@ mod tests {
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }
 
+    /// The translucent-subtree node carries its alpha inline, so its wire shape
+    /// is pinned like the variants above — `GET /scene`, `Scene.equals` and the
+    /// extrapolation copies all read it.
+    #[test]
+    fn opacity_subtree_wire_is_pinned() {
+        use crate::{Scene3D, SceneObject, Shape};
+
+        assert_eq!(PROTOCOL_VERSION, 12);
+        let scene = SceneObject::Opacity(
+            0.35,
+            vec![Scene3D {
+                obj: SceneObject::Geometry(Shape::Cube),
+                xform: cgmath::Matrix4::from_scale(1.0),
+            }],
+        );
+        let json = serde_json::to_string(&scene).expect("serialize opacity subtree");
+        assert_eq!(
+            json,
+            r#"{"Opacity":[0.35,[{"obj":{"Geometry":"Cube"},"xform":[[1.0,0.0,0.0,0.0],[0.0,1.0,0.0,0.0],[0.0,0.0,1.0,0.0],[0.0,0.0,0.0,1.0]]}]]}"#
+        );
+        let back: SceneObject = serde_json::from_str(&json).expect("deserialize opacity subtree");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
     #[test]
     fn two_bone_reach_animation_wire_is_pinned() {
         use crate::anim::AnimExpr;
 
-        assert_eq!(PROTOCOL_VERSION, 11);
+        assert_eq!(PROTOCOL_VERSION, 12);
         let reach = AnimExpr::Reach {
             root: "upper".to_string(),
             middle: "lower".to_string(),

--- a/runtime/functor-runtime-common/src/render_context.rs
+++ b/runtime/functor-runtime-common/src/render_context.rs
@@ -112,6 +112,28 @@ mod tests {
     }
 }
 
+/// What the current pass does when it walks into a
+/// [`SceneObject::Opacity`](crate::scene3d::SceneObject::Opacity) subtree.
+///
+/// The ordinary 3D forward pass splits: it walks the scene once with
+/// [`Defer`](OpacityStage::Defer) (opaque geometry only), then walks the
+/// collected translucent nodes back-to-front with [`Draw`](OpacityStage::Draw).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpacityStage {
+    /// Skip the subtree — it is drawn later by the transparent pass, or (in the
+    /// shadow/depth pass) not at all, so translucent geometry casts no shadow.
+    Defer,
+    /// Draw the subtree now, with the pass's constant-alpha blending set from
+    /// the accumulated opacity.
+    Draw,
+    /// Draw the subtree inline as a plain group, IGNORING its alpha. Used by
+    /// passes that already own the blend state for their own reason: the
+    /// transparent-debug mode (the whole scene is uniformly translucent there)
+    /// and the 2D sprite pass (straight-alpha painter's order; an `Opacity`
+    /// node cannot occur there anyway — `Scene.opacity` builds a `Scene.t`).
+    Ignore,
+}
+
 pub struct RenderContext<'a> {
     pub gl: &'a glow::Context,
     pub shader_version: &'a str,
@@ -138,6 +160,13 @@ pub struct RenderContext<'a> {
     /// A `Cell` because scene rendering walks an immutably-borrowed context on
     /// one thread; nothing here is shared across threads.
     pub blend_active: std::cell::Cell<bool>,
+    /// How this pass treats `Scene.opacity` subtrees.
+    pub opacity_stage: OpacityStage,
+    /// The opacity accumulated by enclosing `Opacity` nodes during an
+    /// [`OpacityStage::Draw`] walk — the value currently programmed into
+    /// `glBlendColor`. Nested opacities multiply into it and restore it on the
+    /// way out. A `Cell` for the same reason as `blend_active`.
+    pub opacity: std::cell::Cell<f32>,
     /// The directional shadow map + light matrix, when shadows are active.
     /// `None` during the depth pass and when no light casts shadows.
     pub shadow: Option<ShadowUniforms>,

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -7,8 +7,8 @@ use crate::asset::AssetCache;
 use crate::material::BasicMaterial;
 use crate::shadow::{self, ShadowMap};
 use crate::{
-    Camera, Camera2D, DebugRenderMode, Frame, FrameTime, Light, RenderContext, RenderPass, Scene3D,
-    SceneContext, ShadowUniforms, Viewport,
+    Camera, Camera2D, DebugRenderMode, Frame, FrameTime, Light, OpacityStage, RenderContext,
+    RenderPass, Scene3D, SceneContext, ShadowUniforms, TransparentDraw, Viewport,
 };
 
 /// Enough authored color to keep the scene readable while opaque diagnostic
@@ -696,18 +696,21 @@ fn forward_pass(
     } else {
         terrain_frusta[..lod_frustum_count].copy_from_slice(&supplied_frusta[..lod_frustum_count]);
     }
-    let render_context = RenderContext {
+    // The forward pass may need TWO contexts (opaque, then transparent), which
+    // differ only in how they treat blending and `Scene.opacity`. Everything
+    // else is frame-constant, so build them from one recipe.
+    let make_context = |pass_blends: bool, opacity_stage: OpacityStage| RenderContext {
         gl,
         shader_version,
-        asset_cache,
+        asset_cache: asset_cache.clone(),
         frame_time,
         debug_render_mode,
         lights,
         render_pass: RenderPass::Forward,
-        // The transparent-debug pass owns the blend state for the whole scene
-        // (constant alpha); leave it alone there too.
-        pass_blends: caller_blends || debug_render_mode == DebugRenderMode::Transparent,
+        pass_blends,
         blend_active: std::cell::Cell::new(false),
+        opacity_stage,
+        opacity: std::cell::Cell::new(1.0),
         shadow,
         fog,
         camera_pos: cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]),
@@ -722,6 +725,26 @@ fn forward_pass(
             .unwrap_or_else(|| default_lod_projection.y.y.abs()),
         viewport_height: lod_viewport_height.unwrap_or(viewport_height),
     };
+
+    // The transparent debug material deliberately reuses authored shading.
+    // Populate depth first, then blend only the nearest surface: blending every
+    // backface and overlapping triangle would make dense meshes nearly opaque.
+    // Clearing depth afterward keeps collider/frustum lines visible through
+    // the scene without cloning every shader just to multiply its alpha.
+    let transparent_debug = debug_render_mode == DebugRenderMode::Transparent;
+    // The transparent-debug pass owns the blend state for the whole scene
+    // (constant alpha); the 2D sprite pass owns it too. Leave both alone —
+    // including their `Scene.opacity` handling, which becomes a no-op modifier
+    // rather than a second, conflicting blend configuration.
+    let pass_blends = caller_blends || transparent_debug;
+    let render_context = make_context(
+        pass_blends,
+        if pass_blends {
+            OpacityStage::Ignore
+        } else {
+            OpacityStage::Defer
+        },
+    );
 
     // The game supplies the camera; derive its ordinary projection from the
     // aspect unless a platform shell (XR) supplied an exact projection.
@@ -754,12 +777,6 @@ fn forward_pass(
         );
     };
 
-    // The transparent debug material deliberately reuses authored shading.
-    // Populate depth first, then blend only the nearest surface: blending every
-    // backface and overlapping triangle would make dense meshes nearly opaque.
-    // Clearing depth afterward keeps collider/frustum lines visible through
-    // the scene without cloning every shader just to multiply its alpha.
-    let transparent_debug = debug_render_mode == DebugRenderMode::Transparent;
     if transparent_debug {
         unsafe {
             gl.disable(glow::BLEND);
@@ -790,6 +807,107 @@ fn forward_pass(
         }
     } else {
         render_scene();
+        transparent_pass(
+            gl,
+            scene_context,
+            scene,
+            camera,
+            &make_context,
+            &world_matrix,
+            &projection_matrix,
+            &view_matrix,
+            pass_blends,
+        );
+    }
+}
+
+/// Draw the frame's `Scene.opacity` subtrees, back-to-front, after the opaque
+/// forward walk.
+///
+/// State: depth TEST on (translucent surfaces are hidden by opaque geometry in
+/// front of them), depth WRITE off (they don't occlude each other or later
+/// draws), constant-alpha blending programmed per node by
+/// [`SceneObject::Opacity`](crate::scene3d::SceneObject::Opacity) — so the alpha
+/// applies to any material, textured or lit, with no shader variants.
+///
+/// Sorting is per outermost `Scene.opacity` node, by the distance of its
+/// [`Scene3D::leaf_centroid`] from the eye; see [`TransparentDraw`] for what
+/// that granularity does and does not fix.
+///
+/// COST WHEN UNUSED: one short-circuiting `has_opacity()` bool walk, no
+/// allocation, no GL calls. A scene that never calls `Scene.opacity` renders
+/// exactly the draw calls it did before.
+#[allow(clippy::too_many_arguments)]
+fn transparent_pass<'a>(
+    gl: &glow::Context,
+    scene_context: &SceneContext,
+    scene: &'a Scene3D,
+    camera: &Camera,
+    make_context: &dyn Fn(bool, OpacityStage) -> RenderContext<'a>,
+    world_matrix: &Matrix4<f32>,
+    projection_matrix: &Matrix4<f32>,
+    view_matrix: &Matrix4<f32>,
+    pass_blends: bool,
+) {
+    if pass_blends || !scene.has_opacity() {
+        return;
+    }
+
+    let mut draws: Vec<TransparentDraw<'a>> = Vec::new();
+    scene.collect_transparent(world_matrix, None, &mut draws);
+
+    let eye = cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]);
+    let distance2 = |draw: &TransparentDraw<'_>| {
+        let d = draw.centroid - eye;
+        d.x * d.x + d.y * d.y + d.z * d.z
+    };
+    // Farthest first. A NaN centroid (a game built a non-finite transform)
+    // sorts as equal rather than panicking the renderer.
+    draws.sort_by(|a, b| {
+        distance2(b)
+            .partial_cmp(&distance2(a))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // `pass_blends: true` — this pass owns the blend state, so a translucent
+    // runtime overlay nested inside must not switch it back off on the way out.
+    let context = make_context(true, OpacityStage::Draw);
+    let mut root_material = BasicMaterial::create();
+    root_material.initialize(&context);
+
+    unsafe {
+        gl.depth_mask(false);
+        gl.enable(glow::BLEND);
+        gl.blend_equation(glow::FUNC_ADD);
+        gl.blend_func_separate(
+            glow::CONSTANT_ALPHA,
+            glow::ONE_MINUS_CONSTANT_ALPHA,
+            // Straight source-over for the destination alpha, matching the
+            // sprite pass — captures and render targets stay opaque.
+            glow::ONE,
+            glow::ONE_MINUS_SRC_ALPHA,
+        );
+    }
+
+    for draw in &draws {
+        let material = draw
+            .material
+            .map(|description| description.get(&context, scene_context));
+        Scene3D::render(
+            draw.node,
+            &context,
+            scene_context,
+            &draw.parent_world,
+            projection_matrix,
+            view_matrix,
+            material.as_ref().unwrap_or(&root_material),
+        );
+    }
+
+    unsafe {
+        gl.disable(glow::BLEND);
+        gl.blend_color(0.0, 0.0, 0.0, 1.0);
+        gl.depth_mask(true);
     }
 }
 

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -660,6 +660,48 @@ fn shadow_pass(
         })
 }
 
+/// Turn on the constant-alpha over-blend with depth writes off — the state both
+/// translucency passes want: [`transparent_pass`] (per-node alpha from
+/// `Scene.opacity`) and the `DebugRenderMode::Transparent` recipe below (one
+/// constant for the whole scene). The alpha itself comes from `glBlendColor`,
+/// which each caller programs, and the destination alpha uses straight
+/// source-over so captures and render targets stay opaque.
+///
+/// # Safety
+/// The caller must hold a current GL context.
+unsafe fn begin_constant_alpha_blend(gl: &glow::Context) {
+    gl.enable(glow::BLEND);
+    gl.blend_equation(glow::FUNC_ADD);
+    gl.blend_func_separate(
+        glow::CONSTANT_ALPHA,
+        glow::ONE_MINUS_CONSTANT_ALPHA,
+        glow::ONE,
+        glow::ONE_MINUS_SRC_ALPHA,
+    );
+    gl.depth_mask(false);
+}
+
+/// Undo [`begin_constant_alpha_blend`]: blending off, depth writes back on, and
+/// the blend constant returned to opaque so no later pass inherits a stale one.
+///
+/// # Safety
+/// The caller must hold a current GL context.
+unsafe fn end_constant_alpha_blend(gl: &glow::Context) {
+    gl.disable(glow::BLEND);
+    // Put the factors back to plain source-over as well. Every site that
+    // enables BLEND today programs its own first, so this is belt-and-braces —
+    // but leaving CONSTANT_ALPHA armed is a trap for the next one that assumes
+    // the default, and the constant itself must not leak either.
+    gl.blend_func_separate(
+        glow::SRC_ALPHA,
+        glow::ONE_MINUS_SRC_ALPHA,
+        glow::ONE,
+        glow::ONE_MINUS_SRC_ALPHA,
+    );
+    gl.blend_color(0.0, 0.0, 0.0, 1.0);
+    gl.depth_mask(true);
+}
+
 /// Forward pass: `Scene3D::render` from `camera` with `lights` + the shadow map
 /// into whatever framebuffer/viewport the caller bound and cleared.
 #[allow(clippy::too_many_arguments)]
@@ -787,22 +829,13 @@ fn forward_pass(
         unsafe {
             gl.color_mask(true, true, true, true);
             gl.depth_func(glow::EQUAL);
-            gl.enable(glow::BLEND);
-            gl.blend_equation(glow::FUNC_ADD);
+            begin_constant_alpha_blend(gl);
             gl.blend_color(0.0, 0.0, 0.0, TRANSPARENT_DEBUG_ALPHA);
-            gl.blend_func_separate(
-                glow::CONSTANT_ALPHA,
-                glow::ONE_MINUS_CONSTANT_ALPHA,
-                glow::ONE,
-                glow::ONE_MINUS_SRC_ALPHA,
-            );
-            gl.depth_mask(false);
         }
         render_scene();
         unsafe {
-            gl.depth_mask(true);
+            end_constant_alpha_blend(gl);
             gl.depth_func(glow::LESS);
-            gl.disable(glow::BLEND);
             gl.clear(glow::DEPTH_BUFFER_BIT);
         }
     } else {
@@ -811,7 +844,6 @@ fn forward_pass(
             gl,
             scene_context,
             scene,
-            camera,
             &make_context,
             &world_matrix,
             &projection_matrix,
@@ -830,9 +862,9 @@ fn forward_pass(
 /// [`SceneObject::Opacity`](crate::scene3d::SceneObject::Opacity) — so the alpha
 /// applies to any material, textured or lit, with no shader variants.
 ///
-/// Sorting is per outermost `Scene.opacity` node, by the distance of its
-/// [`Scene3D::leaf_centroid`] from the eye; see [`TransparentDraw`] for what
-/// that granularity does and does not fix.
+/// Sorting is per outermost `Scene.opacity` node, by the VIEW-SPACE depth of
+/// its [`Scene3D::leaf_centroid`]; see [`TransparentDraw`] for what that
+/// granularity does and does not fix.
 ///
 /// COST WHEN UNUSED: one short-circuiting `has_opacity()` bool walk, no
 /// allocation, no GL calls. A scene that never calls `Scene.opacity` renders
@@ -842,7 +874,6 @@ fn transparent_pass<'a>(
     gl: &glow::Context,
     scene_context: &SceneContext,
     scene: &'a Scene3D,
-    camera: &Camera,
     make_context: &dyn Fn(bool, OpacityStage) -> RenderContext<'a>,
     world_matrix: &Matrix4<f32>,
     projection_matrix: &Matrix4<f32>,
@@ -856,18 +887,7 @@ fn transparent_pass<'a>(
     let mut draws: Vec<TransparentDraw<'a>> = Vec::new();
     scene.collect_transparent(world_matrix, None, &mut draws);
 
-    let eye = cgmath::Vector3::new(camera.eye[0], camera.eye[1], camera.eye[2]);
-    let distance2 = |draw: &TransparentDraw<'_>| {
-        let d = draw.centroid - eye;
-        d.x * d.x + d.y * d.y + d.z * d.z
-    };
-    // Farthest first. A NaN centroid (a game built a non-finite transform)
-    // sorts as equal rather than panicking the renderer.
-    draws.sort_by(|a, b| {
-        distance2(b)
-            .partial_cmp(&distance2(a))
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    crate::scene3d::sort_back_to_front(&mut draws, view_matrix);
 
     // `pass_blends: true` — this pass owns the blend state, so a translucent
     // runtime overlay nested inside must not switch it back off on the way out.
@@ -876,17 +896,7 @@ fn transparent_pass<'a>(
     root_material.initialize(&context);
 
     unsafe {
-        gl.depth_mask(false);
-        gl.enable(glow::BLEND);
-        gl.blend_equation(glow::FUNC_ADD);
-        gl.blend_func_separate(
-            glow::CONSTANT_ALPHA,
-            glow::ONE_MINUS_CONSTANT_ALPHA,
-            // Straight source-over for the destination alpha, matching the
-            // sprite pass — captures and render targets stay opaque.
-            glow::ONE,
-            glow::ONE_MINUS_SRC_ALPHA,
-        );
+        begin_constant_alpha_blend(gl);
     }
 
     for draw in &draws {
@@ -905,9 +915,7 @@ fn transparent_pass<'a>(
     }
 
     unsafe {
-        gl.disable(glow::BLEND);
-        gl.blend_color(0.0, 0.0, 0.0, 1.0);
-        gl.depth_mask(true);
+        end_constant_alpha_blend(gl);
     }
 }
 

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1024,6 +1024,30 @@ pub struct TransparentDraw<'a> {
     pub centroid: cgmath::Vector3<f32>,
 }
 
+/// Order translucent draws BACK-TO-FRONT for source-over compositing.
+///
+/// The key is VIEW-SPACE depth, not distance from the eye. Distance is wrong
+/// for compositing: a large off-axis foreground node can be farther from the
+/// eye than a background node it overlaps on screen, which reverses the blend
+/// order exactly where it is visible. View z is also what the depth test
+/// agrees with, and using the pass's own view matrix means each stereo eye
+/// sorts by its own view.
+///
+/// The view is right-handed (`look_at_rh`), so the camera looks down `-z` and
+/// FARTHER is MORE NEGATIVE — ascending z is back-to-front. `total_cmp` is a
+/// genuine total order, so a non-finite centroid (a game built a NaN transform)
+/// lands somewhere deterministic instead of making the comparator intransitive,
+/// which `sort_by` is allowed to panic on.
+///
+/// Free of GL, so the ordering is testable headlessly.
+pub fn sort_back_to_front(draws: &mut [TransparentDraw<'_>], view_matrix: &Matrix4<f32>) {
+    let view_depth = |draw: &TransparentDraw<'_>| {
+        let c = draw.centroid;
+        (view_matrix * cgmath::vec4(c.x, c.y, c.z, 1.0)).z
+    };
+    draws.sort_by(|a, b| view_depth(a).total_cmp(&view_depth(b)));
+}
+
 impl Scene3D {
     pub fn cube() -> Self {
         Scene3D {
@@ -1125,24 +1149,31 @@ impl Scene3D {
     /// Accumulate the world-space origins of this subtree's drawable leaves.
     ///
     /// `world` is the PARENT's accumulated matrix; this node's own `xform`
-    /// composes on the way in, matching [`Scene3D::render`].
+    /// composes on the way in, matching [`Scene3D::render`] — INCLUDING its
+    /// quirk that a `Material` node ignores its own `xform` (which is why the
+    /// prelude wraps every transform in a `Group`). Composing it here would
+    /// sort a translucent subtree by a position the opaque pass never draws it
+    /// at.
     fn accumulate_leaf_origins(
         &self,
         world: &Matrix4<f32>,
         sum: &mut cgmath::Vector3<f32>,
         count: &mut u32,
     ) {
-        let w = world * self.xform;
         match &self.obj {
-            SceneObject::Group(items)
-            | SceneObject::Material(_, items)
-            | SceneObject::Opacity(_, items) => {
+            SceneObject::Material(_, items) => {
+                for item in items {
+                    item.accumulate_leaf_origins(world, sum, count);
+                }
+            }
+            SceneObject::Group(items) | SceneObject::Opacity(_, items) => {
+                let w = world * self.xform;
                 for item in items {
                     item.accumulate_leaf_origins(&w, sum, count);
                 }
             }
             SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
-                *sum += w.w.truncate();
+                *sum += (world * self.xform).w.truncate();
                 *count += 1;
             }
         }
@@ -1197,10 +1228,11 @@ impl Scene3D {
                     item.collect_transparent(&w, material, out);
                 }
             }
+            // A `Material` node's own `xform` is ignored by `Scene3D::render`
+            // (see `accumulate_leaf_origins`), so it must be ignored here too.
             SceneObject::Material(next_material, items) => {
-                let w = world * self.xform;
                 for item in items {
-                    item.collect_transparent(&w, Some(next_material), out);
+                    item.collect_transparent(world, Some(next_material), out);
                 }
             }
             SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
@@ -1539,10 +1571,21 @@ so the reach is ignored"
                 // KNOWN LIMITATION (Tier A): there is no depth prepass or
                 // back-to-front sort, so overlapping translucent overlay parts
                 // — a mark's crossed arrowheads and its sphere core — blend
-                // twice and read slightly denser where they overlap. The Tier B
-                // follow-up (a dedicated constant-alpha overlay pass, modeled
-                // on the transparent-debug recipe in `renderer.rs`) removes
-                // both that and the overlay's shadow-pass contribution.
+                // twice and read slightly denser where they overlap.
+                //
+                // The Tier B pass the earlier note promised now EXISTS as
+                // `renderer::transparent_pass` (deferred, sorted, shadowless),
+                // but it is reached only through `SceneObject::Opacity`, and
+                // Tier A deliberately stays: this path is the ALPHA-IN-THE-
+                // MATERIAL route, which is what the extrapolation overlay
+                // builds (`trajectory::faded_material` rewrites each copy's own
+                // material) and what the age fade varies PER LEAF. Routing it
+                // through `Opacity` would mean one alpha for a whole subtree,
+                // losing the per-copy ramp the overlay is made of. The two
+                // mechanisms therefore compose rather than compete — inside a
+                // `Scene.opacity` subtree the transparent pass owns the blend
+                // state (`pass_blends`), so this branch stands down and the
+                // node's constant alpha wins.
                 // Only the node that transitions blending OFF→ON restores it:
                 // `Material` nodes nest, so an inner translucent material must
                 // not disable blending out from under the outer subtree's
@@ -1619,6 +1662,12 @@ so the reach is ignored"
                 if blend {
                     // Nested opacities multiply.
                     let accumulated = previous * alpha;
+                    // Fully transparent: every fragment would blend to a no-op
+                    // write, so skip the subtree instead of rasterizing it. A
+                    // fade-out that reaches zero costs nothing to keep drawing.
+                    if accumulated == 0.0 {
+                        return;
+                    }
                     render_context.opacity.set(accumulated);
                     unsafe {
                         render_context
@@ -2177,6 +2226,13 @@ mod opacity_tests {
         }
     }
 
+    fn cube_at_z(z: f32) -> Scene3D {
+        Scene3D {
+            obj: SceneObject::Geometry(Shape::Cube),
+            xform: Matrix4::from_translation(vec3(0.0, 0.0, z)),
+        }
+    }
+
     fn opacity(alpha: f32, child: Scene3D) -> Scene3D {
         Scene3D {
             obj: SceneObject::Opacity(alpha, vec![child]),
@@ -2224,12 +2280,16 @@ mod opacity_tests {
     #[test]
     fn collect_takes_the_outermost_node_and_carries_its_material_and_parent_matrix() {
         let material = MaterialDescription::color(0.25, 0.5, 0.75, 1.0);
-        // A translate ABOVE the opacity node, and a nested opacity below it.
+        // A translate ABOVE the opacity node — as a Group, which is the shape
+        // the prelude builds for every transform — and a nested opacity below.
         let scene = Scene3D {
-            obj: SceneObject::Material(
-                material.clone(),
-                vec![opacity(0.5, opacity(0.5, cube_at(0.0)))],
-            ),
+            obj: SceneObject::Group(vec![Scene3D {
+                obj: SceneObject::Material(
+                    material.clone(),
+                    vec![opacity(0.5, opacity(0.5, cube_at(0.0)))],
+                ),
+                xform: Matrix4::identity(),
+            }]),
             xform: Matrix4::from_translation(vec3(3.0, 0.0, 0.0)),
         };
 
@@ -2279,6 +2339,91 @@ mod opacity_tests {
             xform: Matrix4::from_translation(vec3(0.0, 7.0, 0.0)),
         };
         assert_eq!(node.leaf_centroid(&Matrix4::identity()), vec3(0.0, 7.0, 0.0));
+    }
+
+    /// A camera at +Z looking back toward the origin (`look_at_rh`), matching
+    /// how `Camera::view_matrix` builds one.
+    fn view_from_z(z: f32) -> Matrix4<f32> {
+        Matrix4::look_at_rh(
+            cgmath::Point3::new(0.0, 0.0, z),
+            cgmath::Point3::new(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        )
+    }
+
+    /// The sort is the whole correctness claim of the transparent pass, so it
+    /// is tested WITHOUT a GL context: farthest first, whatever order the game
+    /// declared them in.
+    #[test]
+    fn the_sort_puts_the_farthest_draw_first_regardless_of_declaration_order() {
+        // Declared NEAREST-first, the wrong painter's order on purpose.
+        let scene = group(vec![
+            opacity(0.5, cube_at_z(4.0)),
+            opacity(0.5, cube_at_z(-6.0)),
+            opacity(0.5, cube_at_z(-1.0)),
+        ]);
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+        sort_back_to_front(&mut draws, &view_from_z(10.0));
+
+        let order: Vec<f32> = draws.iter().map(|d| d.centroid.z).collect();
+        assert_eq!(order, vec![-6.0, -1.0, 4.0], "farthest from the eye first");
+    }
+
+    /// Distance from the eye is NOT the key: a big off-axis node can be farther
+    /// away than a node it overlaps on screen, which would reverse the blend
+    /// exactly where it shows. View depth is what the depth test agrees with.
+    #[test]
+    fn the_sort_uses_view_depth_not_distance_from_the_eye() {
+        let near_but_far_off_axis = Scene3D {
+            obj: SceneObject::Opacity(0.5, vec![cube_at_z(0.0)]),
+            xform: Matrix4::from_translation(vec3(40.0, 0.0, 0.0)),
+        };
+        let scene = group(vec![near_but_far_off_axis, opacity(0.5, cube_at_z(-5.0))]);
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+        sort_back_to_front(&mut draws, &view_from_z(10.0));
+
+        // By straight-line distance the off-axis node (~41 away) is FARTHER
+        // than the on-axis one (15) and would sort first; by view depth it is
+        // nearer, and draws last.
+        assert_eq!(draws[0].centroid.z, -5.0);
+        assert_eq!(draws[1].centroid.x, 40.0);
+    }
+
+    /// A non-finite centroid must not make the comparator intransitive —
+    /// `sort_by` is allowed to PANIC on that, which would take the renderer
+    /// down over one bad transform.
+    #[test]
+    fn a_non_finite_centroid_does_not_panic_the_sort() {
+        let scene = group(vec![
+            opacity(0.5, cube_at_z(1.0)),
+            opacity(0.5, cube_at_z(f32::NAN)),
+            opacity(0.5, cube_at_z(-3.0)),
+        ]);
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+        sort_back_to_front(&mut draws, &view_from_z(10.0));
+        assert_eq!(draws.len(), 3);
+    }
+
+    /// A `Material` node's own `xform` is ignored by `Scene3D::render`, so the
+    /// sort key must ignore it too — otherwise a translucent subtree sorts by a
+    /// position nothing is ever drawn at.
+    #[test]
+    fn a_material_nodes_own_transform_is_ignored_like_the_renderer_ignores_it() {
+        let scene = Scene3D {
+            obj: SceneObject::Material(
+                MaterialDescription::color(1.0, 1.0, 1.0, 1.0),
+                vec![opacity(0.5, cube_at_z(0.0))],
+            ),
+            // Never applied by the renderer.
+            xform: Matrix4::from_translation(vec3(100.0, 0.0, 0.0)),
+        };
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+        assert_eq!(draws[0].centroid, vec3(0.0, 0.0, 0.0));
+        assert_eq!(draws[0].parent_world, Matrix4::identity());
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -966,6 +966,15 @@ pub enum SceneObject {
     Terrain(Box<crate::terrain::TerrainDescription>),
     Material(MaterialDescription, Vec<Scene3D>),
     Group(Vec<Scene3D>),
+    /// A TRANSLUCENT subtree — `Scene.opacity`. The `f32` is the subtree's
+    /// alpha in `0..=1`; nested `Opacity` nodes multiply.
+    ///
+    /// The node is only ever built for alpha `< 1`: `Scene.opacity(1.0, s)` is
+    /// the identity and returns `s` unchanged. So the presence of this variant
+    /// in a scene always means "draw me in the transparent pass", and a scene
+    /// that never calls `Scene.opacity` is bit-for-bit the scene it was before
+    /// the variant existed.
+    Opacity(f32, Vec<Scene3D>),
 }
 
 /// A scene node: what it draws, under a transform.
@@ -991,6 +1000,28 @@ pub struct Scene3D {
         deserialize_with = "deserialize_matrix"
     )]
     pub xform: Matrix4<f32>,
+}
+
+/// One unit of the transparent pass: an outermost [`SceneObject::Opacity`]
+/// node, ready to be sorted and drawn.
+///
+/// SORTING GRANULARITY, stated honestly: the transparent pass sorts these
+/// whole nodes back-to-front by `centroid`, and nothing finer. There is no
+/// per-triangle sort and no depth prepass, so within one translucent subtree
+/// overlapping surfaces (including the back faces of a closed mesh — the
+/// engine does not cull) blend in traversal order and read denser where they
+/// overlap. Two translucent objects that interpenetrate sort by their
+/// centroids, which is wrong for the overlapping sliver.
+pub struct TransparentDraw<'a> {
+    /// The `Opacity` node itself. Rendering it re-applies its own `xform`.
+    pub node: &'a Scene3D,
+    /// The matrix accumulated ABOVE the node (its parent's world matrix).
+    pub parent_world: Matrix4<f32>,
+    /// The innermost material enclosing the node, which the deferred draw has
+    /// to re-establish — the opaque walk's `current_material` is gone by then.
+    pub material: Option<&'a MaterialDescription>,
+    /// World-space sort key; see [`Scene3D::leaf_centroid`].
+    pub centroid: cgmath::Vector3<f32>,
 }
 
 impl Scene3D {
@@ -1065,9 +1096,115 @@ impl Scene3D {
                     .map(|item| item.with_animation(expr.clone()))
                     .collect(),
             ),
+            SceneObject::Opacity(alpha, items) => SceneObject::Opacity(
+                alpha,
+                items
+                    .into_iter()
+                    .map(|item| item.with_animation(expr.clone()))
+                    .collect(),
+            ),
             leaf @ (SceneObject::Geometry(_) | SceneObject::Terrain(_)) => leaf,
         };
         Scene3D { obj, ..self }
+    }
+
+    /// Whether this subtree contains any [`SceneObject::Opacity`] node — the
+    /// cheap guard that keeps the transparent pass (collect + sort + a second
+    /// walk) entirely off the frame path of every scene that never calls
+    /// `Scene.opacity`. Short-circuits, allocates nothing, does no matrix math.
+    pub fn has_opacity(&self) -> bool {
+        match &self.obj {
+            SceneObject::Opacity(..) => true,
+            SceneObject::Group(items) | SceneObject::Material(_, items) => {
+                items.iter().any(Scene3D::has_opacity)
+            }
+            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => false,
+        }
+    }
+
+    /// Accumulate the world-space origins of this subtree's drawable leaves.
+    ///
+    /// `world` is the PARENT's accumulated matrix; this node's own `xform`
+    /// composes on the way in, matching [`Scene3D::render`].
+    fn accumulate_leaf_origins(
+        &self,
+        world: &Matrix4<f32>,
+        sum: &mut cgmath::Vector3<f32>,
+        count: &mut u32,
+    ) {
+        let w = world * self.xform;
+        match &self.obj {
+            SceneObject::Group(items)
+            | SceneObject::Material(_, items)
+            | SceneObject::Opacity(_, items) => {
+                for item in items {
+                    item.accumulate_leaf_origins(&w, sum, count);
+                }
+            }
+            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
+                *sum += w.w.truncate();
+                *count += 1;
+            }
+        }
+    }
+
+    /// This subtree's SORT CENTROID: the mean world-space ORIGIN of its
+    /// drawable leaves (geometry / model / terrain nodes), i.e. the translation
+    /// of each leaf's accumulated matrix.
+    ///
+    /// Deliberately not a bounding-box or vertex centroid — nothing here has
+    /// been loaded, and a mesh's extent is unknown until it is. A childless
+    /// subtree falls back to its own origin.
+    pub fn leaf_centroid(&self, world: &Matrix4<f32>) -> cgmath::Vector3<f32> {
+        let mut sum = cgmath::Vector3::new(0.0, 0.0, 0.0);
+        let mut count = 0u32;
+        self.accumulate_leaf_origins(world, &mut sum, &mut count);
+        if count == 0 {
+            (world * self.xform).w.truncate()
+        } else {
+            sum / count as f32
+        }
+    }
+
+    /// Collect the OUTERMOST [`SceneObject::Opacity`] nodes of this subtree —
+    /// the units the transparent pass sorts and draws.
+    ///
+    /// Each entry carries the node, the matrix accumulated ABOVE it (so
+    /// rendering the node reproduces the opaque walk exactly), the innermost
+    /// enclosing material description, and the node's sort centroid. Nested
+    /// opacities are NOT separate entries: they are drawn inside their
+    /// outermost ancestor, multiplying its alpha. That is the honest sorting
+    /// granularity — see [`TransparentDraw`].
+    pub fn collect_transparent<'a>(
+        &'a self,
+        world: &Matrix4<f32>,
+        material: Option<&'a MaterialDescription>,
+        out: &mut Vec<TransparentDraw<'a>>,
+    ) {
+        match &self.obj {
+            SceneObject::Opacity(..) => {
+                let centroid = self.leaf_centroid(world);
+                out.push(TransparentDraw {
+                    node: self,
+                    parent_world: *world,
+                    material,
+                    centroid,
+                });
+            }
+            SceneObject::Group(items) => {
+                let w = world * self.xform;
+                for item in items {
+                    item.collect_transparent(&w, material, out);
+                }
+            }
+            SceneObject::Material(next_material, items) => {
+                let w = world * self.xform;
+                for item in items {
+                    item.collect_transparent(&w, Some(next_material), out);
+                }
+            }
+            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
+        }
     }
 
     pub fn transform(self, xform: Matrix4<f32>) -> Self {
@@ -1457,6 +1594,53 @@ so the reach is ignored"
                         &view_matrix,
                         current_material,
                     )
+                }
+            }
+
+            // `Scene.opacity`. What happens here is the pass's choice — see
+            // [`OpacityStage`]. The alpha itself never touches a material or a
+            // shader: the transparent pass blends with a CONSTANT_ALPHA
+            // equation and this node just programs `glBlendColor`, so opacity
+            // applies uniformly to every surface below it (colors, textures,
+            // lit models, terrain) without cloning a single shader.
+            SceneObject::Opacity(alpha, items) => {
+                let stage = if depth_pass {
+                    // A translucent subtree contributes no shadow.
+                    crate::OpacityStage::Defer
+                } else {
+                    render_context.opacity_stage
+                };
+                if stage == crate::OpacityStage::Defer {
+                    return;
+                }
+                let new_world_matrix = world_matrix * self.xform;
+                let previous = render_context.opacity.get();
+                let blend = stage == crate::OpacityStage::Draw;
+                if blend {
+                    // Nested opacities multiply.
+                    let accumulated = previous * alpha;
+                    render_context.opacity.set(accumulated);
+                    unsafe {
+                        render_context
+                            .gl
+                            .blend_color(0.0, 0.0, 0.0, accumulated);
+                    }
+                }
+                for item in items.into_iter() {
+                    item.render(
+                        &render_context,
+                        &scene_context,
+                        &new_world_matrix,
+                        &projection_matrix,
+                        &view_matrix,
+                        current_material,
+                    )
+                }
+                if blend {
+                    render_context.opacity.set(previous);
+                    unsafe {
+                        render_context.gl.blend_color(0.0, 0.0, 0.0, previous);
+                    }
                 }
             }
             SceneObject::Geometry(Shape::Cube) => {
@@ -1978,5 +2162,161 @@ mod preload_tests {
 
         remove_world(DEFAULT_WORLD);
         let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[cfg(test)]
+mod opacity_tests {
+    use super::*;
+    use cgmath::vec3;
+
+    fn cube_at(x: f32) -> Scene3D {
+        Scene3D {
+            obj: SceneObject::Geometry(Shape::Cube),
+            xform: Matrix4::from_translation(vec3(x, 0.0, 0.0)),
+        }
+    }
+
+    fn opacity(alpha: f32, child: Scene3D) -> Scene3D {
+        Scene3D {
+            obj: SceneObject::Opacity(alpha, vec![child]),
+            xform: Matrix4::identity(),
+        }
+    }
+
+    fn group(items: Vec<Scene3D>) -> Scene3D {
+        Scene3D {
+            obj: SceneObject::Group(items),
+            xform: Matrix4::identity(),
+        }
+    }
+
+    #[test]
+    fn a_scene_without_opacity_reports_none() {
+        let scene = group(vec![
+            cube_at(0.0),
+            Scene3D {
+                obj: SceneObject::Material(MaterialDescription::color(1.0, 0.0, 0.0, 1.0), vec![
+                    cube_at(1.0),
+                ]),
+                xform: Matrix4::identity(),
+            },
+        ]);
+        assert!(!scene.has_opacity());
+
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+        assert!(draws.is_empty());
+    }
+
+    #[test]
+    fn opacity_is_found_through_groups_and_materials() {
+        let scene = group(vec![Scene3D {
+            obj: SceneObject::Material(
+                MaterialDescription::color(0.0, 1.0, 0.0, 1.0),
+                vec![opacity(0.5, cube_at(0.0))],
+            ),
+            xform: Matrix4::identity(),
+        }]);
+        assert!(scene.has_opacity());
+    }
+
+    #[test]
+    fn collect_takes_the_outermost_node_and_carries_its_material_and_parent_matrix() {
+        let material = MaterialDescription::color(0.25, 0.5, 0.75, 1.0);
+        // A translate ABOVE the opacity node, and a nested opacity below it.
+        let scene = Scene3D {
+            obj: SceneObject::Material(
+                material.clone(),
+                vec![opacity(0.5, opacity(0.5, cube_at(0.0)))],
+            ),
+            xform: Matrix4::from_translation(vec3(3.0, 0.0, 0.0)),
+        };
+
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+
+        assert_eq!(draws.len(), 1, "only the OUTERMOST opacity node is a draw");
+        let draw = &draws[0];
+        assert_eq!(draw.material, Some(&material));
+        // The parent world matrix is everything accumulated ABOVE the node —
+        // rendering the node re-applies its own xform, exactly like the opaque
+        // walk does.
+        assert_eq!(draw.parent_world, Matrix4::from_translation(vec3(3.0, 0.0, 0.0)));
+        assert_eq!(draw.centroid, vec3(3.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn sibling_opacity_nodes_are_separate_draws_with_their_own_centroids() {
+        let scene = group(vec![
+            opacity(0.5, cube_at(-4.0)),
+            opacity(0.25, cube_at(6.0)),
+        ]);
+
+        let mut draws = Vec::new();
+        scene.collect_transparent(&Matrix4::identity(), None, &mut draws);
+
+        assert_eq!(draws.len(), 2);
+        assert_eq!(draws[0].centroid, vec3(-4.0, 0.0, 0.0));
+        assert_eq!(draws[1].centroid, vec3(6.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn the_centroid_averages_the_subtree_leaf_origins() {
+        // A translate INSIDE the opacity node still lands in the sort key —
+        // this is why the key is a leaf average, not the node's own origin.
+        let node = opacity(
+            0.5,
+            group(vec![cube_at(0.0), cube_at(10.0), cube_at(20.0)]),
+        );
+        assert_eq!(node.leaf_centroid(&Matrix4::identity()), vec3(10.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn a_childless_opacity_node_falls_back_to_its_own_origin() {
+        let node = Scene3D {
+            obj: SceneObject::Opacity(0.5, vec![]),
+            xform: Matrix4::from_translation(vec3(0.0, 7.0, 0.0)),
+        };
+        assert_eq!(node.leaf_centroid(&Matrix4::identity()), vec3(0.0, 7.0, 0.0));
+    }
+
+    #[test]
+    fn animation_reaches_models_under_an_opacity_node() {
+        let model = Scene3D::model(ModelDescription {
+            handle: ModelHandle::File("Xbot.glb".to_string()),
+            overrides: vec![],
+            animation: None,
+            while_pending: vec![],
+        });
+        let scene = opacity(0.5, model).with_animation(crate::anim::AnimExpr::Clip {
+            name: "walk".to_string(),
+            playhead: 0.0,
+        });
+        match &scene.obj {
+            SceneObject::Opacity(_, items) => match &items[0].obj {
+                SceneObject::Model(description) => {
+                    assert!(description.animation.is_some(), "the pose reached the model")
+                }
+                other => panic!("expected the model, got {other:?}"),
+            },
+            other => panic!("expected the opacity node, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opacity_participates_in_structural_equality_and_serialization() {
+        let a = opacity(0.35, cube_at(0.0));
+        let b = opacity(0.35, cube_at(0.0));
+        let c = opacity(0.36, cube_at(0.0));
+        assert_eq!(a, b, "Scene.equals sees equal alphas as equal");
+        assert_ne!(a, c, "Scene.equals sees a different alpha as different");
+
+        // The debug runtime's `GET /scene` and the golden path both read this.
+        let json = serde_json::to_string(&a).expect("the scene serializes");
+        assert!(json.contains("\"Opacity\""), "the node names itself: {json}");
+        assert!(json.contains("0.35"), "the alpha is on the wire: {json}");
+        let round_tripped: Scene3D = serde_json::from_str(&json).expect("and deserializes");
+        assert_eq!(round_tripped, a);
     }
 }

--- a/runtime/functor-runtime-common/src/shadow.rs
+++ b/runtime/functor-runtime-common/src/shadow.rs
@@ -206,6 +206,10 @@ pub fn render_shadow_pass(
         // translucent-material blend is skipped outright under `DepthOnly`.
         pass_blends: false,
         blend_active: std::cell::Cell::new(false),
+        // The depth pass DEFERS `Scene.opacity` subtrees and never comes back
+        // for them: translucent geometry casts no shadow.
+        opacity_stage: crate::OpacityStage::Defer,
+        opacity: std::cell::Cell::new(1.0),
         shadow: None,
         // Fog is a forward-pass concern; the depth pass renders no color.
         fog: None,

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -1089,11 +1089,16 @@ fn scale_presence(scene: &mut Scene3D, presence: f32) {
                 scale_presence(item, presence);
             }
         }
-        // A translucent subtree fades by scaling its OWN alpha (the presence
-        // ramp is the same multiplication the material rewrite performs); its
-        // materials are then walked as usual.
-        SceneObject::Opacity(alpha, items) => {
-            *alpha *= presence;
+        // KNOWN LIMITATION: an overlay subtree can never actually CONTAIN an
+        // `Opacity` node — `collect_anchor` / `collect_sample_leaves` keep only
+        // each leaf and its innermost material, so `strobe_leaf` rebuilds copies
+        // out of `Group` / `Material` / leaf and the authored `Scene.opacity`
+        // wrapper is dropped. The consequence is that the extrapolation ghost
+        // of a TRANSLUCENT object renders at the overlay's own fade rather than
+        // at the object's authored alpha. Carrying the accumulated opacity into
+        // `AnchorLeaf` / `SampleLeaf` is the fix when that matters; this arm
+        // exists only so the match stays exhaustive and honest if it ever does.
+        SceneObject::Opacity(_, items) => {
             for item in items {
                 scale_presence(item, presence);
             }

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -134,7 +134,9 @@ fn collect_transforms(
 ) {
     let w = world * scene.xform;
     match &scene.obj {
-        SceneObject::Group(children) | SceneObject::Material(_, children) => {
+        SceneObject::Group(children)
+        | SceneObject::Material(_, children)
+        | SceneObject::Opacity(_, children) => {
             let count = children.len();
             for (i, child) in children.iter().enumerate() {
                 path.push((i, count));
@@ -166,7 +168,7 @@ fn collect_anchor(
 ) {
     let w = world * scene.xform;
     match &scene.obj {
-        SceneObject::Group(children) => {
+        SceneObject::Group(children) | SceneObject::Opacity(_, children) => {
             let count = children.len();
             for (i, child) in children.iter().enumerate() {
                 path.push((i, count));
@@ -311,7 +313,7 @@ fn collect_sample_leaves<'a>(
 ) {
     let w = world * scene.xform;
     match &scene.obj {
-        SceneObject::Group(children) => {
+        SceneObject::Group(children) | SceneObject::Opacity(_, children) => {
             let count = children.len();
             for (i, child) in children.iter().enumerate() {
                 path.push((i, count));
@@ -1083,6 +1085,15 @@ fn scale_presence(scene: &mut Scene3D, presence: f32) {
             }
         }
         SceneObject::Group(items) => {
+            for item in items {
+                scale_presence(item, presence);
+            }
+        }
+        // A translucent subtree fades by scaling its OWN alpha (the presence
+        // ramp is the same multiplication the material rewrite performs); its
+        // materials are then walked as usual.
+        SceneObject::Opacity(alpha, items) => {
+            *alpha *= presence;
             for item in items {
                 scale_presence(item, presence);
             }
@@ -2077,7 +2088,7 @@ mod tests {
                     material_alphas(item, out);
                 }
             }
-            SceneObject::Group(items) => {
+            SceneObject::Group(items) | SceneObject::Opacity(_, items) => {
                 for item in items {
                     material_alphas(item, out);
                 }

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 305));
+        assert_eq!(count(ApiGroup::Engine), (27, 306));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
## The gap

There is **no translucency anywhere in the 3D material surface**. `Color.rgb` is
the only color constructor (no alpha channel) and no `Scene` modifier fades a
subtree. Two independent jam entries hit this:

- **speedghost** (P1) could not render its ghost craft as a translucent copy of
  the player craft. It shipped a **wireframe cage** workaround — 24 lines and 12
  extra scene nodes per frame — which its reviewer panned.
- **spellsmith** corroborated it from the other side: a fully-faded emissive
  renders **opaque black**, because there is nothing to fade *to*.

The generated API reference is exhaustive, so "it isn't there" is the whole
finding. Before this change:

```
$ functor -d repro-opacity build native
error: repro-opacity/game.fun:18:48: module `Scene` has no `opacity`
   |
18 | let ghost = () => box(...) |> Scene.opacity(ghostAlpha)
   |                                ^
```

## The fix

One prelude modifier — deliberately **smaller than adding an alpha channel to
`Color.t`**, which would touch every color constructor, every material, and the
whole shader set:

```functor
let opacity : (float, t) => t     // Scene.opacity(0.35, scene)
```

- A new `SceneObject::Opacity(f32, Vec<Scene3D>)` node, so the opacity rides the
  **scene value** — `Scene.equals`, `GET /scene`, the goldens and the debug
  runtime all see it for free (both are derives).
- **`Scene.opacity(1.0, s)` is the IDENTITY** — it returns `s` untouched rather
  than wrapping it. So every scene that does not use translucency is *the same
  value* it was before, and an `Opacity` node in a tree always means "draw me in
  the transparent pass". Out of range is an **error, not a clamp**, matching
  `Sprite.fade` and `Style.opacity`.
- The shared renderer (`renderer.rs::forward_pass`, used by desktop GL, web
  WebGL2 and XR alike) **splits**: the opaque walk defers `Opacity` subtrees,
  then a transparent pass draws them **back-to-front** with depth test ON and
  depth write OFF.
- The alpha **never touches a material or a shader**. The pass blends with a
  `CONSTANT_ALPHA` equation and each `Opacity` node programs `glBlendColor`, so
  the alpha applies uniformly to colors, textures, lit models and terrain with
  zero shader variants. Nested opacities multiply.
- A translucent subtree **casts no shadow** (the depth pass defers it too).

### Sorting granularity, stated honestly

Sorting is per **outermost `Scene.opacity` node**, by the distance from the eye
of the **mean world-space origin of its drawable leaves** — not a bounding box,
not a vertex centroid (nothing has been loaded at sort time). Consequences,
documented in the `.funi` and in `TransparentDraw`'s doc comment:

- There is **no per-triangle sort and no depth prepass**, so within ONE
  translucent subtree overlapping surfaces — including the **back faces of a
  closed mesh**, since the engine does not cull — blend in traversal order and
  read denser where they overlap.
- Two **interpenetrating** translucent objects sort by their centroids, which is
  wrong for the overlapping sliver.

## Evidence

The probe (`repro-opacity`): a fullbright **red** box furthest back, fully hidden
in screen space by a translucent **blue** box, with a translucent **green** box
nearest. The two translucent boxes are declared **nearest-first on purpose** —
the wrong painter's order — so correct compositing is the back-to-front sort
doing its job.

| Before (same scene, no `Scene.opacity` call) | After (`\|> Scene.opacity(0.35)`) |
| --- | --- |
| <img src="https://gist.githubusercontent.com/tommy-xr/89bb643cc2ef10245d1e1cd7a191a6c0/raw/da62a7215b73a41999b3cf187111f11cbf99d8bc/before-opaque.png" width="440"> | <img src="https://gist.githubusercontent.com/tommy-xr/89bb643cc2ef10245d1e1cd7a191a6c0/raw/da62a7215b73a41999b3cf187111f11cbf99d8bc/after-translucent.png" width="440"> |

**Web (WebGL2), same source, real headless Chromium** — the shells share
`renderer.rs`, so the web path is not a compile-only claim:

<img src="https://gist.githubusercontent.com/tommy-xr/89bb643cc2ef10245d1e1cd7a191a6c0/raw/da62a7215b73a41999b3cf187111f11cbf99d8bc/after-translucent-WEB.png" width="560">

## Verification

**Unit tests** at the owning layer — 11 new:

- `scene3d::opacity_tests` (12): `has_opacity` short-circuits; `collect_transparent`
  takes only the **outermost** node and carries its parent world matrix + enclosing
  material; siblings become separate draws; the centroid averages leaf origins;
  a childless node falls back to its own origin; `with_animation` reaches models
  under an `Opacity` node; and the node participates in structural equality **and**
  serde round-trip (`"Opacity"` + the alpha on the wire).
- `functor_lang_prelude::tests` (4): nesting stays nested in the scene value;
  `opacity(1.0)` is byte-identical to the unwrapped scene; `opacity(0.0)` is a
  real node; and an alpha that NARROWS to 1 at 32-bit precision is the identity
  too. Plus two rows in the teaching-error table (`1.5`, `-0.1`) and a
  `protocol::opacity_subtree_wire_is_pinned`.
- The `.funi` ↔ registry **drift test** passes (registered via `reg.fn2`, not a
  legacy match arm).

```
cargo test -p functor_runtime_common -p functor-lang -p functor-docgen   # all green
```

**Goldens — the regression claim.** Nothing existing uses `Scene.opacity`, so
every golden must be unchanged. `npm run test:golden`, base vs change:

| scenario | base | change |
| --- | --- | --- |
| primitives-t2 / hello-t2 / hello-normals-t2 / hello-tangents-t2 | 0 | 0 |
| synthwave-t0 / synthwave-t2 / shapes2d-t26 / text2d-t9 | 0 | 0 |
| lighting-t2 | 309 (0.016%) | 309 (0.016%) |
| terrain-t2 | 15752 (0.820%) | 15752 (0.820%) |
| terrain-normals-t2 / terrain-tangents-t2 | 712 / 609 | 712 / 609 |

**Identical, line for line** (the non-zero rows are pre-existing
machine/display drift present at the base ref too). Additionally, the probe scene
with the `Scene.opacity` call removed renders a **byte-identical PNG**
(`sha1 121c7a74…`) under the base binary and the change binary.

**Inline expects** in the probe (headless, no GPU) pass:
`Scene.equals(cube |> Scene.opacity(1.0), cube)` is true and the 0.35 form is false.

## Perf gate

`cargo run -q --release -p functor_runtime_common --example frame_bench`, 3 runs
each side, back-to-back on the same machine (min column):

| cells | allocs/frame | bytes/frame | us/frame(min) base | us/frame(min) change |
| --- | --- | --- | --- | --- |
| 400 (20x20) | 13877 → **13877** | 844497 → **844497** | 439.0 | 438.5 |
| 1600 (40x40) | 54717 → **54717** | 3308337 → **3308337** | 1728.7 | 1724.6 |
| 3136 (56x56) | 106973 → **106973** | 6461361 → **6461361** | 3377.8 | 3382.2 |

(base = 3 runs at `d5634cc`, change = 6 runs, all release, back-to-back on one
machine after the review fixes; min of each column.)

**Allocations and bytes are byte-for-byte identical** — deterministic, so that is
a real "no cost" result for the scene-building path. Wall clock is inside
run-to-run spread (the base's own spread is ~1% and the two ranges overlap).

Being honest about `frame_bench`'s reach: it is **headless (no GL)**, so it
measures the `draw`/scene-build path and cannot see the renderer at all. The
renderer-side guard is `Scene3D::has_opacity()` — a short-circuiting bool walk
that allocates nothing, does no matrix math, and issues **no GL calls**; when it
returns false the collect, the sort, the second `RenderContext`, and every new GL
state call are skipped entirely. The byte-identical goldens are the empirical
side of that claim.

**No Quest was attached for this change**, so there is no device number. The
change adds no shader, no material, no texture-sampler state and no extra draw
call to any existing scene, which is the class of risk `frame_bench` is blind to
— but that is an argument, not a measurement, and it is stated as such.

## Files changed

| file | why |
| --- | --- |
| `functor-prelude/prelude/scene.funi` | the `let opacity` declaration + its `///` docs |
| `runtime/functor-runtime-common/src/functor_lang_prelude.rs` | `reg.fn2("Scene.opacity", …)` in the typed registry, range error, identity at 1.0; 3 tests + 2 error-table rows |
| `runtime/functor-runtime-common/src/scene3d/mod.rs` | the `Opacity` node, `has_opacity` / `leaf_centroid` / `collect_transparent`, the render arm, `TransparentDraw`; 8 tests |
| `runtime/functor-runtime-common/src/renderer.rs` | `forward_pass` split + the new `transparent_pass` |
| `runtime/functor-runtime-common/src/render_context.rs` | `OpacityStage` + the `opacity` cell |
| `runtime/functor-runtime-common/src/shadow.rs` | the depth pass defers (no shadow from translucent) |
| `runtime/functor-runtime-common/src/protocol.rs` | `PROTOCOL_VERSION` 11 → 12 + a pinned-wire test for the new variant |
| `runtime/functor-runtime-common/src/trajectory.rs` | the extrapolation-overlay walks learn the new node; the presence ramp scales its alpha |
| `tools/functor-docgen/src/lib.rs` | the Engine inventory pin: 305 → 306 |
| `.claude/skills/functor-lang/SKILL.md` | translucency is a subtree modifier, not a color channel |

## Adoption

speedghost deletes `cageW`/`cageH`/`cageD`/`cageT`, `plusMinus`, and the whole
`ghostCage` binding — 24 lines and 12 scene nodes per frame — and renders the
ghost body as:

```functor
craftScene(...) |> Scene.opacity(0.35)
```

Nothing in its model moves, so its 31 expects and `scenario.mjs` must pass
unchanged.


## Cross-engine review (`/xreview`) — dispositions

Three reviewers: a Claude adversarial pass (**A**), the Codex CLI (**B**), and a
dedicated de-duplication pass (**C**). Both A and B also looked at the captures.
Everything Critical/High is **fixed**; each Medium/Low is fixed or explicitly
justified below.

**Fixed**

| # | Sev | Engine | Finding | Fix |
| --- | --- | --- | --- | --- |
| 1 | High | A | `PROTOCOL_VERSION` not bumped for a new serialized `SceneObject` variant — the module's own rule, with `v6 Terrain` / `v8 ConvexPolygon` as precedent | bumped to **12** with the doc line and a pinned-wire test |
| 2 | High B / Low A **[AGREED]** | A+B | sorted by Euclidean eye distance, so a large off-axis foreground node can sort behind a background node it overlaps | sort by **view-space depth** via the pass's own `view_matrix` (so each stereo eye sorts by its own view) |
| 3 | High A / Low B **[AGREED]** | A+B | the NaN-tolerant comparator is not a total order — `sort_by` is *allowed to panic* on that, the very thing it was written to avoid | `f32::total_cmp`; a NaN-centroid test |
| 4 | Medium | A | the new walkers composed a `Material` node's own `xform`, which `Scene3D::render` deliberately ignores — latent, but it would sort/draw translucent children where the opaque pass never draws them | Material arm passes `world` through; dedicated test |
| 5 | Medium | A+B | `Scene.opacity(0.999_999_999)` narrows to `1.0f32` and built an `Opacity` node with alpha 1, contradicting the variant's invariant | narrow **then** test for the identity; test added |
| 6 | Medium | A+C | `scale_presence`'s `Opacity` arm double-applied `presence` and is unreachable (the overlay rebuilds copies from leaves) | reduced to plain recursion; the real limitation (an extrapolation ghost of a translucent object renders at the overlay's own fade) is documented at the site |
| 7 | Medium | A | no headless coverage of the new pass | the sort is now the pure `sort_back_to_front`, with 4 GL-free tests |
| 8 | Low | A | the pass left `blend_func` at `CONSTANT_ALPHA` on the way out | restored to source-over alongside the blend constant |
| 9 | Low | A | `Scene.opacity(0.0)` still rasterized every fragment | an accumulated alpha of 0 skips the subtree; documented in the `.funi` |
| 10 | Low | A | the identity at alpha 1 is a step (depth write and shadow both vanish) and the docs never connected the two facts | one paragraph in the `Scene.opacity` docs |
| 11 | `extract` [S4-read] | C | the constant-alpha blend + teardown was the `DebugRenderMode::Transparent` recipe retyped | one `begin_constant_alpha_blend` / `end_constant_alpha_blend` pair, shared by both sites |
| 12 | `merge` [S4+S3] | C | two translucency mechanisms now coexist and the older one's comment promised this pass as its replacement | the Tier A comment now records **why** it stays: it is the alpha-in-the-material route the overlay's PER-LEAF age fade needs, and inside a `Scene.opacity` subtree it stands down (`pass_blends`) so the two compose rather than compete |

**Justified, not changed**

- **Backface double-blending** (Medium, visual, A) — a closed translucent mesh
  blends its back faces too, plainly visible in the capture. A's fix is
  `GL_CULL_FACE` around the pass. **Declined**: the engine culls nothing today,
  and `Scene.plane` / `Scene.quad` are single-sided core primitives that would
  become **invisible from one side** the moment they were wrapped. A per-node
  depth prepass is the correct fix and doubles the transparent draw count. The
  behavior is instead spelled out in the `Scene.opacity` docs and in
  `TransparentDraw`'s doc comment, as a stated choice rather than an accident.
- **Drop `has_opacity()`** (Medium, A; Low, B — the one cross-engine agreement
  *not* taken) — both argue `Vec::new()` allocates nothing so the collect can be
  its own guard. **Declined**: the two walks are not equivalent.
  `collect_transparent` does a **4×4 matrix multiply at every `Group` node** in
  the whole scene; `has_opacity` does none and short-circuits on the first hit.
  Making every opacity-free scene pay per-frame matrix math is exactly the cost
  this feature promised not to add. The second walk happens only when
  translucency is present — where a transparent pass is being paid for anyway.
- **Collapse the two `RenderContext`s into one with `Cell` fields** (Medium, A)
  — **Declined**: it trades two immutable, obviously-correct pass descriptions
  for mutating shared pass configuration mid-frame. `blend_active` is a `Cell`
  for a different reason (genuine per-node state during a walk, not pass
  config). The closure costs one `Arc::clone` and one `BasicMaterial::create`,
  and only when the scene actually has translucent nodes.
- **`Material::draw_transparent`** (`diverged` [S1-names], C) — a trait hook with
  a `false` default, **zero implementors and zero callers**, predating this
  change. Flagged, deliberately not touched: deleting pre-existing dead code is
  out of scope for this PR.
- **A shared `alpha_0_to_1` helper across `Scene.opacity` / `Sprite.fade` /
  `Style.opacity`** (`extract` [S4-read], C) — **Declined as scope creep**:
  unifying them changes two existing error strings that are pinned by tests, in
  surfaces this PR otherwise does not touch.
- **Overlay copies of translucent geometry lose the authored opacity** (Medium,
  B; also C) — real, and now documented at `trajectory.rs`. Carrying accumulated
  opacity into `AnchorLeaf` / `SampleLeaf` is a self-contained follow-up; the
  visible effect is confined to the extrapolation preview of a translucent
  object.

**C's coverage line**, verbatim:

> Coverage: all four strategies ran; none unavailable. S1-names 12.7 KB / 27
> queries over 7359 candidates (top ~5 per symbol read). S2-clones 262 pairs, of
> which 34 touch changed files — all pre-existing and none overlapping added
> ranges (nearest: trajectory.rs:168-174 ↔ 313-319, a pre-existing clone this
> change extends with an identical `| SceneObject::Opacity(_, children)` arm in
> both halves). S3-index 404 KB API index, grepped for
> centroid/bounds/sort/accumulate/blend/depth-mask/transparent/has_-contains_
> plus direct source greps across `runtime/`. S4 read the full 631-line diff
> across 9 files; worktree has no uncommitted edits.

**Re-validated after the fixes**: full test suite, goldens still identical to
base line-for-line, the probe re-captured on native **and** in the browser
(both images above are post-fix), and `frame_bench` re-run on both sides.

### Pre-existing, unrelated

`cli::commands::init::tests::fps_template_creates_a_typechecked_project` fails
identically at the base ref `d5634cc` (an `Angle.t` vs `float` `<` ambiguity in
the `fps` starter template). Not touched by this change.
