### PR TITLE
feat(examples): netpong — authoritative multiplayer as roles-as-files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,9 +256,11 @@ reference and the SAME-FILE shape — one `game.fun` whose `client` and `server`
 both inline modules of it (`module Client { … }` / `module Server { … }`, with the
 protocol, the world step and the renderer shared bare above them), so one buffer
 hot-reloads both roles atomically and the sandbox runs the two panes off the same source.
-The roles-as-FILES form (one `.fun` per role over a shared sibling) is equally supported —
-reach for it once roles outgrow one buffer or want independent deploy units — but ships
-with no bundled example; the config/parsing tests cover it.
+**`examples/netpong`** is the roles-as-FILES counterpart — authoritative multiplayer Pong
+whose `client.fun` and `server.fun` are separate entry files over a shared `protocol.fun`
+and a shared `game.fun` renderer. Reach for that shape once roles outgrow one buffer or
+want independent deploy units. (`examples/lobby` is the same shape applied to discovery:
+a client, a game server, and a master server.)
 
 Under the hood: `build` typechecks the whole `.fun` project (diagnostics are errors) and
 **verifies every literal `Asset.*` locator**: a relative path must exist on disk (error — with

--- a/e2e/netpong.mjs
+++ b/e2e/netpong.mjs
@@ -148,7 +148,19 @@ try {
   // Restart only the authoritative server. The same original client must
   // observe the disconnect, retry, receive a fresh seat, and resume snapshots —
   // on the RESTARTED server's sequence, which counts from zero again.
-  const seqBeforeKill = (await getState(basePort + 1)).model.lastSnapshotSeq;
+  // Let the session build a high-water mark first. The check below is "the
+  // client came back on a LOWER sequence than it held", which only means
+  // anything if the old line is comfortably ahead of whatever a freshly
+  // started server reaches during the reconnect window — otherwise a short
+  // session and a quick restart can legitimately meet at the same number.
+  const SEQ_HEADROOM = 30;
+  const seqBeforeKill = (await waitFor(
+    `original client to bank a sequence of at least ${SEQ_HEADROOM}`,
+    async () => {
+      const state = await getState(basePort + 1);
+      return state.model.lastSnapshotSeq >= SEQ_HEADROOM ? state : false;
+    }
+  )).model.lastSnapshotSeq;
   server.kill("SIGTERM");
   await new Promise((done) => server.once("exit", done));
   const disconnected = await waitFor("original client to observe server shutdown", async () => {

--- a/e2e/netpong.mjs
+++ b/e2e/netpong.mjs
@@ -1,0 +1,286 @@
+// `examples/netpong` E2E: the multiplayer claims, over a REAL wire.
+//
+// Netpong's claims are all about two processes agreeing, which no inline
+// `expect` can reach — the expects pin the pure simulation, and this pins the
+// session. It launches the roles as INDEPENDENT `functor` processes (one
+// `--entry server`, two `--entry client`), each with its own debug port, and
+// lets their game traffic use the sample's actual WebSocket listener. Every
+// wait is a poll on observable state, never a sleep.
+//
+// It asserts:
+//
+//   1. a client started BEFORE the listener converges by itself — `Sub.connect`
+//      surfaces the failure, then retries into a seat and advancing snapshots,
+//      in the same process (no relaunch);
+//   2. restarting only the server does the same again: the client sees the
+//      disconnect, loses its seat, and the SAME process rejoins;
+//   3. two clients take seats 0 and 1 from the authority;
+//   4. real key input at a client reaches the server as a sequenced
+//      `PaddleIntent` on that client's own seat — nobody steers a paddle they
+//      were not given;
+//   5. a real rally scores and BOTH clients converge on the server scoreboard;
+//   6. the match is won, `R` requests a rematch, and the monotonic snapshot
+//      sequence lets the already-connected clients accept the reset;
+//   7. killing a client cleans up its seat server-side, and a replacement
+//      rejoins and resumes snapshots.
+//
+// Run (needs the CLI built; the wasm bundle is not required):
+//
+//   cargo build -p functor-cli --no-default-features
+//   node e2e/netpong.mjs
+//
+// Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
+import assert from "node:assert/strict";
+import net from "node:net";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const GAME_DIR = resolve(ROOT, "examples/netpong");
+const runner = process.env.FUNCTOR_BIN ?? resolve(ROOT, "target/debug/functor");
+const basePort = Number(process.env.NETPONG_DEBUG_PORT ?? 8318);
+// The sample's own listener, from `Protocol.bind` — real WebSocket traffic.
+const GAME_PORT = 9108;
+const children = [];
+
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+
+const start = (entry, port) => {
+  const child = spawn(runner, [
+    "-d", GAME_DIR, "--entry", entry, "run", "native", "--",
+    "--debug-port", String(port), "--headless",
+  ], { cwd: ROOT, stdio: ["ignore", "pipe", "pipe"] });
+  let log = "";
+  child.stdout.on("data", (b) => { log += b; });
+  child.stderr.on("data", (b) => { log += b; });
+  child.__log = () => log;
+  children.push(child);
+  return child;
+};
+
+const getState = async (port) => {
+  const response = await fetch(`http://127.0.0.1:${port}/state`);
+  if (!response.ok) throw new Error(`state ${port}: ${response.status} ${await response.text()}`);
+  return response.json();
+};
+
+const post = async (port, path, body) => {
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(`${path} ${port}: ${response.status} ${await response.text()}`);
+};
+
+const waitFor = async (description, probe, timeoutMs = 30000) => {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    try {
+      last = await probe();
+      if (last) return last;
+    } catch (error) {
+      last = error;
+    }
+    await sleep(50);
+  }
+  throw new Error(`timeout waiting for ${description}; last=${String(last)}`);
+};
+
+const waitDebug = (port) => waitFor(`debug port ${port}`, async () => {
+  const state = await getState(port);
+  return state.frame > 0 ? state : false;
+});
+
+const waitSocket = (port) => waitFor(`websocket listener ${port}`, () =>
+  new Promise((done) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    socket.once("connect", () => { socket.destroy(); done(true); });
+    socket.once("error", () => done(false));
+  }));
+
+const ctor = (value) => value?.$ctor;
+
+try {
+  // Start the client before any listener exists. `Sub.connect` must retain the
+  // subscription and converge without replacing this process.
+  const clientA = start("client", basePort + 1);
+  const clientAPid = clientA.pid;
+  await waitDebug(basePort + 1);
+  const earlyFailure = await waitFor("connect-before-listen error", async () => {
+    const state = await getState(basePort + 1);
+    return state.model.status.startsWith("NET ERROR:") ? state : false;
+  });
+  assert.equal(ctor(earlyFailure.model.conn), "Offline");
+
+  const connectBeforeListenStartedAt = Date.now();
+  let server = start("server", basePort);
+  await waitDebug(basePort);
+  await waitSocket(GAME_PORT);
+
+  const firstLive = await waitFor("original client to reconnect after listener starts", async () => {
+    const state = await getState(basePort + 1);
+    return state.model.status === "LIVE" && state.model.lastSnapshotSeq > 1
+      && (state.model.seat === 0 || state.model.seat === 1) ? state : false;
+  });
+  const connectBeforeListenMs = Date.now() - connectBeforeListenStartedAt;
+  const firstLiveSeq = firstLive.model.lastSnapshotSeq;
+  await waitFor("original client snapshots to advance", async () => {
+    const state = await getState(basePort + 1);
+    return state.model.lastSnapshotSeq > firstLiveSeq ? state : false;
+  });
+  assert.equal(clientA.pid, clientAPid);
+
+  // Restart only the authoritative server. The same original client must
+  // observe the disconnect, retry, receive a fresh seat, and resume snapshots.
+  server.kill("SIGTERM");
+  await new Promise((done) => server.once("exit", done));
+  const disconnected = await waitFor("original client to observe server shutdown", async () => {
+    const state = await getState(basePort + 1);
+    return state.model.status === "RECONNECTING" && state.model.seat === -1
+      && ctor(state.model.conn) === "Offline" ? state : false;
+  });
+  assert.equal(disconnected.model.seat, -1);
+  const serverRestartStartedAt = Date.now();
+  server = start("server", basePort);
+  await waitDebug(basePort);
+  await waitSocket(GAME_PORT);
+  const liveAfterServerRestart = await waitFor("original client after server restart", async () => {
+    const state = await getState(basePort + 1);
+    return state.model.status === "LIVE" && state.model.lastSnapshotSeq > firstLiveSeq
+      && (state.model.seat === 0 || state.model.seat === 1) ? state : false;
+  });
+  const serverRestartMs = Date.now() - serverRestartStartedAt;
+  const restartedServer = await getState(basePort);
+  assert.equal(restartedServer.model.players.length, 1);
+  assert.equal(restartedServer.model.players[0].seat, liveAfterServerRestart.model.seat);
+  const restartLiveSeq = liveAfterServerRestart.model.lastSnapshotSeq;
+  await waitFor("original client snapshots to advance after server restart", async () => {
+    const state = await getState(basePort + 1);
+    return state.model.lastSnapshotSeq > restartLiveSeq ? state : false;
+  });
+  assert.equal(clientA.pid, clientAPid);
+
+  let clientB = start("client", basePort + 2);
+  await waitDebug(basePort + 2);
+
+  const joined = await waitFor("server to own two connections", async () => {
+    const state = await getState(basePort);
+    return state.model.players.length === 2 ? state : false;
+  });
+  assert.deepEqual(joined.model.players.map((p) => p.seat).sort(), [0, 1]);
+
+  for (const port of [basePort + 1, basePort + 2]) {
+    const synced = await waitFor(`client ${port} snapshot convergence`, async () => {
+      const state = await getState(port);
+      return state.model.lastSnapshotSeq > 1 && state.model.status === "LIVE" ? state : false;
+    });
+    assert.ok(synced.model.seat === 0 || synced.model.seat === 1);
+  }
+
+  const clientASeat = (await getState(basePort + 1)).model.seat;
+  const intentSeqBefore = (await getState(basePort)).model.players
+    .find((p) => p.seat === clientASeat).intentSeq;
+
+  // Drive real input at client A and assert that the authoritative server saw it.
+  await post(basePort + 1, "/input", { type: "key", key: "S", down: true });
+  const intentSeen = await waitFor("client intent to reach authoritative server", async () => {
+    const state = await getState(basePort);
+    return state.model.players.some((p) => p.seat === clientASeat
+      && p.axis === -1 && p.intentSeq > intentSeqBefore) ? state : false;
+  });
+  assert.ok(intentSeen.model.players.find((p) => p.seat === clientASeat).intentSeq > 0);
+
+  // Client A is still holding `S`, so its paddle sits low and a real rally
+  // scores. Both clients must converge on the server's scoreboard.
+  const scored = await waitFor("a real authoritative point", async () => {
+    const state = await getState(basePort);
+    return state.model.leftScore + state.model.rightScore > 0 ? state : false;
+  }, 30000);
+  for (const port of [basePort + 1, basePort + 2]) {
+    const converged = await waitFor(`client ${port} scoreboard convergence`, async () => {
+      const state = await getState(port);
+      const t = state.model.target;
+      return t.leftScore === scored.model.leftScore && t.rightScore === scored.model.rightScore
+        ? state : false;
+    });
+    assert.equal(converged.model.target.leftScore + converged.model.target.rightScore,
+                 scored.model.leftScore + scored.model.rightScore);
+  }
+
+  const won = await waitFor("authoritative win state", async () => {
+    const state = await getState(basePort);
+    return ctor(state.model.phase) === "Protocol.Won" ? state : false;
+  }, 60000);
+  const wonSeq = won.model.snapshotSeq;
+  await post(basePort + 1, "/input", { type: "key", key: "R", down: true });
+  await post(basePort + 1, "/input", { type: "key", key: "R", down: false });
+  const rematched = await waitFor("rematch with monotonic snapshots", async () => {
+    const state = await getState(basePort);
+    return ctor(state.model.phase) === "Protocol.Serving"
+      && state.model.leftScore === 0 && state.model.rightScore === 0
+      && state.model.snapshotSeq > wonSeq ? state : false;
+  });
+  for (const port of [basePort + 1, basePort + 2]) {
+    await waitFor(`client ${port} rematch convergence`, async () => {
+      const state = await getState(port);
+      return state.model.lastSnapshotSeq > wonSeq
+        && state.model.target.leftScore === 0 && state.model.target.rightScore === 0
+        ? state : false;
+    });
+  }
+  await post(basePort + 1, "/input", { type: "key", key: "S", down: false });
+
+  // Disconnect and relaunch a whole client process. The server must remove the
+  // old connection, accept the new one, and snapshots must resume on that end.
+  clientB.kill("SIGTERM");
+  await new Promise((done) => clientB.once("exit", done));
+  const afterDrop = await waitFor("server disconnect cleanup", async () => {
+    const state = await getState(basePort);
+    return state.model.players.length === 1 ? state : false;
+  });
+  assert.equal(afterDrop.model.players.length, 1);
+  clientB = start("client", basePort + 2);
+  await waitDebug(basePort + 2);
+  const rejoined = await waitFor("replacement client to rejoin", async () => {
+    const state = await getState(basePort);
+    return state.model.players.length === 2 ? state : false;
+  });
+  assert.equal(rejoined.model.players.length, 2);
+  const resumed = await waitFor("replacement client snapshots", async () => {
+    const state = await getState(basePort + 2);
+    return state.model.lastSnapshotSeq > rejoined.model.snapshotSeq ? state : false;
+  });
+  assert.equal(resumed.model.status, "LIVE");
+
+  console.log(JSON.stringify({
+    ok: true,
+    processes: 3,
+    // The client that dialled before the listener existed is the SAME process
+    // at the end of the run — the two reconnects below were `Sub.connect`'s.
+    originalClientPid: clientAPid,
+    originalClientSurvivedServerRestart: clientA.pid === clientAPid,
+    connectBeforeListenMs,
+    serverRestartMs,
+    serverRestartSeat: liveAfterServerRestart.model.seat,
+    authoritativePoint: [scored.model.leftScore, scored.model.rightScore],
+    rematchSnapshotSeq: rematched.model.snapshotSeq,
+    serverPlayersAfterReconnect: rejoined.model.players.length,
+    clientSnapshots: [
+      (await getState(basePort + 1)).model.lastSnapshotSeq,
+      resumed.model.lastSnapshotSeq,
+    ],
+    serverPhase: ctor(rejoined.model.phase),
+  }, null, 2));
+} catch (error) {
+  for (const [index, child] of children.entries()) {
+    if (child.__log) process.stderr.write(`\n--- child ${index} ---\n${child.__log()}\n`);
+  }
+  throw error;
+} finally {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  }
+}

--- a/e2e/netpong.mjs
+++ b/e2e/netpong.mjs
@@ -13,7 +13,9 @@
 //      surfaces the failure, then retries into a seat and advancing snapshots,
 //      in the same process (no relaunch);
 //   2. restarting only the server does the same again: the client sees the
-//      disconnect, loses its seat, and the SAME process rejoins;
+//      disconnect, loses its seat, and the SAME process rejoins — adopting the
+//      restarted server's fresh snapshot sequence rather than waiting out the
+//      old one;
 //   3. two clients take seats 0 and 1 from the authority;
 //   4. real key input at a client reaches the server as a sequenced
 //      `PaddleIntent` on that client's own seat — nobody steers a paddle they
@@ -31,20 +33,37 @@
 //
 // Set FUNCTOR_BIN when the build uses a shared CARGO_TARGET_DIR.
 import assert from "node:assert/strict";
-import net from "node:net";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
+import { BIN as runner, ROOT, portIsBound, sleep, waitForPort } from "./mcp-rpc.mjs";
 
-const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const GAME_DIR = resolve(ROOT, "examples/netpong");
-const runner = process.env.FUNCTOR_BIN ?? resolve(ROOT, "target/debug/functor");
 const basePort = Number(process.env.NETPONG_DEBUG_PORT ?? 8318);
-// The sample's own listener, from `Protocol.bind` — real WebSocket traffic.
+// The sample's own listener, from `Protocol.bind` — real WebSocket traffic. It
+// is baked into the .fun, so unlike the debug ports it cannot be moved.
 const GAME_PORT = 9108;
 const children = [];
 
-const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+// Fixed ports mean a leftover process from a crashed run — or a hand-launched
+// `functor -d examples/netpong run native --entry server` — would be mistaken
+// for the server this test starts. Fail loudly instead of asserting against
+// somebody else's game.
+for (const port of [GAME_PORT, basePort, basePort + 1, basePort + 2]) {
+  if (await portIsBound(port)) {
+    console.error(`port ${port} is already in use — kill the process on it first`);
+    process.exit(1);
+  }
+}
+
+/** Wait until nothing is listening on `port` — a killed server must release
+ *  its listener before the replacement can bind it. */
+const waitPortFree = async (port, timeoutMs = 15000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (await portIsBound(port)) {
+    if (Date.now() > deadline) throw new Error(`port ${port} never freed`);
+    await sleep(100);
+  }
+};
 
 const start = (entry, port) => {
   const child = spawn(runner, [
@@ -94,13 +113,6 @@ const waitDebug = (port) => waitFor(`debug port ${port}`, async () => {
   return state.frame > 0 ? state : false;
 });
 
-const waitSocket = (port) => waitFor(`websocket listener ${port}`, () =>
-  new Promise((done) => {
-    const socket = net.createConnection({ host: "127.0.0.1", port });
-    socket.once("connect", () => { socket.destroy(); done(true); });
-    socket.once("error", () => done(false));
-  }));
-
 const ctor = (value) => value?.$ctor;
 
 try {
@@ -118,7 +130,7 @@ try {
   const connectBeforeListenStartedAt = Date.now();
   let server = start("server", basePort);
   await waitDebug(basePort);
-  await waitSocket(GAME_PORT);
+  await waitForPort(GAME_PORT);
 
   const firstLive = await waitFor("original client to reconnect after listener starts", async () => {
     const state = await getState(basePort + 1);
@@ -131,10 +143,12 @@ try {
     const state = await getState(basePort + 1);
     return state.model.lastSnapshotSeq > firstLiveSeq ? state : false;
   });
-  assert.equal(clientA.pid, clientAPid);
+  assert.equal(clientA.exitCode, null, "client A is still the original live process");
 
   // Restart only the authoritative server. The same original client must
-  // observe the disconnect, retry, receive a fresh seat, and resume snapshots.
+  // observe the disconnect, retry, receive a fresh seat, and resume snapshots —
+  // on the RESTARTED server's sequence, which counts from zero again.
+  const seqBeforeKill = (await getState(basePort + 1)).model.lastSnapshotSeq;
   server.kill("SIGTERM");
   await new Promise((done) => server.once("exit", done));
   const disconnected = await waitFor("original client to observe server shutdown", async () => {
@@ -143,16 +157,25 @@ try {
       && ctor(state.model.conn) === "Offline" ? state : false;
   });
   assert.equal(disconnected.model.seat, -1);
+  await waitPortFree(GAME_PORT);
   const serverRestartStartedAt = Date.now();
   server = start("server", basePort);
   await waitDebug(basePort);
-  await waitSocket(GAME_PORT);
+  await waitForPort(GAME_PORT);
   const liveAfterServerRestart = await waitFor("original client after server restart", async () => {
     const state = await getState(basePort + 1);
-    return state.model.status === "LIVE" && state.model.lastSnapshotSeq > firstLiveSeq
+    return state.model.status === "LIVE" && state.model.lastSnapshotSeq >= 1
       && (state.model.seat === 0 || state.model.seat === 1) ? state : false;
   });
   const serverRestartMs = Date.now() - serverRestartStartedAt;
+  // The point of the reset: the client goes LIVE again on a seq BELOW the one
+  // it held before the kill. Carrying the old high-water mark over would make
+  // it wait out the whole old count before drawing anything.
+  assert.ok(
+    liveAfterServerRestart.model.lastSnapshotSeq < seqBeforeKill,
+    `reconnect must adopt the restarted server's fresh sequence ` +
+      `(${liveAfterServerRestart.model.lastSnapshotSeq} < ${seqBeforeKill})`
+  );
   const restartedServer = await getState(basePort);
   assert.equal(restartedServer.model.players.length, 1);
   assert.equal(restartedServer.model.players[0].seat, liveAfterServerRestart.model.seat);
@@ -161,7 +184,7 @@ try {
     const state = await getState(basePort + 1);
     return state.model.lastSnapshotSeq > restartLiveSeq ? state : false;
   });
-  assert.equal(clientA.pid, clientAPid);
+  assert.equal(clientA.exitCode, null, "client A is still the original live process");
 
   let clientB = start("client", basePort + 2);
   await waitDebug(basePort + 2);
@@ -194,11 +217,15 @@ try {
   assert.ok(intentSeen.model.players.find((p) => p.seat === clientASeat).intentSeq > 0);
 
   // Client A is still holding `S`, so its paddle sits low and a real rally
-  // scores. Both clients must converge on the server's scoreboard.
+  // scores. Baseline first: the attract-mode AI has been playing through two
+  // reconnects, so "score > 0" alone could be satisfied by a point that was
+  // already on the board. Both clients must converge on the server's scoreboard.
+  const scoreBefore = (await getState(basePort)).model;
+  const totalBefore = scoreBefore.leftScore + scoreBefore.rightScore;
   const scored = await waitFor("a real authoritative point", async () => {
     const state = await getState(basePort);
-    return state.model.leftScore + state.model.rightScore > 0 ? state : false;
-  }, 30000);
+    return state.model.leftScore + state.model.rightScore > totalBefore ? state : false;
+  }, 60000);
   for (const port of [basePort + 1, basePort + 2]) {
     const converged = await waitFor(`client ${port} scoreboard convergence`, async () => {
       const state = await getState(port);
@@ -213,7 +240,7 @@ try {
   const won = await waitFor("authoritative win state", async () => {
     const state = await getState(basePort);
     return ctor(state.model.phase) === "Protocol.Won" ? state : false;
-  }, 60000);
+  }, 180000);
   const wonSeq = won.model.snapshotSeq;
   await post(basePort + 1, "/input", { type: "key", key: "R", down: true });
   await post(basePort + 1, "/input", { type: "key", key: "R", down: false });
@@ -261,7 +288,7 @@ try {
     // The client that dialled before the listener existed is the SAME process
     // at the end of the run — the two reconnects below were `Sub.connect`'s.
     originalClientPid: clientAPid,
-    originalClientSurvivedServerRestart: clientA.pid === clientAPid,
+    originalClientSurvivedServerRestart: clientA.exitCode === null,
     connectBeforeListenMs,
     serverRestartMs,
     serverRestartSeat: liveAfterServerRestart.model.seat,
@@ -280,7 +307,13 @@ try {
   }
   throw error;
 } finally {
-  for (const child of children) {
-    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
-  }
+  // Await every exit: the next run's port preflight (and a back-to-back
+  // invocation of this one) must not race a still-shutting-down listener.
+  await Promise.all(
+    children.map((child) => {
+      if (child.exitCode !== null || child.signalCode !== null) return null;
+      child.kill("SIGTERM");
+      return new Promise((done) => child.once("exit", done));
+    })
+  );
 }

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -106,10 +106,17 @@ function entrySource(sample) {
     readFileSync(`${ROOT}/examples/${sample}/functor.json`, "utf8"),
   );
   // A multi-entry project (functor.json `entries`) is served at the role the
-  // CLI defaults to — `client`, or the sole entry — which for a roles-as-FILES
+  // CLI defaults to, and this mirrors the CLI's rule exactly (see
+  // cli/src/commands/functor_lang_project.rs): the SOLE entry, else `client`,
+  // else it is ambiguous and `--entry` is required — which for a roles-as-FILES
   // sample is NOT game.fun. A role may also be an object naming a shared file.
   const roles = cfg.entries ? Object.keys(cfg.entries) : null;
-  const role = roles ? cfg.entries[roles.includes("client") ? "client" : roles[0]] : cfg.entry;
+  let role = cfg.entry;
+  if (roles) {
+    const name = roles.length === 1 ? roles[0] : roles.includes("client") ? "client" : null;
+    if (!name) throw new Error(`${sample}: ambiguous entries (${roles}) — no default role`);
+    role = cfg.entries[name];
+  }
   const entry = (typeof role === "object" ? role.file : role) || "game.fun";
   return readFileSync(`${ROOT}/examples/${sample}/${entry}`, "utf8");
 }

--- a/e2e/wasm-smoke.mjs
+++ b/e2e/wasm-smoke.mjs
@@ -105,7 +105,12 @@ function entrySource(sample) {
   const cfg = JSON.parse(
     readFileSync(`${ROOT}/examples/${sample}/functor.json`, "utf8"),
   );
-  const entry = cfg.entry || "game.fun";
+  // A multi-entry project (functor.json `entries`) is served at the role the
+  // CLI defaults to — `client`, or the sole entry — which for a roles-as-FILES
+  // sample is NOT game.fun. A role may also be an object naming a shared file.
+  const roles = cfg.entries ? Object.keys(cfg.entries) : null;
+  const role = roles ? cfg.entries[roles.includes("client") ? "client" : roles[0]] : cfg.entry;
+  const entry = (typeof role === "object" ? role.file : role) || "game.fun";
   return readFileSync(`${ROOT}/examples/${sample}/${entry}`, "utf8");
 }
 

--- a/examples/netpong/client.fun
+++ b/examples/netpong/client.fun
@@ -1,0 +1,174 @@
+// client.fun — Netpong: authoritative Pong over a REAL wire.
+//   functor -d examples/netpong run native --entry server   # the authority
+//   functor -d examples/netpong run native                  # a paddle dials it
+//   functor -d examples/netpong run native                  # …and a second
+// W/S or ↑/↓ steer your paddle (and take it off autopilot), Space toggles
+// autopilot back on, R asks for a rematch once someone has won. Nobody has to
+// connect: with no clients the server plays itself, so the sample is its own
+// attract mode.
+//
+// Netpong is the roles-as-FILES multiplayer reference. Each role is its own
+// buffer — `client.fun` here, `server.fun` beside it — over a shared
+// `protocol.fun` and a shared `game.fun` renderer, with functor.json naming
+// the two entry FILES. `examples/orbs` is the other half of the pair: both of
+// ITS roles are inline `module` blocks of one `game.fun`, so one edit reloads
+// both atomically. Reach for orbs while the whole game fits in one buffer;
+// reach for THIS shape once the roles outgrow it or want to deploy apart.
+//
+// What this file owns is presentation, not truth. `target` is the newest
+// server snapshot; `render` is what you actually see. `tick` moves the local
+// paddle IMMEDIATELY off local input (prediction — no round trip), eases it
+// back toward the server's copy (reconciliation), and interpolates the remote
+// paddle and the ball between the 20 Hz snapshots. Both are ordinary model
+// data, so the inspector and time travel can read the divergence.
+
+type ConnState = | Offline | Online(id: float)
+
+type Model = {
+  conn: ConnState,
+  seat: float,             // which paddle the server handed us; -1 = unseated
+  status: string,
+  target: Protocol.Snapshot,   // the newest server truth
+  render: Protocol.Snapshot,   // what is drawn: predicted + interpolated
+  axis: float,             // held steering, -1/0/+1, echoed to the server
+  autopilot: bool,
+  intentSeq: float,        // OUR sequence, so the server drops stale intents
+  sendClock: float,        // 20 Hz intent cadence
+  lastSnapshotSeq: float,  // THEIRS, so we drop snapshots that arrive late
+}
+
+type Msg =
+  | Joined(id: float)
+  | Packet(id: float, wire: Protocol.Wire)
+  | Dropped
+  | ConnErr(text: string)
+
+let init: Model = {
+  conn: Offline, seat: -1.0, status: "CONNECTING",
+  target: Protocol.initialSnapshot(), render: Protocol.initialSnapshot(),
+  axis: 0.0, autopilot: true,
+  intentSeq: 0.0, sendClock: 0.0, lastSnapshotSeq: -1.0,
+}
+
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => Joined(id)
+  | Net.Data(id, wire) => Packet(id, wire)
+  | Net.Message(_, _) => ConnErr("unexpected text frame")
+  | Net.Disconnected(_) => Dropped
+  | Net.Error(_, message) => ConnErr(message)
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  | Joined(id) => ({ m with conn: Online(id), status: "CONNECTED", sendClock: 0.0 },
+                   Effect.sendMsg(id, Protocol.PaddleIntent(m.intentSeq, m.axis)))
+  | Packet(_, wire) =>
+      (match wire with
+       | Protocol.Welcome(seat) => { m with seat: seat, status: "SYNCED" }
+       // Snapshots are the whole world, so an out-of-order one is not a merge
+       // problem — it is simply older truth. Compare sequence and drop it.
+       | Protocol.State(s) =>
+           if s.seq > m.lastSnapshotSeq
+           then { m with target: s, lastSnapshotSeq: s.seq, status: "LIVE" }
+           else m
+       | _ => m)
+  | Dropped => { m with conn: Offline, seat: -1.0, status: "RECONNECTING" }
+  | ConnErr(message) => { m with conn: Offline, status: Text.concat("NET ERROR: ", message) }
+
+// One declarative line is the whole transport. `Sub.connect` keeps the
+// connection up: dial before the server exists, or restart the server
+// underneath us, and it retries with bounded backoff — the failure arrives as
+// an ordered `Net.Error`, then `Net.Connected` when it lands.
+let subscriptions = (m: Model) => Sub.connect(Protocol.serverUrl, toMsg)
+
+let keyHeld = (key: Key.t, snapshot: Input.snapshot): bool =>
+  snapshot.heldKeys |> List.any((held) => held == key)
+
+let sampledInput = (m: Model, sample: Input.snapshot): Model =>
+  let up = keyHeld(Key.W, sample) || keyHeld(Key.Up, sample) in
+  let down = keyHeld(Key.S, sample) || keyHeld(Key.Down, sample) in
+  let toggleAuto = sample.pressedKeys |> List.any((key) => key == Key.Space) in
+  let axis = (if up then 1.0 else 0.0) - (if down then 1.0 else 0.0) in
+  let toggled = if toggleAuto then { m with autopilot: not m.autopilot } else m in
+  if up || down then { toggled with axis: axis, autopilot: false }
+  else if toggled.autopilot then toggled
+  else { toggled with axis: 0.0 }
+
+let input = (m: Model, key: Key.t, isDown: bool) =>
+  if isDown && key == Key.R then
+    match m.conn with
+    | Online(id) => (m, Effect.sendMsg(id, Protocol.Rematch))
+    | Offline => m
+  else m
+
+let lerp = (from: float, target: float, amount: float): float =>
+  from + (target - from) * Math.clamp(0.0, 1.0, amount)
+
+let autoAxis = (m: Model): float =>
+  let ownY = if m.seat == 1.0 then m.render.rightY else m.render.leftY in
+  let delta = m.target.ballY - ownY in
+  if Math.abs(delta) < 0.32 then 0.0 else Math.sign(delta)
+
+// The heart of the sample: `target` (server truth) -> `render` (what you see).
+// OUR paddle is predicted — it moves this frame off local input, then eases
+// toward the server's copy so a correction is a slide, not a snap. Everything
+// else is interpolated toward the target. A phase change or a score means the
+// world DISCONTINUED, so ball and trail snap instead of sweeping across the
+// court through positions that never happened.
+let smooth = (m: Model, dt: float, axis: float): Protocol.Snapshot =>
+  let k = Math.clamp(0.0, 1.0, dt * 13.0) in
+  let predictedLeft =
+    if m.seat == 0.0
+    then Math.clamp(0.0 - Protocol.paddleYLimit, Protocol.paddleYLimit,
+               m.render.leftY + axis * Protocol.paddleSpeed * dt)
+    else lerp(m.render.leftY, m.target.leftY, k) in
+  let predictedRight =
+    if m.seat == 1.0
+    then Math.clamp(0.0 - Protocol.paddleYLimit, Protocol.paddleYLimit,
+               m.render.rightY + axis * Protocol.paddleSpeed * dt)
+    else lerp(m.render.rightY, m.target.rightY, k) in
+  let continuous = m.render.phase == Protocol.Rally && m.target.phase == Protocol.Rally
+    && m.render.leftScore == m.target.leftScore && m.render.rightScore == m.target.rightScore in
+  { m.target with
+      leftY: if m.seat == 0.0 then lerp(predictedLeft, m.target.leftY, dt * 2.2) else predictedLeft,
+      rightY: if m.seat == 1.0 then lerp(predictedRight, m.target.rightY, dt * 2.2) else predictedRight,
+      ballX: if continuous then lerp(m.render.ballX, m.target.ballX, k) else m.target.ballX,
+      ballY: if continuous then lerp(m.render.ballY, m.target.ballY, k) else m.target.ballY,
+      trail: if continuous then
+               [Protocol.point(lerp(m.render.ballX, m.target.ballX, k),
+                               lerp(m.render.ballY, m.target.ballY, k)), ..m.render.trail]
+               |> List.take(15.0)
+             else m.target.trail }
+
+// Render every frame; send at 20 Hz. Subtracting the interval (rather than
+// zeroing the clock) keeps the leftover, so the cadence doesn't drift with the
+// frame rate — but while offline the clock is capped at one interval, or a
+// long disconnect would burst a queue of intents the moment it reconnects.
+let tick = (m: Model, dt: float, tts: float) =>
+  let axis = if m.autopilot then autoAxis(m) else m.axis in
+  let nextClock = m.sendClock + dt in
+  let next = { m with render: smooth(m, dt, axis), axis: axis, sendClock: nextClock } in
+  if nextClock >= 0.05 then
+    match m.conn with
+    | Online(id) =>
+        let seq = m.intentSeq + 1.0 in
+        ({ next with sendClock: nextClock - 0.05, intentSeq: seq },
+         Effect.sendMsg(id, Protocol.PaddleIntent(seq, axis)))
+    | Offline => { next with sendClock: Math.min(0.05, nextClock) }
+  else next
+
+let draw = (m: Model, tts: float): Frame.t => Game.view(m.render, m.status, m.seat, m.autopilot)
+
+expect Math.abs(lerp(0.0, 10.0, 0.25) - 2.5) < 0.0001
+expect (
+  let m = { init with seat: 0.0, axis: 1.0, autopilot: false } in
+  let predicted = smooth(m, 0.05, 1.0) in
+  predicted.leftY > 0.4)
+expect (
+  let old = { Protocol.initialSnapshot() with phase: Protocol.Rally,
+                                                   ballX: 12.0,
+                                                   trail: [Protocol.point(11.0, 1.0)] } in
+  let target = { Protocol.initialSnapshot() with phase: Protocol.Serving(1.0) } in
+  let m = { init with render: old, target: target } in
+  let reset = smooth(m, 0.05, 0.0) in
+  reset.ballX == 0.0 && List.isEmpty(reset.trail))

--- a/examples/netpong/client.fun
+++ b/examples/netpong/client.fun
@@ -18,9 +18,11 @@
 // What this file owns is presentation, not truth. `target` is the newest
 // server snapshot; `render` is what you actually see. `tick` moves the local
 // paddle IMMEDIATELY off local input (prediction — no round trip), eases it
-// back toward the server's copy (reconciliation), and interpolates the remote
-// paddle and the ball between the 20 Hz snapshots. Both are ordinary model
-// data, so the inspector and time travel can read the divergence.
+// back toward the server's copy (a soft correction), and eases the remote
+// paddle and the ball toward each new 20 Hz snapshot instead of snapping to
+// it. Both are ordinary model data, so the inspector and time travel can read
+// the divergence — and the render is deliberately a hair BEHIND truth, which
+// is what buys the smoothness.
 
 type ConnState = | Offline | Online(id: float)
 
@@ -29,7 +31,7 @@ type Model = {
   seat: float,             // which paddle the server handed us; -1 = unseated
   status: string,
   target: Protocol.Snapshot,   // the newest server truth
-  render: Protocol.Snapshot,   // what is drawn: predicted + interpolated
+  render: Protocol.Snapshot,   // what is drawn: predicted + smoothed
   axis: float,             // held steering, -1/0/+1, echoed to the server
   autopilot: bool,
   intentSeq: float,        // OUR sequence, so the server drops stale intents
@@ -60,7 +62,11 @@ let toMsg = (ev: Net.NetEvent): Msg =>
 
 let update = (m: Model, msg: Msg) =>
   match msg with
-  | Joined(id) => ({ m with conn: Online(id), status: "CONNECTED", sendClock: 0.0 },
+  // A new connection is a new sequence namespace: a restarted server counts
+  // from zero again, so carrying the old high-water mark over would make every
+  // snapshot of the new match look stale and freeze the screen.
+  | Joined(id) => ({ m with conn: Online(id), status: "CONNECTED", sendClock: 0.0,
+                            lastSnapshotSeq: -1.0 },
                    Effect.sendMsg(id, Protocol.PaddleIntent(m.intentSeq, m.axis)))
   | Packet(_, wire) =>
       (match wire with
@@ -73,7 +79,10 @@ let update = (m: Model, msg: Msg) =>
            else m
        | _ => m)
   | Dropped => { m with conn: Offline, seat: -1.0, status: "RECONNECTING" }
-  | ConnErr(message) => { m with conn: Offline, status: Text.concat("NET ERROR: ", message) }
+  // Report the error, but do NOT tear the connection down: a failed dial is
+  // already Offline (and `Sub.connect` is retrying), while a corrupt frame
+  // arrives as an error on a link that is still perfectly up.
+  | ConnErr(message) => { m with status: Text.concat("NET ERROR: ", message) }
 
 // One declarative line is the whole transport. `Sub.connect` keeps the
 // connection up: dial before the server exists, or restart the server
@@ -112,10 +121,15 @@ let autoAxis = (m: Model): float =>
 // The heart of the sample: `target` (server truth) -> `render` (what you see).
 // OUR paddle is predicted — it moves this frame off local input, then eases
 // toward the server's copy so a correction is a slide, not a snap. Everything
-// else is interpolated toward the target. A phase change or a score means the
-// world DISCONTINUED, so ball and trail snap instead of sweeping across the
-// court through positions that never happened.
-let smooth = (m: Model, dt: float, axis: float): Protocol.Snapshot =>
+// else eases toward the target as well: exponential smoothing on the newest
+// snapshot, not a two-snapshot time-buffered interpolator, so the render
+// trails truth by a fraction of a snapshot and never overshoots it. A phase
+// change or a score means the world DISCONTINUED, so ball and trail snap
+// instead of sweeping across the court through positions that never happened.
+let smooth = (m: Model, rawDt: float, axis: float): Protocol.Snapshot =>
+  // Bound the step exactly as the server bounds its own: a frame hitch must
+  // not predict our paddle further than the authority will ever move it.
+  let dt = Math.clamp(0.0, 0.05, rawDt) in
   let k = Math.clamp(0.0, 1.0, dt * 13.0) in
   let predictedLeft =
     if m.seat == 0.0
@@ -140,10 +154,11 @@ let smooth = (m: Model, dt: float, axis: float): Protocol.Snapshot =>
                |> List.take(15.0)
              else m.target.trail }
 
-// Render every frame; send at 20 Hz. Subtracting the interval (rather than
-// zeroing the clock) keeps the leftover, so the cadence doesn't drift with the
-// frame rate — but while offline the clock is capped at one interval, or a
-// long disconnect would burst a queue of intents the moment it reconnects.
+// Render every frame; send at 20 Hz. Keeping the leftover (rather than zeroing
+// the clock) stops the cadence drifting with the frame rate; taking it modulo
+// the interval also collapses a backlog, because an intent is a held LEVEL, not
+// an event that has to be replayed. Offline the clock is pinned at one interval
+// for the same reason: a long disconnect must not burst on reconnect.
 let tick = (m: Model, dt: float, tts: float) =>
   let axis = if m.autopilot then autoAxis(m) else m.axis in
   let nextClock = m.sendClock + dt in
@@ -152,9 +167,9 @@ let tick = (m: Model, dt: float, tts: float) =>
     match m.conn with
     | Online(id) =>
         let seq = m.intentSeq + 1.0 in
-        ({ next with sendClock: nextClock - 0.05, intentSeq: seq },
+        ({ next with sendClock: Math.mod(nextClock, 0.05), intentSeq: seq },
          Effect.sendMsg(id, Protocol.PaddleIntent(seq, axis)))
-    | Offline => { next with sendClock: Math.min(0.05, nextClock) }
+    | Offline => { next with sendClock: 0.05 }
   else next
 
 let draw = (m: Model, tts: float): Frame.t => Game.view(m.render, m.status, m.seat, m.autopilot)

--- a/examples/netpong/functor.json
+++ b/examples/netpong/functor.json
@@ -1,0 +1,8 @@
+{
+  "language": "functor-lang",
+  "entries": {
+    "client": "client.fun",
+    "server": "server.fun"
+  },
+  "mouseCapture": false
+}

--- a/examples/netpong/game.fun
+++ b/examples/netpong/game.fun
@@ -1,0 +1,110 @@
+// gallery: Netpong — authoritative multiplayer Pong with prediction, interpolation, and neon AI attract mode.
+// gallery-controls: W/S or ↑/↓ steer · Space toggles autopilot · R requests a rematch
+
+// game.fun — the renderer both roles call, as `Game.view`.
+//
+// It is not an entry point: functor.json names client.fun and server.fun, and
+// this file is just their shared sibling. It takes a plain
+// `Protocol.Snapshot` and knows nothing about who produced it — which is why
+// the server window and every client window draw the same court, and why a
+// client can hand it PREDICTED state without the renderer caring.
+//
+// Asset-free 2D: every pixel below is a `Sprite` primitive.
+
+let navy = Color.rgb(0.012, 0.018, 0.065)
+let deep = Color.rgb(0.028, 0.035, 0.115)
+let cyan = Color.rgb(0.12, 0.94, 1.0)
+let pink = Color.rgb(1.0, 0.18, 0.68)
+let white = Color.rgb(0.92, 0.98, 1.0)
+let violet = Color.rgb(0.48, 0.25, 0.94)
+let muted = Color.rgb(0.35, 0.48, 0.68)
+let camera = Camera2D.create(32.0, 20.0)
+
+let stars = (): List<Sprite.t> =>
+  List.range(42.0)
+  |> List.map((i) =>
+    let x = -15.4 + Math.mod(i * 8.17, 30.8) in
+    let y = -9.4 + Math.mod(i * 5.31, 18.8) in
+    Sprite.circle(if Math.mod(i, 4.0) == 0.0 then pink else cyan,
+                  if Math.mod(i, 3.0) == 0.0 then 0.055 else 0.032)
+    |> Sprite.fade(0.2 + Math.mod(i, 5.0) * 0.055)
+    |> Sprite.move(x, y))
+
+let trailSprites = (trail: List<Protocol.Point>): List<Sprite.t> =>
+  trail |> List.indexedMap((i, p) =>
+    let size = Math.max(0.035, 0.27 - i * 0.017) in
+    Sprite.circle(cyan, size)
+    |> Sprite.fade(Math.max(0.03, 0.34 - i * 0.022))
+    |> Sprite.move(p.x, p.y))
+
+let paddle = (x: float, y: float, color: Color.t, pulse: float): Sprite.t =>
+  let glow = 0.12 + pulse * 0.22 in
+  Sprite.group([
+    Sprite.rectangle(color, 0.78 + pulse * 0.18, 3.25 + pulse * 0.3)
+      |> Sprite.fade(glow),
+    Sprite.rectangle(color, 0.42, 2.9),
+    Sprite.rectangle(white, 0.12, 2.35) |> Sprite.fade(0.72),
+  ]) |> Sprite.move(x, y)
+
+let scanLines = (): List<Sprite.t> =>
+  List.range(16.0)
+  |> List.map((i) =>
+    Sprite.rectangle(violet, 25.8, 0.025)
+    |> Sprite.fade(0.12)
+    |> Sprite.moveY(-7.0 + i * 0.9))
+
+let view = (s: Protocol.Snapshot, status: string, seat: float, autopilot: bool): Frame.t =>
+  let phaseText = Protocol.phaseLabel(s.phase) in
+  let pulse = Math.max(s.hitPulse, s.scorePulse) in
+  let centerMarks =
+    List.range(11.0)
+    |> List.map((i) =>
+      Sprite.rectangle(muted, 0.08, 0.6)
+      |> Sprite.fade(0.42)
+      |> Sprite.moveY(-5.0 + i)) in
+  let ball = Sprite.group([
+    Sprite.circle(cyan, 0.92 + pulse * 0.25) |> Sprite.fade(0.055 + pulse * 0.04),
+    Sprite.circle(cyan, 0.55) |> Sprite.fade(0.18),
+    Sprite.circle(white, Protocol.ballRadius),
+    Sprite.circle(cyan, 0.12) |> Sprite.move(-0.1, 0.12),
+  ]) |> Sprite.move(s.ballX, s.ballY) in
+  let score = Sprite.group([
+    Sprite.text(cyan, 1.5, Text.fixed(s.leftScore, 0.0)) |> Sprite.move(-4.2, 7.75),
+    Sprite.text(muted, 0.52, "FIRST TO 5") |> Sprite.move(0.0, 7.8),
+    Sprite.text(pink, 1.5, Text.fixed(s.rightScore, 0.0)) |> Sprite.move(4.2, 7.75),
+  ]) in
+  let banner =
+    if phaseText == "" then Sprite.blank()
+    else Sprite.group([
+      Sprite.rectangle(deep, 11.5, 1.55) |> Sprite.fade(0.94),
+      Sprite.rectangle(cyan, 11.1, 0.055) |> Sprite.moveY(0.73),
+      Sprite.text(white, 0.66, phaseText),
+      (match s.phase with
+       | Protocol.Won(_) => Sprite.text(muted, 0.28, "PRESS R TO REMATCH") |> Sprite.moveY(-0.47)
+       | _ => Sprite.blank()),
+    ]) |> Sprite.moveY(-0.15) in
+  let mode =
+    if seat < 0.0 then "AUTHORITATIVE SERVER  //  AI ATTRACT"
+    else $"SEAT {Text.fixed(seat + 1.0, 0.0)}  //  {if autopilot then "AUTOPILOT" else "MANUAL"}  //  {status}" in
+  Frame.create2D(camera, Sprite.group([
+    Sprite.rectangle(navy, 32.0, 20.0),
+    Sprite.group(stars()),
+    Sprite.rectangle(deep, 27.1, 15.0),
+    Sprite.rectangle(navy, 26.3, 14.2),
+    Sprite.group(scanLines()),
+    Sprite.rectangle(cyan, 26.2, 0.08) |> Sprite.fade(0.55) |> Sprite.moveY(7.05),
+    Sprite.rectangle(pink, 26.2, 0.08) |> Sprite.fade(0.55) |> Sprite.moveY(-7.05),
+    Sprite.group(centerMarks),
+    Sprite.group(trailSprites(s.trail)),
+    paddle(0.0 - Protocol.paddleX, s.leftY, cyan, s.hitPulse),
+    paddle(Protocol.paddleX, s.rightY, pink, s.hitPulse),
+    ball,
+    score,
+    banner,
+    Sprite.text(cyan, 0.7, "N E T P O N G") |> Sprite.moveY(9.0),
+    Sprite.text(muted, 0.3, mode) |> Sprite.moveY(-8.65),
+    Sprite.text(muted, 0.25, "SERVER TRUTH  //  CLIENT PREDICTION  //  SNAPSHOT INTERPOLATION")
+      |> Sprite.moveY(-9.18),
+    Sprite.rectangle(if s.scorePulse > 0.0 then pink else cyan, 31.0, 19.0)
+      |> Sprite.fade(s.scorePulse * 0.09),
+  ]))

--- a/examples/netpong/protocol.fun
+++ b/examples/netpong/protocol.fun
@@ -13,15 +13,16 @@ type Phase =
 
 type Point = { x: float, y: float }
 
+// The whole world, every 50 ms. `seq` is the only bookkeeping: a client
+// compares it and drops anything that is not newer. Nothing here is a delta,
+// and nothing is here that the renderer does not draw — the ball's VELOCITY
+// stays server-side, because this client extrapolates nothing.
 type Snapshot = {
   seq: float,
-  serverTime: float,
   leftY: float,
   rightY: float,
   ballX: float,
   ballY: float,
-  ballVx: float,
-  ballVy: float,
   leftScore: float,
   rightScore: float,
   phase: Phase,
@@ -52,13 +53,10 @@ let point = (x: float, y: float): Point => { x: x, y: y }
 
 let initialSnapshot = (): Snapshot => {
   seq: 0.0,
-  serverTime: 0.0,
   leftY: 0.0,
   rightY: 0.0,
   ballX: 0.0,
   ballY: 0.0,
-  ballVx: -9.0,
-  ballVy: 4.2,
   leftScore: 0.0,
   rightScore: 0.0,
   phase: Serving(2.2),

--- a/examples/netpong/protocol.fun
+++ b/examples/netpong/protocol.fun
@@ -1,0 +1,77 @@
+// protocol.fun — what the two role FILES agree on, declared exactly once.
+//
+// `file = module`, so `client.fun` and `server.fun` both see this as
+// `Protocol.*` with no import and no drift: the wire ADT, the snapshot shape,
+// and the court constants that the simulation and the renderer must share.
+// Values cross the socket as plain Functor data through `Effect.sendMsg` /
+// `Net.Data` — there is no string codec, so a typo is a check-time error.
+
+type Phase =
+  | Serving(seconds: float)
+  | Rally
+  | Won(seat: float)
+
+type Point = { x: float, y: float }
+
+type Snapshot = {
+  seq: float,
+  serverTime: float,
+  leftY: float,
+  rightY: float,
+  ballX: float,
+  ballY: float,
+  ballVx: float,
+  ballVy: float,
+  leftScore: float,
+  rightScore: float,
+  phase: Phase,
+  hitPulse: float,
+  scorePulse: float,
+  trail: List<Point>,
+}
+
+type Wire =
+  | Welcome(seat: float)
+  | PaddleIntent(seq: float, axis: float)
+  | State(snapshot: Snapshot)
+  | Rematch
+
+let bind = "127.0.0.1:9108"
+let serverUrl = "ws://127.0.0.1:9108/play"
+
+let courtHalfWidth = 13.0
+let courtHalfHeight = 7.0
+let paddleYLimit = 5.35
+let paddleHalfHeight = 1.45
+let paddleX = 11.35
+let ballRadius = 0.34
+let paddleSpeed = 11.5
+let winningScore = 5.0
+
+let point = (x: float, y: float): Point => { x: x, y: y }
+
+let initialSnapshot = (): Snapshot => {
+  seq: 0.0,
+  serverTime: 0.0,
+  leftY: 0.0,
+  rightY: 0.0,
+  ballX: 0.0,
+  ballY: 0.0,
+  ballVx: -9.0,
+  ballVy: 4.2,
+  leftScore: 0.0,
+  rightScore: 0.0,
+  phase: Serving(2.2),
+  hitPulse: 0.0,
+  scorePulse: 0.0,
+  trail: [],
+}
+
+let phaseLabel = (phase: Phase): string =>
+  match phase with
+  | Serving(seconds) => $"SERVE IN {Text.fixed(Math.ceil(seconds), 0.0)}"
+  | Rally => ""
+  | Won(seat) => if seat == 0.0 then "CYAN WINS" else "PINK WINS"
+
+expect initialSnapshot().leftScore == 0.0
+expect initialSnapshot().phase == Serving(2.2)

--- a/examples/netpong/server.fun
+++ b/examples/netpong/server.fun
@@ -1,0 +1,234 @@
+// server.fun — the authority: it owns the only real match.
+//
+// Paddle positions, ball kinematics, scores, serve timing, the win and the
+// rematch all live HERE. A client never states a fact; it sends a sequenced
+// PaddleIntent ("I am holding up"), and this file decides what that means.
+// Every 50 ms the settled world is broadcast to every connection as one
+// Snapshot — the whole world, not a diff, so a dropped packet costs nothing
+// but a frame of smoothness.
+//
+// An unoccupied seat is played by `aiY`, which is why the server alone is an
+// AI-vs-AI attract mode and one client is a game against the house. Both roles
+// draw the same `Game.view`, so this window shows exactly the truth the
+// clients are trying to converge on.
+
+type Player = { cid: float, seat: float, axis: float, intentSeq: float }
+
+type Model = {
+  players: List<Player>,
+  leftY: float,
+  rightY: float,
+  ballX: float,
+  ballY: float,
+  ballVx: float,
+  ballVy: float,
+  leftScore: float,
+  rightScore: float,
+  phase: Protocol.Phase,
+  hitPulse: float,
+  scorePulse: float,
+  trail: List<Protocol.Point>,
+  snapshotClock: float,
+  snapshotSeq: float,
+  serverTime: float,
+}
+
+type Msg =
+  | Joined(cid: float)
+  | Packet(cid: float, wire: Protocol.Wire)
+  | Left(cid: float)
+  | NetErr(text: string)
+
+let fresh = (): Model => {
+  players: [],
+  leftY: 0.0, rightY: 0.0,
+  ballX: 0.0, ballY: 0.0, ballVx: -9.0, ballVy: 4.2,
+  leftScore: 0.0, rightScore: 0.0,
+  phase: Protocol.Serving(2.2), hitPulse: 0.0, scorePulse: 0.0,
+  trail: [], snapshotClock: 0.0, snapshotSeq: 0.0, serverTime: 0.0,
+}
+
+let init: Model = fresh()
+
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(cid) => Joined(cid)
+  | Net.Data(cid, wire) => Packet(cid, wire)
+  | Net.Message(_, _) => NetErr("unexpected text frame")
+  | Net.Disconnected(cid) => Left(cid)
+  | Net.Error(_, message) => NetErr(message)
+
+let playerForSeat = (seat: float, players: List<Player>): Option.t<Player> =>
+  players |> List.find((p) => p.seat == seat)
+
+// A fresh match, but NOT a fresh sequence: `snapshotSeq` and `serverTime`
+// carry over, because the clients already connected reject anything that isn't
+// newer than what they have. Resetting the counter would make the new match
+// look stale and freeze every screen but this one.
+let rematch = (m: Model): Model =>
+  { fresh() with players: m.players, snapshotSeq: m.snapshotSeq, serverTime: m.serverTime }
+
+let axisFor = (seat: float, players: List<Player>): Option.t<float> =>
+  playerForSeat(seat, players) |> Option.map((p) => p.axis)
+
+let update = (m: Model, msg: Msg) =>
+  match msg with
+  // Seats are assigned, never claimed: the first two connections get 0 and 1,
+  // a third is accepted but seated nowhere (it can watch, not steer).
+  | Joined(cid) =>
+      let occupied0 = playerForSeat(0.0, m.players) |> Option.isSome in
+      let occupied1 = playerForSeat(1.0, m.players) |> Option.isSome in
+      let seat = if not occupied0 then 0.0 else if not occupied1 then 1.0 else -1.0 in
+      if seat < 0.0 then m
+      else
+        let player: Player = { cid: cid, seat: seat, axis: 0.0, intentSeq: -1.0 } in
+        ({ m with players: [player, ..m.players] },
+         Effect.sendMsg(cid, Protocol.Welcome(seat)))
+  | Packet(cid, wire) =>
+      (match wire with
+       // Keyed by the CONNECTION it arrived on, never by a seat in the
+       // payload — so a client can only ever steer its own paddle. The
+       // sequence drops intents that overtook each other in flight, and the
+       // clamp means a doctored axis is still just -1..1.
+       | Protocol.PaddleIntent(seq, axis) =>
+           { m with players:
+               m.players |> List.map((p) =>
+                 if p.cid == cid && seq > p.intentSeq
+                 then { p with axis: Math.clamp(-1.0, 1.0, axis), intentSeq: seq }
+                 else p) }
+       | Protocol.Rematch =>
+           let senderIsPlayer = m.players |> List.any((p) => p.cid == cid) in
+           if senderIsPlayer then
+             (match m.phase with
+              | Protocol.Won(_) => rematch(m)
+              | _ => m)
+           else m
+       | _ => m)
+  | Left(cid) => { m with players: m.players |> List.filter((p) => p.cid != cid) }
+  | NetErr(_) => m
+
+let subscriptions = (m: Model) => Sub.listen(Protocol.bind, toMsg)
+
+let approach = (current: float, target: float, speed: float, dt: float): float =>
+  let delta = target - current in
+  current + Math.clamp(0.0 - speed * dt, speed * dt, delta)
+
+let aiY = (ballY: float, current: float, dt: float): float =>
+  approach(current, Math.clamp(0.0 - Protocol.paddleYLimit, Protocol.paddleYLimit, ballY),
+           Protocol.paddleSpeed * 0.82, dt)
+
+let movePaddle = (seat: float, current: float, ballY: float, players: List<Player>, dt: float): float =>
+  match axisFor(seat, players) with
+  | Option.Some(axis) =>
+      Math.clamp(0.0 - Protocol.paddleYLimit, Protocol.paddleYLimit,
+            current + axis * Protocol.paddleSpeed * dt)
+  | Option.None => aiY(ballY, current, dt)
+
+let servedBall = (leftScore: float, rightScore: float): (float, float) =>
+  let sign = if Math.mod(leftScore + rightScore, 2.0) == 0.0 then -1.0 else 1.0 in
+  (sign * (9.2 + (leftScore + rightScore) * 0.18),
+   if Math.mod(leftScore + rightScore, 3.0) == 0.0 then 4.6 else -4.1)
+
+let snapshot = (m: Model): Protocol.Snapshot => {
+  seq: m.snapshotSeq, serverTime: m.serverTime,
+  leftY: m.leftY, rightY: m.rightY,
+  ballX: m.ballX, ballY: m.ballY, ballVx: m.ballVx, ballVy: m.ballVy,
+  leftScore: m.leftScore, rightScore: m.rightScore,
+  phase: m.phase, hitPulse: m.hitPulse, scorePulse: m.scorePulse, trail: m.trail,
+}
+
+let withPoint = (winner: float, m: Model): Model =>
+  let ls = m.leftScore + (if winner == 0.0 then 1.0 else 0.0) in
+  let rs = m.rightScore + (if winner == 1.0 then 1.0 else 0.0) in
+  let won = ls >= Protocol.winningScore || rs >= Protocol.winningScore in
+  { m with
+      leftScore: ls, rightScore: rs,
+      ballX: 0.0, ballY: 0.0,
+      phase: if won then Protocol.Won(winner) else Protocol.Serving(1.65),
+      scorePulse: 1.0, hitPulse: 0.0, trail: [] }
+
+let stepRally = (m: Model, dt: float): Model =>
+  let x = m.ballX + m.ballVx * dt in
+  let rawY = m.ballY + m.ballVy * dt in
+  let wall = Math.abs(rawY) + Protocol.ballRadius > Protocol.courtHalfHeight in
+  let y = if wall then Math.sign(rawY) * (Protocol.courtHalfHeight - Protocol.ballRadius) else rawY in
+  let vy = if wall then 0.0 - m.ballVy else m.ballVy in
+  let leftHit = m.ballVx < 0.0 && x - Protocol.ballRadius <= 0.0 - Protocol.paddleX
+    && m.ballX > 0.0 - Protocol.paddleX
+    && Math.abs(y - m.leftY) <= Protocol.paddleHalfHeight + Protocol.ballRadius in
+  let rightHit = m.ballVx > 0.0 && x + Protocol.ballRadius >= Protocol.paddleX
+    && m.ballX < Protocol.paddleX
+    && Math.abs(y - m.rightY) <= Protocol.paddleHalfHeight + Protocol.ballRadius in
+  let hit = leftHit || rightHit in
+  let paddleY = if leftHit then m.leftY else m.rightY in
+  let vx = if hit then (0.0 - m.ballVx) * 1.035 else m.ballVx in
+  let hitVy = if hit then vy * 0.62 + (y - paddleY) * 4.2 else vy in
+  let hitX = if leftHit then 0.0 - Protocol.paddleX + Protocol.ballRadius
+             else if rightHit then Protocol.paddleX - Protocol.ballRadius else x in
+  let moved = { m with
+    ballX: hitX, ballY: y, ballVx: vx, ballVy: Math.clamp(-10.5, 10.5, hitVy),
+    hitPulse: if hit then 1.0 else Math.max(0.0, m.hitPulse - dt * 3.8),
+    scorePulse: Math.max(0.0, m.scorePulse - dt * 2.4),
+    trail: [Protocol.point(hitX, y), ..m.trail] |> List.take(15.0) } in
+  if hitX < 0.0 - Protocol.courtHalfWidth then withPoint(1.0, moved)
+  else if hitX > Protocol.courtHalfWidth then withPoint(0.0, moved)
+  else moved
+
+// One pure step of the whole match. `dt` is bounded so a stalled frame (a
+// breakpoint, a dragged window) can't tunnel the ball through a paddle, and so
+// the step stays reproducible: same model + same dt = same next model, which
+// is what the determinism expect below pins.
+let stepWorld = (dt: float, m: Model): Model =>
+  let boundedDt = Math.clamp(0.0, 0.05, dt) in
+  let leftY = movePaddle(0.0, m.leftY, m.ballY, m.players, boundedDt) in
+  let rightY = movePaddle(1.0, m.rightY, m.ballY, m.players, boundedDt) in
+  let base = { m with leftY: leftY, rightY: rightY,
+                       serverTime: m.serverTime + boundedDt,
+                       snapshotClock: m.snapshotClock + boundedDt } in
+  match base.phase with
+  | Protocol.Serving(seconds) =>
+      if seconds - boundedDt <= 0.0 then
+        let (vx, vy) = servedBall(base.leftScore, base.rightScore) in
+        { base with phase: Protocol.Rally, ballVx: vx, ballVy: vy,
+                    ballX: 0.0, ballY: 0.0, trail: [] }
+      else { base with phase: Protocol.Serving(seconds - boundedDt),
+                       hitPulse: Math.max(0.0, base.hitPulse - boundedDt * 3.8),
+                       scorePulse: Math.max(0.0, base.scorePulse - boundedDt * 2.4) }
+  | Protocol.Rally => stepRally(base, boundedDt)
+  | Protocol.Won(_) => { base with hitPulse: Math.max(0.0, base.hitPulse - boundedDt * 3.8),
+                                   scorePulse: Math.max(0.18, base.scorePulse - boundedDt * 1.2) }
+
+// Simulate every frame, broadcast at 20 Hz — one `Effect.sendMsg` per
+// connection, batched into a single effect. Like the client's send clock, the
+// remainder is kept so the cadence doesn't drift with the frame rate.
+let tick = (m: Model, dt: float, tts: float) =>
+  let stepped = stepWorld(dt, m) in
+  if stepped.snapshotClock >= 0.05 then
+    let ready = { stepped with snapshotClock: stepped.snapshotClock - 0.05,
+                               snapshotSeq: stepped.snapshotSeq + 1.0 } in
+    let snap = snapshot(ready) in
+    let sends = ready.players |> List.map((p) => Effect.sendMsg(p.cid, Protocol.State(snap))) in
+    (ready, Effect.batch(sends))
+  else stepped
+
+let draw = (m: Model, tts: float): Frame.t => Game.view(snapshot(m), "LISTENING :9108", -1.0, true)
+
+expect (
+  let m = { fresh() with phase: Protocol.Rally, ballX: 0.0, ballY: 0.0,
+                         ballVx: 10.0, ballVy: 0.0 } in
+  let a = stepWorld(0.05, m) in
+  let b = stepWorld(0.05, m) in
+  a == b && Math.abs(a.ballX - 0.5) < 0.0001)
+expect (
+  let m = { fresh() with phase: Protocol.Rally,
+                         ballX: 12.95, ballY: 6.0, ballVx: 5.0, ballVy: 0.0,
+                         leftScore: 4.0 } in
+  let scored = stepWorld(0.05, m) in
+  scored.leftScore == 5.0 && scored.phase == Protocol.Won(0.0))
+expect (
+  let won = { fresh() with phase: Protocol.Won(1.0), leftScore: 2.0, rightScore: 5.0,
+                           snapshotSeq: 220.0, serverTime: 18.0 } in
+  let reset = rematch(won) in
+  reset.leftScore == 0.0 && reset.rightScore == 0.0
+    && reset.phase == Protocol.Serving(2.2)
+    && reset.snapshotSeq == 220.0 && reset.serverTime == 18.0)

--- a/examples/netpong/server.fun
+++ b/examples/netpong/server.fun
@@ -73,8 +73,10 @@ let axisFor = (seat: float, players: List<Player>): Option.t<float> =>
 
 let update = (m: Model, msg: Msg) =>
   match msg with
-  // Seats are assigned, never claimed: the first two connections get 0 and 1,
-  // a third is accepted but seated nowhere (it can watch, not steer).
+  // Seats are assigned, never claimed: the first two connections get 0 and 1.
+  // A third is accepted by the transport but takes no seat, gets no `Welcome`,
+  // and is not in the broadcast list — deliberately the smallest possible
+  // policy. Spectators would be one more list and one more send.
   | Joined(cid) =>
       let occupied0 = playerForSeat(0.0, m.players) |> Option.isSome in
       let occupied1 = playerForSeat(1.0, m.players) |> Option.isSome in
@@ -129,10 +131,12 @@ let servedBall = (leftScore: float, rightScore: float): (float, float) =>
   (sign * (9.2 + (leftScore + rightScore) * 0.18),
    if Math.mod(leftScore + rightScore, 3.0) == 0.0 then 4.6 else -4.1)
 
+// The model, minus everything a viewer does not need: velocities and the
+// server clock stay here.
 let snapshot = (m: Model): Protocol.Snapshot => {
-  seq: m.snapshotSeq, serverTime: m.serverTime,
+  seq: m.snapshotSeq,
   leftY: m.leftY, rightY: m.rightY,
-  ballX: m.ballX, ballY: m.ballY, ballVx: m.ballVx, ballVy: m.ballVy,
+  ballX: m.ballX, ballY: m.ballY,
   leftScore: m.leftScore, rightScore: m.rightScore,
   phase: m.phase, hitPulse: m.hitPulse, scorePulse: m.scorePulse, trail: m.trail,
 }
@@ -174,10 +178,9 @@ let stepRally = (m: Model, dt: float): Model =>
   else if hitX > Protocol.courtHalfWidth then withPoint(0.0, moved)
   else moved
 
-// One pure step of the whole match. `dt` is bounded so a stalled frame (a
-// breakpoint, a dragged window) can't tunnel the ball through a paddle, and so
-// the step stays reproducible: same model + same dt = same next model, which
-// is what the determinism expect below pins.
+// One pure step of the whole match. `dt` is BOUNDED, so a stalled frame (a
+// breakpoint, a dragged window) advances the world by one step instead of
+// tunnelling the ball through a paddle — the expect below pins exactly that.
 let stepWorld = (dt: float, m: Model): Model =>
   let boundedDt = Math.clamp(0.0, 0.05, dt) in
   let leftY = movePaddle(0.0, m.leftY, m.ballY, m.players, boundedDt) in
@@ -211,13 +214,15 @@ let tick = (m: Model, dt: float, tts: float) =>
     (ready, Effect.batch(sends))
   else stepped
 
-let draw = (m: Model, tts: float): Frame.t => Game.view(snapshot(m), "LISTENING :9108", -1.0, true)
+// Seat -1 tells the shared renderer to draw the authority's banner instead of
+// a player's HUD, so the status/autopilot arguments are a player's business.
+let draw = (m: Model, tts: float): Frame.t => Game.view(snapshot(m), "", -1.0, false)
 
 expect (
   let m = { fresh() with phase: Protocol.Rally, ballX: 0.0, ballY: 0.0,
                          ballVx: 10.0, ballVy: 0.0 } in
   let a = stepWorld(0.05, m) in
-  let b = stepWorld(0.05, m) in
+  let b = stepWorld(5.0, m) in
   a == b && Math.abs(a.ballX - 0.5) < 0.0001)
 expect (
   let m = { fresh() with phase: Protocol.Rally,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:mcp": "cargo build -p functor-cli --no-default-features && node e2e/mcp-server.mjs",
     "test:mcp-step-all": "cargo build -p functor-cli --no-default-features && node e2e/mcp-step-all.mjs",
     "test:code-garden": "cargo build -p functor-cli --no-default-features && node e2e/code-garden.mjs",
+    "test:netpong": "cargo build -p functor-cli --no-default-features && node e2e/netpong.mjs",
     "demo:time-travel": "node site/demos/time-travel.mjs",
     "demo:detached-camera": "node site/demos/detached-camera.mjs",
     "demo:instant-feedback": "node site/demos/instant-feedback.mjs",

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -176,6 +176,29 @@ export const EXAMPLES: Example[] = [
     module: "Client",
     server: { file: exampleEntryPath("orbs"), module: "Server" },
   },
+  // The other half of the multiplayer pair: orbs keeps both roles in one
+  // buffer, netpong keeps them in separate FILES. So the role is the file
+  // here — `server` names server.fun with no module/prefix — and the sandbox
+  // edits client.fun. All three non-entry modules must be copied: the runtime
+  // derives module names from file STEMS, and both roles call the shared
+  // renderer as `Game.view`, so a missing game.fun fails every pane with
+  // `unknown external 'Game.view'`. They live in a per-example subdirectory so
+  // generic stems (`protocol`, `server`, `game`) can't collide with another
+  // sample's files.
+  {
+    id: "netpong",
+    label: "Netpong (multiplayer)",
+    source: "examples/netpong/client.fun",
+    multiplayer: true,
+    // Keyboard-only, like the sample's own functor.json.
+    mouseCapture: false,
+    siblings: [
+      { source: "examples/netpong/server.fun", output: "examples/netpong/server.fun" },
+      { source: "examples/netpong/protocol.fun", output: "examples/netpong/protocol.fun" },
+      { source: "examples/netpong/game.fun", output: "examples/netpong/game.fun" },
+    ],
+    server: { file: "examples/netpong/server.fun" },
+  },
   {
     id: "platformer",
     label: "Platformer",

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -179,9 +179,10 @@ export const EXAMPLES: Example[] = [
   // The other half of the multiplayer pair: orbs keeps both roles in one
   // buffer, netpong keeps them in separate FILES. So the role is the file
   // here — `server` names server.fun with no module/prefix — and the sandbox
-  // edits client.fun. All three non-entry modules must be copied: the runtime
-  // derives module names from file STEMS, and both roles call the shared
-  // renderer as `Game.view`, so a missing game.fun fails every pane with
+  // edits client.fun. All three of the client entry's siblings must be copied
+  // (server.fun is the server pane's OWN entry, and a sibling of the client's):
+  // the runtime derives module names from file STEMS, and both roles call the
+  // shared renderer as `Game.view`, so a missing game.fun fails every pane with
   // `unknown external 'Game.view'`. They live in a per-example subdirectory so
   // generic stems (`protocol`, `server`, `game`) can't collide with another
   // sample's files.


### PR DESCRIPTION
## Visuals

![netpong server attract-mode rally](https://gist.githubusercontent.com/tommy-xr/fdd7b1ed4635576cd3164065dbefb708/raw/netpong_demo.gif)

<sub>Server role (`--entry server`) playing AI-vs-AI attract mode — a full rally, no client attached. Rendered headlessly via `--capture-frame` / `--capture-time`.</sub>

![netpong sandbox 3-pane grid: two clients + server mid-rally](https://gist.githubusercontent.com/tommy-xr/fdd7b1ed4635576cd3164065dbefb708/raw/netpong_sandbox_grid_crop.png)

<sub>Sandbox grid layout (2 clients + 1 server) mid-rally — client-side prediction converging on the server's authoritative ball/paddle state across all three panes.</sub>

Promotes **`netpong`** into the example corpus: authoritative multiplayer Pong, and the corpus's **roles-as-FILES** multiplayer reference.

## What it demonstrates

- **The server is the only authority.** Paddle positions, ball kinematics, scores, serve timing, the win and the rematch all live in `server.fun`. A client never states a fact — it sends a sequenced `PaddleIntent` ("I am holding up"), keyed server-side by the *connection it arrived on*, so a client can only ever steer the paddle it was given, and a doctored axis is still clamped to -1..1.
- **Whole-world snapshots at 20 Hz.** Not deltas — a dropped packet costs a frame of smoothness, nothing else. The client compares `seq` and drops anything that is not newer.
- **Client-side prediction + smoothing.** `target` is the newest server truth; `render` is what you see. `tick` moves the local paddle immediately off local input (no round trip), eases it back toward the server's copy so a correction is a slide rather than a snap, and eases the remote paddle and the ball toward each new snapshot. Both are ordinary model data, so the inspector and time travel can read the divergence. A phase change or a score means the world *discontinued*, so ball and trail snap instead of sweeping through positions that never happened.
- **It demos itself.** An unoccupied seat is played by server-side AI, so the server alone is an AI-vs-AI attract mode and one client is a game against the house.
- **`Sub.connect` recovery, for real.** Dial before the server exists, or restart the server underneath a running client, and the same client process converges — no relaunch.

## The deliberate contrast with `examples/orbs`

The two multiplayer samples are a **pair**, not duplicates — they are the two shapes a role can take:

| | `examples/orbs` | `examples/netpong` (this PR) |
| --- | --- | --- |
| Shape | **SAME-FILE** — both roles are inline `module Client` / `module Server` blocks of one `game.fun` | **roles-as-FILES** — `client.fun` + `server.fun` are separate entry files |
| Shared code | everything above the blocks, in the same buffer | shared siblings: `protocol.fun` (the wire + court constants) and `game.fun` (the renderer both roles call as `Game.view`) |
| Hot reload | one buffer, both roles reload atomically | each role reloads on its own |
| Reach for it when | the whole game fits in one buffer | the roles outgrow one buffer, or want independent deploy units |

`client.fun`'s header says this explicitly and points at orbs; orbs' header already points the other way. `CLAUDE.md` said the roles-as-FILES form "ships with no bundled example" — this PR fixes that paragraph to name netpong (and `examples/lobby`, which is the same shape applied to discovery).

## Files

Added: `examples/netpong/{client.fun,server.fun,protocol.fun,game.fun,functor.json}`, `e2e/netpong.mjs`.
Changed: `package.json` (`test:netpong`), `site/src/examples.ts` (sandbox registration), `e2e/wasm-smoke.mjs` (entry resolution, below), `CLAUDE.md`.

Stripped in promotion: `JAM_NOTES.md`, and every comment referencing the jam, the fix round, PR numbers, or adoption. The `// gallery:` / `// gallery-controls:` header lines are **kept** — `roguelike`, `tetris` and `breakout` already carry them on main, so they are an established corpus convention rather than jam residue.

## Verification

All on the release CLI built in the worktree.

| Check | Result |
| --- | --- |
| `functor -d examples/netpong build native` (client role) | clean |
| `functor -d examples/netpong build native --entry server` | clean |
| `functor -d examples/netpong test` | **8 expects, 8 passed** |
| `node e2e/netpong.mjs` ×2 (post-fix) | green both runs, not flaky |
| `npm ci && npm run site:build`, `tsc -p site --noEmit` | clean |
| `node e2e/wasm-smoke.mjs` (all 31 samples, locally) | ALL PASSED |

**`e2e/netpong.mjs`** launches the roles as three independent `functor` processes on their own debug ports and lets their game traffic use the sample's real WebSocket listener. Every wait polls observable state — no sleeps. It asserts: connect-before-listen convergence *in the same process*; server-restart recovery, adopting the restarted server's fresh sequence; seats 0 and 1 handed out by the authority; real key input arriving as a sequenced intent on that client's own seat; a real rally scoring and both clients converging on the scoreboard; a win, an `R` rematch, and the monotonic sequence letting connected clients accept the reset; and disconnect cleanup plus a replacement client rejoining. It follows the convention the sibling promotion (#675) set: `e2e/<name>.mjs` + a `test:<name>` script, binary from `FUNCTOR_BIN` or the repo-relative default.

**Sandbox registration** (`site/src/examples.ts`): `multiplayer: true`, `mouseCapture: false`, `source` = `client.fun`, `server: { file: "examples/netpong/server.fun" }` with **no** `module`/`prefix` (correct for roles-as-files — the server file's plain top-level contract *is* the role), and all three of the client entry's siblings copied into a per-example subdirectory so the generic stems `protocol`/`server`/`game` cannot collide with another sample's files. `game.fun` in particular is load-bearing: module names come from the file stem and both roles call `Game.view`, so omitting it kills every pane with `unknown external 'Game.view'`.

**Multi-client browser check** (headless Chromium, `sandbox.html?example=netpong&clients=2`): **3 panes** mount (2 clients + 1 server), no `Functor Lang error` overlay in any pane and no `[functor-lang]` console errors. Reading each pane's paused inspector trace, the server owns `players: [{cid: 2, seat: 1}, {cid: 1, seat: 0}]` while both clients report `status: "LIVE"` on adjacent snapshot sequences (217/218) with matching ball state — one session, not three lonely sims. The still below is that view.

**`e2e/wasm-smoke.mjs`** needed a fix to accept this sample: it resolved a project's entry as `cfg.entry || "game.fun"`, which is simply wrong for a multi-entry project (orbs only passed because its entry happens to be named `game.fun`). It now mirrors the CLI's rule — sole entry, else `client`, else ambiguous and it throws.

## Golden scenario: **no** — and deliberately not forced

The golden harness renders a sample's *default* entry at a fixed frame time; `golden-scenarios.json` has no `--entry`, so it can only ever shoot netpong's **client**, which offline draws a static initial snapshot. That would be stable, but it would exercise nothing the existing 2D goldens (`shapes2d-t26`, `text2d-t9`) don't already cover, and it structurally cannot capture the thing this sample exists to demonstrate — two processes agreeing. `e2e/netpong.mjs` is the right regression net here, and it is far stronger than a PNG would be. Adding `--entry` support to the golden schema so the server role could be pinned is a reasonable follow-up, but it is not this PR.

## xreview dispositions

Three reviewers: a Claude adversarial pass, `codex exec` (medium reasoning) — both given the media for visual verification — and a dedicated de-duplication pass. **No Critical findings.** Everything Critical/High/Medium is dispositioned below; fixes landed in `cbc919d` and the full verification above was re-run after them.

**Fixed — High, raised by BOTH engines**
- `client.fun` never reset `lastSnapshotSeq` on reconnect. A restarted server counts from zero, so every snapshot of the new match was rejected as stale until the fresh counter caught up — a blackout as long as the previous session (a 10-minute session ⇒ a 10-minute dead screen). Both engines also spotted that the e2e *masked* it by waiting the blackout out. Fixed by resetting on `Joined`, and the e2e now pins the fix directly: after the restart the client must go LIVE at a sequence **below** the one it held before the kill. (`serverRestartMs` fell from ~440 ms to ~310 ms as a side effect.)

**Fixed — Medium, raised by BOTH engines**
- The comment claimed an unseated third connection "can watch" — it gets no seat, no `Welcome` and no snapshots. The comment now says so, and names spectators as the deliberate non-goal.
- "interpolates between the 20 Hz snapshots" / "reconciliation" overstated the technique: `smooth` holds one snapshot and eases toward it (exponential smoothing), and there is no acked-input replay. Comments reworded to be precise about what it is *and* about the resulting lag.
- `e2e/netpong.mjs` had no port preflight despite fixed ports, against house precedent (`e2e/net-coordinator.mjs`, `e2e/wasm-smoke.mjs`). Now every port is checked before the first spawn, and :9108 must be free before the replacement server binds it.

**Fixed — Medium/Low, single engine**
- A `Net.Error` on a live link set `conn: Offline` without closing anything, wedging all sends until an actual disconnect. Errors are now reported without tearing the connection down.
- The online send clock subtracted one interval per frame, so a stall burst intents at frame rate; it now takes the remainder modulo the interval (an intent is a held *level*, not an event to replay).
- `smooth` predicted with raw `dt` while the server clamps to 50 ms; it now clamps identically.
- The "determinism" expect was a tautology (`f(x) == f(x)` holds for any pure function). It now pins the dt **clamp** the comment actually claims: `stepWorld(5.0, m) == stepWorld(0.05, m)`.
- Dead protocol surface: `serverTime`, `ballVx`, `ballVy` were broadcast 20×/s and read by nobody — removed from the wire (the server keeps them in its own model). Same for the server `draw`'s status string, which hardcoded the port and never rendered.
- The e2e's scoring assertion could be satisfied by a point the attract AI had already scored; it now baselines the scoreboard first. `assert.equal(clientA.pid, clientAPid)` was a tautology → `exitCode === null`. Cleanup now awaits every child's exit.
- De-dup `diverged`: the new `entries` resolution in `wasm-smoke.mjs` was a third copy of the default-role rule that disagreed with the CLI's. Now mirrors it exactly (and throws on genuine ambiguity).
- De-dup `reuse`: `e2e/netpong.mjs` re-implemented `sleep` / socket-probing / port-waiting that `e2e/mcp-rpc.mjs` already exports. It imports them now (including `BIN` and `ROOT`), which also deleted a socket-leaking `waitSocket`.
- De-dup `diverged`: the "roles-as-FILES reference" claim conflicted with `CLAUDE.md` and with `examples/lobby`. Reconciled in `CLAUDE.md`, which now names both.

**Accepted, not changed** (with reasons)
- *Rewrite the e2e on `tools/functor-sdk`* (de-dup `reuse`). Declined: `e2e/*.mjs` is deliberately plain ESM over the raw documented debug protocol, and the SDK ships source-only with no `dist/`. The SDK's own multiplayer test stays where it is.
- *`keyHeld` is the 5th restatement across samples* (de-dup `extract`). Real, but it is prelude work (an `Input` membership helper), not a change to this sample — noted as follow-up.
- *Win-wait budget could be tight on a slow runner.* Raised 60 s → 180 s rather than taking clock control; a real wall-clock rally is the point of the test.
- *`hitPulse` is side-less, so a hit flashes both paddles*; *`ballVx` grows 3.5%/hit uncapped* (bounded in practice by `winningScore`); *`Math.ceil(2.2)` renders "SERVE IN 3"*. All cosmetic, all in service of the sample staying small.
- *The HUD tagline still reads "SNAPSHOT INTERPOLATION".* Kept: it is the sample's caption, not a claim about a line of code, and the precise description now lives in the comments. Changing it would invalidate the media above for no reader benefit.
- *Reviewer note: the captures never show a score, a win banner, or a human-steered paddle.* True — the GIF is attract mode and the sandbox rally was 0-0 when shot. Those paths are covered by the e2e (scoring, win, rematch, real injected input) rather than by pixels.

Visual verification passed on both engines: the GIF shows a genuine rally with both AI paddles tracking the ball, the sandbox still shows two seated clients plus `SERVER authority • 2 linked`, and — usefully — the server's ball sits measurably *ahead* of both clients' while the clients agree with each other, which is exactly the signature of clients trailing 20 Hz truth.
