### PR TITLE
feat(scene): bulk cube instances — one node for thousands of copies

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -963,7 +963,7 @@ The generated modules:
 
 | Module | What it is |
 | --- | --- |
-| `Scene` | 3D scene nodes: primitives, models, terrain, materials, transforms |
+| `Scene` | 3D scene nodes: primitives, bulk fullbright cube instances, models, terrain, materials, transforms |
 | `Sprite` | pure 2D picture values: shapes, text, images, transforms |
 | `Camera3D` | 3D cameras (`lookAt`, `firstPerson`), clip planes, screen→world rays |
 | `Camera2D` | center-origin 2D camera: pan, zoom, screen→world |
@@ -1042,6 +1042,14 @@ error, and `Scene.opacity(1.0, s)` is exactly `s` (so it does not perturb
 back-to-front by the average world position of their leaves, with depth writing
 off and no shadow — see the `Scene.opacity` reference for what that granularity
 does and does not fix. The 2D analogue is `Sprite.fade`.
+
+**Bulk cube instances are fullbright** — `Scene.cubeInstances` takes one list
+of typed `{ data: (x, y, z, sx, sy, sz, r, g, b) }` values and submits it as one
+hardware-instanced draw. The compact flat payload avoids nested per-copy
+vectors, colors, and records. Scale is per-axis and gives the cube's full size. The
+batch owns each copy's emissive RGB color; material wrappers do not override it,
+and this first slice casts no shadows. Outer transforms and `Scene.opacity`
+still apply to the batch.
 
 **Zero-argument constructors take their parens** — `Scene.cube()`,
 `Sprite.blank()`, `Anim.rest()`, `Effect.none()`, `Map.empty()`,

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -14,6 +14,17 @@
 /// An opaque scene node.
 type t = host
 
+/// One fullbright cube submitted by `cubeInstances`.
+///
+/// One compact `{ data: (x, y, z, sx, sy, sz, r, g, b) }` value. `(x, y, z)`
+/// is the cube center. `(sx, sy, sz)` is its full per-axis size: scales of
+/// `1.0` produce the same unit cube as `Scene.cube()`. `(r, g, b)` is
+/// emissive/fullbright RGB. One flat payload tuple avoids three nested vectors,
+/// colors, or records per copy on this performance path.
+type cubeInstance = {
+  data: (float, float, float, float, float, float, float, float, float)
+}
+
 /// Create a unit cube centered at the origin.
 let cube : () => t
 /// Create a unit sphere centered at the origin.
@@ -24,6 +35,16 @@ let cylinder : () => t
 let quad : () => t
 /// Create a unit plane in the XZ ground plane.
 let plane : () => t
+
+/// Submit colored cubes as one hardware-instanced draw call.
+///
+/// Each value carries a center position (`x/y/z`), per-axis scale
+/// (`sx/sy/sz`), and fullbright RGB (`r/g/b`).
+/// The node is an emissive-only first slice: enclosing `Scene.color`,
+/// `Scene.lit`, and `Scene.emissive` modifiers do not replace its per-instance
+/// colors, and instances do not cast shadows. An empty list draws nothing.
+/// Outer scene transforms and `Scene.opacity` still apply to the whole batch.
+let cubeInstances : (List<cubeInstance>) => t
 
 /// Create a scene node from a model asset.
 ///

--- a/runtime/functor-runtime-common/src/debug_protocol.rs
+++ b/runtime/functor-runtime-common/src/debug_protocol.rs
@@ -62,7 +62,11 @@ pub const DEBUG_PROTOCOL_SERVICE: &str = "functor debug runtime";
 /// events. Additive — a pre-v10 runtime simply omits both, which deserializes
 /// as `0`; a client that waits on either must gate on the version rather than
 /// read a constant zero as "quiescent".
-pub const DEBUG_PROTOCOL_VERSION: u32 = 10;
+///
+/// 11 adds the `CubeInstances` scene node returned by `GET /scene`, with each
+/// compact instance carrying position, per-axis scale, and RGB color. Clients
+/// that decode scene variants exhaustively must gate before reading it.
+pub const DEBUG_PROTOCOL_VERSION: u32 = 11;
 
 /// The well-known localhost port `functor develop` serves this protocol on
 /// when no explicit `--debug-port` is given, so an agent can attach to a
@@ -899,7 +903,7 @@ mod tests {
         let discovery: Value = serde_json::from_str(&discovery_json()).unwrap();
         assert_eq!(discovery["service"], DEBUG_PROTOCOL_SERVICE);
         assert_eq!(discovery["protocol_version"], DEBUG_PROTOCOL_VERSION);
-        assert_eq!(DEBUG_PROTOCOL_VERSION, 10);
+        assert_eq!(DEBUG_PROTOCOL_VERSION, 11);
     }
 
     /// The v10 fields are ADDITIVE: a pre-v10 payload (which carries neither)

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -171,7 +171,8 @@ use crate::math::Angle;
 use crate::physics;
 use crate::render_target::RenderTargetDescriptor;
 use crate::scene3d::{
-    MaterialDescription, ModelDescription, ModelHandle, SpriteSampling, TextureDescription,
+    CubeInstance, MaterialDescription, ModelDescription, ModelHandle, SpriteSampling,
+    TextureDescription,
 };
 use crate::skybox::SkyboxDescription;
 use crate::terrain::TerrainDescription;
@@ -989,6 +990,9 @@ pub struct FunctorLangColor(pub (f32, f32, f32));
 /// never three bare floats, so arity slips and float-interleaving mistakes
 /// are unrepresentable (the Angle rule, applied to space).
 pub struct FunctorLangVec3(pub (f32, f32, f32));
+
+/// Plain per-instance data decoded once at the bulk prelude boundary.
+struct FunctorLangCubeInstance(pub CubeInstance);
 
 /// A [`RenderTargetDescriptor`] as an opaque Functor Lang value — declared once via
 /// `RenderTarget.named` and used at both sites: the writer
@@ -2073,6 +2077,15 @@ row 0 has {cols} heights, row {r} has {}",
             FunctorLangScene(group(
                 scenes.into_iter().map(|s| s.0).collect(),
                 Matrix4::from_scale(1.0),
+            ))
+        },
+    );
+    reg.fn1(
+        "Scene.cubeInstances",
+        "Scene.cubeInstances([{ data: (x, y, z, sx, sy, sz, r, g, b) }, …])",
+        |instances: Vec<FunctorLangCubeInstance>| {
+            FunctorLangScene(Scene3D::cube_instances(
+                instances.into_iter().map(|instance| instance.0).collect(),
             ))
         },
     );
@@ -4122,6 +4135,47 @@ impl crate::host_registry::FromArg for FunctorLangAngle {
 impl crate::host_registry::FromArg for FunctorLangVec3 {
     fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
         vec3_of(value, path, span).map(FunctorLangVec3)
+    }
+}
+
+impl crate::host_registry::FromArg for FunctorLangCubeInstance {
+    fn from_arg(value: &Value, path: &str, span: Span) -> Result<Self, RunError> {
+        let Value::Record(fields) = value else {
+            return Err(RunError {
+                message: format!(
+                    "{path}: expected a Scene.cubeInstance record, got {}",
+                    value.kind_name()
+                ),
+                span,
+            });
+        };
+        let Some((_, Value::Tuple(args))) = fields.iter().find(|(name, _)| name == "data") else {
+            return Err(RunError {
+                message: format!(
+                    "{path}: Scene.cubeInstance `data` must be a 9-float tuple"
+                ),
+                span,
+            });
+        };
+        if args.len() != 9 {
+            return Err(RunError {
+                message: format!(
+                    "{path}: Scene.cubeInstance `data` must contain 9 floats, got {}",
+                    args.len()
+                ),
+                span,
+            });
+        }
+        let mut numbers = [0.0; 9];
+        for (index, value) in args.iter().enumerate() {
+            numbers[index] =
+                <f64 as crate::host_registry::FromArg>::from_arg(value, path, span)? as f32;
+        }
+        Ok(FunctorLangCubeInstance(CubeInstance {
+            position: [numbers[0], numbers[1], numbers[2]],
+            scale: [numbers[3], numbers[4], numbers[5]],
+            color: [numbers[6], numbers[7], numbers[8]],
+        }))
     }
 }
 
@@ -7846,6 +7900,37 @@ Vec3.make(x, y, z)"
     }
 
     // --- Scene.equals / Frame.equals (structural equality for draw tests) ---
+
+    #[test]
+    fn cube_instances_decode_typed_records_and_compare_structurally() {
+        let one = "Scene.cubeInstances([{ data: (1.0, 2.0, 3.0, 0.5, 1.0, 2.0, 0.2, 0.4, 0.8) }])";
+        let value = eval(&format!("let main = () => {one}"));
+        let scene = scene_of(&value).expect("cubeInstances returns a Scene");
+        let SceneObject::CubeInstances(instances) = &scene.obj else {
+            panic!("expected CubeInstances, got {:?}", scene.obj);
+        };
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].position, [1.0, 2.0, 3.0]);
+        assert_eq!(instances[0].scale, [0.5, 1.0, 2.0]);
+        assert_eq!(instances[0].color, [0.2, 0.4, 0.8]);
+
+        let module = functor_lang::lower(
+            functor_lang::parse(
+                "let main = () => Scene.cubeInstances([{ data: (1.0 / 0.0, 2.0, 3.0, 0.5, 1.0, 2.0, 0.2, 0.4, 0.8) }])",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        let failure = functor_lang::run_with_host(&module, Tracing::Off, &mut FunctorHost)
+            .err()
+            .expect("non-finite instance data must fail at the host boundary");
+        assert_eq!(failure.error.message, "expected a finite number, got inf");
+
+        assert!(equality(&format!("Scene.equals({one}, {one})")));
+        assert!(!equality(&format!(
+            "Scene.equals({one}, Scene.cubeInstances([{{ data: (1.0, 2.0, 3.0, 0.5, 1.0, 2.0, 0.8, 0.4, 0.2) }}]))"
+        )));
+    }
 
     /// Evaluate a `Scene.equals`/`Frame.equals` expression to its bool.
     fn equality(expr: &str) -> bool {

--- a/runtime/functor-runtime-common/src/geometry/cube.rs
+++ b/runtime/functor-runtime-common/src/geometry/cube.rs
@@ -8,86 +8,97 @@ pub struct Cube;
 
 impl Cube {
     pub fn create() -> Box<dyn Geometry> {
-        // 24 vertices (4 per face) so each face carries its own flat normal —
-        // shared corner vertices could only hold averaged/radial normals, which
-        // would smooth-shade the cube under lighting. Extents are -0.5..0.5.
-        let faces: [(Vector3<f32>, [Vector3<f32>; 4]); 6] = [
-            // +Z (front)
-            (
-                vec3(0.0, 0.0, 1.0),
-                [
-                    vec3(-0.5, -0.5, 0.5),
-                    vec3(0.5, -0.5, 0.5),
-                    vec3(0.5, 0.5, 0.5),
-                    vec3(-0.5, 0.5, 0.5),
-                ],
-            ),
-            // -Z (back)
-            (
-                vec3(0.0, 0.0, -1.0),
-                [
-                    vec3(0.5, -0.5, -0.5),
-                    vec3(-0.5, -0.5, -0.5),
-                    vec3(-0.5, 0.5, -0.5),
-                    vec3(0.5, 0.5, -0.5),
-                ],
-            ),
-            // +X (right)
-            (
-                vec3(1.0, 0.0, 0.0),
-                [
-                    vec3(0.5, -0.5, 0.5),
-                    vec3(0.5, -0.5, -0.5),
-                    vec3(0.5, 0.5, -0.5),
-                    vec3(0.5, 0.5, 0.5),
-                ],
-            ),
-            // -X (left)
-            (
-                vec3(-1.0, 0.0, 0.0),
-                [
-                    vec3(-0.5, -0.5, -0.5),
-                    vec3(-0.5, -0.5, 0.5),
-                    vec3(-0.5, 0.5, 0.5),
-                    vec3(-0.5, 0.5, -0.5),
-                ],
-            ),
-            // +Y (top)
-            (
-                vec3(0.0, 1.0, 0.0),
-                [
-                    vec3(-0.5, 0.5, 0.5),
-                    vec3(0.5, 0.5, 0.5),
-                    vec3(0.5, 0.5, -0.5),
-                    vec3(-0.5, 0.5, -0.5),
-                ],
-            ),
-            // -Y (bottom)
-            (
-                vec3(0.0, -1.0, 0.0),
-                [
-                    vec3(-0.5, -0.5, -0.5),
-                    vec3(0.5, -0.5, -0.5),
-                    vec3(0.5, -0.5, 0.5),
-                    vec3(-0.5, -0.5, 0.5),
-                ],
-            ),
-        ];
-
-        let uvs = [vec2(0.0, 0.0), vec2(1.0, 0.0), vec2(1.0, 1.0), vec2(0.0, 1.0)];
-
-        let mut vertices: Vec<VertexPositionTexture> = Vec::with_capacity(24);
-        let mut indices: Vec<u32> = Vec::with_capacity(36);
-
-        for (normal, corners) in faces {
-            let base = vertices.len() as u32;
-            for (corner, uv) in corners.iter().zip(uvs.iter()) {
-                vertices.push(VertexPositionTexture::new(*corner, *uv, normal));
-            }
-            indices.extend_from_slice(&[base, base + 1, base + 2, base + 2, base + 3, base]);
-        }
-
-        super::compute_tangents(&mut vertices, &indices);
+        let (vertices, indices) = cube_mesh();
         Box::new(IndexedMesh::create(vertices, indices))
     }
+}
+
+/// The canonical unit-cube mesh, shared by ordinary and instanced rendering.
+pub(crate) fn cube_mesh() -> (Vec<VertexPositionTexture>, Vec<u32>) {
+    // 24 vertices (4 per face) so each face carries its own flat normal —
+    // shared corner vertices could only hold averaged/radial normals, which
+    // would smooth-shade the cube under lighting. Extents are -0.5..0.5.
+    let faces: [(Vector3<f32>, [Vector3<f32>; 4]); 6] = [
+        // +Z (front)
+        (
+            vec3(0.0, 0.0, 1.0),
+            [
+                vec3(-0.5, -0.5, 0.5),
+                vec3(0.5, -0.5, 0.5),
+                vec3(0.5, 0.5, 0.5),
+                vec3(-0.5, 0.5, 0.5),
+            ],
+        ),
+        // -Z (back)
+        (
+            vec3(0.0, 0.0, -1.0),
+            [
+                vec3(0.5, -0.5, -0.5),
+                vec3(-0.5, -0.5, -0.5),
+                vec3(-0.5, 0.5, -0.5),
+                vec3(0.5, 0.5, -0.5),
+            ],
+        ),
+        // +X (right)
+        (
+            vec3(1.0, 0.0, 0.0),
+            [
+                vec3(0.5, -0.5, 0.5),
+                vec3(0.5, -0.5, -0.5),
+                vec3(0.5, 0.5, -0.5),
+                vec3(0.5, 0.5, 0.5),
+            ],
+        ),
+        // -X (left)
+        (
+            vec3(-1.0, 0.0, 0.0),
+            [
+                vec3(-0.5, -0.5, -0.5),
+                vec3(-0.5, -0.5, 0.5),
+                vec3(-0.5, 0.5, 0.5),
+                vec3(-0.5, 0.5, -0.5),
+            ],
+        ),
+        // +Y (top)
+        (
+            vec3(0.0, 1.0, 0.0),
+            [
+                vec3(-0.5, 0.5, 0.5),
+                vec3(0.5, 0.5, 0.5),
+                vec3(0.5, 0.5, -0.5),
+                vec3(-0.5, 0.5, -0.5),
+            ],
+        ),
+        // -Y (bottom)
+        (
+            vec3(0.0, -1.0, 0.0),
+            [
+                vec3(-0.5, -0.5, -0.5),
+                vec3(0.5, -0.5, -0.5),
+                vec3(0.5, -0.5, 0.5),
+                vec3(-0.5, -0.5, 0.5),
+            ],
+        ),
+    ];
+
+    let uvs = [
+        vec2(0.0, 0.0),
+        vec2(1.0, 0.0),
+        vec2(1.0, 1.0),
+        vec2(0.0, 1.0),
+    ];
+
+    let mut vertices: Vec<VertexPositionTexture> = Vec::with_capacity(24);
+    let mut indices: Vec<u32> = Vec::with_capacity(36);
+
+    for (normal, corners) in faces {
+        let base = vertices.len() as u32;
+        for (corner, uv) in corners.iter().zip(uvs.iter()) {
+            vertices.push(VertexPositionTexture::new(*corner, *uv, normal));
+        }
+        indices.extend_from_slice(&[base, base + 1, base + 2, base + 2, base + 3, base]);
+    }
+
+    super::compute_tangents(&mut vertices, &indices);
+    (vertices, indices)
 }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -71,6 +71,10 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v13: hardware-instanced cubes — the `SceneObject::CubeInstances` variant,
+/// carrying compact position, per-axis scale, and RGB records inline. Frames
+/// that do not call `Scene.cubeInstances` retain their v12 shape.
+///
 /// v12: translucent subtrees — the `SceneObject::Opacity` variant (a v11 reader
 /// cannot decode a frame carrying one). Only scenes that call `Scene.opacity`
 /// produce it: full opacity is the identity, so every other frame keeps its
@@ -111,7 +115,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 12;
+pub const PROTOCOL_VERSION: u32 = 13;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -625,7 +629,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 12);
+        assert_eq!(PROTOCOL_VERSION, 13);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -652,7 +656,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 12);
+        assert_eq!(PROTOCOL_VERSION, 13);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],
@@ -675,7 +679,7 @@ mod tests {
     fn opacity_subtree_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 12);
+        assert_eq!(PROTOCOL_VERSION, 13);
         let scene = SceneObject::Opacity(
             0.35,
             vec![Scene3D {
@@ -692,11 +696,32 @@ mod tests {
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }
 
+    /// The bulk node's compact instance payload is visible to `GET /scene`
+    /// and must remain decodable by consumers advertising protocol v13.
+    #[test]
+    fn cube_instances_wire_is_pinned() {
+        use crate::{CubeInstance, SceneObject};
+
+        assert_eq!(PROTOCOL_VERSION, 13);
+        let scene = SceneObject::CubeInstances(vec![CubeInstance {
+            position: [1.0, 2.0, 3.0],
+            scale: [0.5, 1.0, 2.0],
+            color: [0.2, 0.4, 0.8],
+        }]);
+        let json = serde_json::to_string(&scene).expect("serialize cube instances");
+        assert_eq!(
+            json,
+            r#"{"CubeInstances":[{"position":[1.0,2.0,3.0],"scale":[0.5,1.0,2.0],"color":[0.2,0.4,0.8]}]}"#
+        );
+        let back: SceneObject = serde_json::from_str(&json).expect("deserialize cube instances");
+        assert_eq!(back, scene);
+    }
+
     #[test]
     fn two_bone_reach_animation_wire_is_pinned() {
         use crate::anim::AnimExpr;
 
-        assert_eq!(PROTOCOL_VERSION, 12);
+        assert_eq!(PROTOCOL_VERSION, 13);
         let reach = AnimExpr::Reach {
             root: "upper".to_string(),
             middle: "lower".to_string(),
@@ -722,8 +747,8 @@ mod tests {
         use crate::math::Angle;
         use crate::render_target::RenderTargetDescriptor;
         use crate::{
-            MaterialDescription, ModelDescription, ModelHandle, RenderTargetPass, Shape,
-            TextureDescription,
+            CubeInstance, MaterialDescription, ModelDescription, ModelHandle, RenderTargetPass,
+            Shape, TextureDescription,
         };
         use cgmath::{Matrix4, SquareMatrix};
 
@@ -756,6 +781,11 @@ mod tests {
                     animation: None,
                     while_pending: vec![],
                 }),
+                Scene3D::cube_instances(vec![CubeInstance {
+                    position: [1.0, 2.0, 3.0],
+                    scale: [0.5, 1.0, 2.0],
+                    color: [0.2, 0.4, 0.8],
+                }]),
                 // A monitor: samples the "feed" render target declared below.
                 Scene3D {
                     obj: SceneObject::Material(

--- a/runtime/functor-runtime-common/src/scene3d/cube_instances.rs
+++ b/runtime/functor-runtime-common/src/scene3d/cube_instances.rs
@@ -1,0 +1,254 @@
+use std::mem::{offset_of, size_of};
+
+use cgmath::Matrix4;
+use glow::HasContext;
+
+use crate::fog::{FogUniforms, FOG_GLSL};
+use crate::geometry::cube_mesh;
+use crate::math::normal_matrix;
+use crate::render::vertex::{Vertex, VertexAttributeType};
+use crate::render::VertexPositionTexture;
+use crate::shader::{Shader, ShaderType};
+use crate::shader_program::{ShaderProgram, UniformLocation};
+use crate::{DebugRenderMode, RenderContext};
+
+use super::CubeInstance;
+
+const VERTEX_SHADER_SOURCE: &str = r#"
+        layout (location = 0) in vec3 inPos;
+        layout (location = 2) in vec3 inNormal;
+        layout (location = 3) in vec4 inTangent;
+        layout (location = 4) in vec3 instancePosition;
+        layout (location = 5) in vec3 instanceScale;
+        layout (location = 6) in vec3 instanceColor;
+
+        uniform mat4 world;
+        uniform mat3 normalMatrix;
+        uniform mat4 view;
+        uniform mat4 projection;
+
+        out vec3 worldPos;
+        out vec3 color;
+        out vec3 worldNormal;
+        out vec3 worldTangent;
+
+        void main() {
+            vec3 local = inPos * instanceScale + instancePosition;
+            vec4 wp = world * vec4(local, 1.0);
+            worldPos = wp.xyz;
+            color = instanceColor;
+            // Applying the inverse instance scale before the enclosing
+            // transform is the inverse-transpose normal transform for the
+            // complete `world * scale` matrix.
+            worldNormal = normalMatrix * (inNormal / instanceScale);
+            worldTangent = mat3(world) * (inTangent.xyz * instanceScale);
+            gl_Position = projection * view * wp;
+        }
+"#;
+
+const FRAGMENT_SHADER_SOURCE: &str = r#"
+        out vec4 fragColor;
+
+        in vec3 worldPos;
+        in vec3 color;
+        in vec3 worldNormal;
+        in vec3 worldTangent;
+
+        uniform int debugMode; // 0 = authored, 1 = normals, 2 = tangents
+
+        void main() {
+            if (debugMode == 1) {
+                fragColor = vec4(normalize(worldNormal) * 0.5 + 0.5, 1.0);
+            } else if (debugMode == 2) {
+                fragColor = vec4(normalize(worldTangent) * 0.5 + 0.5, 1.0);
+            } else {
+                fragColor = vec4(applyFog(color, worldPos), 1.0);
+            }
+        }
+"#;
+
+struct Uniforms {
+    world: UniformLocation,
+    normal_matrix: UniformLocation,
+    view: UniformLocation,
+    projection: UniformLocation,
+    fog: FogUniforms,
+    debug_mode: UniformLocation,
+}
+
+/// Persistent GPU state for `Scene.cubeInstances`. The static unit-cube mesh
+/// uploads once; the compact instance buffer is replaced in place per node and
+/// submitted with one `draw_elements_instanced` call.
+pub(super) struct CubeInstanceRenderer {
+    vao: glow::VertexArray,
+    _vertex_buffer: glow::Buffer,
+    index_buffer: glow::Buffer,
+    instance_buffer: glow::Buffer,
+    index_count: i32,
+    instance_capacity: usize,
+    shader: ShaderProgram,
+    uniforms: Uniforms,
+}
+
+impl CubeInstanceRenderer {
+    pub(super) fn new(gl: &glow::Context, shader_version: &str) -> Self {
+        let (vertices, indices) = cube_mesh();
+        let vertex_bytes = as_bytes(&vertices);
+        let index_bytes = as_bytes(&indices);
+
+        unsafe {
+            let vao = gl.create_vertex_array().expect("cube instance VAO");
+            let vertex_buffer = gl.create_buffer().expect("cube instance vertices");
+            let index_buffer = gl.create_buffer().expect("cube instance indices");
+            let instance_buffer = gl.create_buffer().expect("cube instance data");
+            let counters = crate::gpu_counters::gpu_counters();
+            counters.vao_created();
+            counters.buffer_created();
+            counters.buffer_created();
+            counters.buffer_created();
+
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(vertex_buffer));
+            gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, vertex_bytes, glow::STATIC_DRAW);
+            counters.uploaded(vertex_bytes.len());
+            gl.bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buffer));
+            gl.buffer_data_u8_slice(glow::ELEMENT_ARRAY_BUFFER, index_bytes, glow::STATIC_DRAW);
+            counters.uploaded(index_bytes.len());
+
+            let stride = VertexPositionTexture::get_total_size() as i32;
+            for (location, attribute) in VertexPositionTexture::get_vertex_attributes()
+                .iter()
+                .enumerate()
+            {
+                gl.enable_vertex_attrib_array(location as u32);
+                match attribute.attribute_type {
+                    VertexAttributeType::Float => gl.vertex_attrib_pointer_f32(
+                        location as u32,
+                        attribute.size,
+                        glow::FLOAT,
+                        false,
+                        stride,
+                        attribute.offset as i32,
+                    ),
+                }
+            }
+
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
+            let instance_stride = size_of::<CubeInstance>() as i32;
+            for (location, offset) in [
+                (4, offset_of!(CubeInstance, position)),
+                (5, offset_of!(CubeInstance, scale)),
+                (6, offset_of!(CubeInstance, color)),
+            ] {
+                gl.enable_vertex_attrib_array(location);
+                gl.vertex_attrib_pointer_f32(
+                    location,
+                    3,
+                    glow::FLOAT,
+                    false,
+                    instance_stride,
+                    offset as i32,
+                );
+                gl.vertex_attrib_divisor(location, 1);
+            }
+
+            gl.bind_vertex_array(None);
+            gl.bind_buffer(glow::ARRAY_BUFFER, None);
+
+            let vertex_shader =
+                Shader::build(gl, ShaderType::Vertex, VERTEX_SHADER_SOURCE, shader_version);
+            let fragment_shader = Shader::build(
+                gl,
+                ShaderType::Fragment,
+                &format!("{}\n{}", FOG_GLSL, FRAGMENT_SHADER_SOURCE),
+                shader_version,
+            );
+            let shader = ShaderProgram::link(gl, &vertex_shader, &fragment_shader);
+            let uniforms = Uniforms {
+                world: shader.get_uniform_location(gl, "world"),
+                normal_matrix: shader.get_uniform_location(gl, "normalMatrix"),
+                view: shader.get_uniform_location(gl, "view"),
+                projection: shader.get_uniform_location(gl, "projection"),
+                fog: FogUniforms::get(&shader, gl),
+                debug_mode: shader.get_uniform_location(gl, "debugMode"),
+            };
+
+            Self {
+                vao,
+                _vertex_buffer: vertex_buffer,
+                index_buffer,
+                instance_buffer,
+                index_count: indices.len() as i32,
+                instance_capacity: 0,
+                shader,
+                uniforms,
+            }
+        }
+    }
+
+    pub(super) fn draw(
+        &mut self,
+        ctx: &RenderContext,
+        instances: &[CubeInstance],
+        world: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        let bytes = as_bytes(instances);
+        unsafe {
+            ctx.gl.bind_vertex_array(Some(self.vao));
+            ctx.gl
+                .bind_buffer(glow::ARRAY_BUFFER, Some(self.instance_buffer));
+            if bytes.len() > self.instance_capacity {
+                ctx.gl
+                    .buffer_data_u8_slice(glow::ARRAY_BUFFER, bytes, glow::DYNAMIC_DRAW);
+                self.instance_capacity = bytes.len();
+            } else {
+                ctx.gl
+                    .buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+            }
+            crate::gpu_counters::gpu_counters().uploaded(bytes.len());
+
+            self.shader.use_program(ctx.gl);
+            self.shader
+                .set_uniform_matrix4(ctx.gl, &self.uniforms.world, world);
+            self.shader.set_uniform_matrix3(
+                ctx.gl,
+                &self.uniforms.normal_matrix,
+                &normal_matrix(world),
+            );
+            self.shader
+                .set_uniform_matrix4(ctx.gl, &self.uniforms.view, view);
+            self.shader
+                .set_uniform_matrix4(ctx.gl, &self.uniforms.projection, projection);
+            self.uniforms
+                .fog
+                .set(&self.shader, ctx.gl, ctx.fog, &ctx.camera_pos);
+            let debug_mode = match ctx.debug_render_mode {
+                DebugRenderMode::Normals => 1,
+                DebugRenderMode::Tangents => 2,
+                DebugRenderMode::Default
+                | DebugRenderMode::Transparent
+                | DebugRenderMode::Physics => 0,
+            };
+            self.shader
+                .set_uniform_1i(ctx.gl, &self.uniforms.debug_mode, debug_mode);
+
+            ctx.gl
+                .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(self.index_buffer));
+            ctx.gl.draw_elements_instanced(
+                glow::TRIANGLES,
+                self.index_count,
+                glow::UNSIGNED_INT,
+                0,
+                instances.len() as i32,
+            );
+        }
+    }
+}
+
+fn as_bytes<T>(values: &[T]) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(values.as_ptr().cast::<u8>(), std::mem::size_of_val(values))
+    }
+}

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     DebugRenderMode, RenderContext, RenderPass,
 };
 
+mod cube_instances;
 mod material_description;
 mod model_description;
 mod texture_description;
@@ -44,6 +45,8 @@ mod texture_description;
 pub use material_description::*;
 pub use model_description::*;
 pub use texture_description::*;
+
+use cube_instances::CubeInstanceRenderer;
 
 pub struct SceneContext {
     model_pipeline: Arc<BuiltAssetPipeline<Model>>,
@@ -56,6 +59,9 @@ pub struct SceneContext {
     sphere: RefCell<Box<dyn Geometry>>,
     quad: RefCell<Box<dyn Geometry>>,
     plane: RefCell<Box<dyn Geometry>>,
+    // Lazily created: scenes without CubeInstances allocate no GPU resources
+    // and execute no instancing-specific renderer work.
+    cube_instances: RefCell<Option<CubeInstanceRenderer>>,
     // One persistent mesh per grid size. Animated terrain (heights change every
     // frame) re-uploads its vertex buffer in place instead of rebuilding a fresh
     // GL mesh each frame; static terrain uploads exactly once. Keyed by
@@ -230,6 +236,7 @@ impl SceneContext {
             cylinder: RefCell::new(geometry::Cylinder::create()),
             quad: RefCell::new(geometry::Quad::create()),
             plane: RefCell::new(geometry::Plane::create()),
+            cube_instances: RefCell::new(None),
             heightmaps: RefCell::new(HashMap::new()),
             polygons: RefCell::new(HashMap::new()),
             heightmap_pipeline: asset::build_pipeline(Box::new(HeightmapPipeline)),
@@ -964,6 +971,8 @@ pub enum SceneObject {
     Geometry(Shape),
     Model(ModelDescription),
     Terrain(Box<crate::terrain::TerrainDescription>),
+    /// Fullbright colored unit cubes submitted in one hardware-instanced draw.
+    CubeInstances(Vec<CubeInstance>),
     Material(MaterialDescription, Vec<Scene3D>),
     Group(Vec<Scene3D>),
     /// A TRANSLUCENT subtree — `Scene.opacity`. The `f32` is the subtree's
@@ -975,6 +984,17 @@ pub enum SceneObject {
     /// that never calls `Scene.opacity` is bit-for-bit the scene it was before
     /// the variant existed.
     Opacity(f32, Vec<Scene3D>),
+}
+
+/// Per-copy data for [`SceneObject::CubeInstances`]. Each cube is centered at
+/// `position`, scaled independently on each axis, and rendered fullbright with
+/// `color`.
+#[repr(C)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CubeInstance {
+    pub position: [f32; 3],
+    pub scale: [f32; 3],
+    pub color: [f32; 3],
 }
 
 /// A scene node: what it draws, under a transform.
@@ -1098,6 +1118,13 @@ impl Scene3D {
         }
     }
 
+    pub fn cube_instances(instances: Vec<CubeInstance>) -> Self {
+        Scene3D {
+            obj: SceneObject::CubeInstances(instances),
+            xform: Matrix4::identity(),
+        }
+    }
+
     /// Set the animation expression on every `Model` node in this subtree —
     /// `Scene.animate`'s semantics. Piping right after `Scene.model` targets
     /// that one model; applying over a group animates each model in it.
@@ -1127,7 +1154,9 @@ impl Scene3D {
                     .map(|item| item.with_animation(expr.clone()))
                     .collect(),
             ),
-            leaf @ (SceneObject::Geometry(_) | SceneObject::Terrain(_)) => leaf,
+            leaf @ (SceneObject::Geometry(_)
+            | SceneObject::Terrain(_)
+            | SceneObject::CubeInstances(_)) => leaf,
         };
         Scene3D { obj, ..self }
     }
@@ -1142,7 +1171,10 @@ impl Scene3D {
             SceneObject::Group(items) | SceneObject::Material(_, items) => {
                 items.iter().any(Scene3D::has_opacity)
             }
-            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => false,
+            SceneObject::Geometry(_)
+            | SceneObject::Model(_)
+            | SceneObject::Terrain(_)
+            | SceneObject::CubeInstances(_) => false,
         }
     }
 
@@ -1175,6 +1207,20 @@ impl Scene3D {
             SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
                 *sum += (world * self.xform).w.truncate();
                 *count += 1;
+            }
+            SceneObject::CubeInstances(instances) => {
+                let w = world * self.xform;
+                for instance in instances {
+                    let p = w
+                        * cgmath::vec4(
+                            instance.position[0],
+                            instance.position[1],
+                            instance.position[2],
+                            1.0,
+                        );
+                    *sum += p.truncate();
+                    *count += 1;
+                }
             }
         }
     }
@@ -1235,7 +1281,10 @@ impl Scene3D {
                     item.collect_transparent(world, Some(next_material), out);
                 }
             }
-            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
+            SceneObject::Geometry(_)
+            | SceneObject::Model(_)
+            | SceneObject::Terrain(_)
+            | SceneObject::CubeInstances(_) => {}
         }
     }
 
@@ -1553,6 +1602,28 @@ so the reach is ignored"
             }
             SceneObject::Terrain(_) => {}
 
+            // This first slice is deliberately one material family: each
+            // instance carries a fullbright/emissive RGB color. It does not
+            // enter the shadow pass, and enclosing material nodes do not
+            // override those per-instance colors.
+            SceneObject::CubeInstances(instances) => {
+                if depth_pass || instances.is_empty() {
+                    return;
+                }
+                let xform = world_matrix * self.xform;
+                let mut renderer = scene_context.cube_instances.borrow_mut();
+                let renderer = renderer.get_or_insert_with(|| {
+                    CubeInstanceRenderer::new(&render_context.gl, render_context.shader_version)
+                });
+                renderer.draw(
+                    render_context,
+                    instances,
+                    &xform,
+                    projection_matrix,
+                    view_matrix,
+                );
+            }
+
             SceneObject::Material(material_description, items) => {
                 let material = material_description.get(render_context, scene_context);
                 // The 3D forward pass is otherwise fully opaque — every shader
@@ -1852,6 +1923,46 @@ where
         array[3][2],
         array[3][3],
     ))
+}
+
+#[cfg(test)]
+mod cube_instance_tests {
+    use super::{CubeInstance, Scene3D, SceneObject};
+    use cgmath::Matrix4;
+
+    fn instance(color: [f32; 3]) -> CubeInstance {
+        CubeInstance {
+            position: [1.0, 2.0, 3.0],
+            scale: [0.5, 1.0, 2.0],
+            color,
+        }
+    }
+
+    #[test]
+    fn bulk_node_is_structural_and_serializable() {
+        let scene = Scene3D::cube_instances(vec![instance([0.2, 0.4, 0.8])]);
+        let same = Scene3D::cube_instances(vec![instance([0.2, 0.4, 0.8])]);
+        let changed = Scene3D::cube_instances(vec![instance([0.8, 0.4, 0.2])]);
+        assert_eq!(scene, same, "Scene.equals sees identical instance data");
+        assert_ne!(scene, changed, "Scene.equals sees per-instance colors");
+        assert!(matches!(&scene.obj, SceneObject::CubeInstances(xs) if xs.len() == 1));
+
+        let json = serde_json::to_string(&scene).expect("serialize bulk scene");
+        let back: Scene3D = serde_json::from_str(&json).expect("deserialize bulk scene");
+        assert_eq!(back, scene);
+    }
+
+    #[test]
+    fn empty_bulk_node_remains_visible_to_scene_equality() {
+        let empty = Scene3D::cube_instances(vec![]);
+        assert_ne!(
+            empty,
+            Scene3D {
+                obj: SceneObject::Group(vec![]),
+                xform: Matrix4::from_scale(1.0),
+            }
+        );
+    }
 }
 
 #[cfg(test)]

--- a/runtime/functor-runtime-common/src/trajectory.rs
+++ b/runtime/functor-runtime-common/src/trajectory.rs
@@ -147,6 +147,10 @@ fn collect_transforms(
         SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {
             out.insert(path.clone(), w);
         }
+        // A bulk node has one outer transform but many internal copies. The
+        // trajectory overlay cannot track or fade those copies independently,
+        // so omitting it is less misleading than strobing the entire batch.
+        SceneObject::CubeInstances(_) => {}
     }
 }
 
@@ -194,6 +198,7 @@ fn collect_anchor(
                 },
             );
         }
+        SceneObject::CubeInstances(_) => {}
     }
 }
 
@@ -264,7 +269,10 @@ pub fn mover_tracks(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Vec<MoverTr
         return Vec::new();
     }
     let anchor = anchor_leaves(scenes[0]);
-    let futures: Vec<_> = scenes[1..].iter().map(|scene| transforms_by_path(scene)).collect();
+    let futures: Vec<_> = scenes[1..]
+        .iter()
+        .map(|scene| transforms_by_path(scene))
+        .collect();
     let eps2 = eps * eps;
     let mut tracks = Vec::new();
     for (path, anchor_leaf) in &anchor {
@@ -287,10 +295,7 @@ pub fn mover_tracks(scenes: &[&Scene3D], eps: f32, max_step: f32) -> Vec<MoverTr
             .any(|w| (world_pos(w) - p0).magnitude2() > eps2);
         // A mover is anything whose world TRANSFORM changes — translation, or
         // an in-place rotation/scale (which only the strobe can depict).
-        let moved = translated
-            || worlds
-                .iter()
-                .any(|w| columns_delta2(w, &worlds[0]) > eps2);
+        let moved = translated || worlds.iter().any(|w| columns_delta2(w, &worlds[0]) > eps2);
         if !moved {
             continue;
         }
@@ -339,6 +344,7 @@ fn collect_sample_leaves<'a>(
                 },
             );
         }
+        SceneObject::CubeInstances(_) => {}
     }
 }
 
@@ -377,9 +383,9 @@ fn sampled_mover_tracks<'a>(
         }) {
             samples.truncate(cut);
         }
-        let moved = samples.iter().any(|sample| {
-            columns_delta2(&sample.world, &samples[0].world) > eps2
-        });
+        let moved = samples
+            .iter()
+            .any(|sample| columns_delta2(&sample.world, &samples[0].world) > eps2);
         if moved {
             tracks.push(SampledMoverTrack { samples });
         }
@@ -478,7 +484,10 @@ fn trail_arrow(
             if planar.magnitude() <= radius * HEADING_EPS_RADII {
                 return None;
             }
-            (vec![head], Matrix4::from_angle_z(Rad(planar.y.atan2(planar.x))))
+            (
+                vec![head],
+                Matrix4::from_angle_z(Rad(planar.y.atan2(planar.x))),
+            )
         }
     };
     Some(trail_mark(
@@ -1103,7 +1112,10 @@ fn scale_presence(scene: &mut Scene3D, presence: f32) {
                 scale_presence(item, presence);
             }
         }
-        SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
+        SceneObject::Geometry(_)
+        | SceneObject::Model(_)
+        | SceneObject::Terrain(_)
+        | SceneObject::CubeInstances(_) => {}
     }
 }
 
@@ -1270,10 +1282,7 @@ fn sprite_scene_overlays(
         let sampled = sampled_mover_tracks(scenes, opts.eps, opts.max_step);
         sampled_strobe_overlay(&sampled, &strobe.for_side(side), StrobeFade::Alpha)
     });
-    SceneOverlays {
-        trail,
-        strobe,
-    }
+    SceneOverlays { trail, strobe }
 }
 
 fn sprite_trail_radius(camera: &Camera2D) -> f32 {
@@ -1382,18 +1391,34 @@ pub fn frame_preview(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Camera, Camera2D, SpriteLayer, SpriteSampling, TextureDescription};
+    use crate::{Camera, Camera2D, CubeInstance, SpriteLayer, SpriteSampling, TextureDescription};
     use cgmath::vec3;
 
     /// The FUTURE side's overlays for an explicit frame sequence — the shape
     /// these tests were written against, before the preview grew a second
     /// direction.
-    fn preview_from_frames(anchor: &Frame, futures: &[&Frame], opts: &PreviewOptions) -> FramePreview {
+    fn preview_from_frames(
+        anchor: &Frame,
+        futures: &[&Frame],
+        opts: &PreviewOptions,
+    ) -> FramePreview {
         side_overlays(anchor, futures, opts, PreviewSide::Future)
     }
 
     fn ball_at(x: f32, y: f32) -> Scene3D {
         Scene3D::sphere().transform(Matrix4::from_translation(vec3(x, y, 0.0)))
+    }
+
+    #[test]
+    fn bulk_instances_are_not_misrepresented_as_one_trajectory_leaf() {
+        let scene = Scene3D::cube_instances(vec![CubeInstance {
+            position: [1.0, 2.0, 3.0],
+            scale: [0.5, 1.0, 2.0],
+            color: [0.2, 0.4, 0.8],
+        }]);
+        assert!(transforms_by_path(&scene).is_empty());
+        assert!(anchor_leaves(&scene).is_empty());
+        assert!(sample_leaves_by_path(&scene).is_empty());
     }
 
     #[test]
@@ -1750,8 +1775,14 @@ mod tests {
         let trail = trajectory_trail(&refs, 0.05, 3.0).expect("a trail");
         let stepped = marks(&trail);
         assert_eq!(stepped.len(), 4);
-        assert!(matches!(mark_shapes(&stepped[0])[0], Shape::ConvexPolygon { .. }));
-        assert!(matches!(mark_shapes(&stepped[1])[0], Shape::ConvexPolygon { .. }));
+        assert!(matches!(
+            mark_shapes(&stepped[0])[0],
+            Shape::ConvexPolygon { .. }
+        ));
+        assert!(matches!(
+            mark_shapes(&stepped[1])[0],
+            Shape::ConvexPolygon { .. }
+        ));
         for resting in &stepped[2..] {
             let shapes = mark_shapes(resting);
             assert_eq!(shapes.len(), 1);
@@ -1918,11 +1949,7 @@ mod tests {
         // sibling counts in the key the changed group stops matching, so the
         // mover keeps its trail up to the despawn and the statics get nothing.
         let f = |x: f32| Scene3D {
-            obj: SceneObject::Group(vec![
-                ball_at(x, 0.0),
-                ball_at(1.0, 0.0),
-                ball_at(2.0, 0.0),
-            ]),
+            obj: SceneObject::Group(vec![ball_at(x, 0.0), ball_at(1.0, 0.0), ball_at(2.0, 0.0)]),
             xform: Matrix4::identity(),
         };
         let last = Scene3D {
@@ -1933,7 +1960,9 @@ mod tests {
         match trail.obj {
             // Two dots: the mover's frames before the despawn. Anything more
             // means a static sibling was aliased onto a neighbor's position.
-            SceneObject::Group(dots) => assert_eq!(dots.len(), 2, "expected only the mover's pre-despawn dots"),
+            SceneObject::Group(dots) => {
+                assert_eq!(dots.len(), 2, "expected only the mover's pre-despawn dots")
+            }
             _ => panic!("expected a group of dots"),
         }
     }
@@ -2008,7 +2037,11 @@ mod tests {
         };
         match mat {
             MaterialDescription::Lit { color, .. } => {
-                assert!((color.x - 0.2).abs() < 1e-4, "expected faded red, got {}", color.x);
+                assert!(
+                    (color.x - 0.2).abs() < 1e-4,
+                    "expected faded red, got {}",
+                    color.x
+                );
             }
             _ => panic!("expected a Lit material"),
         }
@@ -2026,7 +2059,14 @@ mod tests {
             copies: 2,
             ..Default::default()
         };
-        let trail = trail_from_tracks(&tracks, Some(&opts), TRAIL_RADIUS_3D, TrailSpace::Scene3D, PreviewSide::Future).expect("a trail");
+        let trail = trail_from_tracks(
+            &tracks,
+            Some(&opts),
+            TRAIL_RADIUS_3D,
+            TrailSpace::Scene3D,
+            PreviewSide::Future,
+        )
+        .expect("a trail");
         match trail.obj {
             SceneObject::Group(dots) => {
                 assert_eq!(dots.len(), 3, "anchor + the two non-copy samples")
@@ -2053,7 +2093,14 @@ mod tests {
         assert!(!tracks[0].translated);
         assert!(strobe_overlay(&tracks, &StrobeOptions::default()).is_some());
         assert!(
-            trail_from_tracks(&tracks, None, TRAIL_RADIUS_3D, TrailSpace::Scene3D, PreviewSide::Future).is_none(),
+            trail_from_tracks(
+                &tracks,
+                None,
+                TRAIL_RADIUS_3D,
+                TrailSpace::Scene3D,
+                PreviewSide::Future
+            )
+            .is_none(),
             "no dots for pure rotation"
         );
     }
@@ -2098,7 +2145,10 @@ mod tests {
                     material_alphas(item, out);
                 }
             }
-            SceneObject::Geometry(_) | SceneObject::Model(_) | SceneObject::Terrain(_) => {}
+            SceneObject::Geometry(_)
+            | SceneObject::Model(_)
+            | SceneObject::Terrain(_)
+            | SceneObject::CubeInstances(_) => {}
         }
     }
 
@@ -2141,7 +2191,9 @@ mod tests {
     }
 
     fn moving_preview() -> (Frame, FramePreview) {
-        let frames: Vec<Frame> = (0..=4).map(|i| materialized_frame(i as f32 * 0.5)).collect();
+        let frames: Vec<Frame> = (0..=4)
+            .map(|i| materialized_frame(i as f32 * 0.5))
+            .collect();
         let futures: Vec<&Frame> = frames.iter().skip(1).collect();
         let preview = preview_from_frames(&frames[0], &futures, &preview_options(true, true));
         assert!(!preview.is_empty(), "the fixture must produce overlays");
@@ -2157,16 +2209,25 @@ mod tests {
         for _ in 0..8 {
             let next = presence_step(p, 1.0, dt);
             assert!(next >= p, "presence must not go backwards while rising");
-            assert!((0.0..=1.0).contains(&next), "presence escaped [0, 1]: {next}");
+            assert!(
+                (0.0..=1.0).contains(&next),
+                "presence escaped [0, 1]: {next}"
+            );
             p = next;
         }
-        assert!((p - 1.0).abs() < 1e-5, "one ramp must complete the fade in: {p}");
+        assert!(
+            (p - 1.0).abs() < 1e-5,
+            "one ramp must complete the fade in: {p}"
+        );
 
         // Falling: the mirror image.
         for _ in 0..8 {
             let next = presence_step(p, 0.0, dt);
             assert!(next <= p, "presence must not go forwards while falling");
-            assert!((0.0..=1.0).contains(&next), "presence escaped [0, 1]: {next}");
+            assert!(
+                (0.0..=1.0).contains(&next),
+                "presence escaped [0, 1]: {next}"
+            );
             p = next;
         }
         assert!(p.abs() < 1e-5, "one ramp must complete the fade out: {p}");
@@ -2219,7 +2280,10 @@ mod tests {
         for i in 0..=20 {
             let alpha = i as f32 / 20.0;
             let phase = presence_phase(alpha);
-            assert!((0.0..=1.0).contains(&phase), "phase escaped [0, 1]: {phase}");
+            assert!(
+                (0.0..=1.0).contains(&phase),
+                "phase escaped [0, 1]: {phase}"
+            );
             assert!(
                 (presence_ease(phase) - alpha).abs() < 1e-4,
                 "pin at {alpha} would resume at {} (phase {phase})",
@@ -2288,7 +2352,11 @@ mod tests {
         preview.apply_all_with_presence(&mut half, 0.5);
         let half = frame_material_alphas(&half);
 
-        assert_eq!(own.len(), 2, "the fixture has a 3D scene and one sprite layer");
+        assert_eq!(
+            own.len(),
+            2,
+            "the fixture has a 3D scene and one sprite layer"
+        );
         assert_eq!(full.len(), own.len());
         assert_eq!(half.len(), own.len());
 

--- a/runtime/functor-runtime-common/tests/prelude_typecheck.rs
+++ b/runtime/functor-runtime-common/tests/prelude_typecheck.rs
@@ -65,6 +65,22 @@ fn host_calls_have_real_types() {
     assert!(diags.iter().any(|m| m.contains("Frame.t")), "{diags:?}");
 }
 
+#[test]
+fn cube_instances_have_a_typed_compact_payload() {
+    let diags = check(
+        "let instance: Scene.cubeInstance =\n\
+         { data: (1.0, 2.0, 3.0, 0.5, 1.0, 2.0, 0.2, 0.4, 0.8) }\n\
+         let scene: Scene.t = Scene.cubeInstances([instance])",
+    );
+    assert!(diags.is_empty(), "bulk cube instances should check: {diags:?}");
+
+    let diags = check(
+        "let bad: Scene.cubeInstance =\n\
+         { data: (1.0, 2.0, 3.0, 0.5, 1.0, 2.0, 0.2, 0.4, true) }",
+    );
+    assert!(!diags.is_empty(), "a non-float channel must be rejected");
+}
+
 /// A camera ray is optional at the surface boundary, and its branded origin
 /// and direction feed the existing Physics.cast Vec3 parameters directly.
 #[test]

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (27, 308));
+        assert_eq!(count(ApiGroup::Engine), (27, 310));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
## Why

Three jam entries independently hit the same scene-construction ceiling:

- **automaton-reactor:** 1,024 cells took 11.8 ms/frame (71% of 60 Hz); 9,216 took 20.4 ms/frame. The scene tree, not the cellular update, was the identified cost.
- **twin-stick:** draw stayed about 2× tick and scaled linearly, with roughly 300 entities as the practical ceiling.
- **code-garden:** rebuilding recursive L-system topology roughly doubled cost per branching generation, reaching 8 ms/frame at depth 4.

This adds the smallest shared primitive: one typed `Scene.cubeInstances` node containing position, per-axis full size, and RGB for every cube.

## API and rendering contract

```functor
type Scene.cubeInstance = {
  data: (float, float, float, float, float, float, float, float, float)
}

let Scene.cubeInstances : (List<Scene.cubeInstance>) => Scene.t
```

The tuple is `(x, y, z, sx, sy, sz, r, g, b)`. Scale is per-axis and is the full cube size; `1,1,1` matches `Scene.cube()`.

This is **real hardware instancing**, not CPU-expanded batching: each non-empty node dynamically uploads one compact 36-byte record per copy and calls `draw_elements_instanced` once. The canonical cube mesh and GPU buffers persist, and the entire renderer is initialized lazily, so scenes that do not use the API allocate no instancing resources and take no instancing branch.

The first slice is deliberately fullbright/emissive RGB. `Scene.color`, `Scene.lit`, and `Scene.emissive` wrappers do not override per-instance colors; instances do not cast shadows. Outer transforms and `Scene.opacity` apply to the batch. Global normals/tangents diagnostic modes are supported. Remaining cost is Functor list/record creation, one CPU decode into compact Rust records, and one 36×N-byte GPU upload per rendered bulk node per frame.

## CPU evidence

### Focused A/B probe

Release probe at `/tmp/functor-jam.YFADHZ/repro-instancing`, three runs, minimum draw + `Frame` retention time. Both paths perform identical per-cell math; only scene construction differs.

| cubes | per-node pipeline | bulk node | reduction |
|---:|---:|---:|---:|
| 1,024 | 3.594 ms/frame | 2.034 ms/frame | 43.4% |
| 4,096 | 14.600 ms/frame | 8.200 ms/frame | 43.8% |
| 9,216 | 34.330 ms/frame | 18.656 ms/frame | 45.7% |

This is headless CPU evidence and cannot see GPU cost. The native and WebGL2 visual smokes separately exercise the actual instanced draw.

### Existing `frame_bench` regression guard

Base `281c8a3` vs final change, release builds back-to-back, three runs, minimum column. This existing workload does **not** call the new API, so it proves the unused path is allocation/byte neutral.

| cells | base min | change min | allocs/frame | bytes/frame |
|---:|---:|---:|---:|---:|
| 1,024 | 1,105.2 µs | 1,106.7 µs | 35,117 → 35,117 | 2,125,809 → 2,125,809 |
| 4,096 | 4,355.5 µs | 4,358.8 µs | 139,629 → 139,629 | 8,431,857 → 8,431,857 |
| 9,216 | 9,764.0 µs | 9,772.2 µs | 313,773 → 313,773 | 18,940,401 → 18,940,401 |

Wall-clock differences are inside run-to-run noise; deterministic allocations and bytes are exact. `frame_bench` is headless and cannot measure shader/upload/GPU cost. No Quest was attached, so device GPU benchmarking remains an explicit gap.

## Visual proof

![Scene.cubeInstances demo](https://gist.githubusercontent.com/tommy-xr/b0f225717b5309f061e890016d02dce3/raw/cube-instances-demo.gif)

<sub>1,024 independently colored, non-uniformly scaled cubes animated through one `Scene.cubeInstances` node and one hardware-instanced draw. Deterministic headless capture.</sub>

![Scene.cubeInstances still](https://gist.githubusercontent.com/tommy-xr/b0f225717b5309f061e890016d02dce3/raw/cube-instances-still.png)

## Serialization and compatibility

- `SceneObject::CubeInstances(Vec<CubeInstance>)` derives structural equality and serde, so `Scene.equals`, `GET /scene`, replay, and protocol frames retain every instance.
- Wire shape has an exact JSON pin and round-trip test.
- `PROTOCOL_VERSION` 12 → 13.
- `DEBUG_PROTOCOL_VERSION` 10 → 11 because `/scene` can return the new exhaustive variant.
- Docgen engine inventory 308 → 310; `.funi` docs and the `functor-lang` skill document the exact material/scale contract.

## Verification

- `cargo test -p functor_runtime_common -p functor-lang -p functor-docgen` — pass (common 721, prelude typecheck 32, language and docgen suites pass)
- `npm run check:docs` — pass
- `npm run test:golden` — pass; all stable scenarios byte-identical. Existing machine-specific accepted drift remained exactly in lighting (309 px) and terrain (15,752 / 712 / 609 px).
- `npm run test:wasm-golden` — pass (1 passed, 1 unrelated webview-input test skipped by its project predicate)
- `npm run build:cli:debug` — pass, compiling both shared desktop GL and web WebGL2 paths
- Native probe capture — pass; default, normals, and tangents modes inspected
- WebGL2 smoke — pass in Playwright Chromium with the rebuilt wasm bundle; 1,024 cubes visible
- Quest — not run; no adb device attached

### CI matrix (head `fb90e2edf1420a3def2686379d034ca0e47f122e`)

- `build-native (macos-latest)` — pass
- `build-native (ubuntu-latest)` — pass
- `build-native (windows-latest)` — pass
- `build-wasm (macos-latest)` — pass
- `build-wasm (ubuntu-latest)` — pass
- `build-wasm (windows-latest)` — pass
- `e2e-headless` — pass
- `golden-wasm` — pass
- `wasm-smoke` — pass

## xreview dispositions

- **High: instanced cubes bypassed global normals/tangents diagnostics — fixed.** The instanced shader now consumes canonical cube normals/tangents and switches diagnostic output globally, including inverse-transpose normal handling under per-axis scale. Native diagnostic captures were inspected; both follow-up reviewers report no remaining Critical/High findings.
- **Medium: trajectory preview treated a whole batch as one fadeable leaf — fixed.** Bulk nodes are excluded from trajectory overlays rather than presenting a misleading whole-batch strobe that cannot fade per instance; a unit test pins that policy.
- **Medium: no committed instanced golden — accepted for this scoped engine surface.** Deterministic external probe captures exercise default plus normals/tangents, Playwright exercises WebGL2, and unchanged committed goldens prove zero-cost/no-visual-regression when unused. The adopting entry supplies the durable scenario-level proof before this draft is readied.
- **Medium: positional payload usability — accepted intentionally.** One typed record keeps completion/typechecking at the collection boundary while the flat tuple avoids three nested values per instance on the measured hot path. `.funi` and skill docs name every position; direct decode tests pin all nine mappings and non-finite rejection.
- **Low: persistent GL resources lack teardown — existing renderer lifecycle policy.** `SceneContext` and its GL context live together for the runtime session; this renderer is lazy and persistent like other context-owned caches. It creates no per-frame GL objects.
- **Duplication:** `dupfinder names --base`, `clones`, and `index` reviewed. No prior general scene-instancing surface exists; canonical cube mesh extraction avoids duplicating geometry.

## Adoption gate: automaton-reactor

Replace its per-cell `cellScene` cube → scale → material → translate pipeline with one mapped list of `Scene.cubeInstance` payloads and `Scene.cubeInstances(instances)`. Keep all three captures and every scenario assertion passing, including the hot-reload deep compare of all 1,024 cells. Then rerun its own entity sweep. Acceptance is the 9,216-cell case below 16.666 ms/frame, or phase-split evidence proving cellular update—not scene construction—is the remaining limit.
