### PR TITLE
fix(site): the authority hot-reloads with its clients

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -428,6 +428,18 @@ const installProbe = (page) =>
         const inv = invocations.find((i) => i.entry === "draw") ?? invocations[0];
         return inv?.bindings?.find((b) => b.name === "m")?.value ?? null;
       },
+      // Reload markers per pane: a hot-swap records one on that runtime's own
+      // timeline, so this counts who actually took a pushed edit.
+      reloads: () =>
+        [...document.querySelectorAll(".mp-pane")].map((shell, index) => {
+          const role = shell.classList.contains("server") ? "server" : `client ${index + 1}`;
+          const seam = shell.querySelector("iframe")?.contentWindow?.__scrub;
+          const markers = seam?.view()?.eventMarkers ?? [];
+          const count = markers
+            .filter((m) => m.category === "reload")
+            .reduce((total, m) => total + (m.count ?? 1), 0);
+          return { role, count };
+        }),
     };
   });
 
@@ -622,6 +634,29 @@ try {
       seated(models.c1) && seated(models.c2),
       "both client panes were seated by the server pane (a pid off the wire)",
       String(models.c1).slice(0, 160)
+    );
+
+    // A pushed edit reaches EVERY runtime, the authority included. Both roles
+    // are modules of the buffer being edited, and each pane re-resolves its own
+    // role on reload — so a session-wide hot swap is one edit, not one edit
+    // plus a reset. (Before the authority was a push target this held for the
+    // clients alone, and the server pane sat on its served source.)
+    const before = await page.evaluate(() => window.__mpProbe.reloads());
+    await page.evaluate(() => {
+      const src = window.__sandbox.source();
+      window.__sandbox.setSource(src.replace("let halfW = 13.0", "let halfW = 12.0"));
+    });
+    await sleep(3500);
+    const after = await page.evaluate(() => window.__mpProbe.reloads());
+    const took = (role) => {
+      const b = before.find((r) => r.role === role)?.count ?? 0;
+      const a = after.find((r) => r.role === role)?.count ?? 0;
+      return a > b;
+    };
+    check(
+      took("server") && took("client 1") && took("client 2"),
+      "one edit hot-reloads every pane, the authority included",
+      JSON.stringify({ before, after })
     );
     // A SEAT, not just a pilot: the world's pilots carry a `pid` too, so only
     // the cid→pid pairing proves the authority bound each connection.

--- a/site/manual/index.html
+++ b/site/manual/index.html
@@ -549,9 +549,9 @@ type Wire =
             Keeping both contracts and the protocol in one file means one edit cannot update a
             client-side copy while forgetting a server-side copy. <code>functor build</code>
             checks every role, and each local role runtime watches and reloads the same file with
-            its own model preserved. The browser sandbox has one narrower limitation today: live
-            editor pushes update the client panes, while the SERVER pane keeps the served source;
-            <strong>↺ reset</strong> reloads both sides from the built example.
+            its own model preserved. The browser sandbox reloads the same way: an editor push
+            reaches every pane, the authority included, and each one re-resolves its own role
+            from the edited buffer — one edit, one session-wide reload, every model preserved.
           </p>
 
           <h3>The transport</h3>

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -1779,10 +1779,16 @@ export function initMultiplayerPanes({
       updateChrome();
       paintAggregate();
     },
-    // Mirror a debounced hot-reload push. The server pane is deliberately not
-    // a target — the buffer being edited is the CLIENT entry (see mountServer).
+    // Mirror a debounced hot-reload push. EVERY pane is a target, the
+    // authority included: a same-file project (`module Client` / `module
+    // Server`) boots both roles from the buffer being edited, and the runtime
+    // re-resolves each pane's own role on reload (`load_source(.., &self.role)`
+    // in the embedded producer), so the server swaps its Server module while
+    // the clients swap theirs — one edit, one atomic session-wide reload, every
+    // model preserved.
     push(source) {
       for (const { bridge } of mirrors) bridge.push(source);
+      serverPane?.bridge.push(source);
     },
     reset() {
       for (const { bridge } of mirrors) bridge.reset();


### PR DESCRIPTION
Stacked on #686 (it corrects a limitation that PR documents).

While reviewing the docs PR, identified that the authority *should* hot-reload too. It turns out the runtime was always ready: `reload_source` re-resolves through the pane's stored role (`load_source(&sources, &self.role)`), so a pushed buffer swaps each pane's own module. The only thing standing in the way was an exclusion in the site's `push()`, carrying a comment whose premise expired when same-file module roles landed — *"the buffer being edited is the CLIENT entry"* is no longer true when both roles are modules of that buffer.

So: push to every pane. One edit is now one session-wide reload, every model preserved — which is what the same-file role shape promises in the first place.

**The test discriminates.** A new per-pane reload-marker probe counts hot-swaps on each runtime's own timeline. Against the previous code the check fails with `client 1: 1, client 2: 1, server: 0`; with the fix, all three reach 1. That asymmetry is the bug, stated as an assertion.

Also updates the manual paragraph #686 added, which honestly documented the old limitation — it now describes the fixed behavior instead.

**Verification**: `tsc -p site --noEmit` clean; site build clean; `e2e/sandbox-mp.mjs` ALL CHECKS PASSED with the new check; failure-mode confirmed by reverting the one-line fix and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)