### PR TITLE
feat(debug): scriptable pointer motion and a discoverable pointer surface

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -294,13 +294,21 @@ regression capture — use `--input-script <file>` instead: the runner replays t
 file against a fixed `--script-dt` per frame, so frame N is always the same sim
 state, and `--capture-at-frame N` grabs a byte-identical still every time.
 
-Each non-blank line is `<frame> <control> <down|up>`; `#` starts a comment.
-A `<control>` is either a KEY name (`Right`, `Up`, `A`, `Space` — the same
-`Key::from_name` spelling `POST /input` uses) or a MOUSE BUTTON written with an
-explicit `Mouse.` prefix:
+Each non-blank line is one of these two forms; `#` starts a comment:
+
+```text
+<frame> <Key|Mouse.Button> <down|up>
+<frame> Mouse.Move <x> <y>
+```
+
+A control is either a KEY name (`Right`, `Up`, `A`, `Space` — the same
+`Key::from_name` spelling `POST /input` uses), a MOUSE BUTTON written with an
+explicit `Mouse.` prefix, or the special `Mouse.Move` pointer form:
 
 ```
 0  Right       down     # hold the right arrow key from frame 0
+0  Mouse.Move  400 300  # establish the pointer at a logical point
+1  Mouse.Move  560 220  # aim by moving before this frame's tick
 4  Mouse.Left  down     # press and hold the left mouse button
 28 Mouse.Left  up
 ```
@@ -315,13 +323,28 @@ updates for later `sampledInput` steps, so holding one scripts full-auto fire
 The scripted transition also appears once in `mouse.pressed` or
 `mouse.released` on that frame's sampled snapshot.
 
+`Mouse.Move` coordinates are signed **logical points** with a top-left origin,
+in exactly the same space as `Input.mouse.x` / `.y` and the debug state's
+`input.mouse.surface_width` / `surface_height`. They are not framebuffer
+pixels: on a Retina window the logical surface may be 800×600 while `viewport`
+is 1600×1200. Motion is delivered before the named frame's `sampledInput` and
+`tick`, and the new position is carried into that sampled snapshot and replay
+history.
+
+With `--emulate-xr`, the position drives the synthesized controller sample and
+does not also invoke the legacy `mouseMove` hook, matching `POST /input`.
+
+Scripts and `POST /input` intentionally preserve negative and out-of-surface
+coordinates instead of rejecting them. Native pointer events can report the
+same transient values, and clamping only one injection path would make replay
+diverge from live input. A mapping API such as `Camera3D.toWorldRay` therefore
+continues to return `None` outside the half-open logical surface; drivers can
+read the published surface extent and choose or validate an in-range point.
+
 A `Mouse.* up` with no preceding press is a **parse error**, not a silently
 dropped line: live playback would suppress it while the forward-step trajectory
 preview would replay it, so a stray release is rejected rather than allowed to
 make the preview and the real run disagree.
-
-Pointer MOTION is not scriptable yet — `mouse_move` is injection-only, since it
-needs a two-coordinate line shape rather than this `<control> <down|up>` triple.
 
 ### Sampled input in `GET /state`
 
@@ -340,6 +363,8 @@ clients should treat absent edge arrays/button sets as empty.
   "mouse": {
     "x": 0,
     "y": 0,
+    "surface_width": 800,
+    "surface_height": 600,
     "buttons": { "left": false, "right": false, "middle": false },
     "pressed": { "left": false, "right": false, "middle": false },
     "released": { "left": false, "right": false, "middle": false }
@@ -376,6 +401,12 @@ clients should treat absent edge arrays/button sets as empty.
   }
 }
 ```
+
+`surface_width` and `surface_height` were added in debug protocol v7. They are
+the logical pointer surface in the same coordinate space as `x` and `y`, not
+the framebuffer dimensions in top-level `viewport` (which are `0×0` in
+headless mode). A client that needs resize-correct pointer mapping must require
+v7 or newer rather than infer the logical extent from `viewport`.
 
 Tracked poses use OpenXR's rig-local convention: +X right, +Y up, -Z forward;
 quaternions are `[x, y, z, w]`. Head and controller poses are relative to the

--- a/examples/shooting-range/aim-and-fire.input
+++ b/examples/shooting-range/aim-and-fire.input
@@ -1,0 +1,13 @@
+# Deterministically aim away from center, then fire.
+#
+# `Mouse.Move` coordinates are logical points in the same top-left-origin space
+# as `Input.mouse.x/y`, not framebuffer pixels. The first move establishes the
+# shooting range's previous sample; the second produces a (+160, -80) delta,
+# turning the camera right and up before the trigger is pressed.
+#
+#   functor -d examples/shooting-range run native \
+#     --input-script aim-and-fire.input --script-dt 0.016 \
+#     --capture-frame .captures/aim-and-fire.png --capture-at-frame 36
+0 Mouse.Move 400 300
+1 Mouse.Move 560 220
+2 Mouse.Left down

--- a/examples/shooting-range/game.fun
+++ b/examples/shooting-range/game.fun
@@ -8,8 +8,8 @@
 //                 `cooldown` is decremented before the fire check, so the
 //                 cadence is ceil(fireInterval / dt) = 11 frames at 60 Hz,
 //                 12 at the replay script's 0.016 s timestep).
-//                 This is also what the committed `firing.input` replay
-//                 script drives, as `0 Mouse.Left down`
+//                 This is also what the committed `firing.input` and
+//                 `aim-and-fire.input` replay scripts drive.
 //   W A S D       move along the firing line
 //   R             reload
 //   SPACE         fire (keyboard fallback)

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -698,6 +698,13 @@ mod tests {
                 }
             })
         );
+        assert_eq!(actual["input"]["mouse"]["surface_width"], 960);
+        assert_eq!(actual["input"]["mouse"]["surface_height"], 540);
+        assert_ne!(
+            actual["input"]["mouse"]["surface_width"],
+            actual["viewport"]["width"],
+            "the logical pointer surface must remain distinct from the framebuffer viewport"
+        );
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/input.rs
+++ b/runtime/functor-runtime-common/src/input.rs
@@ -411,7 +411,9 @@ pub enum RecordedInput {
     /// A keyboard event carrying the raw `Key as i32` code (not the resolved
     /// `Key`), so replay re-runs `Key::from_i32` exactly as the live path does.
     Key { code: i32, is_down: bool },
-    /// A pointer position in window pixels.
+    /// A pointer position in logical window points (GLFW points natively, CSS
+    /// pixels on web), matching `Input.mouse.x` / `.y` rather than framebuffer
+    /// pixels.
     MouseMove { x: i32, y: i32 },
     /// A wheel notch (±1 per notch).
     MouseWheel { delta: i32 },

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -329,6 +329,8 @@ fn refresh_fixed_input_levels(
 
 fn apply_scripted_events(
     game: &mut dyn Game,
+    mouse_pos: &mut (i32, i32),
+    emulate_xr: bool,
     held_keys: &mut BTreeSet<InputKey>,
     held_buttons: &mut MouseButtons,
     edges: &mut InputEdges,
@@ -356,11 +358,19 @@ fn apply_scripted_events(
                     apply_mouse_button_edge(game, held_buttons, edges, b, *is_down);
                 }
             }
+            RecordedInput::MouseMove { x, y } => {
+                *mouse_pos = (*x, *y);
+                // Match POST /input: under the desktop XR emulator the
+                // pointer drives the synthesized controller sample instead of
+                // also reaching the game's legacy 2D mouse hook.
+                if !emulate_xr {
+                    game.mouse_move(*x, *y);
+                }
+            }
             // Listed rather than `_`, so adding a scriptable line shape (e.g.
-            // pointer motion) has to be wired here instead of compiling to a
+            // wheel motion) has to be wired here instead of compiling to a
             // silent no-op.
-            RecordedInput::MouseMove { .. }
-            | RecordedInput::MouseWheel { .. }
+            RecordedInput::MouseWheel { .. }
             | RecordedInput::Snapshot(_)
             | RecordedInput::UiEvent(_)
             | RecordedInput::WebviewEvent(_) => {}
@@ -371,7 +381,8 @@ fn apply_scripted_events(
 /// Parse an `--input-script` file into a frame → events map for deterministic
 /// scripted playback (docs/time-travel.md T6b). Each non-blank, non-comment
 /// line is `<frame:int> <control> <down|up>` — e.g. `0 Right down`,
-/// `18 Up down`, `4 Mouse.Left down`. `#` starts a comment (to end of line).
+/// `18 Up down`, `4 Mouse.Left down` — or `<frame:int> Mouse.Move <x> <y>`.
+/// `#` starts a comment (to end of line).
 ///
 /// A `<control>` is either a KEY name, which goes through the same
 /// [`InputKey::from_name`] map the debug server's POST /input uses, or a MOUSE
@@ -386,11 +397,13 @@ fn apply_scripted_events(
 /// (`MouseButton::ctor_tag`), and no key name contains a `.`, so the two
 /// namespaces cannot collide.
 ///
-/// Events are stored as raw `RecordedInput::Key` / `RecordedInput::MouseButton`
-/// so playback re-runs the identical live input path.
+/// Pointer coordinates are signed logical window points — the same top-left-
+/// origin space as `Input.mouse.x` / `.y`, not framebuffer pixels. They are
+/// deliberately not clamped: live pointer events and `POST /input` preserve
+/// out-of-surface coordinates too, and games decide how to handle a miss.
 ///
-/// Pointer MOTION (`RecordedInput::MouseMove`) is not scriptable yet — it needs
-/// a two-coordinate line shape rather than this `<control> <down|up>` triple.
+/// Events are stored as raw `RecordedInput` values so playback re-runs the
+/// identical live input path.
 fn parse_input_script(path: &str) -> Result<HashMap<u64, Vec<RecordedInput>>, String> {
     let text = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read input script {path}: {e}"))?;
@@ -402,9 +415,33 @@ fn parse_input_script(path: &str) -> Result<HashMap<u64, Vec<RecordedInput>>, St
             continue;
         }
         let parts: Vec<&str> = line.split_whitespace().collect();
+        let is_mouse_move = parts
+            .get(1)
+            .is_some_and(|control| control.eq_ignore_ascii_case("Mouse.Move"));
+        if is_mouse_move {
+            if parts.len() != 4 {
+                return Err(format!(
+                    "{path}:{lineno}: expected `<frame> Mouse.Move <x> <y>`, got `{raw}`"
+                ));
+            }
+            let frame: u64 = parts[0]
+                .parse()
+                .map_err(|_| format!("{path}:{lineno}: bad frame number `{}`", parts[0]))?;
+            let x: i32 = parts[2].parse().map_err(|_| {
+                format!("{path}:{lineno}: bad logical x coordinate `{}`", parts[2])
+            })?;
+            let y: i32 = parts[3].parse().map_err(|_| {
+                format!("{path}:{lineno}: bad logical y coordinate `{}`", parts[3])
+            })?;
+            map.entry(frame)
+                .or_default()
+                .push(RecordedInput::MouseMove { x, y });
+            continue;
+        }
         if parts.len() != 3 {
             return Err(format!(
-                "{path}:{lineno}: expected `<frame> <Key|Mouse.Button> <down|up>`, got `{raw}`"
+                "{path}:{lineno}: expected `<frame> <Key|Mouse.Button> <down|up>` or \
+                 `<frame> Mouse.Move <x> <y>`, got `{raw}`"
             ));
         }
         let frame: u64 = parts[0]
@@ -647,11 +684,14 @@ pub struct Args {
     fixed_time: Option<f32>,
 
     /// Drive the game deterministically from a scripted input file instead of
-    /// live window input (docs/time-travel.md T6b). Each line is
+    /// live window input (docs/time-travel.md T6b). Each line is either
     /// `<frame:int> <control> <down|up>` — a KeyName like `Right`, `Up`, `A`,
     /// `Space`, or a mouse button with an explicit `Mouse.` prefix
     /// (`Mouse.Left`, `Mouse.Right`, `Mouse.Middle`; the prefix is required
-    /// because `Left`/`Right`/`Middle` are also key names).
+    /// because `Left`/`Right`/`Middle` are also key names) — or
+    /// `<frame:int> Mouse.Move <x> <y>`. Pointer coordinates are signed LOGICAL
+    /// window points in the same top-left-origin space as `Input.mouse.x/y`,
+    /// not framebuffer pixels; out-of-surface values are preserved.
     /// `#` starts a comment. The sim advances by a FIXED `--script-dt`
     /// per rendered frame (not wall-clock), and each frame's scripted events are
     /// fed before that frame's tick, so frame N is always the same sim state —
@@ -1231,6 +1271,8 @@ fn run_headless(
             {
                 apply_scripted_events(
                     &mut *game,
+                    &mut mouse_pos,
+                    emulate_xr,
                     &mut held_keys,
                     &mut held_buttons,
                     &mut input_edges,
@@ -2454,6 +2496,8 @@ Escape again to quit"
                     if let Some(events) = script.get(&frame_count) {
                         apply_scripted_events(
                             &mut *game,
+                            &mut game_mouse_pos,
+                            args.emulate_xr,
                             &mut held_keys,
                             &mut held_buttons,
                             &mut input_edges,
@@ -3464,6 +3508,54 @@ mod tests {
             map[&9][0],
             RecordedInput::MouseButton { button, is_down: false } if button == Btn::Right as i32
         ));
+    }
+
+    #[test]
+    fn parse_input_script_maps_logical_pointer_motion() {
+        let path = write_tmp(
+            "functor-test-pointer.script",
+            "0 Mouse.Move 400 300\n7 mouse.move -12 640  # outside is preserved\n",
+        );
+        let map = parse_input_script(path.to_str().unwrap()).unwrap();
+
+        assert!(matches!(
+            map[&0][0],
+            RecordedInput::MouseMove { x: 400, y: 300 }
+        ));
+        assert!(matches!(
+            map[&7][0],
+            RecordedInput::MouseMove { x: -12, y: 640 }
+        ));
+    }
+
+    #[test]
+    fn parse_input_script_teaches_pointer_shape_and_coordinate_range() {
+        let short = write_tmp("functor-test-pointer-short.script", "0 Mouse.Move 400\n");
+        let err = parse_input_script(short.to_str().unwrap()).unwrap_err();
+        assert!(
+            err.contains("<frame> Mouse.Move <x> <y>"),
+            "the arity error must teach the pointer line shape: {err}"
+        );
+
+        let non_number = write_tmp(
+            "functor-test-pointer-number.script",
+            "0 Mouse.Move center 300\n",
+        );
+        let err = parse_input_script(non_number.to_str().unwrap()).unwrap_err();
+        assert!(
+            err.contains("bad logical x coordinate `center`"),
+            "the coordinate error must name the bad axis and value: {err}"
+        );
+
+        // The script stores the same i32 coordinates as live/debug input. A
+        // value outside that representable range is rejected at parse time;
+        // negative or merely out-of-surface i32 values remain valid.
+        let out_of_range = write_tmp(
+            "functor-test-pointer-range.script",
+            "0 Mouse.Move 2147483648 300\n",
+        );
+        let err = parse_input_script(out_of_range.to_str().unwrap()).unwrap_err();
+        assert!(err.contains("bad logical x coordinate `2147483648`"));
     }
 
     /// `Left`/`Right`/`Middle` name a KEY and a MOUSE BUTTON. The `Mouse.`


### PR DESCRIPTION
## Why

The `twin-stick` jam entry could script firing but not aim, so every deterministic capture had to route through an autopilot attract mode. `tactics` independently lost time because pointer input is expressed in logical points while a framebuffer viewport may be Retina-scaled (or `0×0` headless).

On the requested base (`ebab886`), the coordinate half is already present: debug protocol v7 added `input.mouse.surface_width` / `surface_height`, and the current v10 runtime serializes them. This PR documents and pins that existing contract rather than bumping the protocol for an unchanged wire shape. It adds the missing workflow primitive: frame-exact scripted pointer motion.

## What changed

- Add `<frame> Mouse.Move <x> <y>` to `--input-script`; coordinates are signed logical points in the same top-left-origin space as `Input.mouse.x/y`.
- Deliver motion before that frame's `sampledInput` and `tick`, update the sampled pointer, and retain ordinary timeline/replay recording.
- Preserve out-of-surface coordinates, matching native events and `POST /input`; mapping APIs such as `Camera3D.toWorldRay` continue to return `None` outside the half-open surface.
- Match XR-emulator routing: motion drives the synthesized controller sample without also invoking the legacy `mouseMove` hook.
- Document the grammar and `/state` logical-surface fields; add parser/protocol coverage and a committed shooting-range aim-and-fire scenario.

## Before / after proof

Artifacts are under `/tmp/functor-jam.YFADHZ/repro-pointer/` in the fixer environment.

Base rejects pointer motion:

```text
error: /tmp/functor-jam.YFADHZ/repro-pointer/base-move.input:1: expected `<frame> <Key|Mouse.Button> <down|up>`, got `0 Mouse.Move 400 300`
```

Base `/state` also establishes that the logical extent was already fixed before this branch: headless `viewport={width:0,height:0}`, but `input.mouse.surface_width=800` and `surface_height=600` under protocol v10.

After the change, `examples/shooting-range/aim-and-fire.input` moves from `(400,300)` to `(560,220)` and fires. A headless state probe reports `mouse=(560,220)`, logical surface `800×600`, `yaw=-0.4`, `pitch=0.2`, and fired rounds. Two release captures of frame 36 at `800×600` are byte-identical:

```text
fcf320a2d8e956db009a991c286806943ea9a3b64debdc7d96a3efff28557805  aim-run-1.png
fcf320a2d8e956db009a991c286806943ea9a3b64debdc7d96a3efff28557805  aim-run-2.png
BYTE_IDENTICAL
```

## Verification

- `cargo test -p functor-runtime-desktop parse_input_script -- --nocapture` — 8 passed
- `cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` — passed (`functor-docgen` 14, `functor_runtime_common` 712 + 31 prelude integration checks, all `functor-lang` unit/integration/doc tests)
- `npm run check:docs` — Markdown + JSON generation passed
- `target/release/functor -d examples/shooting-range test` — 12/12 expects passed
- headless `--emulate-xr` parity probe — pointer `(560,220)`, XR present, legacy aim unchanged at `yaw=0`, `pitch=0`
- two release frame-36 captures — byte-identical checksum above

## Performance

Three release `frame_bench` runs per side, same machine; table uses the minimum `us/frame`. Allocations and bytes are exact and unchanged.

| Cells | Base min µs | Change min µs | Allocs/frame | Bytes/frame |
|---:|---:|---:|---:|---:|
| 400 | 440.2 | 439.0 | 13,877 → 13,877 | 844,497 → 844,497 |
| 1,600 | 1,724.8 | 1,721.5 | 54,717 → 54,717 | 3,308,337 → 3,308,337 |
| 3,136 | 3,348.5 | 3,368.2 | 106,973 → 106,973 | 6,461,361 → 6,461,361 |

Wall-time deltas are within run-to-run noise (largest minimum delta +0.6%).

## xreview dispositions

- **[AGREED] Medium — fixed:** both the independent reviewer and Codex CLI found that scripted motion initially invoked `mouseMove` under `--emulate-xr`, unlike debug injection. The script path now shares that routing rule, docs call it out, the full gate was rerun, and a headless XR parity probe confirms no legacy aim mutation.
- **Critical / High:** none.
- **Duplication:** no actionable duplication. S1 names, S2 clones, S3 API index, and S4 source reading all ran; no strategy was unavailable.

Review mode note: the xreview skill's requested Opus override was unavailable in this agent pool, so Reviewer A/C used the inherited high-capability model; the Codex CLI half ran read-only at medium reasoning.

## Adoption

Once the jam orchestrator validates the covered entry, `twin-stick` can delete `model.surface` and its four `sampledInput` plumbing lines, commit an `aim.input` using `Mouse.Move`, and golden the player aiming and firing at a chosen logical point. `tactics` can likewise drop its coordinate-space workaround if that cleanup is cheap.

This PR intentionally remains **draft** until entry adoption is proven.
