### PR TITLE
feat(examples): code-garden — a garden whose growth laws are the source file

### DIFF
--- a/e2e/code-garden.mjs
+++ b/e2e/code-garden.mjs
@@ -1,0 +1,138 @@
+// `examples/code-garden` E2E: the model is the garden, the file is the botany.
+//
+// The sample's claim is that its growth LAWS are top-level constants and its
+// model holds only plot/species/age — so editing a law re-shapes a garden that
+// is already growing instead of restarting it. That is a hot-reload property,
+// which no inline `expect` can reach: it needs a running game, a pinned clock,
+// and two frames. This drives it over `functor mcp` (docs/mcp.md), raw
+// JSON-RPC on stdio, exactly as a coding agent's client would:
+//
+//   1. `init` sows five plants at staggered ages.
+//   2. Stepping 7 seconds ages every plant by exactly 7 and fires the
+//      `Sub.every` self-seeding timer once (5 plants -> 6).
+//   3. `1` then `Space` plants a Lantern seed at the next plot (6 -> 7), a
+//      brand-new plant appended at age 0 while the others keep their ages.
+//   4. HOT-RELOADING a changed law (`growthRate`) leaves the model identical —
+//      same plots, same species, same ages — while the RENDERED FRAME changes.
+//   5. Reloading the ORIGINAL source reproduces the original frame byte for
+//      byte, so the reshape is a pure function of the file with no drift.
+//
+// The frames are compared with `capture_frame`, not `get_scene`: a mature
+// garden serializes to ~12 MB of scene JSON, past the MCP response cap.
+// `capture_frame` needs pixels, hence `mode: "hidden"` rather than `headless`.
+//
+// Run (a RELEASE binary — the debug interpreter is far too slow for the
+// 420-step drive; `npm run test:code-garden` builds it for you):
+//
+//   cargo build --release -p functor-cli --no-default-features
+//   FUNCTOR_BIN="$PWD/target/release/functor" node e2e/code-garden.mjs
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { check, failures, ROOT, startMcp } from "./mcp-rpc.mjs";
+
+const GAME_DIR = resolve(ROOT, "examples/code-garden");
+const SOURCE = readFileSync(resolve(GAME_DIR, "game.fun"), "utf8");
+
+const near = (a, b, eps = 1e-4) => Math.abs(a - b) < eps;
+
+/** The rendered frame as a base64 PNG — the only whole-scene read that scales. */
+const frameImage = async (rpc, session) => {
+  const result = await rpc.request("tools/call", { name: "capture_frame", arguments: { session } });
+  const image = result.content.find((block) => block.type === "image");
+  if (!image) throw new Error(`capture_frame returned no image: ${JSON.stringify(result)}`);
+  return image.data;
+};
+
+const { proc, rpc } = await startMcp("code-garden");
+let session;
+
+try {
+  console.log("▸ launch, paused");
+  const launched = await rpc.call("launch_game", { dir: GAME_DIR, mode: "hidden" });
+  session = launched.session;
+  await rpc.call("pause", { session });
+
+  // `pause` cannot pin frame 0 — a few frames always run before it lands — so
+  // every age assertion below is a DELTA from this first observed state.
+  const sown = (await rpc.call("get_state", { session })).model;
+  const ages0 = sown.plants.map((p) => p.age);
+  check(sown.plants.length === 5, `init sows 5 plants (got ${sown.plants.length})`);
+  check(
+    ages0.every((age, i) => near(age - ages0[4], [10, 7, 4.5, 2, 0][i], 0.01)),
+    `their ages are staggered 10/7/4.5/2/0 apart: ${JSON.stringify(ages0.map((a) => +a.toFixed(3)))}`,
+  );
+
+  console.log("\n▸ 7 seconds of growth (420 steps of 1/60s)");
+  const grown = (await rpc.call("step", { session, frames: 420, dts: 1 / 60 })).model;
+  check(
+    grown.plants.slice(0, 5).every((p, i) => near(p.age, ages0[i] + 7.0, 1e-3)),
+    "every original plant aged by exactly 7.0s — age is stored in seconds",
+  );
+  check(
+    grown.plants.length === 6,
+    `Sub.every(7s) self-seeded exactly once (${grown.plants.length} plants)`,
+  );
+  check(
+    grown.plants[5].age >= 0 && grown.plants[5].age < 0.2,
+    `the volunteer starts at age 0 (${grown.plants[5].age.toFixed(3)}s old)`,
+  );
+
+  console.log("\n▸ planting by hand: 1 then Space");
+  await rpc.call("send_input", { session, command: { type: "key", key: "1", down: true } });
+  await rpc.call("send_input", { session, command: { type: "key", key: "1", down: false } });
+  const picked = (await rpc.call("step", { session, frames: 1, dts: 1 / 60 })).model;
+  check(picked.pick === 0, `"1" selects Lantern (pick=${picked.pick})`);
+
+  await rpc.call("send_input", { session, command: { type: "key", key: "space", down: true } });
+  await rpc.call("send_input", { session, command: { type: "key", key: "space", down: false } });
+  await rpc.call("step", { session, frames: 1, dts: 1 / 60 });
+  // Read the SETTLED model with `get_state` rather than reusing the one `step`
+  // returned. The two can disagree in the last ULP of an untouched float
+  // (`15.083333702757956` vs `...55`), which would make the byte-exact
+  // comparison after the reload below flaky; two `get_state` reads agree with
+  // each other, and `get_state` across a reload is bit-exact. So both sides of
+  // that comparison come from the same endpoint and the assertion stays EXACT.
+  const planted = (await rpc.call("get_state", { session })).model;
+  check(planted.plants.length === 7, `Space plants a seed (${planted.plants.length} plants)`);
+  check(planted.plants[6].species === 0, "the new plant is APPENDED, with the picked species");
+  check(
+    planted.plants[6].age >= 0 && planted.plants[6].age <= 1 / 60 + 1e-6,
+    `the new plant is at most one step old (${planted.plants[6].age.toFixed(4)}s)`,
+  );
+  check(
+    planted.plants.slice(0, 6).every((p, i) => near(p.age, grown.plants[i].age, 0.05)),
+    "planting does not disturb the plants already growing",
+  );
+
+  console.log("\n▸ the hot-reload thesis: edit a law, keep the garden");
+  const before = await frameImage(rpc, session);
+
+  const slowed = SOURCE.replace(/^let growthRate = 0\.42/m, "let growthRate = 0.10");
+  check(slowed !== SOURCE, "the edit under test is `growthRate: 0.42 -> 0.10`");
+  // No `step` around the reloads: the clock is pinned, so every frame below is
+  // rendered at the same `tts` and any difference is the EDIT, not the weather.
+  await rpc.call("reload_source", { session, source: slowed });
+  const afterReload = (await rpc.call("get_state", { session })).model;
+
+  // The WHOLE model, not a chosen subset: every plot, species and age, plus
+  // `pick`. No step ran across the reload, so this is exact equality.
+  check(
+    JSON.stringify(afterReload) === JSON.stringify(planted),
+    `the entire model survived the reload unchanged — the model IS the garden (${afterReload.plants.length} plants)`,
+  );
+
+  const after = await frameImage(rpc, session);
+  check(after !== before, "the same garden renders a different frame — the law reshaped it");
+
+  console.log("\n▸ and back: the reshape is a pure function of the file");
+  await rpc.call("reload_source", { session, source: SOURCE });
+  const restored = await frameImage(rpc, session);
+  check(restored === before, "restoring the source reproduces the original frame exactly");
+} finally {
+  if (session) await rpc.call("stop_game", { session }).catch(() => {});
+  proc.stdin.end();
+  proc.kill();
+}
+
+console.log(failures.length ? `\n✗ ${failures.length} failed` : "\n✓ all checks passed");
+process.exit(failures.length ? 1 : 0);

--- a/e2e/code-garden.mjs
+++ b/e2e/code-garden.mjs
@@ -1,15 +1,15 @@
 // `examples/code-garden` E2E: the model is the garden, the file is the botany.
 //
-// The sample's claim is that its growth LAWS are top-level constants and its
-// model holds only plot/species/age — so editing a law re-shapes a garden that
+// The sample's claim is that its growth LAWS are top-level constants and each
+// plant stores only plot/species/age — so editing a law re-shapes a garden that
 // is already growing instead of restarting it. That is a hot-reload property,
 // which no inline `expect` can reach: it needs a running game, a pinned clock,
 // and two frames. This drives it over `functor mcp` (docs/mcp.md), raw
 // JSON-RPC on stdio, exactly as a coding agent's client would:
 //
 //   1. `init` sows five plants at staggered ages.
-//   2. Stepping 7 seconds ages every plant by exactly 7 and fires the
-//      `Sub.every` self-seeding timer once (5 plants -> 6).
+//   2. Stepping 8 seconds ages every plant by exactly 8 and fires the
+//      `Sub.every(7s)` self-seeding timer once (5 plants -> 6).
 //   3. `1` then `Space` plants a Lantern seed at the next plot (6 -> 7), a
 //      brand-new plant appended at age 0 while the others keep their ages.
 //   4. HOT-RELOADING a changed law (`growthRate`) leaves the model identical —
@@ -21,11 +21,12 @@
 // garden serializes to ~12 MB of scene JSON, past the MCP response cap.
 // `capture_frame` needs pixels, hence `mode: "hidden"` rather than `headless`.
 //
-// Run (a RELEASE binary — the debug interpreter is far too slow for the
-// 420-step drive; `npm run test:code-garden` builds it for you):
+// Run (needs the CLI built; the wasm bundle is not required):
 //
-//   cargo build --release -p functor-cli --no-default-features
-//   FUNCTOR_BIN="$PWD/target/release/functor" node e2e/code-garden.mjs
+//   cargo build -p functor-cli --no-default-features
+//   node e2e/code-garden.mjs
+//
+// Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { check, failures, ROOT, startMcp } from "./mcp-rpc.mjs";
@@ -62,19 +63,25 @@ try {
     `their ages are staggered 10/7/4.5/2/0 apart: ${JSON.stringify(ages0.map((a) => +a.toFixed(3)))}`,
   );
 
-  console.log("\n▸ 7 seconds of growth (420 steps of 1/60s)");
-  const grown = (await rpc.call("step", { session, frames: 420, dts: 1 / 60 })).model;
+  // 8 seconds, deliberately clear of the 7s self-seeding period: 420 steps of
+  // 1/60 sum to 6.99999999999998, so a "7 second" drive would sit exactly on
+  // the timer's edge and fire only thanks to the frames that ran before the
+  // pause landed.
+  console.log("\n▸ 8 seconds of growth (80 steps of 0.1s)");
+  const grown = (await rpc.call("step", { session, frames: 80, dts: 0.1 })).model;
   check(
-    grown.plants.slice(0, 5).every((p, i) => near(p.age, ages0[i] + 7.0, 1e-3)),
-    "every original plant aged by exactly 7.0s — age is stored in seconds",
+    grown.plants.slice(0, 5).every((p, i) => near(p.age, ages0[i] + 8.0, 1e-3)),
+    "every original plant aged by exactly 8.0s — age is stored in seconds",
   );
   check(
     grown.plants.length === 6,
     `Sub.every(7s) self-seeded exactly once (${grown.plants.length} plants)`,
   );
+  // It sprouted at the 7s mark and has been growing for the ~1s since, so it is
+  // far younger than every plant `init` sowed.
   check(
-    grown.plants[5].age >= 0 && grown.plants[5].age < 0.2,
-    `the volunteer starts at age 0 (${grown.plants[5].age.toFixed(3)}s old)`,
+    grown.plants[5].age > 0 && grown.plants[5].age < grown.plants[4].age,
+    `the volunteer sprouted mid-drive, younger than every original (${grown.plants[5].age.toFixed(3)}s old)`,
   );
 
   console.log("\n▸ planting by hand: 1 then Space");
@@ -88,10 +95,11 @@ try {
   await rpc.call("step", { session, frames: 1, dts: 1 / 60 });
   // Read the SETTLED model with `get_state` rather than reusing the one `step`
   // returned. The two can disagree in the last ULP of an untouched float
-  // (`15.083333702757956` vs `...55`), which would make the byte-exact
-  // comparison after the reload below flaky; two `get_state` reads agree with
-  // each other, and `get_state` across a reload is bit-exact. So both sides of
-  // that comparison come from the same endpoint and the assertion stays EXACT.
+  // (`15.083333702757956` vs `...55`) — tommy-xr/functor#674 — which would make
+  // the byte-exact comparison after the reload below flaky; two `get_state`
+  // reads agree with each other, and `get_state` across a reload is bit-exact.
+  // So both sides of that comparison come from the same endpoint and the
+  // assertion stays EXACT.
   const planted = (await rpc.call("get_state", { session })).model;
   check(planted.plants.length === 7, `Space plants a seed (${planted.plants.length} plants)`);
   check(planted.plants[6].species === 0, "the new plant is APPENDED, with the picked species");

--- a/e2e/mcp-rpc.mjs
+++ b/e2e/mcp-rpc.mjs
@@ -3,7 +3,7 @@
 // `functor mcp` speaks line-delimited JSON-RPC 2.0 on stdio and the harnesses
 // speak it RAW — no MCP client library — so what they assert is exactly what a
 // coding agent's client would see. That is worth exactly one copy: this module
-// is it, imported by `mcp-server.mjs` and `mcp-step-all.mjs`.
+// is it, imported by every `mcp-*.mjs` harness and by `code-garden.mjs`.
 //
 // Plain ESM with node builtins only, like every other file in `e2e/`.
 import { connect } from "node:net";

--- a/examples/code-garden/functor.json
+++ b/examples/code-garden/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/code-garden/functor.json
+++ b/examples/code-garden/functor.json
@@ -1,4 +1,5 @@
 {
   "language": "functor-lang",
-  "entry": "game.fun"
+  "entry": "game.fun",
+  "mouseCapture": false
 }

--- a/examples/code-garden/game.fun
+++ b/examples/code-garden/game.fun
@@ -1,13 +1,14 @@
-// gallery: A living procedural garden whose laws ARE this file — edit a constant, save, and the plants you already grew re-shape without restarting.
-// gallery-controls: Space plant a seed - 1/2/3 pick species (Lantern/Ember/Sunthread) - R replant the garden - the file itself is the main controller
+// gallery: A living procedural garden whose growth laws ARE this file — edit a constant, save, and the plants you already grew re-shape.
+// gallery-controls: Space plant a seed · 1/2/3 pick species (Lantern/Ember/Sunthread) · R replant · editing this file is the real control
 //
 // code-garden — the source file is the game.
 //
-// Everything you can SEE is derived, every frame, from the definitions in the
-// "THE LAWS" block below. Everything that PERSISTS — which plots were sown,
-// what species each holds, and how many seconds each has been alive — lives in
-// the model. Hot-reload keeps the model, so editing a law bends a garden that
-// is already growing instead of rebooting it:
+// Everything you can SEE is derived, every frame, from the constants in this
+// file — chiefly the "THE LAWS" block below. Everything that PERSISTS — which
+// plots were sown, what species each holds, and how many seconds each has been
+// alive (plus which species the next Space will plant) — lives in the model.
+// Hot-reload keeps the model, so editing a law bends a garden that is already
+// growing instead of rebooting it:
 //
 //   functor -d examples/code-garden run native
 //   ... then edit `branchAngle` to 70deg and save. The same plants, the same
@@ -65,7 +66,7 @@ let hash01 = (n: float): float =>
 // ---------------------------------------------------------------------------
 
 // Botany.
-let maxDepth = 4.0          // branch generations; 5 is lush and ~2x the cost
+let maxDepth = 4.0          // branch generations, 1 or more; 5 is lush and ~2x the cost
 let branchAngle = 27deg     // how far a child leans off its parent
 let branchTwist = 137deg    // how far each generation spins around the stem
 let stemLength = 0.95       // length of a first-generation segment
@@ -79,11 +80,14 @@ let jitter = 0.34           // 0 = topiary, 1 = wild
 // into growth, and it is read in `draw` — so editing it re-ages the garden.
 let growthRate = 0.42       // branch generations gained per second of age
 let sproutEvery = 7.0       // seconds between self-seedings
-let maxPlants = 9.0
+let maxPlants = 9.0         // the self-seeding cap; `init` sows 5 regardless,
+                            // so keep it at 5 or more
 
 // Blooms.
 let bloomSize = 0.115
 let petals = 5.0
+let crownLights = 6.0       // how many crowns get a point light — the renderer
+                            // evaluates 8 lights and ambient + sun take two
 let motes = 16.0            // fireflies, out after dusk
 let nightGlow = 1.15         // emissive multiplier at midnight
 let dayGlow = 0.8            // ... and at noon
@@ -227,10 +231,12 @@ let grow = (sp: Species, salt: float, depth: float, t: float, glow: float, tts: 
 // Roughly how tall a plant of `levels` generations stands — the partial sum of
 // the geometric stem lengths. Used to hang a point light in each crown, which
 // is cheaper and steadier than trying to read a position back out of a Scene.
+// The ratio is capped just under 1 so that editing `lengthFalloff` to exactly
+// 1.0 ("no taper", a natural thing to try) can't divide by zero: a NaN reaching
+// a Vec3 aborts the whole `draw`, which would blank the window on save.
 let crownHeight = (sp: Species, levels: float): float =>
-  stemLength * sp.reach
-    * (1.0 - Math.pow(lengthFalloff, levels))
-    / (1.0 - lengthFalloff)
+  let f = Math.min(lengthFalloff, 0.999) in
+  stemLength * sp.reach * (1.0 - Math.pow(f, levels)) / (1.0 - f)
 
 // ---------------------------------------------------------------------------
 // The model — plots, species, ages. This is what survives a save.
@@ -307,7 +313,9 @@ let input = (m: Model, key: Key.t, isDown: bool): Model =>
 // Growth is stored as seconds and converted by a LAW, so the conversion is the
 // thing worth pinning: it is linear in age and saturates at maxDepth.
 expect levelsOf(sow(0.0, 0.0, 0.0)) == 0.0
-expect levelsOf(sow(0.0, 0.0, 1.0 / growthRate)) == 1.0
+// `(1.0 / g) * g` is not exactly 1.0 for many doubles, so this is a tolerance
+// test — editing `growthRate` must not turn the sample's own suite red.
+expect Math.abs(levelsOf(sow(0.0, 0.0, 1.0 / growthRate)) - 1.0) < 0.000000001
 expect levelsOf(sow(0.0, 0.0, 10000.0)) == maxDepth
 
 // tick only ages; it never touches shape.
@@ -339,8 +347,10 @@ expect (
   Math.sqrt(dx * dx + dz * dz) > 0.6
 )
 
-// A keypress that is not a control leaves the garden alone, and R replants it.
-expect List.length(input(init, Key.Q, true).plants) == List.length(init.plants)
+// A keypress that is not a control leaves the whole model alone (not just the
+// plant count — an unhandled key must not disturb `pick` either), and R
+// replants the garden.
+expect input(init, Key.Q, true) == init
 expect input(init, Key.Num1, true).pick == 0.0
 expect (
   let totalAge = (m: Model) => m.plants |> List.map((p: Plant) => p.age) |> List.sum in
@@ -398,8 +408,8 @@ let fireflies = (d: float, tts: float): Scene.t =>
 // A point light hung in a plant's crown, tinted by its own blooms — the reason
 // the stems are visible at all at night. The engine evaluates at most 8 lights
 // per draw and SILENTLY DROPS the rest, so the ambient + sun pair leaves room
-// for exactly 6 of these: `lightsFor` gives them to the six oldest plants and
-// the youngest three glow without lighting their surroundings.
+// for `crownLights` of these: `lightsFor` gives them to the oldest plants and
+// the youngest few glow without lighting their surroundings.
 let crownLight = (tts: float, p: Plant): Light.t =>
   let sp = speciesOf(p.species) in
   let levels = levelsOf(p) in
@@ -424,7 +434,7 @@ let lightsFor = (m: Model, tts: float): List<Light.t> =>
   let crowns =
     m.plants
       |> List.sortBy((p: Plant) => 0.0 - p.age)
-      |> List.take(6.0)
+      |> List.take(crownLights)
       |> List.map((p: Plant) => crownLight(tts, p)) in
   [Light.ambient(toColor(mix(nightAmbient, dayAmbient, d))), key] |> List.append(crowns)
 

--- a/examples/code-garden/game.fun
+++ b/examples/code-garden/game.fun
@@ -1,0 +1,458 @@
+// gallery: A living procedural garden whose laws ARE this file — edit a constant, save, and the plants you already grew re-shape without restarting.
+// gallery-controls: Space plant a seed - 1/2/3 pick species (Lantern/Ember/Sunthread) - R replant the garden - the file itself is the main controller
+//
+// code-garden — the source file is the game.
+//
+// Everything you can SEE is derived, every frame, from the definitions in the
+// "THE LAWS" block below. Everything that PERSISTS — which plots were sown,
+// what species each holds, and how many seconds each has been alive — lives in
+// the model. Hot-reload keeps the model, so editing a law bends a garden that
+// is already growing instead of rebooting it:
+//
+//   functor -d examples/code-garden run native
+//   ... then edit `branchAngle` to 70deg and save. The same plants, the same
+//   ages, a different botany.
+//
+// The precise mental model (worth internalizing — it is the whole point):
+//
+//   model  = { plants: [{ i, species, age }], pick }
+//   scene  = draw(model, tts) = f(THE LAWS, model, tts)
+//
+//   * `age` is stored in raw SECONDS, never in "how grown is it". `growthRate`
+//     converts seconds to branch levels inside `draw`, so lowering it makes the
+//     WHOLE existing garden younger-looking on the very next frame, and raising
+//     it flowers the garden you already have. Had `tick` folded growthRate into
+//     the model, an edit would only affect future growth — which is exactly the
+//     screensaver-reboot feeling this example is built to avoid.
+//   * No closures and no engine values live in the model, so nothing in it goes
+//     stale on reload; every material, angle and color is rebuilt from the laws.
+//   * `tts` (day/night, wind) is the shell's clock and keeps its phase across a
+//     reload too, so the sky does not jump when you save.
+//   * A plant stores only its PLOT INDEX, not a position: `plotRadius` and the
+//     spiral are laws too, so widening the bed re-arranges the garden you have.
+//
+// It demos well untouched: `init` sows five plants at staggered ages and a
+// `Sub.every` timer keeps self-seeding up to `maxPlants`, so an idle window
+// grows a full garden through a full day. The keyboard is a garnish; the file
+// is the controller.
+
+// ---------------------------------------------------------------------------
+// Small pure helpers the laws are written in terms of.
+// ---------------------------------------------------------------------------
+
+// A plain-data color. `Color.t` is opaque and has no accessors or blend, so a
+// palette that has to be interpolated (day -> night) is kept as floats and
+// converted at the material boundary.
+type Rgb = { r: float, g: float, b: float }
+
+let rgb = (r: float, g: float, b: float): Rgb => { r: r, g: g, b: b }
+let toColor = (c: Rgb) => Color.rgb(c.r, c.g, c.b)
+let mix = (u: Rgb, v: Rgb, t: float): Rgb =>
+  { r: Math.lerp(v.r, t, u.r), g: Math.lerp(v.g, t, u.g), b: Math.lerp(v.b, t, u.b) }
+let gain = (k: float, c: Rgb): Rgb => { r: c.r * k, g: c.g * k, b: c.b * k }
+
+// Per-branch variation, as a pure function of the branch's ADDRESS rather than
+// a drawn random number, so the same plant is the same plant on every frame and
+// after every reload. `Random.seed` hashes the number's BITS, so one `step` off
+// a freshly seeded stream is exactly an address -> 0..1 lookup — no seed to
+// thread, and nothing to keep in the model.
+let hash01 = (n: float): float =>
+  let (v, _) = Random.step(Random.seed(n)) in
+  v
+
+// ---------------------------------------------------------------------------
+// THE LAWS — the garden is these numbers. Edit, save, watch.
+// ---------------------------------------------------------------------------
+
+// Botany.
+let maxDepth = 4.0          // branch generations; 5 is lush and ~2x the cost
+let branchAngle = 27deg     // how far a child leans off its parent
+let branchTwist = 137deg    // how far each generation spins around the stem
+let stemLength = 0.95       // length of a first-generation segment
+let lengthFalloff = 0.74    // each generation is this fraction of its parent
+let stemWidth = 0.07        // DIAMETER of a first-generation segment (the
+                            // unit cylinder has radius 0.5, so this scales it)
+let widthFalloff = 0.62
+let jitter = 0.34           // 0 = topiary, 1 = wild
+
+// Time. `age` is stored in seconds; this is the only thing that turns seconds
+// into growth, and it is read in `draw` — so editing it re-ages the garden.
+let growthRate = 0.42       // branch generations gained per second of age
+let sproutEvery = 7.0       // seconds between self-seedings
+let maxPlants = 9.0
+
+// Blooms.
+let bloomSize = 0.115
+let petals = 5.0
+let motes = 16.0            // fireflies, out after dusk
+let nightGlow = 1.15         // emissive multiplier at midnight
+let dayGlow = 0.8            // ... and at noon
+
+// Weather and sky.
+let windSway = 2.4          // degrees of sway contributed by ONE joint
+let windSpeed = 0.85
+let dayLength = 60.0        // seconds per full day/night cycle
+let dayStart = 0.62         // phase at tts = 0 (0.62 = just past dusk)
+
+// Ground.
+let plotRadius = 4.2
+let groundSize = 90.0
+let groundRes = 22.0
+
+// Camera.
+let camRadius = 9.8
+let camHeight = 2.75
+let camTarget = 1.6
+let camSpeed = 0.055        // radians per second
+let camStart = 0.5
+
+// Palette.
+let moteColor = rgb(1.0, 0.86, 0.45)
+let dayFog = rgb(0.55, 0.66, 0.64)
+let nightFog = rgb(0.030, 0.038, 0.085)
+let daySun = rgb(1.0, 0.93, 0.78)
+let nightSun = rgb(0.42, 0.55, 0.95)
+let dayAmbient = rgb(0.34, 0.39, 0.40)
+let nightAmbient = rgb(0.065, 0.080, 0.135)
+let daySky = rgb(0.63, 0.75, 0.78)     // clear color, a shade off the fog, so
+let nightSky = rgb(0.045, 0.055, 0.125) // ... the horizon reads as a horizon
+let groundDay = rgb(0.27, 0.33, 0.22)
+let groundNight = rgb(0.10, 0.12, 0.13)
+
+// ---------------------------------------------------------------------------
+// Species — three botanies sharing one `grow`.
+// ---------------------------------------------------------------------------
+
+type Species = {
+  stem: Rgb,      // lit stem albedo
+  bloom: Rgb,     // emissive petal color
+  core: Rgb,      // emissive bloom center
+  lean: float,    // multiplier on branchAngle
+  reach: float,   // multiplier on stemLength
+}
+
+let lantern = {
+  stem: rgb(0.17, 0.30, 0.24),
+  bloom: rgb(0.20, 0.95, 0.86),
+  core: rgb(0.66, 0.92, 0.88),
+  lean: 0.85,
+  reach: 1.15,
+}
+
+let ember = {
+  stem: rgb(0.31, 0.19, 0.24),
+  bloom: rgb(1.0, 0.22, 0.58),
+  core: rgb(0.95, 0.68, 0.80),
+  lean: 1.35,
+  reach: 0.88,
+}
+
+let sunthread = {
+  stem: rgb(0.27, 0.28, 0.17),
+  bloom: rgb(1.0, 0.72, 0.20),
+  core: rgb(0.96, 0.90, 0.62),
+  lean: 1.05,
+  reach: 1.0,
+}
+
+let speciesOf = (i: float): Species =>
+  if i < 0.5 then lantern
+  else if i < 1.5 then ember
+  else sunthread
+
+// ---------------------------------------------------------------------------
+// The ground. One height field, sampled twice: once as a mesh, once to seat
+// each plant on the surface it is standing on.
+// ---------------------------------------------------------------------------
+
+let groundHeight = (x: float, z: float): float =>
+  Math.sin(x * 0.31) * 0.22
+    + Math.sin(z * 0.27 + 1.3) * 0.26
+    + Math.sin((x + z) * 0.11) * 0.34
+    - 0.4
+
+// The heightmap spans a unit square centered on the origin, so cell (r, c)
+// lands at these world coordinates once scaled to `groundSize`.
+let cellX = (c: float): float => (c / (groundRes - 1.0) - 0.5) * groundSize
+let cellZ = (r: float): float => (r / (groundRes - 1.0) - 0.5) * groundSize
+
+// ---------------------------------------------------------------------------
+// grow — the recursive L-system. A branch is a tapered stem plus either two
+// children or a bloom, all wrapped in this joint's share of the wind.
+// ---------------------------------------------------------------------------
+
+let bloom = (sp: Species, openAmt: float, glow: float, salt: float): Scene.t =>
+  let petal = (k: float): Scene.t =>
+    Scene.sphere()
+      |> Scene.scaleXYZ(bloomSize * 0.8, bloomSize * 0.26, bloomSize * 1.45)
+      |> Scene.translate(Vec3.make(0.0, 0.0, bloomSize * 1.05))
+      |> Scene.rotateX(58deg * (0.0 - openAmt))
+      |> Scene.rotateY(Angle.degrees(k * 360.0 / petals + salt * 11.0))
+      |> Scene.emissive(toColor(gain(glow, sp.bloom))) in
+  Scene.group([
+    Scene.sphere()
+      |> Scene.scale(bloomSize * 0.5)
+      |> Scene.emissive(toColor(gain(glow * 0.85, sp.core))),
+    Scene.group(List.map(petal, List.range(petals))),
+  ])
+    |> Scene.scale(0.25 + 0.75 * openAmt)
+
+// `t` is how many branch generations are still owed to this subtree. A whole
+// number grows a full segment; the fractional remainder is the tip that is
+// still extending, which is what makes growth continuous rather than steppy.
+let grow = (sp: Species, salt: float, depth: float, t: float, glow: float, tts: float): Scene.t =>
+  let ext = Math.clamp01(t) in
+  let vary = 1.0 - jitter * 0.5 + jitter * hash01(salt) in
+  let len = stemLength * sp.reach * Math.pow(lengthFalloff, depth) * vary * ext in
+  let wid = stemWidth * Math.pow(widthFalloff, depth) in
+  let stem =
+    Scene.cylinder()
+      |> Scene.scaleXYZ(wid, len, wid)
+      |> Scene.translate(Vec3.make(0.0, len * 0.5, 0.0))
+      |> Scene.lit(toColor(sp.stem)) in
+  let child = (k: float): Scene.t =>
+    grow(sp, salt * 2.0 + k * 0.5 + 1.0, depth + 1.0, t - 1.0, glow, tts)
+      |> Scene.rotateZ(branchAngle * sp.lean * (k * 2.0 - 1.0) * vary)
+      |> Scene.rotateY(branchTwist * (depth + hash01(salt + k) * jitter))
+      |> Scene.translate(Vec3.make(0.0, len, 0.0)) in
+  let crown =
+    if t <= 1.0 || depth + 1.0 >= maxDepth then
+      bloom(sp, ext, glow, salt) |> Scene.translate(Vec3.make(0.0, len, 0.0))
+    else
+      Scene.group([child(0.0), child(1.0)]) in
+  let sway = windSway * (0.3 + depth * 0.35)
+    * Math.sin(tts * windSpeed + salt * 1.7 + depth * 0.8) in
+  Scene.group([stem, crown]) |> Scene.rotateZ(Angle.degrees(sway))
+
+// Roughly how tall a plant of `levels` generations stands — the partial sum of
+// the geometric stem lengths. Used to hang a point light in each crown, which
+// is cheaper and steadier than trying to read a position back out of a Scene.
+let crownHeight = (sp: Species, levels: float): float =>
+  stemLength * sp.reach
+    * (1.0 - Math.pow(lengthFalloff, levels))
+    / (1.0 - lengthFalloff)
+
+// ---------------------------------------------------------------------------
+// The model — plots, species, ages. This is what survives a save.
+// ---------------------------------------------------------------------------
+
+type Plant = {
+  i: float,         // plot index on the spiral — the position is DERIVED
+  species: float,
+  age: float,       // SECONDS alive, not growth: see the header
+}
+
+type Model = {
+  plants: List<Plant>,
+  pick: float,      // species the next Space plants
+}
+
+type Msg = | Sprout
+
+// Plot `i` of a phyllotactic spiral, so plants never collide and the garden
+// fills outward the way a real one seeded from its center would. The plot is
+// DERIVED, never stored, so `plotRadius` and the spiral stay live laws: widen
+// the bed and the garden you already grew spreads out on the next frame.
+let plotArm = (i: float): float => plotRadius * Math.sqrt((i + 0.55) / maxPlants)
+let plotX = (i: float): float => Math.cos(i * 2.39996) * plotArm(i)
+let plotZ = (i: float): float => Math.sin(i * 2.39996) * plotArm(i)
+// This plant's variation address, which every branch salts further.
+let saltOf = (i: float): float => i * 1.618 + 0.37
+
+let sow = (i: float, species: float, age: float): Plant =>
+  { i: i, species: species, age: age }
+
+let levelsOf = (p: Plant): float =>
+  p.age * growthRate |> Math.clamp(0.0, maxDepth)
+
+let plantOne = (m: Model, species: float): Model =>
+  if List.length(m.plants) >= maxPlants then m
+  else { m with plants: m.plants |> List.append([sow(List.length(m.plants), species, 0.0)]) }
+
+let init = {
+  plants: [
+    sow(0.0, 0.0, 11.0),
+    sow(1.0, 1.0, 8.0),
+    sow(2.0, 2.0, 5.5),
+    sow(3.0, 0.0, 3.0),
+    sow(4.0, 1.0, 1.0),
+  ],
+  pick: 2.0,
+}
+
+let tick = (m: Model, dt: float, tts: float): Model =>
+  { m with plants: m.plants |> List.map((p: Plant) => { p with age: p.age + dt }) }
+
+let update = (m: Model, msg: Msg): Model =>
+  match msg with
+  | Sprout => plantOne(m, Math.mod(List.length(m.plants), 3.0))
+
+let subscriptions = (m: Model) => Sub.every(Time.seconds(sproutEvery), Sprout)
+
+let input = (m: Model, key: Key.t, isDown: bool): Model =>
+  if not isDown then m
+  else
+    match key with
+    | Key.Space => plantOne(m, m.pick)
+    | Key.Num1 => { m with pick: 0.0 }
+    | Key.Num2 => { m with pick: 1.0 }
+    | Key.Num3 => { m with pick: 2.0 }
+    | Key.R => init
+    | _ => m
+
+// ---------------------------------------------------------------------------
+// Inline tests over the pure core (`functor -d examples/code-garden test`).
+// ---------------------------------------------------------------------------
+
+// Growth is stored as seconds and converted by a LAW, so the conversion is the
+// thing worth pinning: it is linear in age and saturates at maxDepth.
+expect levelsOf(sow(0.0, 0.0, 0.0)) == 0.0
+expect levelsOf(sow(0.0, 0.0, 1.0 / growthRate)) == 1.0
+expect levelsOf(sow(0.0, 0.0, 10000.0)) == maxDepth
+
+// tick only ages; it never touches shape.
+expect (
+  let totalAge = (m: Model) => m.plants |> List.map((p: Plant) => p.age) |> List.sum in
+  totalAge(tick(init, 2.0, 0.0)) == totalAge(init) + 2.0 * List.length(init.plants)
+)
+expect (
+  let plots = (m: Model) => m.plants |> List.map((p: Plant) => p.i) in
+  plots(tick(init, 2.0, 0.0)) == plots(init)
+)
+
+// Self-seeding appends one plot — at the END, so plot order is planting order —
+// and stops at the cap.
+expect List.length(update(init, Sprout).plants) == List.length(init.plants) + 1.0
+expect (
+  let volunteer = update(init, Sprout).plants |> List.last in
+  (volunteer |> Option.map((p: Plant) => p.age) |> Option.defaultValue(0.0 - 1.0)) == 0.0
+)
+expect (
+  let full = List.range(maxPlants) |> List.fold((m, i) => update(m, Sprout), init) in
+  List.length(full.plants) == maxPlants
+)
+
+// Plots never coincide: the spiral separates consecutive seeds.
+expect (
+  let dx = plotX(3.0) - plotX(4.0) in
+  let dz = plotZ(3.0) - plotZ(4.0) in
+  Math.sqrt(dx * dx + dz * dz) > 0.6
+)
+
+// A keypress that is not a control leaves the garden alone, and R replants it.
+expect List.length(input(init, Key.Q, true).plants) == List.length(init.plants)
+expect input(init, Key.Num1, true).pick == 0.0
+expect (
+  let totalAge = (m: Model) => m.plants |> List.map((p: Plant) => p.age) |> List.sum in
+  let old = tick(init, 50.0, 0.0) in
+  totalAge(old) > totalAge(init) && totalAge(input(old, Key.R, true)) == totalAge(init)
+)
+
+// The palette blend is a real lerp with exact endpoints.
+expect mix(nightFog, dayFog, 0.0).r == nightFog.r
+expect mix(nightFog, dayFog, 1.0).b == dayFog.b
+
+// ---------------------------------------------------------------------------
+// draw — one pure function of (laws, model, clock).
+// ---------------------------------------------------------------------------
+
+let dayPhase = (tts: float): float => Math.mod(tts / dayLength + dayStart, 1.0)
+let sunAngle = (tts: float): float => dayPhase(tts) * 2.0 * Math.pi
+let daylight = (tts: float): float => Math.clamp01(Math.sin(sunAngle(tts)) * 1.5 + 0.35)
+let glowOf = (tts: float): float => Math.lerp(dayGlow, daylight(tts), nightGlow)
+
+// A celestial body on the day arc: the sun at `phase`, the moon opposite it.
+// Both sit inside the fog, so they read as a disc glowing through the mist, and
+// the opaque ground hides whichever one has set. The camera orbits on its own
+// period, so they drift in and out of frame rather than being always visible.
+let celestial = (a: float, c: Rgb, size: float): Scene.t =>
+  Scene.sphere()
+    |> Scene.scale(size)
+    |> Scene.emissive(toColor(c))
+    |> Scene.translate(
+         Vec3.make(Math.sin(a) * 15.0, Math.sin(a) * 10.0 + 1.5, Math.cos(a) * 15.0))
+
+let plantNode = (glow: float, tts: float, p: Plant): Scene.t =>
+  let x = plotX(p.i) in
+  let z = plotZ(p.i) in
+  grow(speciesOf(p.species), saltOf(p.i), 0.0, levelsOf(p), glow, tts)
+    |> Scene.translate(Vec3.make(x, groundHeight(x, z), z))
+
+// Fireflies: a handful of motes drifting over the bed after dusk. They fill the
+// night sky, which is otherwise a flat wash, and cost one node each. Emissive
+// black would still read as a dark speck against a bright sky, so at full
+// daylight the whole group is dropped rather than faded.
+let fireflies = (d: float, tts: float): Scene.t =>
+  if d > 0.8 then Scene.group([])
+  else
+    let mote = (k: float): Scene.t =>
+      let a = hash01(k * 3.7) * 6.2832 + tts * (0.10 + hash01(k * 9.1) * 0.22) in
+      let r = 1.4 + hash01(k * 5.3) * 4.4 in
+      let y = 1.0 + hash01(k * 2.9) * 2.4 + Math.sin(tts * 0.8 + k) * 0.3 in
+      Scene.sphere()
+        |> Scene.scale(0.05)
+        |> Scene.emissive(toColor(gain(Math.clamp01(1.0 - d * 1.25), moteColor)))
+        |> Scene.translate(Vec3.make(Math.cos(a) * r, y, Math.sin(a) * r)) in
+    Scene.group(List.map(mote, List.range(motes)))
+
+// A point light hung in a plant's crown, tinted by its own blooms — the reason
+// the stems are visible at all at night. The engine evaluates at most 8 lights
+// per draw and SILENTLY DROPS the rest, so the ambient + sun pair leaves room
+// for exactly 6 of these: `lightsFor` gives them to the six oldest plants and
+// the youngest three glow without lighting their surroundings.
+let crownLight = (tts: float, p: Plant): Light.t =>
+  let sp = speciesOf(p.species) in
+  let levels = levelsOf(p) in
+  let x = plotX(p.i) in
+  let z = plotZ(p.i) in
+  Light.point(
+    Vec3.make(x, groundHeight(x, z) + crownHeight(sp, levels) * 0.62, z),
+    toColor(sp.bloom),
+    (0.55 + 1.15 * (levels / maxDepth)) * Math.clamp01(1.12 - daylight(tts) * 1.12),
+    7.0)
+
+let lightsFor = (m: Model, tts: float): List<Light.t> =>
+  let d = daylight(tts) in
+  let a = sunAngle(tts) in
+  let sunUp = Math.sin(a) in
+  let key =
+    Light.directional(
+      Vec3.make(0.0 - Math.cos(a) * 0.7, 0.0 - Math.abs(sunUp) - 0.25, 0.0 - 0.55),
+      toColor(mix(nightSun, daySun, d)),
+      0.12 + 0.95 * d)
+      |> Light.castShadows in
+  let crowns =
+    m.plants
+      |> List.sortBy((p: Plant) => 0.0 - p.age)
+      |> List.take(6.0)
+      |> List.map((p: Plant) => crownLight(tts, p)) in
+  [Light.ambient(toColor(mix(nightAmbient, dayAmbient, d))), key] |> List.append(crowns)
+
+let draw = (m: Model, tts: float) =>
+  let d = daylight(tts) in
+  let glow = glowOf(tts) in
+  let a = sunAngle(tts) in
+  let fogColor = mix(nightFog, dayFog, d) in
+  let ground =
+    Scene.heightmap(
+      List.grid((r, c) => groundHeight(cellX(c), cellZ(r)), groundRes, groundRes))
+      |> Scene.scaleXYZ(groundSize, 1.0, groundSize)
+      |> Scene.lit(toColor(mix(groundNight, groundDay, d))) in
+  let sky =
+    Scene.group([
+      celestial(a, gain(0.12 + 1.05 * d, daySun), 3.0),
+      celestial(a + Math.pi, gain(1.0 - 0.75 * d, nightSun), 1.7),
+    ]) in
+  let garden = Scene.group(m.plants |> List.map((p: Plant) => plantNode(glow, tts, p))) in
+  let motesNode = fireflies(d, tts) in
+  let eye =
+    Vec3.make(
+      Math.sin(camStart + tts * camSpeed) * camRadius,
+      camHeight,
+      Math.cos(camStart + tts * camSpeed) * camRadius) in
+  Frame.createLit(
+    Camera3D.lookAt(eye, Vec3.make(0.0, camTarget, 0.0)) |> Camera3D.clip(0.1, 140.0),
+    Scene.group([ground, sky, garden, motesNode]),
+    lightsFor(m, tts))
+    |> Frame.withFog(Fog.linear(11.0, 42.0, toColor(fogColor)))
+    |> Frame.withClearColor(toColor(mix(nightSky, daySky, d)))

--- a/examples/code-garden/idle.script
+++ b/examples/code-garden/idle.script
@@ -5,8 +5,10 @@
 #
 # Format: <frame:int> <KeyName> <down|up>; frames advance by --script-dt.
 #
+# `--input-script` resolves against the game dir (`-d`), so name it bare:
+#
 #   functor -d examples/code-garden run native \
-#     --input-script examples/code-garden/idle.script --script-dt 0.0166667 \
+#     --input-script idle.script --script-dt 0.0166667 \
 #     --capture-at-frame 2280 --capture-frame /tmp/noon.png
 #
 # Frames worth capturing: 90 (a young garden at night), 1400 (dawn), 2280 (a

--- a/examples/code-garden/idle.script
+++ b/examples/code-garden/idle.script
@@ -1,0 +1,14 @@
+# No input at all: the garden sows and grows itself, so an empty script is the
+# whole scenario. It exists because `--input-script` is how you capture a
+# deterministic still of a game whose visible state accrues in the MODEL —
+# `--fixed-time` pins dt to 0, which would freeze this garden at its `init`.
+#
+# Format: <frame:int> <KeyName> <down|up>; frames advance by --script-dt.
+#
+#   functor -d examples/code-garden run native \
+#     --input-script examples/code-garden/idle.script --script-dt 0.0166667 \
+#     --capture-at-frame 2280 --capture-frame /tmp/noon.png
+#
+# Frames worth capturing: 90 (a young garden at night), 1400 (dawn), 2280 (a
+# mature garden at noon — lit meadow and branch shadows), 4080 (midnight, with
+# fireflies out and the crown lights pooling on the ground).

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:xr-injection": "cargo build -p functor-cli --no-default-features && node e2e/xr-pose-injection.mjs",
     "test:mcp": "cargo build -p functor-cli --no-default-features && node e2e/mcp-server.mjs",
     "test:mcp-step-all": "cargo build -p functor-cli --no-default-features && node e2e/mcp-step-all.mjs",
-    "test:code-garden": "cargo build --release -p functor-cli --no-default-features && FUNCTOR_BIN=\"$PWD/target/release/functor\" node e2e/code-garden.mjs",
+    "test:code-garden": "cargo build -p functor-cli --no-default-features && node e2e/code-garden.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:detached-camera": "node site/demos/detached-camera.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test:xr-injection": "cargo build -p functor-cli --no-default-features && node e2e/xr-pose-injection.mjs",
     "test:mcp": "cargo build -p functor-cli --no-default-features && node e2e/mcp-server.mjs",
     "test:mcp-step-all": "cargo build -p functor-cli --no-default-features && node e2e/mcp-step-all.mjs",
+    "test:code-garden": "cargo build --release -p functor-cli --no-default-features && FUNCTOR_BIN=\"$PWD/target/release/functor\" node e2e/code-garden.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:detached-camera": "node site/demos/detached-camera.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -146,7 +146,14 @@ export const EXAMPLES: Example[] = [
   // Single-file and asset-free: an L-system garden whose growth LAWS are
   // top-level constants, so editing one in the sandbox re-shapes the plants
   // already on screen instead of restarting them.
-  { id: "code-garden", label: "Code garden", source: "examples/code-garden/game.fun" },
+  {
+    id: "code-garden",
+    label: "Code garden",
+    source: "examples/code-garden/game.fun",
+    // Keyboard-only: there is nothing to steer with the pointer, so don't
+    // capture it (matches the sample's own functor.json).
+    mouseCapture: false,
+  },
   { id: "counter", label: "Counter", source: "examples/counter/game.fun" },
   { id: "primitives", label: "Primitives", source: "examples/primitives/game.fun" },
   { id: "ui", label: "UI widgets", source: "examples/ui/game.fun" },

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -143,6 +143,10 @@ export const EXAMPLES: Example[] = [
       { source: "examples/terrain/heightmap.png", output: "heightmap.png" },
     ],
   },
+  // Single-file and asset-free: an L-system garden whose growth LAWS are
+  // top-level constants, so editing one in the sandbox re-shapes the plants
+  // already on screen instead of restarting them.
+  { id: "code-garden", label: "Code garden", source: "examples/code-garden/game.fun" },
   { id: "counter", label: "Counter", source: "examples/counter/game.fun" },
   { id: "primitives", label: "Primitives", source: "examples/primitives/game.fun" },
   { id: "ui", label: "UI widgets", source: "examples/ui/game.fun" },


### PR DESCRIPTION
A living procedural garden, promoted into the example corpus.

![code-garden time-lapse](https://gist.githubusercontent.com/tommy-xr/27ad899fbd2cdd163189728ad73bf5e3/raw/code-garden.gif)

<sub>25 frames sampled from frame 300 to 3900 of a deterministic run: plants sprout and branch, the 60s day/night cycle turns over, fireflies come out after dusk, crown point-lights pool on the ground. Rendered headlessly via `--input-script` + `--capture-at-frame`.</sub>

![noon](https://gist.githubusercontent.com/tommy-xr/27ad899fbd2cdd163189728ad73bf5e3/raw/garden-noon.png)

<sub>Frame 2280 — a mature garden at noon: lit meadow, sun-cast branch shadows. (This is the shape #664's inverse-transpose normal fix made possible: the ground is a `Scene.heightmap` under a non-uniform `Scene.scaleXYZ`, which before that fix rendered ambient-only with no shadows.)</sub>

![midnight](https://gist.githubusercontent.com/tommy-xr/27ad899fbd2cdd163189728ad73bf5e3/raw/garden-midnight.png)

<sub>Frame 4080 — midnight: fireflies out, crown point-lights pooling amber/teal/magenta on the grass.</sub>

## What it demonstrates, and why it earns a corpus slot

**Hot-reload is the gameplay.** No other sample teaches the reload seam by *being* it:

| Lives in the model (survives a save) | Derived every frame from the file |
| --- | --- |
| which plot indices are sown, in planting order | the phyllotactic spiral, `plotRadius`, `maxPlants` → each plant's position |
| each plant's species | branch angle, twist, segment length/taper, stem width |
| each plant's **age in seconds** | `growthRate` (seconds → branch generations) |
| the species the next `Space` will plant | bloom size/petals, palette, wind, day/night, fog, camera, lighting |

Two load-bearing choices make the demo work:

- `age` is stored in **raw seconds** and `growthRate` is applied inside `draw`. Edit `growthRate` and the *whole existing garden* re-ages on the next frame. Had `tick` folded it into the model, an edit would only affect future growth and the demo would feel like a reboot.
- a plant stores its **plot index**, never a position. `plotX`/`plotZ` derive the position in `draw`, so `plotRadius` and the spiral are live laws too — widening the bed re-arranges the garden you already grew.

Nothing in the model is a closure or an engine value, so nothing goes stale on reload; `tts` (wind, sky) is the shell clock and keeps its phase, so the sky doesn't jump when you save.

Surfaces it exercises that the corpus otherwise covers thinly: recursive `Scene` construction (an L-system, and its honest per-frame cost — `maxDepth` is documented as a budget, not a knob), `Frame.createLit` + `Frame.withFog` + `Frame.withClearColor` for atmosphere, `Light.castShadows` over procedural terrain, `Sub.every` as a slow self-seeding tick, and `Random.seed` used as an **address hash** (stable per-branch variation with nothing stored in the model).

It also demos well untouched: `init` sows five plants at staggered ages and the `Sub.every(7s)` timer self-seeds up to nine, so an idle window grows a full garden through a full day. The keyboard is a garnish.

## Files

| File | What |
| --- | --- |
| `examples/code-garden/game.fun` | the sample (single file, no assets) |
| `examples/code-garden/functor.json` | `mouseCapture: false` — keyboard-only |
| `examples/code-garden/idle.script` | empty input script + the deterministic capture recipe, matching `examples/platformer/jump.script` |
| `e2e/code-garden.mjs` | the hot-reload property, over `functor mcp`, on the shared `e2e/mcp-rpc.mjs` harness |
| `package.json` | `npm run test:code-garden`, in the sibling MCP harnesses' shape |
| `site/src/examples.ts` | sandbox registration |

## Sandbox registration

Single-file and asset-free, so it is just `{ id, label, source, mouseCapture: false }`, placed with the other single-file samples. `exampleEntryPath("code-garden")` → `examples/code_garden.fun` (a valid module stem). The site e2e derives its per-example smoke test from the rendered picker, so it picked the entry up automatically: **`PASS: example 'code-garden' loads live and ticks cleanly`**.

## Verification

All on this head, with a release CLI built in this worktree from current `main`:

| Check | Result |
| --- | --- |
| `functor -d examples/code-garden build native` | clean (`✓ checked game.fun (+30 modules)`) |
| `functor -d examples/code-garden test` | **14/14** inline expects |
| `npm run test:code-garden` (debug CLI, per the sibling MCP harnesses) | **14/14** checks |
| `npm ci && npm run site:build` | succeeds; `site/dist/examples/code_garden.fun` emitted |
| `npm run check:site` (tsc) | clean |
| `npm run test:site` | ALL CHECKS PASSED, including the new example |
| media at head | frame 2280 re-captured post-review is **byte-identical** to the published still |

## Golden scenario: assessed, not added

`golden-scenarios.json` renders a sample at a **fixed frame time**, and this sample's visible state is model-driven — age accrues through `tick`. Under `--fixed-time` the clock is pinned, so `dt` is 0 and the garden never grows: the golden would be perfectly deterministic, but it would only ever pin the frozen `init` pose (five plants at their seeded ages, at one instant of the day cycle). Everything the sample exists to show — growth, self-seeding, the noon meadow with branch shadows, the reload reshape — is unreachable at a fixed time.

The deterministic coverage this sample actually needs is already stronger elsewhere: `e2e/code-garden.mjs` compares `capture_frame` PNGs **byte-exactly** across a `reload_source` and back, which pins rendering *and* the reload seam. Adding a golden would also add a ~570-primitive scene to a renderer/display-specific reference set for little regression value. So: deliberately not added, and this paragraph is the reason rather than a silent skip.

## Adapted from its original form

Stripped: the design/notes document (its content belongs in the jam synthesis, not the corpus), the scratch-captures `.gitignore`. The sample's own comments carried no PR numbers, fix-round or "adoption" references — the engine constraints it *does* mention (opaque `Color.t`, the 8-light cap, `Random.seed` as an address hash, the MCP response cap) are stated as teaching, not as bug reports, and each was re-verified against the runtime source during review. The scripted proof moved from `examples/code-garden/proof.mjs` to `e2e/code-garden.mjs`, where it drops its private copy of the JSON-RPC client in favour of the shared `e2e/mcp-rpc.mjs` harness. `// gallery:` / `// gallery-controls:` headers were kept — `examples/tetris`, `examples/breakout` and `examples/roguelike` all carry them — and re-punctuated to the `·` separator those three use. Comment density is 24%, identical to `platformer` and `orbs`.

## Review (`/xreview`, 3 reviewers: Claude adversarial + Codex CLI + a dedicated de-dup pass)

**Fixed** (second commit):

| Sev | Finding | Disposition |
| --- | --- | --- |
| Critical (both engines) | `crownHeight` divides by `1.0 - lengthFalloff`, so editing `lengthFalloff` to exactly `1.0` — a natural "no taper" experiment, and the sample's whole headline gesture — NaNs the `Vec3` and aborts `draw` **every frame**, blanking the window. The 14 expects still passed. | Cap the ratio at `0.999` in `crownHeight`, with a comment saying why. Re-verified: `lengthFalloff = 1.0` now renders an untapered garden. Ranges documented on `maxDepth` and `maxPlants` too. |
| High | `idle.script`'s documented capture command didn't work — `--input-script` resolves against the game dir, so the `examples/code-garden/` prefix errored. | Bare `idle.script`, plus a line stating the resolution rule. Verified by re-capture. |
| High | `expect levelsOf(…1.0 / growthRate…) == 1.0` is exact-float-sensitive to the constant the sample invites you to edit — `growthRate = 0.36` turns the sample's own suite red. | Tolerance assertion. |
| Medium | The e2e's "7 seconds" drive summed to `6.99999999999998`; `Sub.every(7s)` fired only because of pre-pause jitter — a latent flake, and the comment was false in isolation. | Step 8s as `80 × 0.1` instead of `420 × (1/60)`. |
| Medium | The e2e demanded a release build, unlike every sibling MCP harness. | The above is 5× less interpreter work, so it now runs on `cargo build -p functor-cli --no-default-features` like its siblings (whole npm script: ~3s). |
| Medium | Keyboard-only sample, but the default game-mouse capture pointer-locks the cursor for nothing. | `"mouseCapture": false` in `functor.json` and the sandbox entry, matching `examples/roguelike`. |
| Medium | The `step`-vs-`get_state` ULP discrepancy the test routes around is an engine bug being papered over in a comment. | Filed as #674; the comment cites it. |
| Low (both engines) | The header claimed *everything* visible comes from the `THE LAWS` block; fog band, clip planes, celestial orbit and firefly geometry are inline in `draw`. `pick` is model state the summary omitted. | Claim narrowed to "the constants in this file — chiefly THE LAWS"; `pick` disclosed. |
| Low | `List.take(6.0)` was the one tuning constant outside the laws block. | Named `crownLights`, with the 8-light budget as its comment. |
| Low | The unhandled-key expect only checked plant count, so it would pass if `Key.Q` corrupted `pick`. | Compares the whole model. |
| Low | `e2e/mcp-rpc.mjs`'s docstring listed two importers. | Updated (this change is a new one). |

**Accepted without change**, with reasons:

- *Holding `Space` re-plants on keyboard auto-repeat* (Codex, Medium). Real — `Action::Repeat` does reach `game.key_event` — but corpus-normal: `examples/tetris` hard-drops and `examples/breakout` launches on the same idiom, and the effect is bounded by `maxPlants`. Changing it here would make this sample the odd one out; it belongs in an engine-wide discussion of edge-vs-repeat delivery.
- *Expects break if `maxPlants` is edited below 5* (Claude, Medium). `init` sows 5 unconditionally, so `maxPlants < 5` is out of range rather than a supported edit; documented on the constant instead of adding fixture machinery.
- *The e2e restates what the SDK hot-reload test already covers* (Claude, Medium). The de-dup reviewer checked this explicitly and cleared it: the SDK test covers the engine's reload mechanism on a purpose-built fixture; this covers the *sample's* property — exact whole-model equality plus a pixel-level reshape and a byte-exact restore — which nothing else asserts.
- *Byte-exact PNG equality is flake-prone* (Claude, Low). It is the assertion's entire point (a constant capture fails "different frame", a drifting one fails "byte-identical"), the clock is pinned across both reloads, and it has been stable across repeated runs.

**De-dup pass: "No actionable duplication."** All four strategies ran — S1 lexical (1974 lines ranked; best cross-file score 0.46), S2 clones (272 pairs, **zero** touching the new files), S3 index grep (3760 lines, by domain term), S4 hand reading of all added lines. The e2e reuses `mcp-rpc.mjs` rather than copying it; `Rgb`/`mix`/`gain` are forced by `Color.t` having no accessors or blend (verified in `color.funi`), and `hash01` is a two-call use of `Random.seed`/`Random.step`, not a new PRNG.

**Verification was re-run after the fixes** — build, 14 expects, the e2e on both release and debug binaries, `check:site`, `site:build`, and the full site e2e, all green at this head.
