### PR TITLE
docs: document multiplayer workflows

### DIFF
--- a/docs/debug-runtime.md
+++ b/docs/debug-runtime.md
@@ -659,10 +659,11 @@ An **MCP server** over the same endpoints ships as `functor mcp` — sessions,
 state, scene, capture, input, time, and rewind as standard tools for coding
 agents (docs/mcp.md).
 
-## Future directions
+## Multiplayer simulation
 
-- **Multiplayer simulation.** Launch N runner instances, each on its own
-  `--debug-port`, networked via `Sub.connect`/`Sub.listen`; pin all clocks and step
-  them in lockstep, injecting input and observing state per client. This is the
-  out-of-process counterpart to the browser's hosted panes + net coordinator
-  (`docs/multiplayer.md`).
+`functor mcp` can launch every role of a multi-entry project as a session group
+on `--net-transport embedder`, making the MCP host process the network with no
+sockets open. Use `step_all` for ordered producer → authority → observer rounds,
+`wire_log` for the routed packets, and each session's structured `/state` model
+for assertions. See [`docs/mcp.md`](mcp.md#running-a-multiplayer-session) for the
+socket-backed flow and the hermetic coordinator flow.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -434,8 +434,10 @@ or `reload_project` preserves the live model *and* the live sockets — connecti
 are owned by the shell, which does not reload — so clients stay joined across an
 edit to the server's rules.
 
-Launch the authority first and let its listener bind before a client dials —
-an orbs client connects once and does not retry.
+Launch the authority first and let its listener bind before a client dials.
+`Sub.connect` is a desired connection: a failed attempt reports `Net.Error` and
+retries forever on the deterministic game-time backoff documented by the
+prelude, so a boot race recovers rather than leaving the client dead.
 
 `e2e/mcp-step-all.mjs` is the end-to-end proof: it runs the three roles of
 `examples/orbs` twice from scratch and asserts the ordered lockstep produces
@@ -468,9 +470,10 @@ step_all { "sessions": ["s2", "s1", "s3"] }           // one lockstep round
 wire_log { "group": "g1", "since": 41 }               // …and what crossed in it
 ```
 
-`roles` is the launch order **and** the order to hand `step_all`; repeats are
-how a group gets two clients. Omit it for one session per declared entry, with
-a role named `server` first. Labels (`server`, `client1`, `client2`) are the
+`roles` is the launch order; repeats are how a group gets two clients. Omit it
+for one session per declared entry, with a role named `server` first. Choose the
+later `step_all` order by the producer → authority → observer law rather than by
+blindly copying launch order. Labels (`server`, `client1`, `client2`) are the
 routing identities the wire log reads by.
 
 **Routing (what the coordinator does).** It mirrors the browser coordinator

--- a/docs/multiplayer.md
+++ b/docs/multiplayer.md
@@ -1,9 +1,8 @@
 # Multiplayer / networking design
 
-Status: **active** (Phase 0 in progress). This is the design doc and roadmap for
-networking in Functor. The backlog stubs in `docs/todo.md` ("Async inbox",
-"Keyed resource registry", `Sub.Net.*`) are the first concrete steps and are
-expanded here.
+Status: **active**. The networking spine, HTTP and WebSocket transports, typed
+messages, multi-entry roles, the browser coordinator, and hermetic MCP session
+groups are shipped. Direct TCP/UDP and WebRTC remain roadmap work.
 
 ## Goal
 
@@ -92,7 +91,7 @@ when the response lands, the broker applies the tagger and delivers the message.
 ```functor
 // client: declares a desired connection; runtime keeps it open + reconnects
 Sub.connect(url, tagger)   // tagger: (Net.NetEvent) => Msg
-// server: accepts many; yields per-client events (native only for TCP/UDP/WS)
+// server: accepts many; real socket listeners are native, embedders may host either role
 Sub.listen(addr, tagger)   // tagger: (Net.NetEvent) => Msg
 
 Effect.send(connId, text)     // send on an open connection
@@ -192,13 +191,14 @@ clamped so it can never overtake an earlier packet on the same connection) and
 flushed when the session's reference clock reaches it. Every pane's link chip
 sets that latency and jitter; the wire rows print `sent → delivered`.
 
-**Latency and jitter only, and that is a decision** (design Addendum 8.2):
+**Latency and jitter only, and that is a decision**:
 `Sub.connect` promises reliable, ordered delivery, so the coordinator must never
 drop or reorder a packet. The chips keep their loss numbers, labelled as
-applying to datagrams, and those activate with `Net.Udp`. Still to come:
-partitions, and the step-time delivery barrier — the schedule is keyed to the
-session's reference clock rather than to each receiving pane's own step, which
-is what stands between the reproducible jitter DRAWS and reproducible runs.
+applying to datagrams; they remain inert because no datagram channel is shipped.
+Still to come: partitions, and the step-time delivery barrier — the schedule is
+keyed to the session's reference clock rather than to each receiving pane's own
+step, which is what stands between the reproducible jitter DRAWS and
+reproducible runs.
 
 `e2e/net-coordinator.mjs` (`npm run test:net-coordinator`) drives `examples/orbs`
 as a server plus two clients in headless Chromium and asserts the handshake,
@@ -210,10 +210,15 @@ removed: it duplicated the protocol the coordinator now owns while running the
 games in a shape (shared command queues, one thread, one clock) that the panes
 do not. `VirtualNet` itself survives as the semantics above.
 
-**B. Multi-process integration harness.** Real `functor` game processes driven
-over an extended debug-server API (add `/net` inject + `/tick` step to the
-existing `/input`, `/time`, `/state`, `/scene`). Slower, less deterministic;
-validates the real I/O + serialization path. Smoke/integration only.
+**B. Multi-process integration harness (shipped).** `functor mcp`'s
+`launch_session_group` reads a project's declared roles, launches one native
+runtime per role on `--net-transport embedder`, and makes the MCP process the
+network. `step_all` runs caller-ordered producer → authority → observer rounds;
+`wire_log` exposes every routed packet as data; `/state` exposes each role's
+structured model for assertions. The embedder endpoints are
+`GET /net/outbound` and `POST /net/deliver`; no runtime socket opens. See
+[`docs/mcp.md`](mcp.md#the-coordinator-this-process-is-the-network) and
+[`docs/debug-runtime.md`](debug-runtime.md#the-embedder-transport-protocol-v11).
 
 ## Whole-environment time travel
 
@@ -249,19 +254,19 @@ not recorded state, so it survives a restore — "rewind, worsen the link, watch
 again" works.
 
 This is **not built on the coordinator yet**: the removed in-process harness is
-where these rules were first implemented and regression-tested, and the
-coordinator-seek PR re-establishes them over the panes.
+where these rules were first implemented and regression-tested; future
+coordinator seek work must re-establish them over the panes.
 
 ## Roadmap (small, stacked PRs; each protocol ships with a test)
 
-| Phase | Scope | Targets |
-| --- | --- | --- |
-| **0. Spine** | the `ConnCommand`/`NetEvent` vocabulary + `AsyncInbox` + `VirtualNet`, Rust-only unit tests (latency/loss/reorder/partition). No game yet. | n/a |
-| **1. HTTP** | `Effect` request + inbound `Sub` response (correlate by token); reqwest/hyper (native) + fetch (wasm). | wasm+native |
-| **2. WebSocket** | `Sub.connect` + `Effect.send`; sub identity/reconciliation. Client first, then `Sub.listen` (server, native). | wasm+native |
-| **3. Multi-instance SDK** | runner handle refactor + the embedder seam + the host coordinator + first sync/latency/disconnect suite. | both |
-| **4. TCP/UDP direct** | raw TCP + UDP `listen`/`connect` (UDP matters most for the real-time game). | native only |
-| **5. WebRTC** | data channels + signaling. Deferred. | wasm+native |
+| Phase | Status | Scope | Targets |
+| --- | --- | --- | --- |
+| **0. Spine** | shipped | the `ConnCommand`/`NetEvent` vocabulary + `AsyncInbox` + `VirtualNet` | n/a |
+| **1. HTTP** | shipped | `Effect.httpGet` / `httpPost`, with the response tagger folded through `update` | wasm+native |
+| **2. WebSocket** | shipped | `Sub.connect` (wasm+native), `Sub.listen` (native sockets or an embedder), and `Effect.send` / `sendMsg` | wasm+native |
+| **3. Multi-instance SDK** | shipped | multi-entry roles, the embedder seam, browser host coordinator, and MCP session groups | both |
+| **4. TCP/UDP direct** | pending | raw TCP + UDP `listen`/`connect` | native only |
+| **5. WebRTC** | deferred | data channels + signaling | wasm+native |
 
 ## Netcode epic (Phase 6+, scoped separately)
 

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -37,6 +37,7 @@
           <div class="docs-nav-group-label" id="nav-concepts">Concepts</div>
           <a href="#contract">The game contract</a>
           <a href="#debug-camera">The debug camera</a>
+          <a href="#multiplayer">Multiplayer</a>
           <a href="#language">The language</a>
         </div>
         <div class="docs-nav-group" role="group" aria-labelledby="nav-tooling">
@@ -292,8 +293,10 @@ let draw = (model, tts: float) =>
             Everything above the two blocks is <em>shared</em>: the protocol type both roles agree
             on, and the authoritative rules written as pure functions. That sharing is the point —
             one declaration of the protocol, so a typo on either side is a check-time error. And
-            because it is one buffer, one save hot-reloads both roles atomically; delete a block a
-            role names and the reload fails loudly, keeping the old program running.
+            because it is one buffer, the protocol and both role contracts change together;
+            <code>build</code> validates every declared role in one pass. Each local
+            runtime watches that same file and reloads its own live model when it changes; delete a
+            block a role names and the reload fails loudly, keeping the old program running.
           </p>
           <p class="docs-callout">
             <strong>This step is the role structure, not the wire.</strong> To keep it runnable in
@@ -502,6 +505,142 @@ functor -d . run native --entry server  # the same world, seen from the authorit
           </p>
         </section>
 
+        <section id="multiplayer">
+          <h2>Building and debugging multiplayer</h2>
+          <p>
+            Functor does not make one model magically shared. A multiplayer project declares
+            <strong>roles</strong>, and each role is an ordinary game runtime with its own model.
+            The usual compact shape is one <code>game.fun</code>: shared protocol and world rules
+            at file scope, then <code>module Client { … }</code> and
+            <code>module Server { … }</code>. The manifest maps role names to those inline
+            modules:
+          </p>
+          <pre class="shell">{
+  "language": "functor-lang",
+  "entries": {
+    "client": { "file": "game.fun", "module": "Client" },
+    "server": { "file": "game.fun", "module": "Server" }
+  }
+}</pre>
+          <p>
+            <a href="https://github.com/tommy-xr/functor/tree/main/examples/orbs"><code>examples/orbs</code></a>
+            is the reference. Its one buffer declares the wire exactly once, above both roles:
+          </p>
+          <pre class="functor-lang">type Ship = { pid: float, x: float, y: float, rot: float }
+type Orb = { id: float, x: float, y: float, owner: float }
+type Intent = { turn: float, thrust: bool, claim: bool }
+
+type Wire =
+  | Join
+  | Welcome(pid: float)
+  | Steer(intent: Intent)
+  | Claim(orbId: float)
+  | Snapshot(ships: List&lt;Ship>, orbs: List&lt;Orb>)</pre>
+          <p>
+            <code>Join</code> opens the handshake; <code>Welcome(pid)</code> gives a client the
+            identity the authority assigned it; <code>Snapshot</code> carries the authoritative
+            ships and orbs back. Two details are the design lesson. <code>Steer(intent)</code>
+            carries no pid: identity is the connection the packet arrived on, so a client cannot
+            choose whom it steers. And <code>Claim(orbId)</code> is a <em>request</em>, not a fact.
+            The server looks up the sender, checks that ship is really in range, resolves ties, and
+            announces the result in a later snapshot.
+          </p>
+          <p>
+            Keeping both contracts and the protocol in one file means one edit cannot update a
+            client-side copy while forgetting a server-side copy. <code>functor build</code>
+            checks every role, and each local role runtime watches and reloads the same file with
+            its own model preserved. The browser sandbox has one narrower limitation today: live
+            editor pushes update the client panes, while the SERVER pane keeps the served source;
+            <strong>↺ reset</strong> reloads both sides from the built example.
+          </p>
+
+          <h3>The transport</h3>
+          <p>
+            Networking follows the same subscription/effect split as the rest of the game
+            contract. A client returns <code>Sub.connect(url, tagger)</code> from
+            <code>subscriptions</code>; an authority returns
+            <code>Sub.listen(address, tagger)</code>. The tagger maps ordered
+            <code>Net.NetEvent</code> values — <code>Net.Connected</code>,
+            <code>Net.Data</code>, <code>Net.Disconnected</code>, and
+            <code>Net.Error</code> (plus <code>Net.Message</code> for text) — into your game's
+            messages. <code>Effect.sendMsg(connectionId, value)</code> sends plain data and the
+            peer receives that value already decoded in <code>Net.Data</code>; there is no string
+            codec to maintain for the shared <code>Wire</code> type.
+          </p>
+          <p>
+            In the sandbox every pane boots on the embedder transport. Its
+            <code>Sub.connect</code>, <code>Sub.listen</code>, and
+            <code>Effect.sendMsg</code> commands go to the host page, which matches the listener,
+            assigns connection ids, and routes events back into the panes. No browser socket or
+            separate server process is involved; the page is the network.
+          </p>
+
+          <h3>The sandbox is the instrument</h3>
+          <p>
+            <a href="../sandbox.html?example=orbs">Open Orbs in the sandbox</a>. The
+            <strong>CLIENTS</strong> control chooses one, two, or three player seats, and the
+            <strong>+</strong> seat adds the next client without restarting the existing panes.
+            The SERVER pane is separate from that count. Its slate chrome marks it as the
+            authority: it has no player number, no keyboard owner, and is never another player.
+            Press <strong>f</strong> to cycle the available layouts, or choose one in the chrono
+            bar:
+          </p>
+          <table>
+            <thead><tr><th>layout</th><th>use it for</th></tr></thead>
+            <tbody>
+              <tr><td><strong>TILED</strong></td><td>scan every client and the authority in one row</td></tr>
+              <tr><td><strong>GRID</strong></td><td>give clients a two-column play area and the SERVER its own full-width authority strip</td></tr>
+              <tr><td><strong>NETWORK</strong></td><td>put the SERVER at the hub and inspect the links and packet flow around it</td></tr>
+              <tr><td><strong>TABS</strong></td><td>give one selected pane the full preview while every other runtime keeps running</td></tr>
+            </tbody>
+          </table>
+          <p>
+            NETWORK draws one wire from each client to the hub, with one packet circle per link,
+            direction, and frame that carried traffic. Circles moving toward the server are
+            intents in that client's color; packets moving back are authority traffic in slate.
+            Size reflects bytes carried. On a delayed link, a dot's flight is the
+            packet's real scheduled <code>sent → delivered</code> latency. The default 8 ms LAN
+            preset rounds to the same 60 Hz frame, so its chip says <code>&lt;1f</code> and the UI
+            draws a short 40 ms visibility floor; that one streak is not a latency measurement.
+            Pause or scrub and the moving feed becomes a replay of the packet log at the
+            playhead.
+          </p>
+          <p>
+            Each client header has a link chip. Pick <strong>LAN</strong>,
+            <strong>Wi-Fi</strong>, <strong>mobile</strong>, or <strong>awful</strong>, or enter
+            custom latency and jitter. Those two numbers are live: the host schedules the next
+            packet with that one-way delay plus a deterministic jitter draw, while packets already
+            in flight keep their schedule.
+          </p>
+          <p class="docs-callout">
+            <strong><code>Sub.connect</code> is reliable and ordered.</strong> The coordinator
+            never drops a packet and never lets a later packet overtake an earlier one. The link
+            chip's loss field is displayed but inert, and no reorder control is shipped; loss and
+            reordering belong to a future datagram channel. There is no datagram API today. This
+            is transport semantics, not a sandbox convenience.
+          </p>
+          <p>
+            The bottom panel's <strong>WIRE</strong> tab is available in every layout whenever a
+            SERVER is present. Its badge counts routed packets even while the panel is closed.
+            Open it to tail all traffic, filter to one client↔server link, then choose
+            <strong>both</strong>, <strong>intent</strong> (client → server), or
+            <strong>authority</strong> (server → client). Each row reads
+            <code>#f sent→delivered</code>, direction, payload, and byte count; a same-frame
+            delivery omits the redundant arrow. <code>Effect.sendMsg</code> payloads appear as
+            decoded Functor values such as <code>Steer(…)</code> and
+            <code>Snapshot(…)</code>, not as a byte dump. Plain <code>Effect.send</code> text is
+            the explicit exception and is shown exactly as sent.
+          </p>
+          <p>
+            Click a structured payload to open its value tree. Records, lists, tuples, maps, and
+            variants expand a level at a time; the same tree opens when you click a structured
+            return value in the neighbouring <strong>EXECUTIONS</strong> tab. The chrono bar above
+            the panes controls the whole session: pause every role, step every role once, or seek
+            every pane to the same session instant. While it is parked, NETWORK and WIRE read the
+            recorded traffic at that playhead instead of continuing to show the live tail.
+          </p>
+        </section>
+
         <section id="language">
           <h2>The language</h2>
 
@@ -686,10 +825,12 @@ let changed = (a: float, b: float): bool =&gt; a != b</pre>
           </p>
 
           <p>
-            The tools cover sessions (<code>launch_game</code> / <code>connect_game</code> /
+            The tools cover sessions (<code>launch_game</code> /
+            <code>launch_session_group</code> / <code>connect_game</code> /
             <code>list_sessions</code> / <code>stop_game</code>), observation
             (<code>get_state</code> / <code>get_scene</code> / <code>get_trace</code> /
-            <code>capture_frame</code>), driving (<code>pause</code> / <code>step</code> /
+            <code>capture_frame</code> / <code>wire_log</code>), driving
+            (<code>pause</code> / <code>step</code> / <code>step_all</code> /
             <code>resume</code> / <code>send_input</code> / <code>rewind</code> /
             <code>reload_source</code>), authoring (<code>init_game</code> /
             <code>save_project</code>), and two knowledge tools that need no session at all
@@ -699,6 +840,56 @@ let changed = (a: float, b: float): bool =&gt; a != b</pre>
             CI-friendly, but nothing to read back). The full tool-by-tool reference — every
             argument, the protocol versions each tool needs, and the errors they surface — is
             <a href="https://github.com/tommy-xr/functor/blob/main/docs/mcp.md">docs/mcp.md</a>.
+          </p>
+
+          <h3>Driving a multiplayer group</h3>
+          <p>
+            <code>launch_session_group</code> reads the roles from the project's
+            <code>functor.json</code> and starts one runtime per role. With no explicit role list,
+            it launches one of each and puts a role named <code>server</code> first so the
+            authority exists before clients dial. Repeat a role when the test needs more seats.
+            Every runtime starts with <code>--net-transport embedder</code>: the MCP host process
+            drains and routes the traffic itself, and no runtime opens a socket.
+          </p>
+          <pre class="shell">launch_session_group { "dir": "examples/orbs",
+                       "roles": ["server", "client", "client"],
+                       "mode": "headless" }
+// → group g1: server s1, client1 s2, client2 s3
+
+pause     { "session": "s1" }
+pause     { "session": "s2" }
+pause     { "session": "s3" }
+step_all  { "sessions": ["s2", "s1", "s3"] }
+wire_log  { "group": "g1", "since": 0 }
+get_state { "session": "s1" }
+get_state { "session": "s3" }</pre>
+          <p>
+            The loop is <code>step_all</code> → <code>wire_log</code> → assertions against each
+            <code>get_state</code> response's structured <code>model</code>. The wire log returns
+            routed packets as rows — sequence, endpoints, connection, size, and the exact
+            <code>payload_text</code> the receiver saw — so an agent can prove what crossed as
+            well as what each role eventually believed. Use its <code>since</code> cursor to read
+            only the traffic from the round just stepped. The complete filters and row shape live
+            in
+            <a href="https://github.com/tommy-xr/functor/blob/main/docs/mcp.md">docs/mcp.md</a>.
+          </p>
+          <p class="docs-callout">
+            <strong>Ordering is semantics:</strong> step producer → authority → observer. In the
+            example above <code>s2</code> produces intent, <code>s1</code> applies it and
+            broadcasts authority, then <code>s3</code> observes. <code>step_all</code> steps
+            sessions strictly sequentially in the caller's order; concurrent stepping makes
+            packet arrival a race and is not reproducible.
+          </p>
+          <p>
+            <strong>Pause freezes the clock, not the network.</strong> Inbound messages still fold
+            through <code>update</code>, so a paused model can change while <code>frame</code> and
+            <code>tts</code> do not. Do not use <code>frame</code> as a networked model's version
+            label: compare <code>model_revision</code>. Before taking a baseline, wait for
+            <code>pending_net</code> to reach zero on every role; it reports inbound events the
+            shell has accepted but not yet folded. It cannot see a packet still in transit, so
+            pair it with a game-level convergence assertion. The exact state fields and transport
+            endpoints are documented in
+            <a href="https://github.com/tommy-xr/functor/blob/main/docs/debug-runtime.md">docs/debug-runtime.md</a>.
           </p>
 
           <h3>One trusted automation function</h3>


### PR DESCRIPTION
The machine-facing references tracked the shipped networking work, but nothing told a **human** the multiplayer sandbox exists: an audit found zero mentions of the network view, the wire tab, or the value tree anywhere in `docs/` or the manual, and the "Driving games with agents" section stopped at single-session MCP.

**New manual section — "Building and debugging multiplayer"**, covering the project shape (roles as inline `module Client` / `module Server` in one `game.fun`, mapped by the manifest, with `examples/orbs`' wire as the teaching example — including why `Steer` carries no pid and why `Claim` is a request the authority re-checks), the transport API (`Sub.connect` / `Sub.listen` / `Effect.sendMsg` and the embedder routing that makes sandbox panes socketless), and the sandbox as an instrument: the CLIENTS control and `+` seat, the four layouts, the network view's packet flow, link chips, the WIRE tab's filters and `#f sent→delivered` rows, the value tree, and the chrono bar's whole-session control.

**"Driving games with agents" extended** with the group workflow — `launch_session_group` → `step_all` → `wire_log` → assertions — plus the two laws that are easy to get wrong: step producer → authority → observer (concurrent stepping is not reproducible), and pausing freezes the *clock*, not the network (so `frame` is not a version label for a networked model; `model_revision` is, and `pending_net` reports quiescence).

**One rule stated as engine semantics**, because a future contributor would otherwise "fix" it: `Sub.connect` is reliable and ordered, so the coordinator never drops a packet and never lets one overtake another. The link chip's loss field is displayed but inert; loss and reordering belong to a future datagram channel.

**Three corrections the author found by checking the code** (the brief was wrong; the text follows the code):
- browser editor pushes reload the **client** panes only — the SERVER pane keeps its served source until `↺ reset`, so the atomic both-roles hot reload is a local-runtime property, not a sandbox one;
- the link chips have a loss field but **no reorder control**;
- the sub-frame LAN preset's dot flight is a **40 ms visibility floor, explicitly not a latency measurement** (delayed links do show real scheduled sent→delivered flight).

Also refreshed the shipped-status claims in `docs/multiplayer.md`, `docs/mcp.md`, and `docs/debug-runtime.md` (the latter's speculative "future multiplayer" section replaced with the shipped group workflow).

Written by `gpt-5.6-sol` via Codex against the code, then reviewed and verified here. Docs-only: no engine, runtime, or site source changed. The supplied screenshots were deliberately **not** embedded — the manual is text-only and has no comparable figure pattern.

**Verification**: `node site/build.mjs` clean; `npm run check:docs` clean; spot-checked the riskiest specific claims against the source (`$map` support in the value tree, the same-frame arrow suppression in `wire-rows.ts`, `Net.Message` in orbs); no private-note paths or PR numbers leaked into public docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
