### PR TITLE
fix(desktop): cap hidden/fixed-time windowed loop near 60 Hz

### DIFF
--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1636,8 +1636,10 @@ sockets)."
             // a cheap scene doesn't spin uncapped and pin the GPU. GATED OFF for
             // hidden/capture and deterministic (`--fixed-time`) runs, which must
             // keep their current timing behavior — a golden capture or the debug
-            // server's /capture must never block on the compositor's swap. Applies
-            // to the current context, so it must follow `make_current`.
+            // server's /capture must never block on the compositor's swap.
+            // Non-capture hidden/fixed-time runs get an explicit sleep-based
+            // cap at the end of the loop body instead. Applies to the current
+            // context, so it must follow `make_current`.
             if !hidden && args.fixed_time.is_none() {
                 glfw.set_swap_interval(glfw::SwapInterval::Sync(1));
             }
@@ -3553,6 +3555,17 @@ Escape again to quit"
             // Hand this frame's shell-measured GL cost to the producer, which
             // folds it into the same rolling window it averages tick/draw over.
             game.record_gl_timing(render_ns, swap_ns);
+
+            // Hidden and `--fixed-time` runs skip vsync above, and a hidden
+            // window's swap never blocks on the compositor — cap the loop near
+            // 60 Hz explicitly so a long-lived session (`--hidden
+            // --debug-port`) doesn't busy-spin a core (mirrors the headless
+            // loop's cap). `--capture-frame` runs are exempt: they exit at the
+            // capture, and `--capture-at-frame N` counts sim frames, so the
+            // cap would stretch a near-instant scripted capture to N/60 s.
+            if (hidden || args.fixed_time.is_some()) && args.capture_frame.is_none() {
+                std::thread::sleep(std::time::Duration::from_millis(16));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The windowed loop's only pacing is vsync, which is deliberately gated off for hidden and `--fixed-time` runs (`run.rs` — "a golden capture or the debug server's /capture must never block on the compositor's swap"). But a hidden window's `swap_buffers` never blocks on the compositor either, so a long-lived `--hidden --debug-port N` session — the standard debug-runtime setup for agent/driver sessions (`docs/debug-runtime.md`) — busy-spins a core at ~100%, even while the debug clock is paused (pause only empties the fixed-step list; render + GL draw + swap still run every iteration).

This mirrors the same bug/fix in shock2quest (tommy-xr/shock2quest@1d445e8), minus the log-spam half — functor's render paths already dedupe via `SceneContext::warn_once`.

**The fix:** a 16 ms `thread::sleep` at the end of the windowed loop body when `(hidden || fixed_time) && capture_frame.is_none()` — exactly the complement of the vsync condition, mirroring the headless loop's existing 60 Hz cap.

**`--capture-frame` runs are exempt** on purpose: they exit at the capture, so their brief uncapped spin matches pre-fix behavior — and `--capture-at-frame N` counts *sim frames*, so capping it would stretch a near-instant scripted capture to N/60 s of wall clock.

Deliberately out of scope (minimal fix): no pause-aware skipping of render/GL work — the cap alone takes idle CPU from ~100% of a core to near-nothing, and keeping render running means `/capture` and `/scene` stay warm. Debug-server polling gains up to ~16 ms latency per request in capped sessions, same as headless already has.

## Verification

- `cargo test -p functor-runtime-desktop`: 95 passed, 0 failed, 2 ignored (GL-display goldens)
- `cargo test -p functor_runtime_common`: 758 passed, 0 failed, 1 ignored
- Not a visual change (no rendered output differs) and not a per-frame hot-path change for live play — the sleep only fires in hidden/fixed-time runs, and `frame_bench` is headless and doesn't execute this loop.

## Review

Codex review (gpt-5.6-terra) over the diff: no findings — "The new sleep cap is correctly limited to non-capture hidden or fixed-time runs, preserving uncapped deterministic capture behavior while preventing long-lived sessions from busy-spinning."