### PR TITLE
fix(net): Sub.connect retries with bounded backoff

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -328,6 +328,10 @@ let grab = (s) =>
   and falls through the peer's catch-all silently: share ONE module.
   Non-finite numbers (NaN/Infinity) in a payload are teaching errors at
   the `sendMsg` call site (JSON cannot carry them).
+  `Sub.connect` describes a desired connection: every failed attempt delivers
+  `Net.Error`, then retries forever on the deterministic game-time clock after
+  250ms, doubling through 500ms, 1s, 2s, 4s, and at most 8s. `Connected`
+  resets the next delay to 250ms; dropping the subscription cancels the retry.
 - **`Key` is a built-in module**: `Key.t`, the variant the `input` hook's
   `key` parameter carries — `Key.A`..`Key.Z`, `Key.Up`/`Down`/`Left`/`Right`,
   `Key.Space`/`Enter`/`Escape`, and the digit row as `Key.Num0`..`Key.Num9`

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -105,9 +105,11 @@ delivers `Net.Error` and retries forever on the deterministic game-time clock:
 Every failed attempt delivers an error so a game's diagnostics stay honest;
 `Net.Connected` resets the next retry to 250 ms. Events retain transport order,
 and dropping the subscription cancels both the live socket and any pending
-retry. Because the schedule uses frame `tts` rather than wall time or an effect
-read, fake and replay runners issue the same retries for the same recorded
-frames and network events.
+retry. The schedule uses frame `tts`, not wall time or an `EffectRunner` read,
+so fake/replay effect runners cannot perturb it; a live timeline rewind rebases
+the deadline to preserve its remaining delay. Dry counterfactual replay does not
+open, close, or retry real sockets—network commands stay suppressed at that
+side-effect boundary.
 
 `Net` is a built-in module, always in scope:
 `type NetEvent = | Connected(id: float) | Message(id: float, text: string) |

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -99,6 +99,16 @@ Effect.send(connId, text)     // send on an open connection
 Effect.sendMsg(connId, msg)   // send a plain-data VALUE; received as Net.Data(id, value)
 ```
 
+`Sub.connect` is a desired connection, not a one-shot dial. A failed attempt
+delivers `Net.Error` and retries forever on the deterministic game-time clock:
+250 ms initially, doubling to 500 ms, 1 s, 2 s, 4 s, then capped at 8 s.
+Every failed attempt delivers an error so a game's diagnostics stay honest;
+`Net.Connected` resets the next retry to 250 ms. Events retain transport order,
+and dropping the subscription cancels both the live socket and any pending
+retry. Because the schedule uses frame `tts` rather than wall time or an effect
+read, fake and replay runners issue the same retries for the same recorded
+frames and network events.
+
 `Net` is a built-in module, always in scope:
 `type NetEvent = | Connected(id: float) | Message(id: float, text: string) |
 Data(id: float, value: unknown) | Disconnected(id: float) |

--- a/functor-prelude/prelude/sub.funi
+++ b/functor-prelude/prelude/sub.funi
@@ -17,7 +17,13 @@ let none : () => t
 let every : (Time.t, 'msg) => t
 /// Combine subscriptions.
 let batch : (List<t>) => t
-/// Maintain a client connection and tag its `Net.NetEvent` values as messages.
+/// Maintain a client connection and tag its ordered `Net.NetEvent` values as messages.
+///
+/// A failed attempt delivers `Net.Error`, then retries forever on the game-time
+/// clock after 250ms, doubling through 500ms, 1s, 2s, 4s, and at most 8s.
+/// Every failed attempt remains observable as an `Error`; `Connected` resets
+/// the next retry to 250ms. Dropping the subscription cancels the connection
+/// and its pending retry.
 let connect : (string, (Net.NetEvent) => 'msg) => t
 /// Maintain a server listener and tag its `Net.NetEvent` values as messages.
 let listen : (string, (Net.NetEvent) => 'msg) => t

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -31,8 +31,8 @@ use crate::functor_lang_prelude::{
     EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
-    journal_arm, journal_swap, validate_contract, EntryNames, EntryRole, FrameCtx, JournalEntry,
-    Reporter, SpanSource,
+    journal_arm, journal_swap, validate_contract, ConnectRetryState, EntryNames, EntryRole,
+    FrameCtx, JournalEntry, Reporter, SpanSource,
 };
 use crate::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use crate::physics;
@@ -182,6 +182,7 @@ pub struct FunctorLangEmbeddedGame {
     /// Declared connection keys (`Sub.connect`/`Sub.listen`), reconciled each
     /// frame — see the desktop producer.
     live_conn_keys: std::collections::HashSet<String>,
+    connect_retries: std::collections::HashMap<String, ConnectRetryState>,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -368,6 +369,7 @@ impl FunctorLangEmbeddedGame {
             recorder: SceneRecorder::new(),
             input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
+            connect_retries: std::collections::HashMap::new(),
             asset_progress: None,
             delivered_asset_progress: None,
             has_physics: loaded.has_physics,
@@ -584,6 +586,7 @@ impl FunctorLangEmbeddedGame {
             deferred_queries: &mut self.deferred_queries,
             pending_events: &mut self.pending_events,
             live_conn_keys: &mut self.live_conn_keys,
+            connect_retries: &mut self.connect_retries,
             prev_tts: &mut self.prev_tts,
             input_buf: &mut self.input_buf,
             has_physics: self.has_physics,

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -31,8 +31,8 @@ use crate::functor_lang_prelude::{
     EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
-    journal_arm, journal_swap, validate_contract, ConnectRetryState, EntryNames, EntryRole,
-    FrameCtx, JournalEntry, Reporter, SpanSource,
+    journal_arm, journal_swap, rebase_connect_retry_deadlines, validate_contract,
+    ConnectRetryState, EntryNames, EntryRole, FrameCtx, JournalEntry, Reporter, SpanSource,
 };
 use crate::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use crate::physics;
@@ -405,12 +405,18 @@ impl FunctorLangEmbeddedGame {
     /// time grid, so timers tick right through a reload. Returns the number of
     /// stored closures rebound, for the status line.
     fn swap_in(&mut self, loaded: Loaded) -> (usize, Option<(usize, f64)>) {
+        let retry_tts_before_reload = self.prev_tts;
         let live_model_was_safe = self.recorder.prepare_reload(
             &mut self.model,
             &mut self.physics_rt,
             &mut self.physics_frame,
             self.has_physics,
             &mut self.prev_tts,
+        );
+        rebase_connect_retry_deadlines(
+            &mut self.connect_retries,
+            retry_tts_before_reload,
+            self.prev_tts,
         );
         let (model, report) = functor_lang::rebind_value(&self.model, &self.module, &loaded.module);
         self.model = model;
@@ -712,6 +718,7 @@ impl GameProducer for FunctorLangEmbeddedGame {
     /// Coupled scene rewind — delegated to the shared [`SceneRecorder`]
     /// (docs/time-travel.md T1), identical to the other producers.
     fn rewind_scene_to(&mut self, target: u64) -> Result<String, String> {
+        let retry_tts_before_rewind = self.prev_tts;
         let result = self.recorder.rewind_scene_to(
             target,
             &mut self.model,
@@ -721,6 +728,11 @@ impl GameProducer for FunctorLangEmbeddedGame {
             &mut self.prev_tts,
         );
         if result.is_ok() {
+            rebase_connect_retry_deadlines(
+                &mut self.connect_retries,
+                retry_tts_before_rewind,
+                self.prev_tts,
+            );
             self.deferred_queries.clear();
             self.pending_events.clear();
             // The restored model predates the current loading snapshot —

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -825,6 +825,20 @@ impl ConnectRetryState {
     }
 }
 
+/// Preserve every pending retry's remaining delay when a destructive timeline
+/// operation rebases game time. Socket IO itself stays outside replay.
+pub fn rebase_connect_retry_deadlines(
+    retries: &mut HashMap<String, ConnectRetryState>,
+    old_tts: Option<f64>,
+    new_tts: Option<f64>,
+) {
+    if let (Some(old_tts), Some(new_tts)) = (old_tts, new_tts) {
+        for retry in retries.values_mut() {
+            retry.rebase_deadline(old_tts, new_tts);
+        }
+    }
+}
+
 /// Infinite bounded exponential backoff: 250ms through 8s, then 8s forever.
 pub fn connect_retry_delay_seconds(failed_attempts: u32) -> f64 {
     let exponent = failed_attempts.saturating_sub(1).min(5);
@@ -869,11 +883,11 @@ impl FrameCtx<'_> {
                 self.prev_tts,
             )
         {
-            if let (Some(old_tts), Some(new_tts)) = (retry_tts_before_scrub, *self.prev_tts) {
-                for retry in self.connect_retries.values_mut() {
-                    retry.rebase_deadline(old_tts, new_tts);
-                }
-            }
+            rebase_connect_retry_deadlines(
+                self.connect_retries,
+                retry_tts_before_scrub,
+                *self.prev_tts,
+            );
             self.deferred_queries.clear();
             self.pending_events.clear();
             // The restored model predates the current loading snapshot, so
@@ -2398,9 +2412,11 @@ mod tests {
 
     #[test]
     fn retry_deadline_preserves_remaining_delay_across_timeline_rebase() {
-        let mut retry = ConnectRetryState::pending();
+        let mut retries = HashMap::from([("endpoint".to_string(), ConnectRetryState::pending())]);
+        let retry = retries.get_mut("endpoint").unwrap();
         retry.failed(10.0);
-        retry.rebase_deadline(10.0, 2.0);
+        rebase_connect_retry_deadlines(&mut retries, Some(10.0), Some(2.0));
+        let retry = retries.get_mut("endpoint").unwrap();
         assert!(!retry.begin_retry_if_due(2.249));
         assert!(retry.begin_retry_if_due(2.25));
     }

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -804,6 +804,15 @@ impl ConnectRetryState {
         self.phase = ConnectRetryPhase::Connected(conn);
     }
 
+    /// Preserve the remaining game-time delay when a destructive timeline
+    /// branch moves `tts`. Socket IO stays live and is never replayed, but its
+    /// next deterministic retry must not inherit time discarded by the branch.
+    fn rebase_deadline(&mut self, old_tts: f64, new_tts: f64) {
+        if let ConnectRetryPhase::WaitingUntil(deadline) = &mut self.phase {
+            *deadline += new_tts - old_tts;
+        }
+    }
+
     fn begin_retry_if_due(&mut self, now: f64) -> bool {
         let ConnectRetryPhase::WaitingUntil(deadline) = self.phase else {
             return false;
@@ -850,6 +859,7 @@ impl FrameCtx<'_> {
         // while the draggable bar is parked on an earlier frame, branch the
         // timeline from there BEFORE this frame advances — and drop any in-flight
         // frame work so it doesn't cross the branch (the reload discipline).
+        let retry_tts_before_scrub = *self.prev_tts;
         if frame_time.dts > 0.0
             && self.recorder.commit_scrub_if_resuming(
                 self.model,
@@ -859,6 +869,11 @@ impl FrameCtx<'_> {
                 self.prev_tts,
             )
         {
+            if let (Some(old_tts), Some(new_tts)) = (retry_tts_before_scrub, *self.prev_tts) {
+                for retry in self.connect_retries.values_mut() {
+                    retry.rebase_deadline(old_tts, new_tts);
+                }
+            }
             self.deferred_queries.clear();
             self.pending_events.clear();
             // The restored model predates the current loading snapshot, so
@@ -2379,6 +2394,15 @@ mod tests {
         retry.disconnected(42, 20.0);
         assert!(!retry.begin_retry_if_due(20.249));
         assert!(retry.begin_retry_if_due(20.25));
+    }
+
+    #[test]
+    fn retry_deadline_preserves_remaining_delay_across_timeline_rebase() {
+        let mut retry = ConnectRetryState::pending();
+        retry.failed(10.0);
+        retry.rebase_deadline(10.0, 2.0);
+        assert!(!retry.begin_retry_if_due(2.249));
+        assert!(retry.begin_retry_if_due(2.25));
     }
     use crate::functor_lang_prelude::UiHandler;
     use crate::ui::{UiEvent, UiEventKind};

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -732,6 +732,7 @@ pub struct FrameCtx<'a> {
     pub deferred_queries: &'a mut Vec<EffectTree>,
     pub pending_events: &'a mut Vec<PhysicsEvent>,
     pub live_conn_keys: &'a mut HashSet<String>,
+    pub connect_retries: &'a mut HashMap<String, ConnectRetryState>,
     pub prev_tts: &'a mut Option<f64>,
     /// This frame's buffered input events (docs/time-travel.md T6b): each shell
     /// appends to it in `key_event`/`mouse_move`/`mouse_wheel`, and
@@ -756,6 +757,69 @@ pub struct FrameCtx<'a> {
     /// world or the global queues. Always `false` on the live frame body.
     pub suppress_outbound: bool,
     pub reporter: &'a mut Reporter,
+}
+
+/// Retry state for one still-declared `Sub.connect` endpoint. Deadlines use
+/// game time (`tts`), so real, fake, and replay effects stay deterministic.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ConnectRetryState {
+    failures: u32,
+    phase: ConnectRetryPhase,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ConnectRetryPhase {
+    Pending,
+    Connected(u64),
+    WaitingUntil(f64),
+}
+
+impl ConnectRetryState {
+    fn pending() -> Self {
+        Self { failures: 0, phase: ConnectRetryPhase::Pending }
+    }
+
+    fn failed(&mut self, now: f64) {
+        if self.phase != ConnectRetryPhase::Pending {
+            return;
+        }
+        self.failures = self.failures.saturating_add(1);
+        self.phase = ConnectRetryPhase::WaitingUntil(
+            now + connect_retry_delay_seconds(self.failures),
+        );
+    }
+
+    fn disconnected(&mut self, conn: u64, now: f64) {
+        if self.phase != ConnectRetryPhase::Connected(conn) {
+            return;
+        }
+        self.failures = 1;
+        self.phase = ConnectRetryPhase::WaitingUntil(
+            now + connect_retry_delay_seconds(self.failures),
+        );
+    }
+
+    fn connected(&mut self, conn: u64) {
+        self.failures = 0;
+        self.phase = ConnectRetryPhase::Connected(conn);
+    }
+
+    fn begin_retry_if_due(&mut self, now: f64) -> bool {
+        let ConnectRetryPhase::WaitingUntil(deadline) = self.phase else {
+            return false;
+        };
+        if now < deadline {
+            return false;
+        }
+        self.phase = ConnectRetryPhase::Pending;
+        true
+    }
+}
+
+/// Infinite bounded exponential backoff: 250ms through 8s, then 8s forever.
+pub fn connect_retry_delay_seconds(failed_attempts: u32) -> f64 {
+    let exponent = failed_attempts.saturating_sub(1).min(5);
+    0.25 * (1u32 << exponent) as f64
 }
 
 impl FrameCtx<'_> {
@@ -1282,7 +1346,7 @@ to receive their messages; dropping them",
         };
         // Reconcile connections EVERY frame — including frame one (before the
         // timer window exists), so a declared connection opens immediately.
-        self.reconcile_connections(&subs);
+        self.reconcile_connections(&subs, tts);
         // Asset progress also delivers on frame one: a loading screen wants
         // the initial snapshot, not the first change after it.
         self.deliver_asset_progress(&subs);
@@ -1492,13 +1556,14 @@ LAST stepped world, so a read of a tag this hook has never declared still raises
         for key in std::mem::take(self.live_conn_keys) {
             push_conn_command(ConnCommand::CloseKey { key });
         }
+        self.connect_retries.clear();
     }
 
     /// Open connections newly declared this frame and close ones no longer
     /// declared (keyed by endpoint). Commands go to the shell's connection
     /// manager, drained via `net_drain_conn_commands`. The physics-events
     /// pattern for connections.
-    fn reconcile_connections(&mut self, subs: &Value) {
+    fn reconcile_connections(&mut self, subs: &Value, tts: f64) {
         // A dry-run forward-step (docs/time-travel.md T6b) must not open/close
         // live sockets: connection reconcile is purely OUTBOUND (it feeds
         // nothing back into the model), so suppress it wholesale — the same
@@ -1533,11 +1598,29 @@ LAST stepped world, so a read of a tag this hook has never declared still raises
                         url: conn.key.clone(),
                     }
                 });
+                if !conn.listen {
+                    self.connect_retries
+                        .insert(conn.key.clone(), ConnectRetryState::pending());
+                }
+            } else if !conn.listen
+                && self
+                    .connect_retries
+                    .get_mut(&conn.key)
+                    .is_some_and(|retry| retry.begin_retry_if_due(tts))
+            {
+                // Native retains failed keys for idempotency, so release the
+                // old attempt before either shell opens the next one.
+                push_conn_command(ConnCommand::CloseKey { key: conn.key.clone() });
+                push_conn_command(ConnCommand::Connect {
+                    key: conn.key.clone(),
+                    url: conn.key.clone(),
+                });
             }
         }
         for key in self.live_conn_keys.iter() {
             if !declared.contains(key) {
                 push_conn_command(ConnCommand::CloseKey { key: key.clone() });
+                self.connect_retries.remove(key);
             }
         }
         *self.live_conn_keys = declared;
@@ -1547,6 +1630,15 @@ LAST stepped world, so a read of a tag this hook has never declared still raises
     /// the message through `update`. Taggers are read FRESH from the current
     /// `subscriptions(model)` (never cached — a reload rebinds them).
     pub fn deliver_net_event(&mut self, key: String, kind: NetEventKind, conn: i32, text: String) {
+        let now = self.prev_tts.unwrap_or(0.0);
+        if let Some(retry) = self.connect_retries.get_mut(&key) {
+            match kind {
+                NetEventKind::Connected => retry.connected(conn as u64),
+                NetEventKind::Disconnected => retry.disconnected(conn as u64, now),
+                NetEventKind::Error => retry.failed(now),
+                NetEventKind::Message => {}
+            }
+        }
         if !self.has_subscriptions {
             return;
         }
@@ -1846,6 +1938,7 @@ fn forward_step_scene_with_error(
     let mut deferred_queries: Vec<EffectTree> = Vec::new();
     let mut pending_events: Vec<PhysicsEvent> = Vec::new();
     let mut live_conn_keys: HashSet<String> = HashSet::new();
+    let mut connect_retries: HashMap<String, ConnectRetryState> = HashMap::new();
     let mut prev_tts = prev_tts;
     // Throwaway input buffer: the forward-step replays `inputs` directly and
     // never records, so this stays empty — it just satisfies the borrow.
@@ -1876,6 +1969,7 @@ fn forward_step_scene_with_error(
             deferred_queries: &mut deferred_queries,
             pending_events: &mut pending_events,
             live_conn_keys: &mut live_conn_keys,
+            connect_retries: &mut connect_retries,
             prev_tts: &mut prev_tts,
             input_buf: &mut input_buf,
             has_physics,
@@ -2264,6 +2358,28 @@ pub fn history_frames(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connect_retry_backoff_is_bounded_exponential_and_infinite() {
+        let first_ten = (1..=10).map(connect_retry_delay_seconds).collect::<Vec<_>>();
+        assert_eq!(first_ten, vec![0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 8.0, 8.0, 8.0, 8.0]);
+        assert_eq!(connect_retry_delay_seconds(u32::MAX), 8.0);
+    }
+
+    #[test]
+    fn successful_connect_resets_the_backoff() {
+        let mut retry = ConnectRetryState::pending();
+        retry.failed(10.0);
+        assert!(!retry.begin_retry_if_due(10.249));
+        assert!(retry.begin_retry_if_due(10.25));
+        retry.failed(10.25);
+        assert!(!retry.begin_retry_if_due(10.749));
+        assert!(retry.begin_retry_if_due(10.75));
+        retry.connected(42);
+        retry.disconnected(42, 20.0);
+        assert!(!retry.begin_retry_if_due(20.249));
+        assert!(retry.begin_retry_if_due(20.25));
+    }
     use crate::functor_lang_prelude::UiHandler;
     use crate::ui::{UiEvent, UiEventKind};
 
@@ -2718,6 +2834,7 @@ mod tests {
         let mut deferred_queries: Vec<EffectTree> = Vec::new();
         let mut pending_events: Vec<PhysicsEvent> = Vec::new();
         let mut live_conn_keys: HashSet<String> = HashSet::new();
+        let mut connect_retries: HashMap<String, ConnectRetryState> = HashMap::new();
         let mut prev_tts: Option<f64> = None;
         let mut input_buf: Vec<RecordedInput> = Vec::new();
         let mut delivered_asset_progress: Option<AssetProgress> = None;
@@ -2742,6 +2859,7 @@ mod tests {
             deferred_queries: &mut deferred_queries,
             pending_events: &mut pending_events,
             live_conn_keys: &mut live_conn_keys,
+            connect_retries: &mut connect_retries,
             prev_tts: &mut prev_tts,
             input_buf: &mut input_buf,
             has_physics: false,
@@ -2884,6 +3002,7 @@ mod tests {
         let mut deferred_queries: Vec<EffectTree> = Vec::new();
         let mut pending_events: Vec<PhysicsEvent> = Vec::new();
         let mut live_conn_keys: HashSet<String> = HashSet::new();
+        let mut connect_retries: HashMap<String, ConnectRetryState> = HashMap::new();
         // prev_tts just below a period boundary so this frame crosses 1.0s and
         // fires the `Sub.every` timer.
         let mut prev_tts: Option<f64> = Some(0.9);
@@ -2910,6 +3029,7 @@ mod tests {
             deferred_queries: &mut deferred_queries,
             pending_events: &mut pending_events,
             live_conn_keys: &mut live_conn_keys,
+            connect_retries: &mut connect_retries,
             prev_tts: &mut prev_tts,
             input_buf: &mut input_buf,
             has_physics: false,
@@ -2950,6 +3070,7 @@ mod tests {
         let mut deferred_queries: Vec<EffectTree> = Vec::new();
         let mut pending_events: Vec<PhysicsEvent> = Vec::new();
         let mut live_conn_keys: HashSet<String> = HashSet::new();
+        let mut connect_retries: HashMap<String, ConnectRetryState> = HashMap::new();
         let mut prev_tts: Option<f64> = Some(tts - 0.1);
         let mut input_buf: Vec<RecordedInput> = Vec::new();
         let mut reporter = Reporter::new(
@@ -2973,6 +3094,7 @@ mod tests {
             deferred_queries: &mut deferred_queries,
             pending_events: &mut pending_events,
             live_conn_keys: &mut live_conn_keys,
+            connect_retries: &mut connect_retries,
             prev_tts: &mut prev_tts,
             input_buf: &mut input_buf,
             has_physics: false,
@@ -3178,6 +3300,7 @@ mod tests {
         deferred_queries: Vec<EffectTree>,
         pending_events: Vec<PhysicsEvent>,
         live_conn_keys: HashSet<String>,
+        connect_retries: HashMap<String, ConnectRetryState>,
         prev_tts: Option<f64>,
         input_buf: Vec<RecordedInput>,
         delivered_asset_progress: Option<AssetProgress>,
@@ -3206,6 +3329,7 @@ mod tests {
                 deferred_queries: Vec::new(),
                 pending_events: Vec::new(),
                 live_conn_keys: HashSet::new(),
+                connect_retries: HashMap::new(),
                 prev_tts: None,
                 input_buf: Vec::new(),
                 delivered_asset_progress: None,
@@ -3234,6 +3358,7 @@ mod tests {
                 deferred_queries: &mut self.deferred_queries,
                 pending_events: &mut self.pending_events,
                 live_conn_keys: &mut self.live_conn_keys,
+                connect_retries: &mut self.connect_retries,
                 prev_tts: &mut self.prev_tts,
                 input_buf: &mut self.input_buf,
                 has_physics: true,

--- a/runtime/functor-runtime-common/src/net/connection.rs
+++ b/runtime/functor-runtime-common/src/net/connection.rs
@@ -113,6 +113,18 @@ pub fn drain_conn_events() -> Vec<KeyedEvent> {
     CONN_IN.drain()
 }
 
+/// Host seam for a transport constructor that can fail synchronously. Returning
+/// the keyed error lets a dispatcher which already owns the game borrow deliver
+/// it without attempting a nested callback borrow (notably browser WebSocket).
+#[doc(hidden)]
+pub fn opened_connection<T, E>(
+    key: String,
+    result: Result<T, E>,
+    message: &str,
+) -> Result<T, (String, String)> {
+    result.map_err(|_| (key, message.to_string()))
+}
+
 // Host (primitive ABI): one helper per event kind so the dylib's exported shim
 // stays plain scalars + bytes.
 pub fn push_connected(key: String, conn: ConnectionId) {
@@ -151,6 +163,22 @@ mod tests {
         ];
         let json = serde_json::to_string(&cmds).unwrap();
         assert_eq!(cmds, serde_json::from_str::<Vec<ConnCommand>>(&json).unwrap());
+    }
+
+    #[test]
+    fn synchronous_open_failure_returns_to_the_owning_dispatcher() {
+        let failure = opened_connection::<(), _>(
+            "ws://blocked".to_string(),
+            Err("denied"),
+            "failed to open WebSocket",
+        );
+        assert_eq!(
+            failure,
+            Err((
+                "ws://blocked".to_string(),
+                "failed to open WebSocket".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -40,8 +40,9 @@ use functor_runtime_common::functor_lang_prelude::{
     EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
-    journal_arm, journal_push, journal_swap, validate_contract, ConnectRetryState, EntryNames,
-    EntryRole, FrameCtx, JournalEntry, Provenance, Reporter, SpanSource,
+    journal_arm, journal_push, journal_swap, rebase_connect_retry_deadlines, validate_contract,
+    ConnectRetryState, EntryNames, EntryRole, FrameCtx, JournalEntry, Provenance, Reporter,
+    SpanSource,
 };
 use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use functor_runtime_common::physics;
@@ -555,12 +556,18 @@ impl FunctorLangGame {
     /// tick right through a reload. Returns the number of stored closures
     /// rebound, for the status line.
     fn swap_in(&mut self, loaded: Loaded) -> (usize, Option<(usize, f64)>) {
+        let retry_tts_before_reload = self.prev_tts;
         let live_model_was_safe = self.recorder.prepare_reload(
             &mut self.model,
             &mut self.physics_rt,
             &mut self.physics_frame,
             self.has_physics,
             &mut self.prev_tts,
+        );
+        rebase_connect_retry_deadlines(
+            &mut self.connect_retries,
+            retry_tts_before_reload,
+            self.prev_tts,
         );
         let (model, report) = functor_lang::rebind_value(&self.model, &self.module, &loaded.module);
         self.model = model;
@@ -951,6 +958,7 @@ impl Game for FunctorLangGame {
     /// the future; exact-or-refused. After a successful branch, drop any
     /// in-flight frame work so it doesn't carry across (the reload discipline).
     fn rewind_scene_to(&mut self, target: u64) -> Result<String, String> {
+        let retry_tts_before_rewind = self.prev_tts;
         let result = self.recorder.rewind_scene_to(
             target,
             &mut self.model,
@@ -960,6 +968,11 @@ impl Game for FunctorLangGame {
             &mut self.prev_tts,
         );
         if result.is_ok() {
+            rebase_connect_retry_deadlines(
+                &mut self.connect_retries,
+                retry_tts_before_rewind,
+                self.prev_tts,
+            );
             // No in-flight frame work should carry across the branch (matches
             // the reload discipline); between-frame callers have these empty.
             self.deferred_queries.clear();

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -40,8 +40,8 @@ use functor_runtime_common::functor_lang_prelude::{
     EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use functor_runtime_common::functor_lang_producer::{
-    journal_arm, journal_push, journal_swap, validate_contract, EntryNames, EntryRole, FrameCtx,
-    JournalEntry, Provenance, Reporter, SpanSource,
+    journal_arm, journal_push, journal_swap, validate_contract, ConnectRetryState, EntryNames,
+    EntryRole, FrameCtx, JournalEntry, Provenance, Reporter, SpanSource,
 };
 use functor_runtime_common::inspector::{build_trace_doc, inspector_sources, InspectorSource};
 use functor_runtime_common::physics;
@@ -192,6 +192,7 @@ pub struct FunctorLangGame {
     /// key set (kept across hot reload, like the model — Connect is
     /// idempotent).
     live_conn_keys: std::collections::HashSet<String>,
+    connect_retries: std::collections::HashMap<String, ConnectRetryState>,
     /// The last successfully drawn frame, kept so a bad draw shows the last
     /// good picture instead of a blank.
     last_frame: Frame,
@@ -485,6 +486,7 @@ impl FunctorLangGame {
             recorder: SceneRecorder::new(),
             input_buf: Vec::new(),
             live_conn_keys: std::collections::HashSet::new(),
+            connect_retries: std::collections::HashMap::new(),
             asset_progress: None,
             delivered_asset_progress: None,
             last_frame: empty_frame(),
@@ -529,6 +531,7 @@ impl FunctorLangGame {
             deferred_queries: &mut self.deferred_queries,
             pending_events: &mut self.pending_events,
             live_conn_keys: &mut self.live_conn_keys,
+            connect_retries: &mut self.connect_retries,
             prev_tts: &mut self.prev_tts,
             input_buf: &mut self.input_buf,
             has_physics: self.has_physics,

--- a/runtime/functor-runtime-desktop/src/ws_host.rs
+++ b/runtime/functor-runtime-desktop/src/ws_host.rs
@@ -75,13 +75,14 @@ struct ConnEntry {
 }
 
 type SharedConns = Arc<Mutex<HashMap<u64, ConnEntry>>>;
+type SharedClientKeys = Arc<Mutex<HashMap<String, u64>>>;
 
 /// Owns the live connections and turns [`ConnCommand`]s into socket operations.
 pub struct WsManager {
     conns: SharedConns,
     /// Connect-initiated client connections: url key -> id (for idempotent connect
     /// and CloseKey). Server-accepted clients are not here (many per listener).
-    client_by_key: HashMap<String, u64>,
+    client_by_key: SharedClientKeys,
     /// Active listeners: bind key -> accept-loop task.
     listeners: HashMap<String, tokio::task::JoinHandle<()>>,
     next_id: Arc<AtomicU64>,
@@ -92,7 +93,7 @@ impl WsManager {
     pub fn new(events: Sender<HostNetEvent>) -> WsManager {
         WsManager {
             conns: Arc::new(Mutex::new(HashMap::new())),
-            client_by_key: HashMap::new(),
+            client_by_key: Arc::new(Mutex::new(HashMap::new())),
             listeners: HashMap::new(),
             next_id: Arc::new(AtomicU64::new(1)),
             events: EventTx(events),
@@ -119,17 +120,18 @@ impl WsManager {
     fn connect(&mut self, key: String, url: String) {
         // Idempotent by key: a re-declared connection (e.g. after a hot reload)
         // reattaches to the live socket instead of opening a second one.
-        if self.client_by_key.contains_key(&key) {
+        if self.client_by_key.lock().unwrap().contains_key(&key) {
             return;
         }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        self.client_by_key.insert(key.clone(), id);
+        self.client_by_key.lock().unwrap().insert(key.clone(), id);
         tokio::spawn(run_client(
             key,
             id,
             url,
             self.events.clone(),
             self.conns.clone(),
+            self.client_by_key.clone(),
         ));
     }
 
@@ -149,7 +151,7 @@ impl WsManager {
 
     fn close_key(&mut self, key: &str) {
         // A client connection for this key.
-        if let Some(id) = self.client_by_key.remove(key) {
+        if let Some(id) = self.client_by_key.lock().unwrap().remove(key) {
             self.send_to(id, OutMsg::Close);
         }
         // A listener: stop accepting and close its accepted clients.
@@ -172,19 +174,25 @@ async fn run_client(
     url: String,
     events: EventTx,
     conns: SharedConns,
+    client_by_key: SharedClientKeys,
 ) {
     let ws = match tokio_tungstenite::connect_async(&url).await {
         Ok((ws, _resp)) => ws,
         Err(e) => {
-            events.send(HostNetEvent::Error {
-                key,
-                id,
-                message: e.to_string(),
-            });
+            if client_by_key.lock().unwrap().get(&key) == Some(&id) {
+                events.send(HostNetEvent::Error {
+                    key,
+                    id,
+                    message: e.to_string(),
+                });
+            }
             return;
         }
     };
-    serve(ws, key, id, events, conns).await;
+    if client_by_key.lock().unwrap().get(&key) != Some(&id) {
+        return;
+    }
+    serve(ws, key, id, events, conns, Some(client_by_key)).await;
 }
 
 /// Accept connections until the listener is dropped/aborted; each accepted client
@@ -216,7 +224,7 @@ async fn accept_loop(
                 let conns = conns.clone();
                 tokio::spawn(async move {
                     match tokio_tungstenite::accept_async(stream).await {
-                        Ok(ws) => serve(ws, key, id, events, conns).await,
+                        Ok(ws) => serve(ws, key, id, events, conns, None).await,
                         Err(e) => {
                             events.send(HostNetEvent::Error {
                                 key,
@@ -241,6 +249,7 @@ async fn serve<S>(
     id: u64,
     events: EventTx,
     conns: SharedConns,
+    client_by_key: Option<SharedClientKeys>,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
@@ -252,10 +261,16 @@ async fn serve<S>(
             key: key.clone(),
         },
     );
-    events.send(HostNetEvent::Connected {
-        key: key.clone(),
-        id,
-    });
+    let is_current = || {
+        client_by_key
+            .as_ref()
+            .is_none_or(|keys| keys.lock().unwrap().get(&key) == Some(&id))
+    };
+    if !is_current() {
+        conns.lock().unwrap().remove(&id);
+        return;
+    }
+    events.send(HostNetEvent::Connected { key: key.clone(), id });
 
     let (mut write, mut read) = ws.split();
     loop {
@@ -278,19 +293,25 @@ async fn serve<S>(
             },
             incoming = read.next() => match incoming {
                 Some(Ok(Message::Text(text))) => {
-                    events.send(HostNetEvent::Message { key: key.clone(), id, text });
+                    if is_current() {
+                        events.send(HostNetEvent::Message { key: key.clone(), id, text });
+                    }
                 }
                 Some(Ok(Message::Binary(data))) => {
-                    events.send(HostNetEvent::Message {
-                        key: key.clone(),
-                        id,
-                        text: String::from_utf8_lossy(&data).to_string(),
-                    });
+                    if is_current() {
+                        events.send(HostNetEvent::Message {
+                            key: key.clone(),
+                            id,
+                            text: String::from_utf8_lossy(&data).to_string(),
+                        });
+                    }
                 }
                 Some(Ok(Message::Close(_))) | None => break,
                 Some(Ok(_)) => {}
                 Some(Err(e)) => {
-                    events.send(HostNetEvent::Error { key: key.clone(), id, message: e.to_string() });
+                    if is_current() {
+                        events.send(HostNetEvent::Error { key: key.clone(), id, message: e.to_string() });
+                    }
                     break;
                 }
             },
@@ -298,7 +319,9 @@ async fn serve<S>(
     }
 
     conns.lock().unwrap().remove(&id);
-    events.send(HostNetEvent::Disconnected { key, id });
+    if is_current() {
+        events.send(HostNetEvent::Disconnected { key, id });
+    }
 }
 
 #[cfg(test)]
@@ -380,6 +403,37 @@ mod tests {
             HostNetEvent::Error { .. } => {}
             _ => panic!("expected an Error connecting to a dead port"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn close_key_invalidates_an_in_flight_client_dial() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = accepted_tx.send(());
+            let _ = release_rx.await;
+            let _ = tokio_tungstenite::accept_async(stream).await;
+        });
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut mgr = WsManager::new(tx);
+        let key = format!("ws://127.0.0.1:{port}/");
+        mgr.handle(ConnCommand::Connect {
+            key: key.clone(),
+            url: key.clone(),
+        });
+        accepted_rx.await.unwrap();
+        mgr.handle(ConnCommand::CloseKey { key });
+        let _ = release_tx.send(());
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "a dial invalidated by CloseKey must not emit a stale event"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -14,7 +14,8 @@ use functor_runtime_common::functor_lang_producer::EntryRole;
 use functor_runtime_common::geometry::Geometry;
 use functor_runtime_common::io::load_bytes_async;
 use functor_runtime_common::net::{
-    parse_delivered_events, ConnCommand, DeliveredEvent, HttpMethod, NetCommand,
+    opened_connection, parse_delivered_events, ConnCommand, DeliveredEvent, HttpMethod,
+    NetCommand,
 };
 use functor_runtime_common::protocol::GameProducer;
 use functor_runtime_common::texture::{
@@ -981,7 +982,7 @@ struct WsClient {
 /// Drain the game's queued connection commands and perform them: with browser
 /// WebSockets (socket events are pushed back into the game from the handlers),
 /// or — under [`NetTransport::Embedder`] — by handing them to the embedding page.
-fn dispatch_conn_commands(game: &dyn GameProducer, state: &Rc<RefCell<WsClient>>) {
+fn dispatch_conn_commands(game: &mut dyn GameProducer, state: &Rc<RefCell<WsClient>>) {
     let json = game.net_drain_conn_commands();
     if json == "[]" {
         return;
@@ -999,7 +1000,14 @@ fn dispatch_conn_commands(game: &dyn GameProducer, state: &Rc<RefCell<WsClient>>
     };
     for cmd in commands {
         match cmd {
-            ConnCommand::Connect { key, url } => ws_connect(state, key, url),
+            ConnCommand::Connect { key, url } => {
+                if let Err((key, message)) = ws_connect(state, key, url) {
+                    // Dispatch already owns the live game's mutable RefCell borrow.
+                    // Report synchronous constructor failures through that borrow;
+                    // `with_live_game` cannot re-borrow it and would drop the error.
+                    game.net_push_conn_error(key, 0, message);
+                }
+            }
             ConnCommand::Listen { .. } => {
                 web_sys::console::warn_1(
                     &"[net] Sub.listen is unsupported in the browser (client only)".into(),
@@ -1016,11 +1024,18 @@ fn dispatch_conn_commands(game: &dyn GameProducer, state: &Rc<RefCell<WsClient>>
                 }
             }
             ConnCommand::CloseKey { key } => {
-                let id = state.borrow().by_key.get(&key).copied();
-                if let Some(id) = id {
-                    if let Some(ws) = state.borrow().conns.get(&id) {
-                        let _ = ws.close();
-                    }
+                // Remove synchronously before `close()`: a retry deliberately
+                // queues CloseKey + Connect together, while the close event is
+                // asynchronous in browsers.
+                let ws = {
+                    let mut state = state.borrow_mut();
+                    state
+                        .by_key
+                        .remove(&key)
+                        .and_then(|id| state.conns.remove(&id))
+                };
+                if let Some(ws) = ws {
+                    let _ = ws.close();
                 }
             }
         }
@@ -1119,22 +1134,22 @@ pub fn functor_lang_net_deliver(events_json: &str) {
     });
 }
 
-fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
+fn ws_connect(
+    state: &Rc<RefCell<WsClient>>,
+    key: String,
+    url: String,
+) -> Result<(), (String, String)> {
     // Idempotent by key (matches the native host); a re-declared connection
     // reattaches rather than opening a second socket. Event callbacks push into
     // the live producer (the Functor Lang page's FunctorLangEmbeddedGame) via `with_live_game`.
     if state.borrow().by_key.contains_key(&key) {
-        return;
+        return Ok(());
     }
-    let ws = match web_sys::WebSocket::new(&url) {
-        Ok(ws) => ws,
-        Err(_) => {
-            with_live_game(|g| {
-                g.net_push_conn_error(key, 0, "failed to open WebSocket".to_string())
-            });
-            return;
-        }
-    };
+    let ws = opened_connection(
+        key.clone(),
+        web_sys::WebSocket::new(&url),
+        "failed to open WebSocket",
+    )?;
     let id = {
         let mut s = state.borrow_mut();
         s.next_id += 1;
@@ -1170,19 +1185,13 @@ fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
         let state = state.clone();
         Closure::<dyn FnMut(web_sys::CloseEvent)>::new(move |_e: web_sys::CloseEvent| {
             with_live_game(|g| g.net_push_disconnected(key.clone(), iid));
-            // Drop our handle so the key is free to be opened again.
-            //
-            // NB it will not be, today: `reconcile_connections` only emits a
-            // `Connect` for a key ABSENT from the producer's `live_conn_keys`,
-            // and that set is re-seeded from the declared subs every frame — so
-            // a still-declared `Sub.connect` never re-fires and a dropped
-            // connection stays down. (This comment used to claim the reconnect
-            // happened.) Reconnect/backoff is its own change: the shell would
-            // have to retract the key from the producer's live set here.
-            // [xreview]
+            // Drop our handle so the producer's backoff-driven `CloseKey` +
+            // `Connect` retry can open a fresh socket for this key.
             let mut s = state.borrow_mut();
             s.conns.remove(&id);
-            s.by_key.remove(&key);
+            if s.by_key.get(&key) == Some(&id) {
+                s.by_key.remove(&key);
+            }
         })
     };
     ws.set_onclose(Some(on_close.as_ref().unchecked_ref()));
@@ -1206,6 +1215,7 @@ fn ws_connect(state: &Rc<RefCell<WsClient>>, key: String, url: String) {
     };
     ws.set_onerror(Some(on_error.as_ref().unchecked_ref()));
     on_error.forget();
+    Ok(())
 }
 
 #[wasm_bindgen(start)]
@@ -1671,7 +1681,7 @@ async fn run_async() -> Result<(), JsValue> {
             // Play any one-shot sounds this frame's tick queued (fetch + decode
             // the first time, then from the cache).
             dispatch_audio_commands(&**game);
-            dispatch_conn_commands(&**game, &ws_state);
+            dispatch_conn_commands(&mut **game, &ws_state);
 
             let mut frame: Frame = game.render(frame_time.clone());
             if pending_detach

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1162,8 +1162,11 @@ fn ws_connect(
 
     let on_open = {
         let key = key.clone();
+        let state = state.clone();
         Closure::<dyn FnMut()>::new(move || {
-            with_live_game(|g| g.net_push_connected(key.clone(), iid))
+            if state.borrow().by_key.get(&key) == Some(&id) {
+                with_live_game(|g| g.net_push_connected(key.clone(), iid));
+            }
         })
     };
     ws.set_onopen(Some(on_open.as_ref().unchecked_ref()));
@@ -1171,9 +1174,12 @@ fn ws_connect(
 
     let on_message = {
         let key = key.clone();
+        let state = state.clone();
         Closure::<dyn FnMut(web_sys::MessageEvent)>::new(move |e: web_sys::MessageEvent| {
-            if let Some(text) = e.data().as_string() {
-                with_live_game(|g| g.net_push_conn_message(key.clone(), iid, text));
+            if state.borrow().by_key.get(&key) == Some(&id) {
+                if let Some(text) = e.data().as_string() {
+                    with_live_game(|g| g.net_push_conn_message(key.clone(), iid, text));
+                }
             }
         })
     };
@@ -1184,13 +1190,17 @@ fn ws_connect(
         let key = key.clone();
         let state = state.clone();
         Closure::<dyn FnMut(web_sys::CloseEvent)>::new(move |_e: web_sys::CloseEvent| {
-            with_live_game(|g| g.net_push_disconnected(key.clone(), iid));
             // Drop our handle so the producer's backoff-driven `CloseKey` +
             // `Connect` retry can open a fresh socket for this key.
             let mut s = state.borrow_mut();
             s.conns.remove(&id);
-            if s.by_key.get(&key) == Some(&id) {
+            let was_current = s.by_key.get(&key) == Some(&id);
+            if was_current {
                 s.by_key.remove(&key);
+            }
+            drop(s);
+            if was_current {
+                with_live_game(|g| g.net_push_disconnected(key.clone(), iid));
             }
         })
     };
@@ -1199,6 +1209,7 @@ fn ws_connect(
 
     let on_error = {
         let key = key.clone();
+        let state = state.clone();
         // A WebSocket's `error` event is a PLAIN `Event`, not an `ErrorEvent` —
         // it carries no `message`. Typing it as `ErrorEvent` and calling
         // `.message()` made the generated glue read `length` off `undefined`,
@@ -1208,9 +1219,11 @@ fn ws_connect(
         // there is nothing to recover — and the endpoint is already the `key`
         // this error is reported against. [xreview]
         Closure::<dyn FnMut(web_sys::Event)>::new(move |_e: web_sys::Event| {
-            with_live_game(|g| {
-                g.net_push_conn_error(key.clone(), iid, "connection failed".to_string())
-            });
+            if state.borrow().by_key.get(&key) == Some(&id) {
+                with_live_game(|g| {
+                    g.net_push_conn_error(key.clone(), iid, "connection failed".to_string())
+                });
+            }
         })
     };
     ws.set_onerror(Some(on_error.as_ref().unchecked_ref()));

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -301,7 +301,9 @@ let draw = (model, tts: float) =>
             is the <em>shape</em> a networked game has, with the transport left out. The real
             transport is <code>Sub.connect</code> / <code>Sub.listen</code> and
             <code>Effect.sendMsg</code>, whose events arrive as the built-in <code>Net</code>
-            module's variants;
+            module's variants. <code>Sub.connect</code> is a desired connection: it reports each
+            failed attempt as <code>Net.Error</code> and retries forever with bounded exponential
+            backoff (250 ms initially, at most 8 s), resetting after <code>Net.Connected</code>;
             <a href="https://github.com/tommy-xr/functor/tree/main/examples/orbs"><code>examples/orbs</code></a>
             is a client and an authoritative server actually talking over it.
           </p>

--- a/tools/functor-sdk/test/multiplayer.e2e.test.ts
+++ b/tools/functor-sdk/test/multiplayer.e2e.test.ts
@@ -69,9 +69,12 @@ test(
         headless,
       });
 
-    // Server first, and wait for its Sub.listen socket to actually bind before
-    // launching clients — the client connects once with no retry, so a client
-    // that races ahead of the listener would land in "error" and never converge.
+    // Deliberately start client A before any listener exists and leave enough
+    // time for its first connection attempt to fail. `Sub.connect` is a desired
+    // connection, so the same runner must converge after the server appears.
+    await using clientA = await launch("client");
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+
     await using server = await launch("server");
     await waitForPort("127.0.0.1", 9101, {
       timeoutMs: 60_000,
@@ -80,7 +83,6 @@ test(
 
     // The client Joins on connect and streams a Steer every tick from there,
     // so no input injection is needed.
-    await using clientA = await launch("client");
     await using clientB = await launch("client");
 
     const waitOpts = { timeoutMs: 90_000, intervalMs: 200 };


### PR DESCRIPTION
## Summary

`Sub.connect` now retains a still-declared desired connection after failure and retries forever with bounded exponential backoff. The policy is 250 ms, 500 ms, 1 s, 2 s, 4 s, then 8 s forever; `Connected` resets the sequence. Every failed attempt remains observable as `Net.Error`, which keeps game diagnostics honest while the 8-second cap bounds noise. Dropping the subscription cancels the socket and pending retry.

Deadlines use simulation `tts`, not wall time or the effect runner. Live timeline rewinds preserve the remaining delay; dry counterfactual replay suppresses socket commands at the side-effect boundary. Inbound `NetEvent`s continue through the existing FIFO inbox.

The shared producer policy covers native and wasm. The browser host additionally removes `CloseKey` synchronously before a close-plus-connect retry, ignores stale close callbacks by connection ID, and reports synchronous WebSocket constructor failures through its existing game borrow.

Tested head: `b710a3cc597477cc2aa30a48689221fcb88a0d12`.

## Netpong blocker

The jam's `netpong` proof currently kills and relaunches a client because the one-shot behavior cannot recover when the client starts first or the authoritative server restarts. This change removes that engine limitation: adoption should delete that workaround, preserve the original client process, and assert it returns to LIVE after both the initial late server start and a server-only restart.

## Probe evidence

Probe: `/tmp/functor-jam.YFADHZ/repro-reconnect`, roles-as-files, client started before server.

Base `d5634cc` before the server existed (`tts=9.883354`):

```text
{ connected: 0, errors: 1, disconnected: 0, welcomes: 0, lastId: -1 }
```

Base after the server had listened for another 8.55 game seconds—the same client never converged:

```text
client { connected: 0, errors: 1, disconnected: 0, welcomes: 0, lastId: -1 }
server { connected: 0, hellos: 0 }
```

Fixed head, client still running when the server appeared:

```text
before server { connected: 0, errors: 4, disconnected: 0, welcomes: 0, lastId: -1 }
after server  { connected: 1, errors: 4, disconnected: 0, welcomes: 1, lastId: 5 }
```

Kill only the server, then restart only the server; the original client process reconnects:

```text
server down      { connected: 1, errors: 7, disconnected: 1, welcomes: 1, lastId: 5 }
server restarted { connected: 2, errors: 7, disconnected: 1, welcomes: 2, lastId: 8 }
```

## Verification

- `cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` — pass (common 716, prelude typecheck 31, docgen 14, language suite and doctests pass).
- Isolated SDK multiplayer e2e with client A started one second before the server — pass, 3.36 s.
- Full SDK headless attempt was locally obstructed by an unrelated process already owning the suite's fixed port 8090; the changed multiplayer case passes in isolation on debug-port base 18400.
- `cargo test -p functor-runtime-desktop ws_host::tests` — pass (4), including a delayed-handshake regression proving `CloseKey` invalidates an in-flight dial.
- `npm run build:cli` — pass at the tested head. This actually built the wasm bundle and release native CLI.
- Web verification: implemented and wasm release-build checked. No browser WebSocket smoke was claimed locally because this checkout did not have the root Playwright dependency installed.

## Performance

Release `frame_bench`, three runs per side, back-to-back on this machine; time is the minimum across runs. Allocations and bytes are exact parity.

| cells | base min us/frame | change min us/frame | delta | base/change allocs | base/change bytes |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 400 | 439.0 | 436.0 | -0.7% | 13,877 / 13,877 | 844,497 / 844,497 |
| 1,600 | 1,721.9 | 1,721.2 | -0.0% | 54,717 / 54,717 | 3,308,337 / 3,308,337 |
| 3,136 | 3,374.2 | 3,368.8 | -0.2% | 106,973 / 106,973 | 6,461,361 / 6,461,361 |

The sub-percent wall-clock movement is within observed run-to-run noise; the deterministic allocation counters are unchanged.

## Docs

Updated `Sub.connect` API docs, the multiplayer guide, the Functor Lang skill, and the site manual with the exact retry/error/reset/cancellation contract and the replay side-effect boundary.

## xreview dispositions

- **High — browser `CloseKey` + immediate `Connect` could discard the replacement socket:** fixed by synchronously removing the old mapping and ID-guarding stale close callbacks.
- **High — native in-flight dials and browser retired sockets could emit stale events after `CloseKey`:** fixed with per-key connection generations gating every native/browser event; added the native delayed-handshake regression.
- **Medium — synchronous browser WebSocket constructor errors were dropped by a nested borrow:** fixed by returning the keyed error to the dispatcher; added a tested shared host seam.
- **Medium — absolute retry deadlines could inherit discarded timeline time:** fixed with centralized remaining-delay rebasing across scrub-resume, explicit rewind, and reload preparation in both producers; added a unit regression.
- **Low — browser comment still described one-shot behavior:** updated.
- Dedicated lexical/clone/API-index duplication pass: no actionable duplication (23 queries / 7,352 candidates; 262 clone pairs; 3,010 APIs).
- Reviewer A final reruns: clean, including focused verification of both stale-event High findings; no actionable Critical/High findings remain.

This PR intentionally remains **draft** until the jam orchestrator verifies `netpong` adoption.

## Visual verification

Desktop manual at the same 1440×1100 viewport and scroll position. The copy-only change leaves layout and styling intact while documenting the reconnect policy.

### Before — `main` at `ebab886`

![Multiplayer manual before the Sub.connect retry contract](https://gist.githubusercontent.com/tommy-xr/bd1ba577a9b6a076917eb2ab02232cc2/raw/pr-671-manual-before.png)

### After — `b710a3c`

![Multiplayer manual with the Sub.connect retry contract](https://gist.githubusercontent.com/tommy-xr/bd1ba577a9b6a076917eb2ab02232cc2/raw/pr-671-manual-after.png)

<sub>Built from each ref and captured headlessly in Chromium. A GIF is intentionally omitted because this is a static documentation-copy change.</sub>