### PR TITLE
feat(persistence): Persistence.save and Persistence.load — local persistence through the broker

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1150,16 +1150,19 @@ let tick = (m, dt, tts) =>
 ```
 
 `load`'s tagger receives `Option.Some(value)` or `Option.None` — absent OR
-unreadable (a save from an incompatible model shape degrades to "no save", it
-never stops the game). A slot key is a NAME, not a path: letters, digits, `_`
-and `-`, 1–64 characters. Natively a slot is
+unreadable (a corrupt file degrades to "no save", it never stops the game).
+A save written by an OLDER MODEL SHAPE still arrives as `Option.Some`: nothing
+checks the shape, so version it yourself (a new slot name, or a version field
+you match on) exactly as you would any external data. A slot key is a NAME,
+not a path: letters, digits, `_` and `-`, 1–64 characters. Natively a slot is
 `<project>/.functor/saves/<slot>.json`, written atomically; on the web it is
 one project-scoped `localStorage` key. Both are ordinary effects — they drain
 through the broker, land in the structured effect log (`storage.save` /
 `storage.load`), and are canned by the fake/replay runners, so a saving game
 still replays deterministically. Hot-reload preserves the model in dev, which
 HIDES the absence of a save: reach for these as soon as progress must survive
-quitting.
+quitting. (Desktop and web today — the Quest shell's store follows the process
+working directory, so treat slots there as unsupported for now.)
 
 **Interactive widgets are numbered by SLOT in construction order**, which is how
 they are driven headlessly through the debug server —

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -303,8 +303,8 @@ let grab = (s) =>
   builtin/prelude or bundled-core namespace (Net, Key, Mouse, Random, Option, Result,
   List, Map, Text, Math, Debug, Scene,
   Sprite, Anim, Asset, Camera3D, Camera2D, Frame, Light, Fog, Color, Vec3, Skybox,
-  Angle, Texture, Time, Input, Sub, Effect, Physics, RenderTarget, Ui, Html, Attr,
-  Style, AudioSource, AudioScene) is a
+  Angle, Texture, Time, Input, Sub, Effect, Persistence, Physics, RenderTarget, Ui, Html,
+  Attr, Style, AudioSource, AudioScene) is a
   load error — rename the file. (`assets.fun` → `Assets` — the generated
   manifest — is fine; only the exact name collides.)
 - **`Net` is a built-in module**, always in scope: `type NetEvent =
@@ -541,8 +541,8 @@ open Widget                                              // …or open, bringing
 - This is how the **engine prelude's types are declared**: the `functor-prelude`
   crate ships a `.funi` for every host namespace (`Scene`, `Sprite`, `Asset`,
   `Camera3D`, `Camera2D`, `Frame`, `Light`, `Fog`, `Skybox`, `RenderTarget`,
-  `Texture`, `Angle`, `Time`, `Sub`, `Effect`, `Physics`, `Ui`, `Html`, `Attr`,
-  `Style`, `AudioSource`, `AudioScene`),
+  `Texture`, `Angle`, `Time`, `Sub`, `Effect`, `Persistence`, `Physics`, `Ui`, `Html`,
+  `Attr`, `Style`, `AudioSource`, `AudioScene`),
   loaded by the
   runner so engine calls carry real types (no longer `Unknown`). Each module's
   primary opaque handle is `Mod.t` (`Camera3D.t`, `Frame.t`, `Effect.t`, …);
@@ -1010,6 +1010,7 @@ The generated modules:
 | `Physics` | shapes, bodies, the `physics` hook's world, live reads, commands, raycasts, events |
 | `Effect` | one-shot commands returned beside a model (time, random, HTTP, net sends, sounds, preloads) |
 | `Sub` | what `subscriptions` returns: timers, connections, asset progress, physics events |
+| `Persistence` | durable local save slots: `save` / `load`, as ordinary effects |
 | `AudioScene` / `AudioSource` | what `soundScape` returns, and its keyed continuous voices |
 | `Ui` | the lightweight HUD `ui` hook: text, rows/columns, anchored panels, button/slider/textInput |
 | `Html` / `Attr` / `Style` | the `webview` hook: an Elm-style HTML tree, attributes/handlers, typed inline CSS |
@@ -1138,15 +1139,16 @@ need no declaration, and these are the variants to match:
 structurally (usually a shared-module ADT), with no string codec; functions and
 opaque host values in the payload are teaching errors.
 
-**Durable local state is `Effect.save` / `Effect.load`** — the same plain-data
-codec, aimed at a named SLOT instead of a connection:
+**Durable local state is `Persistence.save` / `Persistence.load`** — its own
+module, producing ordinary `Effect.t` values through the same plain-data codec,
+aimed at a named SLOT instead of a connection:
 
 ```functor
 let tick = (m, dt, tts) =>
   if m.booted then (m, Effect.none())
-  else (m, Effect.load("autosave", (loaded) => Restored(loaded)))   // Option.t<Model>
+  else (m, Persistence.load("autosave", (loaded) => Restored(loaded)))   // Option.t<Model>
 
-| Saved => (m, Effect.save("autosave", m))                          // in `update`
+| Saved => (m, Persistence.save("autosave", m))                          // in `update`
 ```
 
 `load`'s tagger receives `Option.Some(value)` or `Option.None` — absent OR

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1138,6 +1138,29 @@ need no declaration, and these are the variants to match:
 structurally (usually a shared-module ADT), with no string codec; functions and
 opaque host values in the payload are teaching errors.
 
+**Durable local state is `Effect.save` / `Effect.load`** — the same plain-data
+codec, aimed at a named SLOT instead of a connection:
+
+```functor
+let tick = (m, dt, tts) =>
+  if m.booted then (m, Effect.none())
+  else (m, Effect.load("autosave", (loaded) => Restored(loaded)))   // Option.t<Model>
+
+| Saved => (m, Effect.save("autosave", m))                          // in `update`
+```
+
+`load`'s tagger receives `Option.Some(value)` or `Option.None` — absent OR
+unreadable (a save from an incompatible model shape degrades to "no save", it
+never stops the game). A slot key is a NAME, not a path: letters, digits, `_`
+and `-`, 1–64 characters. Natively a slot is
+`<project>/.functor/saves/<slot>.json`, written atomically; on the web it is
+one project-scoped `localStorage` key. Both are ordinary effects — they drain
+through the broker, land in the structured effect log (`storage.save` /
+`storage.load`), and are canned by the fake/replay runners, so a saving game
+still replays deterministically. Hot-reload preserves the model in dev, which
+HIDES the absence of a save: reach for these as soon as progress must survive
+quitting.
+
 **Interactive widgets are numbered by SLOT in construction order**, which is how
 they are driven headlessly through the debug server —
 `Ui.button`/`slider`/`textInput` via

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ tools/functor-lang-vscode/images/functor-lang-extension.png
 # `npm run generate:docs` recreates them; site:build regenerates its JSON input.
 docs/api-reference.md
 site/generated/api-reference.json
+
+# Local save slots written by `Effect.save` — a player's (or an example run's)
+# progress, not source. `<project>/.functor/saves/<slot>.json`.
+.functor/

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,6 @@ tools/functor-lang-vscode/images/functor-lang-extension.png
 docs/api-reference.md
 site/generated/api-reference.json
 
-# Local save slots written by `Effect.save` — a player's (or an example run's)
+# Local save slots written by `Persistence.save` — a player's (or an example run's)
 # progress, not source. `<project>/.functor/saves/<slot>.json`.
 .functor/

--- a/functor-lang/src/project.rs
+++ b/functor-lang/src/project.rs
@@ -56,6 +56,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Scene",
     "Instance",
     "Anim",
+    "Terrain",
     "Asset",
     "Camera3D",
     "Camera2D",
@@ -72,6 +73,7 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "Input",
     "Sub",
     "Effect",
+    "Persistence",
     "Physics",
     "RenderTarget",
     "Ui",
@@ -82,6 +84,15 @@ const PROTECTED_NAMESPACES: &[&str] = &[
     "AudioScene",
     "Debug",
 ];
+
+/// Whether a module name is one the language or the Functor prelude owns.
+///
+/// Exposed so a host that SHIPS a namespace can assert its own modules are
+/// reserved here — a new prelude module that nobody adds to the list above is
+/// silently shadowable by a game's file or inline `module`.
+pub fn is_protected_namespace(name: &str) -> bool {
+    PROTECTED_NAMESPACES.contains(&name)
+}
 
 /// One source module bundled by the language or a host rather than read from
 /// the user's project directory.

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -21,35 +21,6 @@ let send : (float, string) => t
 /// The peer receives `Net.Data(id, value)`. Functions and opaque host values
 /// cannot be sent.
 let sendMsg : (float, 'a) => t
-/// Persist a plain-data value in a local save slot.
-///
-/// The durable dual of the model: a slot survives quitting the game, where
-/// hot-reload's preserved model does not. The value is carried by the same
-/// codec as `sendMsg` — numbers, strings, bools, lists, maps, tuples,
-/// records and variants of those — so functions and opaque host values are a
-/// teaching error at the call site. Saving the whole model is the common
-/// case; save what `init` can rebuild from.
-///
-/// The slot is a NAME, not a path: letters, digits, `_` and `-` (1–64
-/// characters). Natively it lands in `<project>/.functor/saves/<slot>.json`,
-/// written atomically; in the browser it is one project-scoped
-/// `localStorage` key. Writing the same slot again replaces it.
-let save : (string, 'a) => t
-/// Read a local save slot back and tag it as a message.
-///
-/// The tagger receives `Option.Some(value)` — the value exactly as saved —
-/// or `Option.None` when the slot has never been written or what is there
-/// cannot be read at all (a corrupt or hand-mangled file): an unreadable
-/// save degrades to "no save", it never stops the game.
-///
-/// A save that reads back fine but was written by an OLDER MODEL SHAPE is
-/// still `Option.Some` — nothing checks the shape for you. Handle that the
-/// way you would any external data: change the slot name when the model
-/// changes incompatibly, or save a record carrying your own version field
-/// and match on it.
-///
-/// Usually issued once at boot from the first `tick`.
-let load : (string, (Option.t<'a>) => 'msg) => t
 /// Perform an HTTP GET and tag its `Net.HttpResponse` as a message.
 let httpGet : (string, (Net.HttpResponse) => 'msg) => t
 /// Perform an HTTP POST with a text body and tag its response as a message.

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -21,6 +21,28 @@ let send : (float, string) => t
 /// The peer receives `Net.Data(id, value)`. Functions and opaque host values
 /// cannot be sent.
 let sendMsg : (float, 'a) => t
+/// Persist a plain-data value in a local save slot.
+///
+/// The durable dual of the model: a slot survives quitting the game, where
+/// hot-reload's preserved model does not. The value is carried by the same
+/// codec as `sendMsg` — numbers, strings, bools, lists, maps, tuples,
+/// records and variants of those — so functions and opaque host values are a
+/// teaching error at the call site. Saving the whole model is the common
+/// case; save what `init` can rebuild from.
+///
+/// The slot is a NAME, not a path: letters, digits, `_` and `-` (1–64
+/// characters). Natively it lands in `<project>/.functor/saves/<slot>.json`,
+/// written atomically; in the browser it is one project-scoped
+/// `localStorage` key. Writing the same slot again replaces it.
+let save : (string, 'a) => t
+/// Read a local save slot back and tag it as a message.
+///
+/// The tagger receives `Option.Some(value)` — the value exactly as saved —
+/// or `Option.None` when the slot has never been written, or when what is
+/// there cannot be read (a save from an incompatible version, a corrupt
+/// file): a broken save degrades to "no save", it never stops the game.
+/// Usually issued once at boot from the first `tick`.
+let load : (string, (Option.t<'a>) => 'msg) => t
 /// Perform an HTTP GET and tag its `Net.HttpResponse` as a message.
 let httpGet : (string, (Net.HttpResponse) => 'msg) => t
 /// Perform an HTTP POST with a text body and tag its response as a message.

--- a/functor-prelude/prelude/effect.funi
+++ b/functor-prelude/prelude/effect.funi
@@ -38,9 +38,16 @@ let save : (string, 'a) => t
 /// Read a local save slot back and tag it as a message.
 ///
 /// The tagger receives `Option.Some(value)` — the value exactly as saved —
-/// or `Option.None` when the slot has never been written, or when what is
-/// there cannot be read (a save from an incompatible version, a corrupt
-/// file): a broken save degrades to "no save", it never stops the game.
+/// or `Option.None` when the slot has never been written or what is there
+/// cannot be read at all (a corrupt or hand-mangled file): an unreadable
+/// save degrades to "no save", it never stops the game.
+///
+/// A save that reads back fine but was written by an OLDER MODEL SHAPE is
+/// still `Option.Some` — nothing checks the shape for you. Handle that the
+/// way you would any external data: change the slot name when the model
+/// changes incompatibly, or save a record carrying your own version field
+/// and match on it.
+///
 /// Usually issued once at boot from the first `tick`.
 let load : (string, (Option.t<'a>) => 'msg) => t
 /// Perform an HTTP GET and tag its `Net.HttpResponse` as a message.

--- a/functor-prelude/prelude/persistence.funi
+++ b/functor-prelude/prelude/persistence.funi
@@ -1,0 +1,49 @@
+//! Durable local state — the save slot that outlives the process.
+//!
+//! The model is the game's live state and hot-reload preserves it, but
+//! quitting does not: a slot is where progress goes to survive. Both
+//! functions produce an ordinary `Effect.t`, performed by the same broker as
+//! every other effect, so a save is deterministic under replay like anything
+//! else.
+//!
+//! This is the simple path for the common case — one autosave, saved whole and
+//! read back at boot. It deliberately says nothing about where the bytes live;
+//! a general file API over a virtual user namespace is planned, and these two
+//! functions are meant to keep reading as the two-line convenience layer over
+//! it.
+//!
+//! Slots belong to the running project: natively `<project>/.functor/saves/`,
+//! in the browser a page- and entry-scoped `localStorage` key. One process
+//! runs one game, so the store root is process-global. The Quest/embedded
+//! producer does not name a writable project root yet — there slots follow the
+//! process working directory.
+
+/// Persist a plain-data value in a local save slot.
+///
+/// The durable dual of the model: a slot survives quitting the game, where
+/// hot-reload's preserved model does not. The value is carried by the same
+/// codec as `Effect.sendMsg` — numbers, strings, bools, lists, maps, tuples,
+/// records and variants of those — so functions and opaque host values are a
+/// teaching error at the call site. Saving the whole model is the common
+/// case; save what `init` can rebuild from.
+///
+/// The slot is a NAME, not a path: letters, digits, `_` and `-` (1–64
+/// characters). Natively it lands in `<project>/.functor/saves/<slot>.json`,
+/// written atomically; in the browser it is one project-scoped
+/// `localStorage` key. Writing the same slot again replaces it.
+let save : (string, 'a) => Effect.t
+/// Read a local save slot back and tag it as a message.
+///
+/// The tagger receives `Option.Some(value)` — the value exactly as saved —
+/// or `Option.None` when the slot has never been written or what is there
+/// cannot be read at all (a corrupt or hand-mangled file): an unreadable
+/// save degrades to "no save", it never stops the game.
+///
+/// A save that reads back fine but was written by an OLDER MODEL SHAPE is
+/// still `Option.Some` — nothing checks the shape for you. Handle that the
+/// way you would any external data: change the slot name when the model
+/// changes incompatibly, or save a record carrying your own version field
+/// and match on it.
+///
+/// Usually issued once at boot from the first `tick`.
+let load : (string, (Option.t<'a>) => 'msg) => Effect.t

--- a/functor-prelude/src/lib.rs
+++ b/functor-prelude/src/lib.rs
@@ -63,6 +63,7 @@ pub fn modules() -> Vec<(String, String)> {
         module("Input", include_str!("../prelude/input.funi")),
         module("Sub", include_str!("../prelude/sub.funi")),
         module("Effect", include_str!("../prelude/effect.funi")),
+        module("Persistence", include_str!("../prelude/persistence.funi")),
         module("Physics", include_str!("../prelude/physics.funi")),
         module("Ui", include_str!("../prelude/ui.funi")),
         module("Html", include_str!("../prelude/html.funi")),

--- a/runtime/functor-runtime-common/Cargo.toml
+++ b/runtime/functor-runtime-common/Cargo.toml
@@ -64,4 +64,4 @@ serde-wasm-bindgen = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.4"
-features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Performance', 'PerformanceTiming', 'Headers', 'Request', 'RequestInit', 'RequestMode', 'Response', 'Document', 'Element']
+features = ['Blob', 'HtmlCanvasElement', 'WebGl2RenderingContext', 'console', 'Window', 'Performance', 'PerformanceTiming', 'Headers', 'Request', 'RequestInit', 'RequestMode', 'Response', 'Document', 'Element', 'Storage', 'Location']

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -371,7 +371,7 @@ pub enum EffectTree {
         body: String,
         tagger: Value,
     },
-    /// Persist a plain-data value in a local save slot (`Effect.save(slot,
+    /// Persist a plain-data value in a local save slot (`Persistence.save(slot,
     /// value)`). The payload is converted to its [`EffectValue`] at
     /// construction (a closure inside is a teaching error at the call site,
     /// exactly like [`Self::SendMsg`]) and written by the runner —
@@ -381,7 +381,7 @@ pub enum EffectTree {
         slot: String,
         payload: EffectValue,
     },
-    /// Read a local save slot back (`Effect.load(slot, tagger)`). A same-frame
+    /// Read a local save slot back (`Persistence.load(slot, tagger)`). A same-frame
     /// runner read like [`Self::Now`]: the tagger receives
     /// `Option.Some(value)` or `Option.None` (absent OR unreadable/corrupt —
     /// a broken save must not kill a running game), and the result lands in
@@ -458,13 +458,13 @@ pub trait EffectRunner {
     /// singleton physics world; `Fake`/`Replay` return canned/recorded
     /// records — physics queries are testable without a world at all.
     fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue;
-    /// Persist a save slot (`Effect.save`). `Real` writes the platform store;
+    /// Persist a save slot (`Persistence.save`). `Real` writes the platform store;
     /// `Fake` records the write in memory (so a test can assert what a game
     /// saved without touching a disk); `Replay` drops it — a replay must not
     /// rewrite the world it is replaying. An error is returned for the drain
     /// to report; the game keeps running.
     fn save(&mut self, slot: &str, payload: &EffectValue) -> Result<(), String>;
-    /// Read a save slot (`Effect.load`) as `Option.Some(value)` /
+    /// Read a save slot (`Persistence.load`) as `Option.Some(value)` /
     /// `Option.None` — see [`save_slot_value`]. `Real` asks the platform
     /// store; `Fake` answers from what it recorded (empty = `None`); `Replay`
     /// replays the recorded result.
@@ -490,7 +490,7 @@ fn read_saved_slot(slot: &str) -> EffectValue {
         Ok(Some(text)) => text,
         Ok(None) => return save_slot_value(None),
         Err(error) => {
-            log::warn!("[functor-lang] Effect.load(\"{slot}\"): {error}");
+            log::warn!("[functor-lang] Persistence.load(\"{slot}\"): {error}");
             return save_slot_value(None);
         }
     };
@@ -503,14 +503,14 @@ fn read_saved_slot(slot: &str) -> EffectValue {
         Ok(value) if value.to_functor_lang().is_ok() => save_slot_value(Some(value)),
         Ok(_) => {
             log::warn!(
-                "[functor-lang] Effect.load(\"{slot}\"): the saved data is not \
+                "[functor-lang] Persistence.load(\"{slot}\"): the saved data is not \
 representable — answering Option.None"
             );
             save_slot_value(None)
         }
         Err(error) => {
             log::warn!(
-                "[functor-lang] Effect.load(\"{slot}\"): the saved data could not be \
+                "[functor-lang] Persistence.load(\"{slot}\"): the saved data could not be \
 read ({error}) — answering Option.None"
             );
             save_slot_value(None)
@@ -940,11 +940,11 @@ pub struct FakeEffects {
     /// misses. Test physics-query handling with no world at all.
     pub ray_hits: Vec<EffectValue>,
     next_ray: usize,
-    /// The in-memory save store, newest last: every `Effect.save` this runner
+    /// The in-memory save store, newest last: every `Persistence.save` this runner
     /// performed, appended after anything [`FakeEffects::with_saves`] seeded
     /// (seeding reads as "the game had already saved this"). One vector, so
     /// it is both the store and the journal of what a game wrote — a test
-    /// asserts persistence with no disk and no browser. `Effect.load` answers
+    /// asserts persistence with no disk and no browser. `Persistence.load` answers
     /// with the LAST value written to that slot (`Option.None` when the slot
     /// was never written), which is exactly the real store's rule.
     pub saves: Vec<(String, EffectValue)>,
@@ -1634,6 +1634,7 @@ pub(crate) fn registry() -> &'static crate::host_registry::Registry {
         register_assets(&mut reg);
         register_anim(&mut reg);
         register_effects(&mut reg);
+        register_persistence(&mut reg);
         register_subs(&mut reg);
         register_ui_widgets(&mut reg);
         register_html(&mut reg);
@@ -3598,32 +3599,6 @@ fn register_effects(reg: &mut crate::host_registry::Registry) {
             Ok(FunctorLangEffect(EffectTree::SendMsg { conn, payload }))
         },
     );
-    // save(slot, value) / load(slot, tagger): durable LOCAL state through the
-    // same broker (and the same plain-data codec as `sendMsg`) — a game's
-    // "write my progress" and "read it back at boot". The slot key and the
-    // payload are validated HERE, at the construction site, so a bad key or a
-    // closure in the model errors at the call instead of mid-drain.
-    reg.fn2(
-        "Effect.save",
-        "Effect.save(slot, value)",
-        |slot: String, value: Value| {
-            crate::storage::validate_slot(&slot).map_err(|e| format!("Effect.save: {e}"))?;
-            let payload =
-                effect_value_from_value(&value).map_err(|e| format!("Effect.save: {e}"))?;
-            Ok(FunctorLangEffect(EffectTree::Save { slot, payload }))
-        },
-    );
-    reg.fn2(
-        "Effect.load",
-        "Effect.load(slot, tagger)",
-        |slot: String, tagger: Tagger| {
-            crate::storage::validate_slot(&slot).map_err(|e| format!("Effect.load: {e}"))?;
-            Ok(FunctorLangEffect(EffectTree::Load {
-                slot,
-                tagger: tagger.0,
-            }))
-        },
-    );
     // httpGet(url, tagger) / httpPost(url, body, tagger). The tagger is a
     // function of the Net.HttpResponse; performing the effect (drain) mints a
     // token, queues the request, and registers the tagger by token — see
@@ -3713,6 +3688,35 @@ message delivered when its load settles",
                 locator: asset.locator,
                 message: msg,
             })
+        },
+    );
+}
+
+/// The Persistence vocabulary — durable LOCAL state through the same broker
+/// (and the same plain-data codec as `Effect.sendMsg`) as every other effect:
+/// a game's "write my progress" and "read it back at boot". The slot key and
+/// the payload are validated HERE, at the construction site, so a bad key or
+/// a closure in the model errors at the call instead of mid-drain.
+fn register_persistence(reg: &mut crate::host_registry::Registry) {
+    reg.fn2(
+        "Persistence.save",
+        "Persistence.save(slot, value)",
+        |slot: String, value: Value| {
+            crate::storage::validate_slot(&slot).map_err(|e| format!("Persistence.save: {e}"))?;
+            let payload =
+                effect_value_from_value(&value).map_err(|e| format!("Persistence.save: {e}"))?;
+            Ok(FunctorLangEffect(EffectTree::Save { slot, payload }))
+        },
+    );
+    reg.fn2(
+        "Persistence.load",
+        "Persistence.load(slot, tagger)",
+        |slot: String, tagger: Tagger| {
+            crate::storage::validate_slot(&slot).map_err(|e| format!("Persistence.load: {e}"))?;
+            Ok(FunctorLangEffect(EffectTree::Load {
+                slot,
+                tagger: tagger.0,
+            }))
         },
     );
 }
@@ -5266,7 +5270,7 @@ pub fn needs_update(tree: &EffectTree) -> bool {
         | EffectTree::PlayAudioThen { .. }
         | EffectTree::PreloadAsset { .. }
         | EffectTree::PreloadAssetThen { .. }
-        // A save reports nothing back; only `Effect.load` has a tagger.
+        // A save reports nothing back; only `Persistence.load` has a tagger.
         | EffectTree::Save { .. } => false,
         EffectTree::Now { .. }
         | EffectTree::Random { .. }
@@ -5584,7 +5588,7 @@ dropping the rest"
                 // a replayed save/load pair index-aligned with its recording.
                 if let Err(error) = runner.save(&slot, &payload) {
                     report(format!(
-                        "[functor-lang] Effect.save(\"{slot}\") failed: {error}"
+                        "[functor-lang] Persistence.save(\"{slot}\") failed: {error}"
                     ));
                 }
                 log.push(EffectRecord {
@@ -11263,8 +11267,8 @@ the game dir"
                      match msg with\n\
                      | Option.Some(saved) => saved\n\
                      | Option.None => m\n\
-                   let save = (m) => (m, Effect.save(\"autosave\", m))\n\
-                   let restore = (m) => (m, Effect.load(\"autosave\", (o) => o))\n";
+                   let save = (m) => (m, Persistence.save(\"autosave\", m))\n\
+                   let restore = (m) => (m, Persistence.load(\"autosave\", (o) => o))\n";
         let project = functor_lang::project::load_single_source("game", src)
             .unwrap_or_else(|e| panic!("load: {}", e.render()));
         let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
@@ -11304,9 +11308,9 @@ the game dir"
         (restarted.to_string(), log)
     }
 
-    /// The persistence spine on the REAL store: `Effect.save` writes the
+    /// The persistence spine on the REAL store: `Persistence.save` writes the
     /// project's slot file (atomically, as canonical plain-data JSON) and a
-    /// later `Effect.load` restores exactly the saved value into a fresh
+    /// later `Persistence.load` restores exactly the saved value into a fresh
     /// model — the quit-and-relaunch contract, plus the on-disk artifact.
     #[test]
     fn save_writes_the_slot_file_and_load_restores_it() {
@@ -11415,22 +11419,22 @@ the game dir"
     /// at the construction site, not frames later.
     #[test]
     fn save_rejects_bad_slots_and_non_plain_values() {
-        let msg = run_fail("let main = () => Effect.save(\"../escape\", 1.0)");
+        let msg = run_fail("let main = () => Persistence.save(\"../escape\", 1.0)");
         assert!(
-            msg.contains("Effect.save: slot key") && msg.contains("a slot is a NAME, not a path"),
+            msg.contains("Persistence.save: slot key") && msg.contains("a slot is a NAME, not a path"),
             "expected the slot teaching error, got: {msg}"
         );
-        let msg = run_fail("let main = () => Effect.load(\"\", (o) => o)");
+        let msg = run_fail("let main = () => Persistence.load(\"\", (o) => o)");
         assert!(
-            msg.contains("Effect.load: slot key must not be empty"),
+            msg.contains("Persistence.load: slot key must not be empty"),
             "expected the empty-slot teaching error, got: {msg}"
         );
-        let msg = run_fail("let main = () => Effect.save(\"autosave\", (x) => x)");
+        let msg = run_fail("let main = () => Persistence.save(\"autosave\", (x) => x)");
         assert!(
-            msg.contains("Effect.save: not plain data") && msg.contains("a function"),
+            msg.contains("Persistence.save: not plain data") && msg.contains("a function"),
             "expected the plain-data teaching error, got: {msg}"
         );
-        let msg = run_fail("let main = () => Effect.save(\"autosave\", Scene.cube())");
+        let msg = run_fail("let main = () => Persistence.save(\"autosave\", Scene.cube())");
         assert!(
             msg.contains("not plain data") && msg.contains("opaque host value"),
             "expected the host-value teaching error, got: {msg}"
@@ -11438,7 +11442,7 @@ the game dir"
         // A NaN would serialize as JSON `null` and fail to READ BACK — after
         // the rename had already replaced the last good save. Refuse it at the
         // call site, as a value and as a map key.
-        let msg = run_fail("let main = () => Effect.save(\"autosave\", 0.0 / 0.0)");
+        let msg = run_fail("let main = () => Persistence.save(\"autosave\", 0.0 / 0.0)");
         assert!(
             msg.contains("non-finite"),
             "expected the non-finite teaching error, got: {msg}"
@@ -11446,14 +11450,14 @@ the game dir"
         // The other NaN door — a map KEY — is already shut by the
         // interpreter, so a save can never carry one either.
         let msg = run_fail(
-            "let main = () => Effect.save(\"autosave\", Map.insert(0.0 / 0.0, 1.0, Map.empty()))",
+            "let main = () => Persistence.save(\"autosave\", Map.insert(0.0 / 0.0, 1.0, Map.empty()))",
         );
         assert!(
             msg.contains("keys must be finite"),
             "expected the map-key finiteness error, got: {msg}"
         );
         // A reserved Windows device name would write nowhere on that platform.
-        let msg = run_fail("let main = () => Effect.save(\"con\", 1.0)");
+        let msg = run_fail("let main = () => Persistence.save(\"con\", 1.0)");
         assert!(
             msg.contains("reserved device name"),
             "expected the reserved-name teaching error, got: {msg}"

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -495,7 +495,19 @@ fn read_saved_slot(slot: &str) -> EffectValue {
         }
     };
     match serde_json::from_str::<EffectValue>(&text) {
-        Ok(value) => save_slot_value(Some(value)),
+        // Convertibility is part of "readable": a slot file is EXTERNAL data
+        // (hand-edited, foreign, version-skewed), and a value that decodes but
+        // cannot become a Functor value would otherwise report mid-drain and
+        // silently never call the tagger — the game would wait forever for a
+        // restore message. Answer None instead.
+        Ok(value) if value.to_functor_lang().is_ok() => save_slot_value(Some(value)),
+        Ok(_) => {
+            log::warn!(
+                "[functor-lang] Effect.load(\"{slot}\"): the saved data is not \
+representable — answering Option.None"
+            );
+            save_slot_value(None)
+        }
         Err(error) => {
             log::warn!(
                 "[functor-lang] Effect.load(\"{slot}\"): the saved data could not be \
@@ -761,6 +773,10 @@ pub fn effect_value_from_value(value: &Value) -> Result<EffectValue, String> {
                 .map(|(key, value)| {
                     let key = match key {
                         functor_lang::value::MapKey::Bool(value) => EffectMapKey::Bool(*value),
+                        // No finiteness check needed here (unlike a non-finite
+                        // VALUE above): the interpreter already refuses a
+                        // NaN/Infinity map key at insertion, so one cannot
+                        // reach this walker.
                         functor_lang::value::MapKey::Number(value) => EffectMapKey::Number(*value),
                         functor_lang::value::MapKey::String(value) => {
                             EffectMapKey::Text(value.to_string())
@@ -924,11 +940,13 @@ pub struct FakeEffects {
     /// misses. Test physics-query handling with no world at all.
     pub ray_hits: Vec<EffectValue>,
     next_ray: usize,
-    /// Every `Effect.save` this runner performed, in order — an in-memory
-    /// save store AND the journal of what the game wrote, so a test asserts
-    /// persistence without touching a disk or a browser. `Effect.load`
-    /// answers with the LAST value written to that slot (`Option.None` when
-    /// the slot was never written), which is exactly the real store's rule.
+    /// The in-memory save store, newest last: every `Effect.save` this runner
+    /// performed, appended after anything [`FakeEffects::with_saves`] seeded
+    /// (seeding reads as "the game had already saved this"). One vector, so
+    /// it is both the store and the journal of what a game wrote — a test
+    /// asserts persistence with no disk and no browser. `Effect.load` answers
+    /// with the LAST value written to that slot (`Option.None` when the slot
+    /// was never written), which is exactly the real store's rule.
     pub saves: Vec<(String, EffectValue)>,
 }
 
@@ -994,34 +1012,50 @@ impl EffectRunner for FakeEffects {
 /// on wall clock or entropy — but a raycast is a WORLD read, not an
 /// environment read, so it answers against the ACTIVE world (the forward-step
 /// scopes that to its throwaway projected world) exactly like the live runner.
-pub struct DryRunEffects(FakeEffects);
+pub struct DryRunEffects {
+    env: FakeEffects,
+    /// Slots the PROJECTION wrote, newest last. A dry run must not touch the
+    /// player's store, but within the projection a save must still be
+    /// visible to a later load — otherwise the projected model diverges from
+    /// the live one for the one program shape (save-then-load) this exists
+    /// to project faithfully. Reads fall through to the real store.
+    saves: Vec<(String, EffectValue)>,
+}
 
 impl DryRunEffects {
     #[allow(clippy::new_without_default)]
     pub fn new() -> DryRunEffects {
-        DryRunEffects(FakeEffects::new(0.0, vec![0.0]))
+        DryRunEffects {
+            env: FakeEffects::new(0.0, vec![0.0]),
+            saves: Vec::new(),
+        }
     }
 }
 
 impl EffectRunner for DryRunEffects {
     fn now(&mut self) -> f64 {
-        self.0.now()
+        self.env.now()
     }
     fn random(&mut self) -> f64 {
-        self.0.random()
+        self.env.random()
     }
     fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
         active_world_raycast(origin, dir, max_dist)
     }
-    fn save(&mut self, _slot: &str, _payload: &EffectValue) -> Result<(), String> {
-        // A projection must not touch the player's save. (The drain already
-        // suppresses outbound work on this path; this is the belt.)
+    fn save(&mut self, slot: &str, payload: &EffectValue) -> Result<(), String> {
+        // A projection must not touch the player's save — it writes to its own
+        // throwaway overlay instead, exactly as it steps a throwaway world.
+        self.saves.push((slot.to_string(), payload.clone()));
         Ok(())
     }
     fn load(&mut self, slot: &str) -> EffectValue {
         // A slot READ is a world read, not an environment read — same rule as
-        // `raycast`: the projection sees the store the live game sees.
-        read_saved_slot(slot)
+        // `raycast`: the projection sees the store the live game sees, with
+        // its own uncommitted writes on top.
+        match self.saves.iter().rev().find(|(key, _)| key == slot) {
+            Some((_, value)) => save_slot_value(Some(value.clone())),
+            None => read_saved_slot(slot),
+        }
     }
 }
 
@@ -11400,6 +11434,63 @@ the game dir"
         assert!(
             msg.contains("not plain data") && msg.contains("opaque host value"),
             "expected the host-value teaching error, got: {msg}"
+        );
+        // A NaN would serialize as JSON `null` and fail to READ BACK — after
+        // the rename had already replaced the last good save. Refuse it at the
+        // call site, as a value and as a map key.
+        let msg = run_fail("let main = () => Effect.save(\"autosave\", 0.0 / 0.0)");
+        assert!(
+            msg.contains("non-finite"),
+            "expected the non-finite teaching error, got: {msg}"
+        );
+        // The other NaN door — a map KEY — is already shut by the
+        // interpreter, so a save can never carry one either.
+        let msg = run_fail(
+            "let main = () => Effect.save(\"autosave\", Map.insert(0.0 / 0.0, 1.0, Map.empty()))",
+        );
+        assert!(
+            msg.contains("keys must be finite"),
+            "expected the map-key finiteness error, got: {msg}"
+        );
+        // A reserved Windows device name would write nowhere on that platform.
+        let msg = run_fail("let main = () => Effect.save(\"con\", 1.0)");
+        assert!(
+            msg.contains("reserved device name"),
+            "expected the reserved-name teaching error, got: {msg}"
+        );
+    }
+
+    /// The store is defence-in-depth, not just call-site validation: the Rust
+    /// API refuses a traversing key too, so no future host caller can reach
+    /// outside the saves directory.
+    #[test]
+    fn the_store_itself_refuses_a_traversing_slot() {
+        let _guard = crate::storage::SAVE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        crate::storage::set_project_root(dir.path().to_path_buf());
+        assert!(crate::storage::write_slot("../escape", "1").is_err());
+        assert!(crate::storage::read_slot("../escape").is_err());
+        assert!(!dir.path().parent().unwrap().join("escape.json").exists());
+    }
+
+    /// A dry-run projection writes to its OWN overlay: the player's store is
+    /// untouched, but a save is still visible to a later load inside the
+    /// projection (otherwise the projected model would diverge from the live
+    /// one for exactly the program this exists to project).
+    #[test]
+    fn a_dry_run_save_stays_in_the_projection() {
+        let _guard = crate::storage::SAVE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        crate::storage::set_project_root(dir.path().to_path_buf());
+        let (restored, _) = run_save_then_load(&mut DryRunEffects::new());
+        assert_eq!(restored, "{ score: 42, tags: [\"a\"] }");
+        assert!(
+            !dir.path().join(".functor/saves").exists(),
+            "a projection must not write the player's store"
         );
     }
 

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -5351,7 +5351,10 @@ dropping the rest"
             ));
             return;
         }
-        let (kind, value, tagger) = match tree {
+        // `kind` is the structured log's wire label; `api` is what a game
+        // author actually typed, so a message about a failed tagger names a
+        // function that exists (`Persistence.load`, not `Effect.storage.load`).
+        let (kind, api, value, tagger) = match tree {
             EffectTree::None => continue,
             EffectTree::Batch(items) => {
                 // Preserve declaration order against the LIFO queue.
@@ -5570,6 +5573,7 @@ dropping the rest"
                 }
                 None => (
                     "physics.raycast",
+                    "Physics.raycast",
                     runner.raycast(origin, dir, max_dist),
                     tagger,
                 ),
@@ -5600,16 +5604,23 @@ dropping the rest"
                 }
                 continue;
             }
-            EffectTree::Load { slot, tagger } => ("storage.load", runner.load(&slot), tagger),
-            EffectTree::Now { tagger } => ("now", runner.now().into(), tagger),
-            EffectTree::Random { tagger } => ("random", runner.random().into(), tagger),
+            EffectTree::Load { slot, tagger } => (
+                "storage.load",
+                "Persistence.load",
+                runner.load(&slot),
+                tagger,
+            ),
+            EffectTree::Now { tagger } => ("now", "Effect.now", runner.now().into(), tagger),
+            EffectTree::Random { tagger } => {
+                ("random", "Effect.random", runner.random().into(), tagger)
+            }
         };
         let value: EffectValue = value;
         let functor_lang_value = match value.to_functor_lang() {
             Ok(value) => value,
             Err(error) => {
                 report(format!(
-                    "[functor-lang] Effect.{kind} produced invalid structured data: {error}"
+                    "[functor-lang] {api} produced invalid structured data: {error}"
                 ));
                 continue;
             }
@@ -5621,12 +5632,12 @@ dropping the rest"
         let msg = match session.apply(
             tagger,
             vec![functor_lang_value],
-            &format!("Effect.{kind} tagger"),
+            &format!("{api} tagger"),
             &mut FunctorHost,
         ) {
             Ok(msg) => msg,
             Err(e) => {
-                report(format!("[functor-lang] Effect.{kind} tagger error: {}", e.message));
+                report(format!("[functor-lang] {api} tagger error: {}", e.message));
                 continue;
             }
         };
@@ -6245,6 +6256,25 @@ in this file (they quote `90deg` / `1.5rad` / `0.5s` / `500ms`) and this list to
     fn a_branded_sum_flows_into_a_branded_parameter() {
         eval_with_prelude("let main = () => Scene.cube() |> Scene.rotateY(90deg + 45deg)\n")
             .expect("a summed angle is still an Angle");
+    }
+
+    /// Drift guard: every namespace the prelude SHIPS must be reserved by the
+    /// language, or a game's `persistence.fun` — or an inline `module
+    /// Persistence` — silently steals it. `PROTECTED_NAMESPACES` is a static
+    /// list, so without this a new `.funi` lands unprotected by omission
+    /// (which is exactly what `Persistence` did, and `Terrain` before it).
+    #[test]
+    fn every_prelude_module_is_a_protected_namespace() {
+        let unprotected: Vec<String> = functor_prelude::modules()
+            .into_iter()
+            .map(|(name, _)| name)
+            .filter(|name| !functor_lang::project::is_protected_namespace(name))
+            .collect();
+        assert_eq!(
+            unprotected,
+            Vec::<String>::new(),
+            "prelude modules missing from PROTECTED_NAMESPACES (functor-lang/src/project.rs)"
+        );
     }
 
     // Drift guard: a HARD BIJECTION between the `functor-prelude` `.funi`

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -371,6 +371,25 @@ pub enum EffectTree {
         body: String,
         tagger: Value,
     },
+    /// Persist a plain-data value in a local save slot (`Effect.save(slot,
+    /// value)`). The payload is converted to its [`EffectValue`] at
+    /// construction (a closure inside is a teaching error at the call site,
+    /// exactly like [`Self::SendMsg`]) and written by the runner —
+    /// `Real` to the platform store ([`crate::storage`]), `Fake`/`Replay`
+    /// to memory. Tagger-less: a save reports nothing back.
+    Save {
+        slot: String,
+        payload: EffectValue,
+    },
+    /// Read a local save slot back (`Effect.load(slot, tagger)`). A same-frame
+    /// runner read like [`Self::Now`]: the tagger receives
+    /// `Option.Some(value)` or `Option.None` (absent OR unreadable/corrupt —
+    /// a broken save must not kill a running game), and the result lands in
+    /// the effect log, so a replay feeds back exactly what was loaded.
+    Load {
+        slot: String,
+        tagger: Value,
+    },
     /// A physics query (docs/physics.md Phase 4). Unlike `Now`/`Random`,
     /// queries are **deferred**: the pre-step drain holds them and the
     /// driver performs them right after the frame's physics step, so the
@@ -439,6 +458,52 @@ pub trait EffectRunner {
     /// singleton physics world; `Fake`/`Replay` return canned/recorded
     /// records — physics queries are testable without a world at all.
     fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue;
+    /// Persist a save slot (`Effect.save`). `Real` writes the platform store;
+    /// `Fake` records the write in memory (so a test can assert what a game
+    /// saved without touching a disk); `Replay` drops it — a replay must not
+    /// rewrite the world it is replaying. An error is returned for the drain
+    /// to report; the game keeps running.
+    fn save(&mut self, slot: &str, payload: &EffectValue) -> Result<(), String>;
+    /// Read a save slot (`Effect.load`) as `Option.Some(value)` /
+    /// `Option.None` — see [`save_slot_value`]. `Real` asks the platform
+    /// store; `Fake` answers from what it recorded (empty = `None`); `Replay`
+    /// replays the recorded result.
+    fn load(&mut self, slot: &str) -> EffectValue;
+}
+
+/// The tagger-facing `Option` for a loaded save slot. The ctors are the
+/// stdlib `Option`'s canonical names, so a game matches the ordinary
+/// `Option.Some(v)` / `Option.None` it already knows.
+pub fn save_slot_value(loaded: Option<EffectValue>) -> EffectValue {
+    match loaded {
+        Some(value) => EffectValue::Variant("Option.Some".to_string(), vec![value]),
+        None => EffectValue::Variant("Option.None".to_string(), Vec::new()),
+    }
+}
+
+/// Read a slot through the platform store and decode it — the `Real`/dry-run
+/// load. Absent OR undecodable both answer `None` (loudly logged): a save
+/// written by an older version of the game must degrade to "no save", never
+/// to a crash.
+fn read_saved_slot(slot: &str) -> EffectValue {
+    let text = match crate::storage::read_slot(slot) {
+        Ok(Some(text)) => text,
+        Ok(None) => return save_slot_value(None),
+        Err(error) => {
+            log::warn!("[functor-lang] Effect.load(\"{slot}\"): {error}");
+            return save_slot_value(None);
+        }
+    };
+    match serde_json::from_str::<EffectValue>(&text) {
+        Ok(value) => save_slot_value(Some(value)),
+        Err(error) => {
+            log::warn!(
+                "[functor-lang] Effect.load(\"{slot}\"): the saved data could not be \
+read ({error}) — answering Option.None"
+            );
+            save_slot_value(None)
+        }
+    }
 }
 
 /// The tagger-facing record for a raycast result. Always the full shape —
@@ -830,6 +895,14 @@ impl EffectRunner for RealEffects {
     fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
         active_world_raycast(origin, dir, max_dist)
     }
+    fn save(&mut self, slot: &str, payload: &EffectValue) -> Result<(), String> {
+        let text = serde_json::to_string(payload)
+            .expect("EffectValue is a closed plain-data enum; serialization cannot fail");
+        crate::storage::write_slot(slot, &text)
+    }
+    fn load(&mut self, slot: &str) -> EffectValue {
+        read_saved_slot(slot)
+    }
     fn random(&mut self) -> f64 {
         // xorshift64*; map the top 53 bits into [0, 1).
         let mut x = self.rng_state;
@@ -851,6 +924,12 @@ pub struct FakeEffects {
     /// misses. Test physics-query handling with no world at all.
     pub ray_hits: Vec<EffectValue>,
     next_ray: usize,
+    /// Every `Effect.save` this runner performed, in order — an in-memory
+    /// save store AND the journal of what the game wrote, so a test asserts
+    /// persistence without touching a disk or a browser. `Effect.load`
+    /// answers with the LAST value written to that slot (`Option.None` when
+    /// the slot was never written), which is exactly the real store's rule.
+    pub saves: Vec<(String, EffectValue)>,
 }
 
 impl FakeEffects {
@@ -861,7 +940,15 @@ impl FakeEffects {
             next: 0,
             ray_hits: Vec::new(),
             next_ray: 0,
+            saves: Vec::new(),
         }
+    }
+
+    /// Pre-seed the in-memory save store — a game booting against an
+    /// EXISTING save, with no disk involved.
+    pub fn with_saves(mut self, saves: Vec<(String, EffectValue)>) -> FakeEffects {
+        self.saves = saves;
+        self
     }
 
     pub fn with_ray_hits(mut self, ray_hits: Vec<EffectValue>) -> FakeEffects {
@@ -886,6 +973,19 @@ impl EffectRunner for FakeEffects {
         let v = self.ray_hits[self.next_ray % self.ray_hits.len()].clone();
         self.next_ray += 1;
         v
+    }
+    fn save(&mut self, slot: &str, payload: &EffectValue) -> Result<(), String> {
+        self.saves.push((slot.to_string(), payload.clone()));
+        Ok(())
+    }
+    fn load(&mut self, slot: &str) -> EffectValue {
+        save_slot_value(
+            self.saves
+                .iter()
+                .rev()
+                .find(|(key, _)| key == slot)
+                .map(|(_, value)| value.clone()),
+        )
     }
 }
 
@@ -912,6 +1012,16 @@ impl EffectRunner for DryRunEffects {
     }
     fn raycast(&mut self, origin: [f32; 3], dir: [f32; 3], max_dist: f32) -> EffectValue {
         active_world_raycast(origin, dir, max_dist)
+    }
+    fn save(&mut self, _slot: &str, _payload: &EffectValue) -> Result<(), String> {
+        // A projection must not touch the player's save. (The drain already
+        // suppresses outbound work on this path; this is the belt.)
+        Ok(())
+    }
+    fn load(&mut self, slot: &str) -> EffectValue {
+        // A slot READ is a world read, not an environment read — same rule as
+        // `raycast`: the projection sees the store the live game sees.
+        read_saved_slot(slot)
     }
 }
 
@@ -960,6 +1070,16 @@ impl EffectRunner for ReplayEffects {
     }
     fn raycast(&mut self, _origin: [f32; 3], _dir: [f32; 3], _max_dist: f32) -> EffectValue {
         self.take("physics.raycast")
+    }
+    fn save(&mut self, _slot: &str, _payload: &EffectValue) -> Result<(), String> {
+        // A replay must not rewrite the world it is replaying — but it DOES
+        // consume the recording's `storage.save` record, so the log stays
+        // index-aligned and a save/load sequence replays exactly.
+        self.take("storage.save");
+        Ok(())
+    }
+    fn load(&mut self, _slot: &str) -> EffectValue {
+        self.take("storage.load")
     }
 }
 
@@ -3444,6 +3564,32 @@ fn register_effects(reg: &mut crate::host_registry::Registry) {
             Ok(FunctorLangEffect(EffectTree::SendMsg { conn, payload }))
         },
     );
+    // save(slot, value) / load(slot, tagger): durable LOCAL state through the
+    // same broker (and the same plain-data codec as `sendMsg`) — a game's
+    // "write my progress" and "read it back at boot". The slot key and the
+    // payload are validated HERE, at the construction site, so a bad key or a
+    // closure in the model errors at the call instead of mid-drain.
+    reg.fn2(
+        "Effect.save",
+        "Effect.save(slot, value)",
+        |slot: String, value: Value| {
+            crate::storage::validate_slot(&slot).map_err(|e| format!("Effect.save: {e}"))?;
+            let payload =
+                effect_value_from_value(&value).map_err(|e| format!("Effect.save: {e}"))?;
+            Ok(FunctorLangEffect(EffectTree::Save { slot, payload }))
+        },
+    );
+    reg.fn2(
+        "Effect.load",
+        "Effect.load(slot, tagger)",
+        |slot: String, tagger: Tagger| {
+            crate::storage::validate_slot(&slot).map_err(|e| format!("Effect.load: {e}"))?;
+            Ok(FunctorLangEffect(EffectTree::Load {
+                slot,
+                tagger: tagger.0,
+            }))
+        },
+    );
     // httpGet(url, tagger) / httpPost(url, body, tagger). The tagger is a
     // function of the Net.HttpResponse; performing the effect (drain) mints a
     // token, queues the request, and registers the tagger by token — see
@@ -5085,8 +5231,13 @@ pub fn needs_update(tree: &EffectTree) -> bool {
         | EffectTree::PlayAudio { .. }
         | EffectTree::PlayAudioThen { .. }
         | EffectTree::PreloadAsset { .. }
-        | EffectTree::PreloadAssetThen { .. } => false,
-        EffectTree::Now { .. } | EffectTree::Random { .. } | EffectTree::Raycast { .. } => true,
+        | EffectTree::PreloadAssetThen { .. }
+        // A save reports nothing back; only `Effect.load` has a tagger.
+        | EffectTree::Save { .. } => false,
+        EffectTree::Now { .. }
+        | EffectTree::Random { .. }
+        | EffectTree::Raycast { .. }
+        | EffectTree::Load { .. } => true,
         EffectTree::Batch(items) => items.iter().any(needs_update),
     }
 }
@@ -5385,6 +5536,33 @@ dropping the rest"
                     tagger,
                 ),
             },
+            EffectTree::Save { slot, payload } => {
+                // Tagger-less, like a physics command: perform the write and
+                // log the STRUCTURED payload, so what a game persisted is
+                // observable (and replayable) as data. A failed write is
+                // reported and dropped — a full disk must not kill the game.
+                //
+                // Unlike the outbound arms below, a save is NOT gated on
+                // `suppress_outbound`: the RUNNER is already the world seam
+                // here (a dry run holds a `DryRunEffects`, whose `save` is a
+                // no-op; a replay consumes its record instead of writing), and
+                // routing it through the runner unconditionally is what keeps
+                // a replayed save/load pair index-aligned with its recording.
+                if let Err(error) = runner.save(&slot, &payload) {
+                    report(format!(
+                        "[functor-lang] Effect.save(\"{slot}\") failed: {error}"
+                    ));
+                }
+                log.push(EffectRecord {
+                    kind: "storage.save",
+                    value: payload,
+                });
+                if log.len() > EFFECT_LOG_CAP {
+                    log.remove(0);
+                }
+                continue;
+            }
+            EffectTree::Load { slot, tagger } => ("storage.load", runner.load(&slot), tagger),
             EffectTree::Now { tagger } => ("now", runner.now().into(), tagger),
             EffectTree::Random { tagger } => ("random", runner.random().into(), tagger),
         };
@@ -11039,6 +11217,189 @@ the game dir"
         assert!(
             msg.contains("non-finite"),
             "expected the non-finite teaching error, got: {msg}"
+        );
+    }
+
+    /// A save/load program, run under whichever runner a test hands it: the
+    /// first tick saves the model, the second loads it into a FRESH model —
+    /// the "quit and relaunch" shape, minus the process boundary.
+    fn run_save_then_load(runner: &mut dyn EffectRunner) -> (String, EffectLog) {
+        let src = "let init = { score: 0.0, tags: [\"a\"] }\n\
+                   let update = (m, msg) =>\n\
+                     match msg with\n\
+                     | Option.Some(saved) => saved\n\
+                     | Option.None => m\n\
+                   let save = (m) => (m, Effect.save(\"autosave\", m))\n\
+                   let restore = (m) => (m, Effect.load(\"autosave\", (o) => o))\n";
+        let project = functor_lang::project::load_single_source("game", src)
+            .unwrap_or_else(|e| panic!("load: {}", e.render()));
+        let session = functor_lang::Session::load(&project.module, &mut FunctorHost)
+            .unwrap_or_else(|f| panic!("session: {}", f.error.message));
+        let mut log = EffectLog::new();
+        let mut drain = |model: &mut Value, name: &str| {
+            let (next, fx) = split_model_effect(
+                session
+                    .call(name, vec![model.clone()], &mut FunctorHost)
+                    .unwrap_or_else(|e| panic!("{name}: {}", e.message)),
+            );
+            *model = next;
+            let deferred = drain_effects(
+                &session,
+                "update",
+                model,
+                fx.expect("an effect"),
+                runner,
+                &mut log,
+                &mut |m| panic!("unexpected report: {m}"),
+                false,
+            );
+            assert!(deferred.is_empty(), "nothing should defer here");
+        };
+        // Play a little, then save.
+        let mut model = Value::Record(std::rc::Rc::new(vec![
+            ("score".to_string(), Value::Number(42.0)),
+            (
+                "tags".to_string(),
+                Value::List(std::rc::Rc::new(vec![Value::String(Rc::from("a"))])),
+            ),
+        ]));
+        drain(&mut model, "save");
+        // Relaunch: a fresh model, restored from the slot.
+        let mut restarted = session.global("init").unwrap();
+        drain(&mut restarted, "restore");
+        (restarted.to_string(), log)
+    }
+
+    /// The persistence spine on the REAL store: `Effect.save` writes the
+    /// project's slot file (atomically, as canonical plain-data JSON) and a
+    /// later `Effect.load` restores exactly the saved value into a fresh
+    /// model — the quit-and-relaunch contract, plus the on-disk artifact.
+    #[test]
+    fn save_writes_the_slot_file_and_load_restores_it() {
+        let _guard = crate::storage::SAVE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        crate::storage::set_project_root(dir.path().to_path_buf());
+        let (restored, log) = run_save_then_load(&mut RealEffects::new());
+        assert_eq!(restored, "{ score: 42, tags: [\"a\"] }");
+        let expected = EffectValue::Record(vec![
+            ("score".into(), EffectValue::Number(42.0)),
+            ("tags".into(), EffectValue::List(vec![EffectValue::Text("a".into())])),
+        ]);
+        assert_eq!(
+            log,
+            vec![
+                EffectRecord {
+                    kind: "storage.save",
+                    value: expected.clone()
+                },
+                EffectRecord {
+                    kind: "storage.load",
+                    value: save_slot_value(Some(expected.clone()))
+                },
+            ]
+        );
+        // The artifact a player's save actually is: one JSON file under the
+        // project, decodable back into the same plain data.
+        let text = std::fs::read_to_string(dir.path().join(".functor/saves/autosave.json")).unwrap();
+        assert_eq!(serde_json::from_str::<EffectValue>(&text).unwrap(), expected);
+    }
+
+    /// A slot that was never written — and one whose file is corrupt — both
+    /// answer `Option.None` instead of failing the frame.
+    #[test]
+    fn an_absent_or_corrupt_slot_loads_as_none() {
+        let _guard = crate::storage::SAVE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        crate::storage::set_project_root(dir.path().to_path_buf());
+        assert_eq!(
+            RealEffects::new().load("autosave"),
+            save_slot_value(None),
+            "an unwritten slot is None"
+        );
+        std::fs::create_dir_all(dir.path().join(".functor/saves")).unwrap();
+        std::fs::write(dir.path().join(".functor/saves/autosave.json"), "{not json").unwrap();
+        assert_eq!(
+            RealEffects::new().load("autosave"),
+            save_slot_value(None),
+            "a corrupt slot is None, not a crash"
+        );
+    }
+
+    /// `FakeEffects` is an in-memory store: it RECORDS what the game saved
+    /// (so a test asserts persistence with no disk at all) and answers loads
+    /// from it — the same program, no world.
+    #[test]
+    fn fake_effects_record_saves_and_answer_loads() {
+        let mut fake = FakeEffects::new(0.0, vec![0.0]);
+        let (restored, log) = run_save_then_load(&mut fake);
+        assert_eq!(restored, "{ score: 42, tags: [\"a\"] }");
+        assert_eq!(fake.saves.len(), 1);
+        assert_eq!(fake.saves[0].0, "autosave");
+        assert_eq!(log[0].kind, "storage.save");
+        // An untouched slot is absent, and a pre-seeded one boots restored.
+        assert_eq!(
+            FakeEffects::new(0.0, vec![0.0]).load("nothing-here"),
+            save_slot_value(None)
+        );
+        let seeded = EffectValue::Number(7.0);
+        assert_eq!(
+            FakeEffects::new(0.0, vec![0.0])
+                .with_saves(vec![("autosave".into(), seeded.clone())])
+                .load("autosave"),
+            save_slot_value(Some(seeded))
+        );
+    }
+
+    /// Replay determinism: a recorded save/load log replays to the SAME model
+    /// and the same log, with no store consulted — and the replay does not
+    /// rewrite the slot it is replaying.
+    #[test]
+    fn a_recorded_save_load_sequence_replays_exactly() {
+        let (fake_model, fake_log) = run_save_then_load(&mut FakeEffects::new(0.0, vec![0.0]));
+        let _guard = crate::storage::SAVE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Point the real store at an empty directory: if replay touched it,
+        // the assertions below (and this directory) would show it.
+        let dir = tempfile::tempdir().unwrap();
+        crate::storage::set_project_root(dir.path().to_path_buf());
+        let (replay_model, replay_log) = run_save_then_load(&mut ReplayEffects::new(fake_log.clone()));
+        assert_eq!(replay_model, fake_model);
+        assert_eq!(replay_log, fake_log);
+        assert!(
+            !dir.path().join(".functor/saves").exists(),
+            "a replay must not write the store it is replaying"
+        );
+    }
+
+    /// The two call-site guards: a slot key is a NAME (no traversal, no
+    /// separators, no empty), and a payload must be plain data — both taught
+    /// at the construction site, not frames later.
+    #[test]
+    fn save_rejects_bad_slots_and_non_plain_values() {
+        let msg = run_fail("let main = () => Effect.save(\"../escape\", 1.0)");
+        assert!(
+            msg.contains("Effect.save: slot key") && msg.contains("a slot is a NAME, not a path"),
+            "expected the slot teaching error, got: {msg}"
+        );
+        let msg = run_fail("let main = () => Effect.load(\"\", (o) => o)");
+        assert!(
+            msg.contains("Effect.load: slot key must not be empty"),
+            "expected the empty-slot teaching error, got: {msg}"
+        );
+        let msg = run_fail("let main = () => Effect.save(\"autosave\", (x) => x)");
+        assert!(
+            msg.contains("Effect.save: not plain data") && msg.contains("a function"),
+            "expected the plain-data teaching error, got: {msg}"
+        );
+        let msg = run_fail("let main = () => Effect.save(\"autosave\", Scene.cube())");
+        assert!(
+            msg.contains("not plain data") && msg.contains("opaque host value"),
+            "expected the host-value teaching error, got: {msg}"
         );
     }
 

--- a/runtime/functor-runtime-common/src/lib.rs
+++ b/runtime/functor-runtime-common/src/lib.rs
@@ -96,6 +96,7 @@ mod sprite2d;
 // The built-in font is an implementation detail of `Sprite.text`, not public
 // API — nothing outside this crate should depend on its atlas layout.
 mod sprite_font;
+pub mod storage;
 pub mod terrain;
 mod terrain_renderer;
 pub mod texture;

--- a/runtime/functor-runtime-common/src/storage.rs
+++ b/runtime/functor-runtime-common/src/storage.rs
@@ -8,13 +8,20 @@
 //! Two backends, one API:
 //!
 //! - **native** — `<project>/.functor/saves/<slot>.json`, written atomically
-//!   (temp file in the same directory, then rename) so a crash mid-write
-//!   leaves the previous save intact rather than a truncated one. The project
-//!   root is declared by the producer at load ([`set_project_root`]); until
-//!   then it falls back to the process's working directory.
-//! - **wasm** — one `localStorage` key per slot, scoped by the page's path
-//!   (`functor:save:<pathname>:<slot>`), so two games served from one origin
-//!   do not share slots.
+//!   (a per-process temp file in the same directory, then rename) so a reader
+//!   never sees a half-written slot. The project root is declared by the
+//!   producer at load ([`set_project_root`]); until then it falls back to the
+//!   process's working directory — which is the project directory for
+//!   `functor run native` (the CLI chdirs), but NOT for the embedded producer
+//!   on Quest, where saves are not yet wired to a writable app directory.
+//! - **wasm** — one `localStorage` key per slot, scoped by the page path AND
+//!   the entry the page booted (`functor:save:<pathname>|<entry>:<slot>`):
+//!   the site serves every game from one `player.html`, so the page alone
+//!   would make all of them share an `"autosave"`.
+//!
+//! The store is process-global (one root, one page) because a process runs
+//! one game. Two producers in one process would share it — the same
+//! constraint the physics world and the audio queue already carry.
 //!
 //! Slot keys are restricted to a safe charset ([`validate_slot`]) — a slot is
 //! a NAME, never a path, so `../` can never escape the saves directory.
@@ -24,10 +31,23 @@
 /// every filesystem.
 pub const MAX_SLOT_LEN: usize = 64;
 
+/// Windows reserved device names: `con.json` still resolves to the console
+/// device there, so a slot named `con` would write nowhere on that platform
+/// while working everywhere else. Refuse them on every platform, so a game
+/// cannot be portable-by-accident.
+const RESERVED_SLOTS: &[&str] = &[
+    "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+    "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+];
+
 /// Accept a slot key, or teach why it was refused. The charset is
 /// deliberately narrow — letters, digits, `_` and `-` — so a slot cannot
 /// carry a path separator, a `..`, a drive letter, or a leading dot: the key
 /// is a name the store places, never a path the game chooses.
+///
+/// Note that slots are case-SENSITIVE in `localStorage` but not on a
+/// case-insensitive filesystem (macOS, Windows), so `"Save"` and `"save"` are
+/// one slot natively and two on the web. Pick one casing per game.
 pub fn validate_slot(slot: &str) -> Result<(), String> {
     if slot.is_empty() {
         return Err("slot key must not be empty — name the slot, e.g. \"autosave\"".to_string());
@@ -46,6 +66,12 @@ e.g. \"autosave\"",
         return Err(format!(
             "slot key {slot:?} contains {bad:?} — a slot is a NAME, not a path: use \
 letters, digits, '_' or '-' (e.g. \"autosave\", \"profile-2\")"
+        ));
+    }
+    if RESERVED_SLOTS.contains(&slot.to_ascii_lowercase().as_str()) {
+        return Err(format!(
+            "slot key {slot:?} is a reserved device name on Windows — pick another \
+name (e.g. \"autosave\")"
         ));
     }
     Ok(())
@@ -90,41 +116,66 @@ mod backend {
         root.join(".functor").join("saves")
     }
 
-    /// The on-disk file for a slot. The key is already validated (see
-    /// [`super::validate_slot`]), so this join cannot escape the directory.
-    pub fn slot_path(slot: &str) -> PathBuf {
+    /// The on-disk file for a slot. Callers validate the key first (see
+    /// [`super::validate_slot`]), so this join cannot escape the directory —
+    /// which is why it stays private to the backend.
+    fn slot_path(slot: &str) -> PathBuf {
         saves_dir().join(format!("{slot}.json"))
     }
 
     /// Write a slot ATOMICALLY: a temp file beside the target, flushed, then
     /// renamed over it. A crash (or a full disk) leaves the previous save
     /// readable instead of a half-written one.
+    ///
+    /// The temp name is unique per process AND per call (the `io` disk
+    /// cache's rule, one step further): two `functor` processes on one project
+    /// — a game plus an MCP session, a `run` plus a debug client — must not
+    /// interleave into one shared temp, and `create_new` refuses to follow a
+    /// pre-existing file or symlink at that path.
     pub fn write_slot(slot: &str, text: &str) -> Result<(), String> {
         use std::io::Write;
+        super::validate_slot(slot)?;
         let path = slot_path(slot);
         let dir = saves_dir();
         std::fs::create_dir_all(&dir)
             .map_err(|e| format!("could not create {}: {e}", dir.display()))?;
-        let tmp = dir.join(format!("{slot}.json.tmp"));
-        {
-            let mut file = std::fs::File::create(&tmp)
+        static NEXT_TMP: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let tmp = dir.join(format!(
+            "{slot}.{}-{}.tmp",
+            std::process::id(),
+            NEXT_TMP.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        let write = || -> Result<(), String> {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp)
                 .map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
             file.write_all(text.as_bytes())
                 .map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
-            // Durability before the rename: without the sync the rename can
-            // become visible ahead of the bytes, which is the one failure the
-            // temp+rename dance exists to prevent.
-            file.sync_all()
-                .map_err(|e| format!("could not flush {}: {e}", tmp.display()))?;
+            // Deliberately NO `fsync`: this runs inline on the frame thread
+            // (a game may autosave on a timer), and the property being bought
+            // is that a READER never sees a half-written slot — which the
+            // rename alone gives. Surviving a power cut mid-write is not
+            // promised, and the crate's other atomic write (`io::cache_write`)
+            // makes the same trade.
+            drop(file);
+            std::fs::rename(&tmp, &path)
+                .map_err(|e| format!("could not replace {}: {e}", path.display()))
+        };
+        let result = write();
+        if result.is_err() {
+            // Never leave a stray temp behind for a later `create_new` to trip on.
+            let _ = std::fs::remove_file(&tmp);
         }
-        std::fs::rename(&tmp, &path)
-            .map_err(|e| format!("could not replace {}: {e}", path.display()))
+        result
     }
 
     /// Read a slot's text, or `None` when the slot has never been written.
     /// An unreadable file is an error (the caller reports it and answers
     /// `Option.None`, so a broken save never kills a running game).
     pub fn read_slot(slot: &str) -> Result<Option<String>, String> {
+        super::validate_slot(slot)?;
         let path = slot_path(slot);
         match std::fs::read_to_string(&path) {
             Ok(text) => Ok(Some(text)),
@@ -136,14 +187,36 @@ mod backend {
 
 #[cfg(target_arch = "wasm32")]
 mod backend {
-    /// Every slot lives under one prefix, scoped by the page's PATH — two
-    /// games served from the same origin (the site's sandbox, an itch.io
-    /// bundle) keep separate saves.
+    /// Every slot lives under one prefix, scoped by the PROJECT: the page's
+    /// path plus the entry the page booted (`window.__functorLangGamePath` —
+    /// the wasm counterpart of `--game-path`, which every host page sets).
+    /// The page alone is not enough: the site's player serves many games from
+    /// one `player.html`, and they must not share an `"autosave"`. The entry
+    /// path is stable across edits (a source hash would not be), so a save
+    /// survives hot-pushed source.
     fn storage_key(slot: &str) -> String {
-        let scope = web_sys::window()
+        let page = web_sys::window()
             .and_then(|w| w.location().pathname().ok())
             .unwrap_or_default();
-        format!("functor:save:{scope}:{slot}")
+        let entry = web_sys::window()
+            .and_then(|w| {
+                js_sys::Reflect::get(&w, &wasm_bindgen::JsValue::from_str("__functorLangGamePath"))
+                    .ok()
+            })
+            .and_then(|value| value.as_string())
+            .unwrap_or_default();
+        // A `data:` entry is a whole inline program (the docs' "try it"
+        // buttons) — it is neither stable nor short, so those share one
+        // scratch scope instead of minting a key per edit.
+        let entry = if entry.starts_with("data:") {
+            "inline"
+        } else {
+            entry
+                .char_indices()
+                .nth(128)
+                .map_or(entry.as_str(), |(byte, _)| &entry[..byte])
+        };
+        format!("functor:save:{page}|{entry}:{slot}")
     }
 
     fn local_storage() -> Result<web_sys::Storage, String> {
@@ -158,6 +231,7 @@ mod backend {
     /// lands whole or raises (a quota error, which is reported like a failed
     /// disk write on native).
     pub fn write_slot(slot: &str, text: &str) -> Result<(), String> {
+        super::validate_slot(slot)?;
         local_storage()?
             .set_item(&storage_key(slot), text)
             .map_err(|_| "localStorage write failed (quota exceeded?)".to_string())
@@ -165,6 +239,7 @@ mod backend {
 
     /// Read a slot's text, or `None` when the key has never been written.
     pub fn read_slot(slot: &str) -> Result<Option<String>, String> {
+        super::validate_slot(slot)?;
         local_storage()?
             .get_item(&storage_key(slot))
             .map_err(|_| "localStorage read failed".to_string())
@@ -174,7 +249,10 @@ mod backend {
 pub use backend::{read_slot, write_slot};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use backend::{saves_dir, set_project_root, slot_path};
+pub use backend::set_project_root;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+use backend::saves_dir;
 
 /// Serializes tests that point the (process-global) native store at a
 /// throwaway directory — `Effect.save`/`load` tests live in the prelude too.

--- a/runtime/functor-runtime-common/src/storage.rs
+++ b/runtime/functor-runtime-common/src/storage.rs
@@ -1,0 +1,241 @@
+//! Durable local save slots — the store behind `Effect.save` / `Effect.load`.
+//!
+//! A slot is a named blob of PLAIN DATA (the same structural codec
+//! `Effect.sendMsg` uses: [`crate::functor_lang_prelude::EffectValue`] as
+//! canonical JSON), so what a game persists is exactly what can cross a wire
+//! or land in the effect log — no closures, no host handles.
+//!
+//! Two backends, one API:
+//!
+//! - **native** — `<project>/.functor/saves/<slot>.json`, written atomically
+//!   (temp file in the same directory, then rename) so a crash mid-write
+//!   leaves the previous save intact rather than a truncated one. The project
+//!   root is declared by the producer at load ([`set_project_root`]); until
+//!   then it falls back to the process's working directory.
+//! - **wasm** — one `localStorage` key per slot, scoped by the page's path
+//!   (`functor:save:<pathname>:<slot>`), so two games served from one origin
+//!   do not share slots.
+//!
+//! Slot keys are restricted to a safe charset ([`validate_slot`]) — a slot is
+//! a NAME, never a path, so `../` can never escape the saves directory.
+
+/// The longest accepted slot key. Long enough for any human-authored slot
+/// name (`"autosave"`, `"profile-2"`), short enough to stay a filename on
+/// every filesystem.
+pub const MAX_SLOT_LEN: usize = 64;
+
+/// Accept a slot key, or teach why it was refused. The charset is
+/// deliberately narrow — letters, digits, `_` and `-` — so a slot cannot
+/// carry a path separator, a `..`, a drive letter, or a leading dot: the key
+/// is a name the store places, never a path the game chooses.
+pub fn validate_slot(slot: &str) -> Result<(), String> {
+    if slot.is_empty() {
+        return Err("slot key must not be empty — name the slot, e.g. \"autosave\"".to_string());
+    }
+    if slot.len() > MAX_SLOT_LEN {
+        return Err(format!(
+            "slot key is too long ({} chars, max {MAX_SLOT_LEN}) — name the slot, \
+e.g. \"autosave\"",
+            slot.len()
+        ));
+    }
+    if let Some(bad) = slot
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '-'))
+    {
+        return Err(format!(
+            "slot key {slot:?} contains {bad:?} — a slot is a NAME, not a path: use \
+letters, digits, '_' or '-' (e.g. \"autosave\", \"profile-2\")"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod backend {
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    use once_cell::sync::Lazy;
+
+    /// The project directory saves live under. Declared by the producer at
+    /// load; `None` means "the working directory" (the embedded native
+    /// producer runs from pushed sources and has no directory of its own).
+    static ROOT: Lazy<Mutex<Option<PathBuf>>> = Lazy::new(|| Mutex::new(None));
+
+    /// Point the store at a project — its saves land in
+    /// `<project>/.functor/saves`. The producers name a project by either its
+    /// DIRECTORY or its entry FILE (both are valid `functor run` inputs), so
+    /// a file path is normalized to its containing directory here rather than
+    /// at each call site.
+    pub fn set_project_root(root: PathBuf) {
+        let root = if root.extension().is_some() && !root.is_dir() {
+            root.parent()
+                .map(|dir| dir.to_path_buf())
+                .filter(|dir| !dir.as_os_str().is_empty())
+                .unwrap_or_else(|| PathBuf::from("."))
+        } else {
+            root
+        };
+        *ROOT.lock().unwrap_or_else(|e| e.into_inner()) = Some(root);
+    }
+
+    /// `<project>/.functor/saves` — the directory holding every slot file.
+    pub fn saves_dir() -> PathBuf {
+        let root = ROOT
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        root.join(".functor").join("saves")
+    }
+
+    /// The on-disk file for a slot. The key is already validated (see
+    /// [`super::validate_slot`]), so this join cannot escape the directory.
+    pub fn slot_path(slot: &str) -> PathBuf {
+        saves_dir().join(format!("{slot}.json"))
+    }
+
+    /// Write a slot ATOMICALLY: a temp file beside the target, flushed, then
+    /// renamed over it. A crash (or a full disk) leaves the previous save
+    /// readable instead of a half-written one.
+    pub fn write_slot(slot: &str, text: &str) -> Result<(), String> {
+        use std::io::Write;
+        let path = slot_path(slot);
+        let dir = saves_dir();
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("could not create {}: {e}", dir.display()))?;
+        let tmp = dir.join(format!("{slot}.json.tmp"));
+        {
+            let mut file = std::fs::File::create(&tmp)
+                .map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
+            file.write_all(text.as_bytes())
+                .map_err(|e| format!("could not write {}: {e}", tmp.display()))?;
+            // Durability before the rename: without the sync the rename can
+            // become visible ahead of the bytes, which is the one failure the
+            // temp+rename dance exists to prevent.
+            file.sync_all()
+                .map_err(|e| format!("could not flush {}: {e}", tmp.display()))?;
+        }
+        std::fs::rename(&tmp, &path)
+            .map_err(|e| format!("could not replace {}: {e}", path.display()))
+    }
+
+    /// Read a slot's text, or `None` when the slot has never been written.
+    /// An unreadable file is an error (the caller reports it and answers
+    /// `Option.None`, so a broken save never kills a running game).
+    pub fn read_slot(slot: &str) -> Result<Option<String>, String> {
+        let path = slot_path(slot);
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Ok(Some(text)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(format!("could not read {}: {e}", path.display())),
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod backend {
+    /// Every slot lives under one prefix, scoped by the page's PATH — two
+    /// games served from the same origin (the site's sandbox, an itch.io
+    /// bundle) keep separate saves.
+    fn storage_key(slot: &str) -> String {
+        let scope = web_sys::window()
+            .and_then(|w| w.location().pathname().ok())
+            .unwrap_or_default();
+        format!("functor:save:{scope}:{slot}")
+    }
+
+    fn local_storage() -> Result<web_sys::Storage, String> {
+        web_sys::window()
+            .ok_or_else(|| "no window".to_string())?
+            .local_storage()
+            .map_err(|_| "localStorage is unavailable (blocked by the browser?)".to_string())?
+            .ok_or_else(|| "localStorage is unavailable".to_string())
+    }
+
+    /// Write a slot. `localStorage` is already atomic per key — a set either
+    /// lands whole or raises (a quota error, which is reported like a failed
+    /// disk write on native).
+    pub fn write_slot(slot: &str, text: &str) -> Result<(), String> {
+        local_storage()?
+            .set_item(&storage_key(slot), text)
+            .map_err(|_| "localStorage write failed (quota exceeded?)".to_string())
+    }
+
+    /// Read a slot's text, or `None` when the key has never been written.
+    pub fn read_slot(slot: &str) -> Result<Option<String>, String> {
+        local_storage()?
+            .get_item(&storage_key(slot))
+            .map_err(|_| "localStorage read failed".to_string())
+    }
+}
+
+pub use backend::{read_slot, write_slot};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use backend::{saves_dir, set_project_root, slot_path};
+
+/// Serializes tests that point the (process-global) native store at a
+/// throwaway directory — `Effect.save`/`load` tests live in the prelude too.
+#[cfg(test)]
+pub(crate) static SAVE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A slot key is a NAME: traversal, separators, and empties are refused
+    /// at the door, with a message that teaches the shape.
+    #[test]
+    fn slot_keys_are_names_not_paths() {
+        for ok in ["autosave", "profile-2", "SLOT_9", "a"] {
+            assert!(validate_slot(ok).is_ok(), "{ok} should be a valid slot");
+        }
+        for bad in ["", "../escape", "a/b", "a\\b", ".hidden", "с", "with space", "x.json"] {
+            assert!(validate_slot(bad).is_err(), "{bad:?} should be refused");
+        }
+        assert!(validate_slot(&"a".repeat(MAX_SLOT_LEN)).is_ok());
+        assert!(validate_slot(&"a".repeat(MAX_SLOT_LEN + 1)).is_err());
+        let message = validate_slot("../escape").unwrap_err();
+        assert!(
+            message.contains("a slot is a NAME, not a path"),
+            "expected the teaching error, got: {message}"
+        );
+    }
+
+    /// Native round-trip through a real directory: absent reads as `None`,
+    /// a write lands under `<root>/.functor/saves/<slot>.json`, and no temp
+    /// file survives a successful write.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn writes_land_under_the_project_root_and_read_back() {
+        let _guard = SAVE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        set_project_root(dir.path().to_path_buf());
+        assert_eq!(read_slot("fresh").unwrap(), None);
+        write_slot("fresh", "{\"n\":1}").unwrap();
+        let path = dir.path().join(".functor/saves/fresh.json");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{\"n\":1}");
+        assert_eq!(read_slot("fresh").unwrap().as_deref(), Some("{\"n\":1}"));
+        // Overwrite in place, leaving no temp behind.
+        write_slot("fresh", "{\"n\":2}").unwrap();
+        assert_eq!(read_slot("fresh").unwrap().as_deref(), Some("{\"n\":2}"));
+        assert!(!dir.path().join(".functor/saves/fresh.json.tmp").exists());
+    }
+
+    /// A project is named by its directory OR its entry file (both are valid
+    /// `functor run` inputs) — an entry file resolves to the directory
+    /// holding it, so saves never land beside a path like `game.fun/…`.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn an_entry_file_names_its_directory() {
+        let _guard = SAVE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("game.fun"), "let init = 0.0\n").unwrap();
+        set_project_root(dir.path().join("game.fun"));
+        assert_eq!(saves_dir(), dir.path().join(".functor").join("saves"));
+        set_project_root(dir.path().to_path_buf());
+        assert_eq!(saves_dir(), dir.path().join(".functor").join("saves"));
+    }
+}

--- a/runtime/functor-runtime-common/src/storage.rs
+++ b/runtime/functor-runtime-common/src/storage.rs
@@ -1,4 +1,4 @@
-//! Durable local save slots — the store behind `Effect.save` / `Effect.load`.
+//! Durable local save slots — the store behind `Persistence.save` / `Persistence.load`.
 //!
 //! A slot is a named blob of PLAIN DATA (the same structural codec
 //! `Effect.sendMsg` uses: [`crate::functor_lang_prelude::EffectValue`] as
@@ -255,7 +255,7 @@ pub use backend::set_project_root;
 use backend::saves_dir;
 
 /// Serializes tests that point the (process-global) native store at a
-/// throwaway directory — `Effect.save`/`load` tests live in the prelude too.
+/// throwaway directory — `Persistence.save`/`load` tests live in the prelude too.
 #[cfg(test)]
 pub(crate) static SAVE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -430,6 +430,10 @@ impl FunctorLangGame {
         // per process; survives hot-reload's Session rebuild — the sink is
         // installed on the process, not the Session). See functor_lang_prelude.
         functor_runtime_common::functor_lang_prelude::install_debug_log_sink();
+        // `Effect.save`/`Effect.load` slots belong to the PROJECT, not the
+        // process's working directory: point the store at the game dir before
+        // the first frame can issue a load.
+        functor_runtime_common::storage::set_project_root(std::path::PathBuf::from(path));
         // Stat BEFORE reading: an edit that lands mid-load then compares
         // unequal on the next frame and triggers a reload, instead of being
         // silently absorbed into a stale session.

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -430,7 +430,7 @@ impl FunctorLangGame {
         // per process; survives hot-reload's Session rebuild — the sink is
         // installed on the process, not the Session). See functor_lang_prelude.
         functor_runtime_common::functor_lang_prelude::install_debug_log_sink();
-        // `Effect.save`/`Effect.load` slots belong to the PROJECT, not the
+        // `Persistence.save`/`Persistence.load` slots belong to the PROJECT, not the
         // process's working directory: point the store at the game dir before
         // the first frame can issue a load.
         functor_runtime_common::storage::set_project_root(std::path::PathBuf::from(path));

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -78,7 +78,11 @@ const CATEGORIES: &[(ApiGroup, &str, &[&str])] = &[
         &["Physics", "Anim", "Terrain", "Time"],
     ),
     (ApiGroup::Engine, "Input", &["Input"]),
-    (ApiGroup::Engine, "Effects & messaging", &["Effect", "Sub"]),
+    (
+        ApiGroup::Engine,
+        "Effects & messaging",
+        &["Effect", "Sub", "Persistence"],
+    ),
     (ApiGroup::Engine, "Audio", &["AudioScene", "AudioSource"]),
     (ApiGroup::Engine, "UI", &["Ui", "Html", "Attr", "Style"]),
     (ApiGroup::Engine, "Assets", &["Asset"]),
@@ -670,7 +674,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (28, 323));
+        assert_eq!(count(ApiGroup::Engine), (29, 323));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -670,7 +670,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (28, 321));
+        assert_eq!(count(ApiGroup::Engine), (28, 323));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
Closes the jam's P0 persistence gap: **nothing in Functor could write durable local state.** The whole `Effect` surface (`none, now, random, batch, send, sendMsg, httpGet, httpPost, play, playAt, playThen, preload, preloadThen`) was in-memory or outbound. Hot-reload preserving the model hides this in dev — every real exit lost everything. The jam's `clicker` entry shipped an **85-line player-visible save-code workaround** (an `NF1:…` string in the HUD, a `Ui.textInput`, and manual copy/paste) because there was no alternative.

## The fix

Two ordinary effects riding the existing broker — in their own **`Persistence`
module**, per maintainer feedback on the API surface (this is not more `Effect`
vocabulary). Both produce an ordinary `Effect.t`; only the name the game calls
moved. The module doc frames them as the simple path for the common case (one
autosave, saved whole and read back at boot), and notes that a general file API
over a virtual user namespace is planned that these two are meant to keep
reading as a two-line convenience layer over — without documenting that API as
if it existed.

```functor
let tick = (m, dt, tts) =>
  if m.booted then (m, Effect.none())
  else (m, Persistence.load("autosave", (loaded) => Restored(loaded)))   // Option.t<Model>

| Saved => (m, Persistence.save("autosave", m))                          // in `update`
```

- `Persistence.save : (string, 'a) => Effect.t` — persists plain data under a slot key, through the **same structural codec `Effect.sendMsg` uses** (`effect_value_from_value` → `EffectValue` → canonical JSON). A closure or opaque host value is a teaching error **at the call site**, not mid-drain.
- `Persistence.load : (string, (Option.t<'a>) => 'msg) => Effect.t` — `Option.Some(value)` or `Option.None` (absent OR unreadable; a corrupt slot degrades to "no save" and never stops the game).
- **Native**: `<project>/.functor/saves/<slot>.json`, written atomically (unique per-process temp + `create_new` + rename). **Wasm**: one `localStorage` key per slot, scoped by page path **and** booted entry (`functor:save:<page>|<entry>:<slot>`) — the site serves every game from one `player.html`.
- **Slot keys are NAMES, not paths**: letters, digits, `_`, `-`, 1–64 chars, no Windows device names. Path traversal is unrepresentable, and the store re-validates (defence in depth).
- Registered through the **typed registry** (`register_persistence`, no legacy match arms), documented in its own `persistence.funi`, categorized in docgen's `CATEGORIES` under **Effects & messaging**, pinned in the docgen inventory, and the `functor-lang` skill updated in this PR.

They are ordinary effects end to end: they drain through the broker, land in the structured effect log as `storage.save` / `storage.load`, and are honest in all three runners — `RealEffects` hits the platform store, `FakeEffects` is an in-memory store (recording what the game saved), `ReplayEffects` replays the recording **without rewriting the store it replays**, and `DryRunEffects` (time-travel projection) keeps its own overlay so a projection never touches the player's save yet still sees its own writes.

## Evidence — absent before, working after

Probe project: `/tmp/functor-jam.YFADHZ/repro-persistence` (counter; Space increments, `S` saves, boot loads).

**Before** (base `origin/main` — and, equally, the old `Effect.` spelling on this branch's HEAD):

```
▸ build /tmp/functor-jam.YFADHZ/repro-persistence
error: /tmp/functor-jam.YFADHZ/repro-persistence/game.fun:19:9: module `Effect` has no `load`
   |
19 |     (m, Persistence.load("autosave", (loaded) => loaded))
   |         ^
error: cannot load the .../game.fun project
✗ failed in 7ms
```

**After** — driven headlessly through the debug runtime, with a real process kill in between:

```
=== session 1: launch ===
model at boot:      {"booted":true,"count":0}
--- three space presses (count += 1 each) ---
model after clicks: {"booted":true,"count":3}
--- press S: Persistence.save("autosave", model) ---
on-disk saves:
-rw-r--r--  1 bryphe  wheel  62 autosave.json
slot contents:      {"Record":[["count",{"Number":3.0}],["booted",{"Bool":true}]]}
=== killing the process (SIGKILL — no clean shutdown hook) ===
=== session 2: relaunch, same directory ===
model after reload: {"booted":true,"count":3}
```

**Web** (headless Chromium, release CLI serving the same project with `run wasm`):

```
localStorage after save:
 "functor:save:/|game.fun:autosave": "{\"Record\":[[\"count\",{\"Number\":3.0}],[\"booted\",{\"Bool\":true}]]}"
pixel diff  restored vs pre-reload: 0.00%     (page reload → boot load restored count 3)
pixel diff  restored vs fresh boot: 100.00%   (a fresh profile boots at count 0)
PASS: the web slot persisted across a page reload
```

(The canvas comparison is byte-equality of PNG screenshots: identical to the pre-reload frame, different from a fresh profile's — the cube's rotation is `count * 15°`.)

## Tests

`cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` — green. New:

| Test | What it pins |
| --- | --- |
| `save_writes_the_slot_file_and_load_restores_it` | full round trip on the REAL store: log records (`storage.save` payload, `storage.load` Option), the on-disk JSON decoding back to the same plain data |
| `an_absent_or_corrupt_slot_loads_as_none` | unwritten and corrupt slots both answer `Option.None`, never a crash |
| `fake_effects_record_saves_and_answer_loads` | `FakeEffects` as an in-memory store + journal, and `with_saves` seeding |
| `a_recorded_save_load_sequence_replays_exactly` | **replay determinism**: same model, same log, and the store is provably untouched |
| `a_dry_run_save_stays_in_the_projection` | a projection sees its own save but never writes the player's store |
| `save_rejects_bad_slots_and_non_plain_values` | traversal / empty / reserved-name keys, functions, host values, NaN (value and map key) — all teaching errors at the construction site |
| `the_store_itself_refuses_a_traversing_slot` | the Rust store API validates too, so no host caller can escape |
| `slot_keys_are_names_not_paths`, `writes_land_under_the_project_root_and_read_back`, `an_entry_file_names_its_directory` | slot-key charset, atomic write placement/overwrite with no temp left behind, project-root normalization |

Docgen: `npm run check:docs` ✓ and `cargo test -p functor-docgen` ✓; the Engine inventory pin moved `(27 modules, 309 declarations)` on current `main` → `(28, 311)` — a new module plus its two `.funi` items. (`npm run check:docs` does NOT cover that pin; the cargo test is the real gate.)

Web verification level, stated honestly: `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` clean, **plus** the headless-Chromium probe above against the real wasm bundle. The Quest/embedded producer does **not** wire a writable root yet — there `saves_dir()` follows the process working directory; that limitation is stated in the skill and the module docs.

## Perf — parity (nothing per-frame changed)

`cargo run -q --release -p functor_runtime_common --example frame_bench`, base vs change, back to back:

| cells | us/frame(min) base | us/frame(min) change | allocs/frame base → change | bytes/frame base → change |
| --- | --- | --- | --- | --- |
| 400 | 443.1 / 442.9 | 445.0 / 443.5 / 442.2 | 13877 → 13877 | 844497 → 844497 |
| 1600 | 1739.0 / 1738.9 | 1735.2 / 1730.2 / 1745.2 | 54717 → 54717 | 3308337 → 3308337 |
| 3136 | 3379.8 / 3405.6 | 3416.2 / 3386.5 / 3370.7 | 106973 → 106973 | 6461361 → 6461361 |

Allocations and bytes are **byte-identical**; wall clock is inside run-to-run spread.

## Review (`/xreview`) — dispositions

Two adversarial engines (Claude subagent + Codex) plus a dedicated de-dup pass.

**Fixed:**

- **[AGREED] High — shared temp file.** `<slot>.json.tmp` was process-shared and `File::create` follows symlinks. Now a unique `{slot}.{pid}-{n}.tmp` with `create_new(true)`, removed on failure.
- **[AGREED] High — web slot namespace.** Page-path-only scoping made every site game share `"autosave"`. The key now includes `window.__functorLangGamePath` (a `data:` inline program collapses to one `inline` scope; entry truncated to 128 chars).
- **[AGREED] Medium-High — docs overpromised.** "an incompatible version degrades to `None`" was false: only an unreadable FILE does. Corrected in `effect.funi` and the skill, with the guidance to version the slot yourself.
- **Medium — dry-run semantics.** `DryRunEffects` now has its own save overlay (was: writes dropped, reads from the live store — so a projected save-then-load diverged from the live run).
- **Medium — `fsync` on the frame thread.** Dropped; the rename alone gives readers atomicity, matching `io::cache_write`.
- **Low/Medium — store-level validation, reserved device names, unconvertible-but-valid JSON answering `None` (which also kept replay index-aligned), `saves_dir`/`slot_path` no longer public, `.functor/` gitignored.**

**Dispositioned, not changed:**

- **Medium — process-global store root.** Both engines flagged that a second producer in one process would share it. A process runs one game; the physics world and audio queue carry the same constraint. Documented in the module header rather than threaded through every runner.
- **Medium — Quest/embedded producer has no writable root.** Real; out of scope for this PR. Stated in the skill and the module docs instead of pretending it works.
- **High (A) — "a NaN in the model silently destroys the save".** Not reachable: `effect_value_from_value` already refuses non-finite numbers, and the interpreter refuses non-finite map keys at insertion. Both doors are now pinned by tests.
- **De-dup: `extract` — one shared `atomic_write` with `io::cache_write`.** The *lesson* was taken (per-process temp name); extracting a helper across four differently-shaped call sites (cache, import, LSP, saves) is a separate refactor. **Coverage line (Reviewer C):** all four strategies run. S1 = 169-line names report (26 queries, 7368 candidates, min-score 0.3); S2 = 264-line clone report filtered to the 20 pairs touching the changed files; S3 = 3600-line index grepped for save/slot/persist/storage/atomic-write/localStorage/json/EffectValue/project-root/traversal; S4 = full read of the diff across all 8 files.

## Rework round: `Effect.save`/`load` → `Persistence.save`/`load`

Rebased onto current `origin/main` and renamed. Semantics, storage backing,
effect-broker shape and determinism guarantees are unchanged.

- New `functor-prelude/prelude/persistence.funi`, carrying the existing doc text
  verbatim — including the two rules worth keeping loud: an unreadable save
  degrades to `Option.None` and never stops the game, and a save written by an
  older MODEL SHAPE still reads back as `Option.Some`, so version your own data.
- `register_persistence` in the typed registry; the `.funi` ≡ registry drift test
  derives both sides from `functor_prelude::modules()`, so it covers the new
  module with no edit and pins its arity.
- Category: **Effects & messaging** (beside `Effect` and `Sub`). Judgement call —
  what these produce is an `Effect.t`, and there is no storage category to belong
  to yet.

### `/xreview` round 2 — dispositions

Claude subagent + Codex, plus the dedicated de-dup pass. **Fixed (both engines
agreed on both):**

- **[AGREED] `Persistence` was missing from `PROTECTED_NAMESPACES`.** A game's
  `module Persistence { … }` silently shadowed the prelude, while `module Effect
  { … }` was refused — the exact invariant the guard's own comment states. Added,
  plus a new drift test asserting it for EVERY prelude `.funi` module, since the
  list is static and a new module otherwise lands unprotected by omission. It sits
  beside the existing `.funi` ≡ registry drift test in `functor_runtime_common`,
  which is deliberate: that is a crate CI's `cargo test -p functor_runtime_common
  -p functor-lang -p functor-docgen` actually runs, and `functor-prelude` is not.
  The test immediately caught the same **pre-existing** gap for `Terrain`, so it is
  reserved too (its only in-repo use, `site/examples/terrain.fun`, is a
  single-source example, where a protected stem already collapses to `Main`).
- **[AGREED] The drain named a function that does not exist.** Failures reported
  as `Effect.storage.load` (the log's wire kind, prefixed with `Effect.`). The
  drain tuple now carries the public API name beside the kind, so the message says
  `Persistence.load` while the structured log keeps `storage.load`.

**Dispositioned, not changed:**

- **High (Codex) — "`fs::rename` does not replace on Windows".** Not true of Rust
  std: `std::fs::rename` is specified to overwrite the destination, and on Windows
  is implemented with `MoveFileEx`/`MOVEFILE_REPLACE_EXISTING`. No change.
- **Medium (Codex) — the effect log omits the slot name, so replay does not
  validate which slot it is answering.** Real, but `ReplayEffects` is positional
  for *every* effect (`now`, `random`, `net.send` alike) — that is the broker's
  recording contract, not something specific to saves. Changing the record shape
  is exactly the "effect-broker shape" this rework was told to leave alone; worth
  a follow-up across all effects rather than one arm.
- **Medium (Claude) — two ROLES of one project share a slot.** `examples/orbs`'
  `client` and `server` resolve to the same page+entry on web and the same project
  dir natively, so both roles' `"autosave"` collide. Genuine, and out of scope for
  a rename; folding `EntryRole` into the scope on both shells is the follow-up.
- **Low (Claude) — Quest/embedded producer names no writable root.** Already
  stated in the skill and the module docs; unchanged.
- **Simplicity (Claude + de-dup `merge`) — `DryRunEffects`' save overlay
  duplicates `FakeEffects`' store.** From the previous round's fix, not this one;
  left as-is rather than re-opening a reviewed hunk during a rename.
- **De-dup `extract` — one shared `atomic_write`.** Same disposition as round 1.

**De-dup coverage line (Reviewer C), verbatim:** *all four strategies ran; none
unavailable. S1 = 33 queries / 7609 candidates (min-score 0.3); S2 = 277 clone
pairs whole-repo, 25 touching a changed file, all in pre-existing regions except
one trait-impl pair (discarded); S3 = ~12 greps over the API index and the tree
(save/slot/persist/storage/localStorage/atomic/rename/tmp/traversal/sanitize/project
root/EffectValue-json); S4 = full read of the 879-line diff.*

### Verification after the rework

- `cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` (CI's exact gate — and the one that carries the docgen inventory pin `npm run check:docs` does not) — green.
- `cargo check -p functor-runtime-web --target wasm32-unknown-unknown` — clean.
- `npm run generate:docs && npm run check:docs` — clean.
- The old spelling is gone, provably:

```
▸ build /tmp/functor-jam.YFADHZ/probe-oldname
error: .../game.fun:19:9: module `Effect` has no `load`
   |
19 |     (m, Effect.load("autosave", (loaded) => Restored(loaded)))
   |         ^
```

- Kill/relaunch probe re-run against the release CLI on the renamed API, in a
  scratch project outside the repo:

```
=== session 1: launch (no save on disk) ===
ls: .../repro-persistence2/.functor/saves: No such file or directory
model at boot:      {"booted":true,"count":0.0}
--- three Space presses (count += 1 each) ---
model after clicks: {"booted":true,"count":3.0}
--- press S: Persistence.save("autosave", model) ---
on-disk saves:
-rw-r--r--  1 bryphe  wheel  62 autosave.json
slot contents:      {"Record":[["count",{"Number":3.0}],["booted",{"Bool":true}]]}
=== killing the process (SIGKILL — no clean shutdown hook) ===
=== session 2: relaunch, same directory ===
model after reload: {"booted":true,"count":3.0}
```

## Adoption for `clicker`

The entry deletes `Save`, `encode`, `decode`, `isWholeNumber`, the `field`/`status` model fields and the entire save panel — **~85 lines and 2 of its 9 widget slots** — replacing them with one `Persistence.save("autosave", m)` on its existing autosave timer and one `Persistence.load("autosave", …)` at boot. `pendingSince`/`credit` offline-progress logic stays byte-identical (it already keys off a saved wall-clock stamp; the stamp now rides in the slot instead of the save code). Its `scenario.mjs` finally gains the assertion it could not make: **restart the process mid-run and the counts survive.**

