### PR TITLE
ci: add secure per-PR site previews

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,7 +1,8 @@
 name: Build PR Preview
 
 # This is deliberately the unprivileged half of preview deployment. It builds
-# PR code with a read-only token and no secrets, then uploads only site/dist.
+# PR code with a read-only token and requests no secrets, then uploads only
+# site/dist.
 # The default-branch workflow_run job independently authorizes the PR before it
 # exposes Cloudflare credentials or publishes these files as static assets.
 

--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,72 @@
+name: Build PR Preview
+
+# This is deliberately the unprivileged half of preview deployment. It builds
+# PR code with a read-only token and no secrets, then uploads only site/dist.
+# The default-branch workflow_run job independently authorizes the PR before it
+# exposes Cloudflare credentials or publishes these files as static assets.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # This saves Actions minutes; it is not the security boundary. The trusted
+    # deploy workflow repeats this gate using GitHub's API and default-branch
+    # code, so changing this line in a PR cannot authorize that PR.
+    if: >-
+      github.event.pull_request.user.login == 'tommy-xr' &&
+      github.event.pull_request.head.repo.full_name == 'tommy-xr/functor'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: npm install -g wasm-pack
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build web runtime bundle
+        run: wasm-pack build --target=web
+        working-directory: runtime/functor-runtime-web
+
+      - name: Build language analysis wasm
+        run: npm run build:lang-wasm
+
+      - name: Build site for the immutable PR head
+        env:
+          FUNCTOR_SITE_PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npm run site:build
+
+      - name: Upload static preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-site
+          path: site/dist
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -3,6 +3,9 @@ name: Cleanup PR Preview
 # pull_request_target is intentional for close cleanup: GitHub loads this file
 # from the default branch, where a PR cannot alter the author gate or commands.
 # Never check out or execute the PR head in this workflow.
+#
+# Uses the same CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_PREVIEW_API_TOKEN documented
+# by pr-preview-deploy.yml and DEVELOPMENT.md.
 
 on:
   pull_request_target:
@@ -13,7 +16,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-preview-${{ github.repository }}-${{ github.event.pull_request.head.ref }}
+  group: pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}
   queue: max
   cancel-in-progress: false
 

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,64 @@
+name: Cleanup PR Preview
+
+# pull_request_target is intentional for close cleanup: GitHub loads this file
+# from the default branch, where a PR cannot alter the author gate or commands.
+# Never check out or execute the PR head in this workflow.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.repository }}-${{ github.event.pull_request.head.ref }}
+  queue: max
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    if: >-
+      github.event.pull_request.user.login == 'tommy-xr' &&
+      github.event.pull_request.head.repo.full_name == 'tommy-xr/functor'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out trusted lifecycle code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Detach domain and delete temporary Worker
+        id: cleanup
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: node scripts/pr-preview.mjs cleanup --pr "${{ github.event.pull_request.number }}"
+
+      - name: Mark sticky comment as removed
+        if: steps.cleanup.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          node scripts/pr-preview.mjs comment
+          --pr "${{ github.event.pull_request.number }}"
+          --sha "${{ github.event.pull_request.head.sha }}"
+          --state closed
+
+      - name: Mark sticky comment with cleanup failure
+        if: steps.cleanup.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          node scripts/pr-preview.mjs comment
+          --pr "${{ github.event.pull_request.number }}"
+          --sha "${{ github.event.pull_request.head.sha }}"
+          --state cleanup-failed
+
+      - name: Fail when resource cleanup was incomplete
+        if: steps.cleanup.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -3,6 +3,9 @@ name: Deploy PR Preview
 # Privileged half of PR previews. GitHub loads this workflow and the lifecycle
 # script from main, not from the PR. The downloaded artifact is untrusted static
 # data: it is validated and uploaded, never sourced or executed.
+#
+# Requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_PREVIEW_API_TOKEN. The token
+# permissions and rollout/cleanup behavior are documented in DEVELOPMENT.md.
 
 on:
   workflow_run:
@@ -14,21 +17,17 @@ permissions:
   contents: read
   pull-requests: write
 
-# Serialize deploy and close cleanup for a PR. Stale runs are rejected against
-# the current head SHA, so canceling an in-flight cleanup is neither necessary
-# nor safe.
-concurrency:
-  group: pr-preview-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}
-  queue: max
-  cancel-in-progress: false
-
 jobs:
-  deploy:
+  authorize:
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    outputs:
+      authorized: ${{ steps.authorize.outputs.authorized }}
+      pr_number: ${{ steps.authorize.outputs.pr_number }}
+      head_sha: ${{ steps.authorize.outputs.head_sha }}
     steps:
       - name: Check out trusted lifecycle code
         uses: actions/checkout@v6
@@ -42,27 +41,42 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/pr-preview.mjs authorize-run --run-id "${{ github.event.workflow_run.id }}"
 
+  deploy:
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Serialize every mutation by immutable PR number, including close cleanup.
+    # Stale runs recheck the current SHA, so canceling an in-flight run is unsafe.
+    concurrency:
+      group: pr-preview-${{ github.repository }}-${{ needs.authorize.outputs.pr_number }}
+      queue: max
+      cancel-in-progress: false
+    steps:
+      - name: Check out trusted lifecycle code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Download this run's static artifact
-        if: steps.authorize.outputs.authorized == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: ${{ steps.authorize.outputs.artifact_name }}
+          name: pr-preview-site
           path: site/dist
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Validate untrusted static artifact
-        if: steps.authorize.outputs.authorized == 'true'
         run: >-
           node scripts/pr-preview.mjs validate-artifact
           --dir site/dist
-          --sha "${{ steps.authorize.outputs.head_sha }}"
+          --sha "${{ needs.authorize.outputs.head_sha }}"
 
       # Close/push races can happen while the artifact downloads. Re-query the
       # PR immediately before the first step that receives a Cloudflare secret.
       - name: Recheck open state and current head
-        if: steps.authorize.outputs.authorized == 'true'
         id: recheck
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy PR Preview
+
+# Privileged half of PR previews. GitHub loads this workflow and the lifecycle
+# script from main, not from the PR. The downloaded artifact is untrusted static
+# data: it is validated and uploaded, never sourced or executed.
+
+on:
+  workflow_run:
+    workflows: ["Build PR Preview"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+# Serialize deploy and close cleanup for a PR. Stale runs are rejected against
+# the current head SHA, so canceling an in-flight cleanup is neither necessary
+# nor safe.
+concurrency:
+  group: pr-preview-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}
+  queue: max
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out trusted lifecycle code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Independently authorize source run
+        id: authorize
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/pr-preview.mjs authorize-run --run-id "${{ github.event.workflow_run.id }}"
+
+      - name: Download this run's static artifact
+        if: steps.authorize.outputs.authorized == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.authorize.outputs.artifact_name }}
+          path: site/dist
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate untrusted static artifact
+        if: steps.authorize.outputs.authorized == 'true'
+        run: >-
+          node scripts/pr-preview.mjs validate-artifact
+          --dir site/dist
+          --sha "${{ steps.authorize.outputs.head_sha }}"
+
+      # Close/push races can happen while the artifact downloads. Re-query the
+      # PR immediately before the first step that receives a Cloudflare secret.
+      - name: Recheck open state and current head
+        if: steps.authorize.outputs.authorized == 'true'
+        id: recheck
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/pr-preview.mjs authorize-run --run-id "${{ github.event.workflow_run.id }}"
+
+      - name: Deploy temporary static-assets Worker
+        if: steps.recheck.outputs.authorized == 'true'
+        # Pin the secret-bearing third-party action to an immutable revision.
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
+        with:
+          wranglerVersion: "4.110.0"
+          apiToken: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            deploy
+            --name ${{ steps.recheck.outputs.worker_name }}
+            --message "PR #${{ steps.recheck.outputs.pr_number }} at ${{ steps.recheck.outputs.head_sha }}"
+
+      - name: Attach stable preview domain
+        if: steps.recheck.outputs.authorized == 'true'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PREVIEW_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: node scripts/pr-preview.mjs attach --pr "${{ steps.recheck.outputs.pr_number }}"
+
+      - name: Create or update sticky PR comment
+        if: steps.recheck.outputs.authorized == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          node scripts/pr-preview.mjs comment
+          --pr "${{ steps.recheck.outputs.pr_number }}"
+          --sha "${{ steps.recheck.outputs.head_sha }}"
+          --state ready

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -35,6 +35,12 @@ jobs:
           node-version: 22
           cache: npm
 
+      # Fast, hermetic coverage for the trusted preview authorization and
+      # static-artifact validation boundary. It needs only Node's standard
+      # library, so run it before the expensive toolchain/browser setup.
+      - name: Test PR preview lifecycle
+        run: npm run test:pr-preview
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,44 @@ Install the following (the versions in parentheses are known-good):
 On Linux you also need the native GL/X11 dev packages (see
 `.github/workflows/build-native.yml` for the exact `apt` list).
 
+## PR preview infrastructure
+
+Eligible pull requests build the static site without secrets, then a trusted
+default-branch workflow independently authorizes and deploys the artifact to
+`pr-<number>.preview.functor.games`. Preview deployment is currently limited to
+PRs authored and pushed by `tommy-xr` from branches in `tommy-xr/functor`.
+
+The deploy and close-cleanup workflows require these repository secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID` — the account containing the `functor.games` zone.
+- `CLOUDFLARE_PREVIEW_API_TOKEN` — a dedicated token scoped to that account and
+  zone with **Account / Workers Scripts: Edit** and
+  **Zone / SSL and Certificates: Edit** for `functor.games`. Workers Scripts
+  covers Worker deploy/delete and Custom Domain attach/detach; the zone
+  permission is only for best-effort cleanup of the certificate Cloudflare
+  generates for each Custom Domain.
+
+The split is intentional: `.github/workflows/pr-preview-build.yml` runs PR code
+with read-only repository access and no secrets. After it uploads `site/dist`,
+`.github/workflows/pr-preview-deploy.yml` runs code from the default branch,
+rechecks the workflow, actor, repository, open PR, and current head SHA, validates
+the artifact as static data, and only then exposes the preview token. Authorization
+rejects duplicate/expired artifacts and archives over 50 MiB; validation rejects
+expanded bundles over 100 MiB, individual assets over 25 MiB, symlinks, and
+Cloudflare deployment-control files. On close,
+`.github/workflows/pr-preview-cleanup.yml` detaches the domain and deletes the
+temporary Worker. A domain or Worker cleanup failure fails the job and marks the
+sticky PR comment with a warning; certificate cleanup is non-quota-critical and
+warns without failing the otherwise successful cleanup.
+
+These event workflows must already exist on the default branch, so the PR that
+introduces them cannot preview itself. After rollout, push a new commit to an
+eligible open PR to exercise the full path. The hermetic lifecycle checks are:
+
+```sh
+npm run test:pr-preview
+```
+
 ## Building the CLI
 
 Build the CLI. **Order matters:** the CLI embeds the web runtime bundle at compile

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:inspector-emit": "node e2e/inspector-emit.mjs",
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",
     "test:wire-value": "node --test site/src/wire-value.test.ts",
+    "test:pr-preview": "node --test scripts/pr-preview.test.mjs",
     "test:vscode-e2e": "playwright test -c tools/functor-lang-vscode/tests-integration/playwright.config.mjs",
     "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",

--- a/scripts/pr-preview.mjs
+++ b/scripts/pr-preview.mjs
@@ -13,6 +13,7 @@
 
 // Required environment is command-specific:
 //   GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT
+//   GITHUB_STEP_SUMMARY (optional; records authorization rejections)
 //   CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
 
 // Keep the allowlist and namespace here, in trusted default-branch code. A PR
@@ -23,6 +24,7 @@ import { resolve } from "node:path";
 
 const ALLOWED_AUTHOR = "tommy-xr";
 const ALLOWED_REPOSITORY = "tommy-xr/functor";
+const ALLOWED_REPOSITORY_API_URL = `https://api.github.com/repos/${ALLOWED_REPOSITORY}`;
 const BUILD_WORKFLOW_NAME = "Build PR Preview";
 const BUILD_WORKFLOW_PATH = ".github/workflows/pr-preview-build.yml";
 const ARTIFACT_NAME = "pr-preview-site";
@@ -30,6 +32,8 @@ const PREVIEW_ZONE = "functor.games";
 const COMMENT_MARKER = "<!-- functor-pr-preview -->";
 const MAX_ASSET_FILES = 20_000;
 const MAX_ASSET_BYTES = 25 * 1024 * 1024;
+const MAX_ASSET_TOTAL_BYTES = 100 * 1024 * 1024;
+const MAX_ARTIFACT_ARCHIVE_BYTES = 50 * 1024 * 1024;
 const FORBIDDEN_ASSET_FILES = new Set([".assetsignore", "_headers", "_redirects"]);
 
 const [, , command, ...rawArgs] = process.argv;
@@ -94,6 +98,13 @@ const githubRepository = () => {
   return repository;
 };
 
+// Workflow-run payloads embed a minimal repository object with only `url`,
+// while pull and repository endpoints include `full_name`. Accept either exact
+// representation without falling back to a name-only comparison.
+const isAllowedRepository = (repository) =>
+  repository?.full_name === ALLOWED_REPOSITORY ||
+  repository?.url === ALLOWED_REPOSITORY_API_URL;
+
 const githubRequest = async (path, init = {}) => {
   const response = await fetch(`https://api.github.com${path}`, {
     ...init,
@@ -128,7 +139,7 @@ const authorizeRun = async () => {
 
   let pullNumbers = [...new Set(
     (run.pull_requests ?? [])
-      .filter((pull) => pull.base?.repo?.full_name === ALLOWED_REPOSITORY)
+      .filter((pull) => isAllowedRepository(pull.base?.repo))
       .map((pull) => pull.number),
   )];
 
@@ -143,7 +154,7 @@ const authorizeRun = async () => {
       associated
         .filter(
           (pull) =>
-            pull.base?.repo?.full_name === ALLOWED_REPOSITORY &&
+            isAllowedRepository(pull.base?.repo) &&
             pull.head?.sha?.toLowerCase() === run.head_sha.toLowerCase(),
         )
         .map((pull) => pull.number),
@@ -151,7 +162,12 @@ const authorizeRun = async () => {
   }
 
   const reject = async (reason) => {
-    console.log(`PR preview skipped: ${safeLog(reason)}`);
+    const safeReason = safeLog(reason);
+    console.log(`PR preview skipped: ${safeReason}`);
+    const summary = process.env.GITHUB_STEP_SUMMARY;
+    if (summary) {
+      await appendFile(summary, `### PR preview skipped\n\n${safeReason}\n`);
+    }
     await writeOutput({ authorized: "false" });
   };
 
@@ -165,7 +181,7 @@ const authorizeRun = async () => {
   if (run.triggering_actor?.login && run.triggering_actor.login !== ALLOWED_AUTHOR) {
     return reject("rerun actor is not allowlisted");
   }
-  if (run.head_repository?.full_name !== ALLOWED_REPOSITORY) {
+  if (!isAllowedRepository(run.head_repository)) {
     return reject("source branch is not in the trusted repository");
   }
   if (pullNumbers.length !== 1) return reject("source run does not identify exactly one PR");
@@ -173,15 +189,33 @@ const authorizeRun = async () => {
   const prNumber = pullNumbers[0];
   const pull = await githubRequest(`/repos/${repository}/pulls/${prNumber}`);
   if (pull.user?.login !== ALLOWED_AUTHOR) return reject("PR author is not allowlisted");
-  if (pull.head?.repo?.full_name !== ALLOWED_REPOSITORY) {
+  if (!isAllowedRepository(pull.head?.repo)) {
     return reject("PR head repository is not allowlisted");
   }
-  if (pull.base?.repo?.full_name !== ALLOWED_REPOSITORY) {
+  if (!isAllowedRepository(pull.base?.repo)) {
     return reject("PR targets an unexpected repository");
   }
   if (pull.state !== "open") return reject("PR is no longer open");
   if (pull.head?.sha?.toLowerCase() !== run.head_sha?.toLowerCase()) {
     return reject("source artifact is stale for the current PR head");
+  }
+
+  const artifactQuery = new URLSearchParams({ name: ARTIFACT_NAME, per_page: "100" });
+  const artifactData = await githubRequest(
+    `/repos/${repository}/actions/runs/${runId}/artifacts?${artifactQuery}`,
+  );
+  const artifacts = (artifactData?.artifacts ?? []).filter(
+    (artifact) => artifact.name === ARTIFACT_NAME && artifact.expired !== true,
+  );
+  if (artifactData?.total_count !== 1 || artifacts.length !== 1) {
+    return reject(`source run must contain exactly one ${ARTIFACT_NAME} artifact`);
+  }
+  const archiveBytes = artifacts[0].size_in_bytes;
+  if (!Number.isSafeInteger(archiveBytes) || archiveBytes <= 0) {
+    return reject("source artifact reports an invalid archive size");
+  }
+  if (archiveBytes > MAX_ARTIFACT_ARCHIVE_BYTES) {
+    return reject("source artifact archive exceeds the 50 MiB preview limit");
   }
 
   const sha = pull.head.sha.toLowerCase();
@@ -190,11 +224,7 @@ const authorizeRun = async () => {
     authorized: "true",
     pr_number: prNumber,
     head_sha: sha,
-    short_sha: sha.slice(0, 7),
-    artifact_name: ARTIFACT_NAME,
     worker_name: target.worker,
-    hostname: target.hostname,
-    url: target.url,
   });
   console.log(`Authorized PR #${prNumber} at ${sha}`);
 };
@@ -202,6 +232,7 @@ const authorizeRun = async () => {
 const walkArtifact = async (directory) => {
   const root = resolve(directory);
   const files = [];
+  let totalBytes = 0;
   const pending = [root];
   while (pending.length > 0) {
     const current = pending.pop();
@@ -214,6 +245,10 @@ const walkArtifact = async (directory) => {
       } else if (info.isFile()) {
         if (info.size > MAX_ASSET_BYTES) {
           throw new Error("preview artifact contains a file larger than Cloudflare's 25 MiB limit");
+        }
+        totalBytes += info.size;
+        if (totalBytes > MAX_ASSET_TOTAL_BYTES) {
+          throw new Error("preview artifact exceeds the 100 MiB expanded-size limit");
         }
         files.push(path.slice(root.length + 1));
         if (files.length > MAX_ASSET_FILES) {
@@ -338,12 +373,15 @@ const attach = async () => {
 
 const listCertificatePacks = async (zoneId) => {
   const packs = [];
-  for (let page = 1; ; page += 1) {
-    const query = new URLSearchParams({ per_page: "50", page: String(page) });
+  for (let page = 1; page <= 20; page += 1) {
+    // A PR can close while its Custom Domain certificate is still provisioning,
+    // so include non-active packs when resolving Cloudflare's returned cert_id.
+    const query = new URLSearchParams({ status: "all", per_page: "50", page: String(page) });
     const data = await cloudflareRequest(`/zones/${zoneId}/ssl/certificate_packs?${query}`);
     packs.push(...(data?.result ?? []));
     if (page >= (data?.result_info?.total_pages ?? 1)) return packs;
   }
+  throw new Error("certificate pack inventory exceeds 20 pages");
 };
 
 const packOnlyCovers = (pack, hostname) => {
@@ -362,14 +400,15 @@ const cleanupCertificate = async (domain) => {
     const packs = (await listCertificatePacks(domain.zone_id)).filter(
       (pack) => !["deleted", "pending_deletion"].includes(pack.status),
     );
-    let candidates = packs.filter((pack) =>
-      pack.certificates?.some((certificate) => certificate.id === domain.cert_id),
+    const domainCertificateId = String(domain.cert_id).replaceAll("-", "").toLowerCase();
+    const candidates = packs.filter((pack) =>
+      pack.certificates?.some(
+        (certificate) =>
+          String(certificate.id).replaceAll("-", "").toLowerCase() === domainCertificateId,
+      ),
     );
-    if (candidates.length === 0) {
-      candidates = packs.filter(
-        (pack) => pack.type === "advanced" && packOnlyCovers(pack, domain.hostname),
-      );
-    }
+    // Never substitute a hostname-only guess: certificate cleanup is optional,
+    // and an exact ID miss is safer to leave for inventory review than delete.
     if (candidates.length !== 1 || !packOnlyCovers(candidates[0], domain.hostname)) {
       console.warn(
         `Could not safely identify the generated certificate for ${domain.hostname}; ` +
@@ -395,16 +434,16 @@ const cleanup = async () => {
   const pr = positiveInteger("pr");
   const account = cloudflareAccount();
   const target = preview(pr);
-  const failures = [];
   const detached = [];
 
-  let domains = [];
+  let domains;
   try {
     domains = await listDomains(target.hostname);
   } catch (error) {
-    failures.push(`list domain: ${error.message}`);
+    throw new Error(`preview cleanup incomplete: list domain: ${safeLog(error.message)}`);
   }
 
+  const failures = [];
   for (const domain of domains) {
     if (domain.service !== target.worker) {
       failures.push(`${target.hostname} belongs to unexpected Worker ${domain.service}`);
@@ -421,6 +460,12 @@ const cleanup = async () => {
     } catch (error) {
       failures.push(`detach domain: ${error.message}`);
     }
+  }
+
+  // Do not delete a Worker while one of its Custom Domains may still be
+  // attached. A later rerun can retry the detach without leaving a dangling URL.
+  if (failures.length > 0) {
+    throw new Error(`preview cleanup incomplete: ${failures.map(safeLog).join("; ")}`);
   }
 
   try {
@@ -468,7 +513,8 @@ const comment = async () => {
   let body;
   if (state === "ready") {
     body = `${COMMENT_MARKER}\n### Functor PR preview\n\n` +
-      `Ready for commit ${commit}. The stable URL updates after each push.\n\n` +
+      `Deployed commit ${commit}. The stable URL updates after each push. ` +
+      `On this PR's first deploy, TLS provisioning may take a few minutes.\n\n` +
       `[Site](${target.url}/) · ` +
       `[Sandbox](${target.url}/sandbox.html) · ` +
       `[IDE](${target.url}/ide.html) · ` +

--- a/scripts/pr-preview.mjs
+++ b/scripts/pr-preview.mjs
@@ -1,0 +1,519 @@
+// Trusted lifecycle tooling for Functor's per-PR static-site previews.
+//
+// This file is always run from the default branch by the secret-bearing
+// workflow_run / pull_request_target workflows. The PR build artifact is data:
+// validate it, upload it as static assets, but never execute anything from it.
+
+// Commands:
+//   authorize-run --run-id N
+//   validate-artifact --dir site/dist --sha FULL_SHA
+//   attach --pr N
+//   cleanup --pr N
+//   comment --pr N --sha FULL_SHA --state ready|closed|cleanup-failed
+
+// Required environment is command-specific:
+//   GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_OUTPUT
+//   CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+
+// Keep the allowlist and namespace here, in trusted default-branch code. A PR
+// that edits its own build workflow or a copy of this script cannot widen it.
+
+import { appendFile, lstat, readFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const ALLOWED_AUTHOR = "tommy-xr";
+const ALLOWED_REPOSITORY = "tommy-xr/functor";
+const BUILD_WORKFLOW_NAME = "Build PR Preview";
+const BUILD_WORKFLOW_PATH = ".github/workflows/pr-preview-build.yml";
+const ARTIFACT_NAME = "pr-preview-site";
+const PREVIEW_ZONE = "functor.games";
+const COMMENT_MARKER = "<!-- functor-pr-preview -->";
+const MAX_ASSET_FILES = 20_000;
+const MAX_ASSET_BYTES = 25 * 1024 * 1024;
+const FORBIDDEN_ASSET_FILES = new Set([".assetsignore", "_headers", "_redirects"]);
+
+const [, , command, ...rawArgs] = process.argv;
+
+const flags = new Map();
+for (let index = 0; index < rawArgs.length; index += 2) {
+  const name = rawArgs[index];
+  const value = rawArgs[index + 1];
+  if (!name?.startsWith("--") || value === undefined) {
+    throw new Error(`expected --name value arguments; got ${JSON.stringify(rawArgs)}`);
+  }
+  flags.set(name.slice(2), value);
+}
+
+const flag = (name) => {
+  const value = flags.get(name);
+  if (value === undefined) throw new Error(`missing --${name}`);
+  return value;
+};
+
+const positiveInteger = (name) => {
+  const raw = flag(name);
+  if (!/^[1-9]\d*$/.test(raw)) throw new Error(`--${name} must be a positive integer`);
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) throw new Error(`--${name} is too large`);
+  return value;
+};
+
+const fullSha = (name = "sha") => {
+  const raw = flag(name);
+  if (!/^[0-9a-f]{40}$/i.test(raw)) {
+    throw new Error(`--${name} must be a full 40-character Git commit SHA`);
+  }
+  return raw.toLowerCase();
+};
+
+const requiredEnv = (name) => {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+};
+
+const preview = (pr) => ({
+  worker: `functor-pr-${pr}`,
+  hostname: `pr-${pr}.preview.${PREVIEW_ZONE}`,
+  url: `https://pr-${pr}.preview.${PREVIEW_ZONE}`,
+});
+
+const safeLog = (value) => String(value).replace(/[\r\n%]/g, " ");
+
+const writeOutput = async (values) => {
+  const output = requiredEnv("GITHUB_OUTPUT");
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}\n`).join("");
+  await appendFile(output, lines);
+};
+
+const githubRepository = () => {
+  const repository = requiredEnv("GITHUB_REPOSITORY");
+  if (repository !== ALLOWED_REPOSITORY) {
+    throw new Error(`refusing to manage previews for repository ${safeLog(repository)}`);
+  }
+  return repository;
+};
+
+const githubRequest = async (path, init = {}) => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${requiredEnv("GITHUB_TOKEN")}`,
+      "X-GitHub-Api-Version": "2026-03-10",
+      "User-Agent": "functor-pr-preview",
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(`GitHub API returned non-JSON (${response.status})`);
+    }
+  }
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}: ${safeLog(data?.message ?? response.statusText)}`);
+  }
+  return data;
+};
+
+const authorizeRun = async () => {
+  const runId = positiveInteger("run-id");
+  const repository = githubRepository();
+  const run = await githubRequest(`/repos/${repository}/actions/runs/${runId}`);
+
+  let pullNumbers = [...new Set(
+    (run.pull_requests ?? [])
+      .filter((pull) => pull.base?.repo?.full_name === ALLOWED_REPOSITORY)
+      .map((pull) => pull.number),
+  )];
+
+  // GitHub occasionally omits pull_requests from historical workflow-run
+  // payloads. The associated-pulls endpoint is a safe fallback, but ambiguity
+  // is rejected rather than guessing which PR owns the deployment URL.
+  if (pullNumbers.length === 0 && /^[0-9a-f]{40}$/i.test(run.head_sha ?? "")) {
+    const associated = await githubRequest(
+      `/repos/${repository}/commits/${run.head_sha}/pulls?per_page=100`,
+    );
+    pullNumbers = [...new Set(
+      associated
+        .filter(
+          (pull) =>
+            pull.base?.repo?.full_name === ALLOWED_REPOSITORY &&
+            pull.head?.sha?.toLowerCase() === run.head_sha.toLowerCase(),
+        )
+        .map((pull) => pull.number),
+    )];
+  }
+
+  const reject = async (reason) => {
+    console.log(`PR preview skipped: ${safeLog(reason)}`);
+    await writeOutput({ authorized: "false" });
+  };
+
+  if (run.name !== BUILD_WORKFLOW_NAME) return reject("unexpected source workflow");
+  if (run.path !== BUILD_WORKFLOW_PATH) return reject("unexpected source workflow path");
+  if (run.event !== "pull_request") return reject("source event was not pull_request");
+  if (run.status !== "completed" || run.conclusion !== "success") {
+    return reject("source build did not complete successfully");
+  }
+  if (run.actor?.login !== ALLOWED_AUTHOR) return reject("source actor is not allowlisted");
+  if (run.triggering_actor?.login && run.triggering_actor.login !== ALLOWED_AUTHOR) {
+    return reject("rerun actor is not allowlisted");
+  }
+  if (run.head_repository?.full_name !== ALLOWED_REPOSITORY) {
+    return reject("source branch is not in the trusted repository");
+  }
+  if (pullNumbers.length !== 1) return reject("source run does not identify exactly one PR");
+
+  const prNumber = pullNumbers[0];
+  const pull = await githubRequest(`/repos/${repository}/pulls/${prNumber}`);
+  if (pull.user?.login !== ALLOWED_AUTHOR) return reject("PR author is not allowlisted");
+  if (pull.head?.repo?.full_name !== ALLOWED_REPOSITORY) {
+    return reject("PR head repository is not allowlisted");
+  }
+  if (pull.base?.repo?.full_name !== ALLOWED_REPOSITORY) {
+    return reject("PR targets an unexpected repository");
+  }
+  if (pull.state !== "open") return reject("PR is no longer open");
+  if (pull.head?.sha?.toLowerCase() !== run.head_sha?.toLowerCase()) {
+    return reject("source artifact is stale for the current PR head");
+  }
+
+  const sha = pull.head.sha.toLowerCase();
+  const target = preview(prNumber);
+  await writeOutput({
+    authorized: "true",
+    pr_number: prNumber,
+    head_sha: sha,
+    short_sha: sha.slice(0, 7),
+    artifact_name: ARTIFACT_NAME,
+    worker_name: target.worker,
+    hostname: target.hostname,
+    url: target.url,
+  });
+  console.log(`Authorized PR #${prNumber} at ${sha}`);
+};
+
+const walkArtifact = async (directory) => {
+  const root = resolve(directory);
+  const files = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const name of await readdir(current)) {
+      const path = resolve(current, name);
+      const info = await lstat(path);
+      if (info.isSymbolicLink()) throw new Error("preview artifact may not contain symbolic links");
+      if (info.isDirectory()) {
+        pending.push(path);
+      } else if (info.isFile()) {
+        if (info.size > MAX_ASSET_BYTES) {
+          throw new Error("preview artifact contains a file larger than Cloudflare's 25 MiB limit");
+        }
+        files.push(path.slice(root.length + 1));
+        if (files.length > MAX_ASSET_FILES) {
+          throw new Error(`preview artifact exceeds Cloudflare's ${MAX_ASSET_FILES}-file limit`);
+        }
+      } else {
+        throw new Error("preview artifact may contain only regular files and directories");
+      }
+    }
+  }
+  return { root, files };
+};
+
+const validateArtifact = async () => {
+  const sha = fullSha();
+  const { root, files } = await walkArtifact(flag("dir"));
+  const required = [
+    "index.html",
+    "sandbox.html",
+    "ide.html",
+    "docs/index.html",
+    "manual/index.html",
+    "pkg/functor_runtime_web.js",
+    "pkg/functor_runtime_web_bg.wasm",
+    "pkg/functor_lang_wasm.js",
+    "pkg/functor_lang_wasm_bg.wasm",
+  ];
+  const present = new Set(files);
+  const missing = required.filter((path) => !present.has(path));
+  if (missing.length > 0) {
+    throw new Error(`preview artifact is incomplete; missing ${missing.join(", ")}`);
+  }
+  const forbidden = files.filter((path) => FORBIDDEN_ASSET_FILES.has(path));
+  if (forbidden.length > 0) {
+    throw new Error(
+      `preview artifact may not contain Cloudflare deployment controls: ${forbidden.join(", ")}`,
+    );
+  }
+
+  const expectedBadge =
+    `<span class="version-badge" title="PR preview for commit ${sha}">` +
+    `${sha.slice(0, 7)} · preview</span>`;
+  for (const path of [
+    "index.html",
+    "sandbox.html",
+    "ide.html",
+    "docs/index.html",
+    "manual/index.html",
+  ]) {
+    const html = await readFile(resolve(root, path), "utf8");
+    const badges = html.match(/<span class="version-badge"[^>]*>[^<]*<\/span>/g) ?? [];
+    if (badges.length !== 1 || badges[0] !== expectedBadge) {
+      throw new Error(`${path} does not contain exactly one badge for its source commit`);
+    }
+  }
+  console.log(`Validated ${files.length} static preview assets for ${sha}`);
+};
+
+const cloudflareRequest = async (path, init = {}, { allowNotFound = false } = {}) => {
+  const response = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${requiredEnv("CLOUDFLARE_API_TOKEN")}`,
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+  if (allowNotFound && response.status === 404) return null;
+  const text = await response.text();
+  let data = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(`Cloudflare API returned non-JSON (${response.status})`);
+    }
+  }
+  if (!response.ok || data?.success === false) {
+    const detail = data?.errors?.map((error) => error.message).join("; ") || response.statusText;
+    throw new Error(`Cloudflare API ${response.status}: ${safeLog(detail)}`);
+  }
+  return data;
+};
+
+const cloudflareAccount = () => {
+  const account = requiredEnv("CLOUDFLARE_ACCOUNT_ID");
+  if (!/^[0-9a-f]{32}$/i.test(account)) throw new Error("CLOUDFLARE_ACCOUNT_ID is malformed");
+  return account;
+};
+
+const listDomains = async (hostname) => {
+  const account = cloudflareAccount();
+  const query = new URLSearchParams({ hostname });
+  const data = await cloudflareRequest(`/accounts/${account}/workers/domains?${query}`);
+  return (data?.result ?? []).filter((domain) => domain.hostname === hostname);
+};
+
+const attach = async () => {
+  const pr = positiveInteger("pr");
+  const account = cloudflareAccount();
+  const target = preview(pr);
+  const domains = await listDomains(target.hostname);
+  const foreign = domains.find((domain) => domain.service !== target.worker);
+  if (foreign) {
+    throw new Error(`refusing to replace ${target.hostname}; it belongs to another Worker`);
+  }
+  if (domains.some((domain) => domain.service === target.worker)) {
+    console.log(`${target.hostname} is already attached to ${target.worker}`);
+    return;
+  }
+
+  await cloudflareRequest(`/accounts/${account}/workers/domains`, {
+    method: "PUT",
+    body: JSON.stringify({
+      hostname: target.hostname,
+      service: target.worker,
+      zone_name: PREVIEW_ZONE,
+    }),
+  });
+  console.log(`Attached ${target.url} to ${target.worker}`);
+};
+
+const listCertificatePacks = async (zoneId) => {
+  const packs = [];
+  for (let page = 1; ; page += 1) {
+    const query = new URLSearchParams({ per_page: "50", page: String(page) });
+    const data = await cloudflareRequest(`/zones/${zoneId}/ssl/certificate_packs?${query}`);
+    packs.push(...(data?.result ?? []));
+    if (page >= (data?.result_info?.total_pages ?? 1)) return packs;
+  }
+};
+
+const packOnlyCovers = (pack, hostname) => {
+  const hosts = [
+    ...(Array.isArray(pack.hosts) ? pack.hosts : []),
+    ...(Array.isArray(pack.certificates)
+      ? pack.certificates.flatMap((certificate) => certificate.hosts ?? [])
+      : []),
+  ].map((host) => String(host).toLowerCase());
+  return hosts.length > 0 && hosts.every((host) => host === hostname);
+};
+
+const cleanupCertificate = async (domain) => {
+  if (!domain.zone_id || !domain.cert_id) return;
+  try {
+    const packs = (await listCertificatePacks(domain.zone_id)).filter(
+      (pack) => !["deleted", "pending_deletion"].includes(pack.status),
+    );
+    let candidates = packs.filter((pack) =>
+      pack.certificates?.some((certificate) => certificate.id === domain.cert_id),
+    );
+    if (candidates.length === 0) {
+      candidates = packs.filter(
+        (pack) => pack.type === "advanced" && packOnlyCovers(pack, domain.hostname),
+      );
+    }
+    if (candidates.length !== 1 || !packOnlyCovers(candidates[0], domain.hostname)) {
+      console.warn(
+        `Could not safely identify the generated certificate for ${domain.hostname}; ` +
+          "leaving it for manual review",
+      );
+      return;
+    }
+    await cloudflareRequest(
+      `/zones/${domain.zone_id}/ssl/certificate_packs/${candidates[0].id}`,
+      { method: "DELETE" },
+      { allowNotFound: true },
+    );
+    console.log(`Deleted generated certificate for ${domain.hostname}`);
+  } catch (error) {
+    // Cloudflare documents leftover Custom Domain certificates as harmless.
+    // Domain and Worker deletion are the quota-relevant cleanup; keep them
+    // successful while making certificate inventory drift visible in logs.
+    console.warn(`Certificate cleanup warning: ${safeLog(error.message)}`);
+  }
+};
+
+const cleanup = async () => {
+  const pr = positiveInteger("pr");
+  const account = cloudflareAccount();
+  const target = preview(pr);
+  const failures = [];
+  const detached = [];
+
+  let domains = [];
+  try {
+    domains = await listDomains(target.hostname);
+  } catch (error) {
+    failures.push(`list domain: ${error.message}`);
+  }
+
+  for (const domain of domains) {
+    if (domain.service !== target.worker) {
+      failures.push(`${target.hostname} belongs to unexpected Worker ${domain.service}`);
+      continue;
+    }
+    try {
+      await cloudflareRequest(
+        `/accounts/${account}/workers/domains/${domain.id}`,
+        { method: "DELETE" },
+        { allowNotFound: true },
+      );
+      detached.push(domain);
+      console.log(`Detached ${target.hostname}`);
+    } catch (error) {
+      failures.push(`detach domain: ${error.message}`);
+    }
+  }
+
+  try {
+    await cloudflareRequest(
+      `/accounts/${account}/workers/scripts/${target.worker}`,
+      { method: "DELETE" },
+      { allowNotFound: true },
+    );
+    console.log(`Deleted ${target.worker} (or it was already absent)`);
+  } catch (error) {
+    failures.push(`delete Worker: ${error.message}`);
+  }
+
+  for (const domain of detached) await cleanupCertificate(domain);
+
+  if (failures.length > 0) {
+    throw new Error(`preview cleanup incomplete: ${failures.map(safeLog).join("; ")}`);
+  }
+};
+
+const findStickyComment = async (repository, pr) => {
+  for (let page = 1; page <= 20; page += 1) {
+    const comments = await githubRequest(
+      `/repos/${repository}/issues/${pr}/comments?per_page=100&page=${page}`,
+    );
+    const found = comments.find(
+      (comment) =>
+        comment.user?.login === "github-actions[bot]" && comment.body?.includes(COMMENT_MARKER),
+    );
+    if (found) return found;
+    if (comments.length < 100) return null;
+  }
+  throw new Error("could not search all PR comments for the preview marker");
+};
+
+const comment = async () => {
+  const repository = githubRepository();
+  const pr = positiveInteger("pr");
+  const sha = fullSha();
+  const state = flag("state");
+  const target = preview(pr);
+  const commitUrl = `https://github.com/${repository}/commit/${sha}`;
+  const commit = `[\`${sha.slice(0, 7)}\`](${commitUrl})`;
+
+  let body;
+  if (state === "ready") {
+    body = `${COMMENT_MARKER}\n### Functor PR preview\n\n` +
+      `Ready for commit ${commit}. The stable URL updates after each push.\n\n` +
+      `[Site](${target.url}/) · ` +
+      `[Sandbox](${target.url}/sandbox.html) · ` +
+      `[IDE](${target.url}/ide.html) · ` +
+      `[API reference](${target.url}/docs/)\n\n` +
+      `<sub>Full commit: <code>${sha}</code>. This temporary Worker is removed when the PR closes.</sub>`;
+  } else if (state === "closed") {
+    body = `${COMMENT_MARKER}\n### Functor PR preview\n\n` +
+      `🧹 Preview removed because this PR closed. Last previewed commit: ${commit}.`;
+  } else if (state === "cleanup-failed") {
+    body = `${COMMENT_MARKER}\n### Functor PR preview\n\n` +
+      `⚠️ Automatic cleanup failed for ${target.hostname}. ` +
+      `Check the **Cleanup PR Preview** workflow logs. Last commit: ${commit}.`;
+  } else {
+    throw new Error("--state must be ready, closed, or cleanup-failed");
+  }
+
+  const existing = await findStickyComment(repository, pr);
+  if (existing) {
+    await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ body }),
+    });
+    console.log(`Updated preview comment on PR #${pr}`);
+  } else if (state === "closed") {
+    // A build can fail before ever creating a preview. Closing that PR should
+    // still run idempotent resource cleanup, but should not add a misleading
+    // new "removed" comment for a URL that never existed.
+    console.log(`No preview comment exists on PR #${pr}; nothing to mark as removed`);
+  } else {
+    await githubRequest(`/repos/${repository}/issues/${pr}/comments`, {
+      method: "POST",
+      body: JSON.stringify({ body }),
+    });
+    console.log(`Created preview comment on PR #${pr}`);
+  }
+};
+
+try {
+  if (command === "authorize-run") await authorizeRun();
+  else if (command === "validate-artifact") await validateArtifact();
+  else if (command === "attach") await attach();
+  else if (command === "cleanup") await cleanup();
+  else if (command === "comment") await comment();
+  else throw new Error(`unknown command ${JSON.stringify(command)}`);
+} catch (error) {
+  console.error(`PR preview error: ${safeLog(error?.message ?? error)}`);
+  process.exitCode = 1;
+}

--- a/scripts/pr-preview.test.mjs
+++ b/scripts/pr-preview.test.mjs
@@ -1,0 +1,499 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  truncate,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const script = fileURLToPath(new URL("./pr-preview.mjs", import.meta.url));
+const sha = "0123456789abcdef0123456789abcdef01234567";
+const repository = "tommy-xr/functor";
+const repositoryApiUrl = `https://api.github.com/repos/${repository}`;
+const accountId = "a".repeat(32);
+const zoneId = "b".repeat(32);
+const certificatePackId = "c".repeat(32);
+const domainCertificateId = "9fdf92c8-64c2-4a3d-b1af-e15304961145";
+const packedCertificateId = domainCertificateId.replaceAll("-", "");
+const previewHostname = "pr-690.preview.functor.games";
+const headerPages = [
+  "index.html",
+  "sandbox.html",
+  "ide.html",
+  "docs/index.html",
+  "manual/index.html",
+];
+const runtimeFiles = [
+  "pkg/functor_runtime_web.js",
+  "pkg/functor_runtime_web_bg.wasm",
+  "pkg/functor_lang_wasm.js",
+  "pkg/functor_lang_wasm_bg.wasm",
+];
+const badge =
+  `<span class="version-badge" title="PR preview for commit ${sha}">` +
+  `${sha.slice(0, 7)} · preview</span>`;
+
+const temporaryDirectory = async (t, prefix) => {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  return directory;
+};
+
+const makePreviewArtifact = async (t) => {
+  const root = await temporaryDirectory(t, "functor-pr-preview-artifact-");
+  for (const path of [...headerPages, ...runtimeFiles]) {
+    const target = join(root, path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(
+      target,
+      path.endsWith(".html") ? `<!doctype html><body>${badge}</body>` : "fixture",
+    );
+  }
+  return root;
+};
+
+const runPreview = async (args, env = {}) => {
+  try {
+    const result = await execFileAsync(process.execPath, [script, ...args], {
+      env: { ...process.env, ...env },
+      maxBuffer: 1024 * 1024,
+    });
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    return {
+      code: typeof error.code === "number" ? error.code : 1,
+      stdout: String(error.stdout ?? ""),
+      stderr: String(error.stderr ?? error.message ?? error),
+    };
+  }
+};
+
+const validateArtifact = (directory, commit = sha) =>
+  runPreview(["validate-artifact", "--dir", directory, "--sha", commit]);
+
+const validArtifacts = () => ({
+  total_count: 1,
+  artifacts: [{ name: "pr-preview-site", expired: false, size_in_bytes: 1024 }],
+});
+
+const writeGitHubStub = async (
+  t,
+  run,
+  pull,
+  artifacts = validArtifacts(),
+  associated = [],
+) => {
+  const root = await temporaryDirectory(t, "functor-pr-preview-github-");
+  const stub = join(root, "fetch-stub.mjs");
+  await writeFile(
+    stub,
+    `const run = ${JSON.stringify(run)};\n` +
+      `const pull = ${JSON.stringify(pull)};\n` +
+      `const artifacts = ${JSON.stringify(artifacts)};\n` +
+      `const associated = ${JSON.stringify(associated)};\n` +
+      `globalThis.fetch = async (input) => {\n` +
+      `  const path = new URL(String(input)).pathname;\n` +
+      `  const body = /\\/commits\\/[0-9a-f]{40}\\/pulls$/.test(path)\n` +
+      `    ? associated\n` +
+      `    : /\\/actions\\/runs\\/\\d+\\/artifacts$/.test(path)\n` +
+      `    ? artifacts\n` +
+      `    : /\\/actions\\/runs\\/\\d+$/.test(path) ? run : pull;\n` +
+      `  return new Response(JSON.stringify(body), {\n` +
+      `    status: 200, headers: { "Content-Type": "application/json" },\n` +
+      `  });\n` +
+      `};\n`,
+  );
+  return pathToFileURL(stub).href;
+};
+
+const writeCloudflareStub = async (
+  t,
+  { failDomainList = false, failDomainDetach = false, foreignDomain = false } = {},
+) => {
+  const root = await temporaryDirectory(t, "functor-pr-preview-cloudflare-");
+  const stub = join(root, "fetch-stub.mjs");
+  const log = join(root, "requests.jsonl");
+  await writeFile(log, "");
+  await writeFile(
+    stub,
+    `import { appendFileSync } from "node:fs";\n` +
+      `const log = ${JSON.stringify(log)};\n` +
+      `const failDomainList = ${JSON.stringify(failDomainList)};\n` +
+      `const failDomainDetach = ${JSON.stringify(failDomainDetach)};\n` +
+      `const foreignDomain = ${JSON.stringify(foreignDomain)};\n` +
+      `const json = (body, status = 200) => new Response(JSON.stringify(body), {\n` +
+      `  status, headers: { "Content-Type": "application/json" },\n` +
+      `});\n` +
+      `globalThis.fetch = async (input, init = {}) => {\n` +
+      `  const url = new URL(String(input));\n` +
+      `  const method = init.method ?? "GET";\n` +
+      `  appendFileSync(log, JSON.stringify({ method, path: url.pathname + url.search }) + "\\n");\n` +
+      `  if (method === "GET" && url.pathname.endsWith("/workers/domains")) {\n` +
+      `    if (failDomainList) return json({ success: false, errors: [{ message: "denied" }] }, 403);\n` +
+      `    return json({ success: true, result: [{\n` +
+      `      id: "domain-id", hostname: ${JSON.stringify(previewHostname)},\n` +
+      `      service: foreignDomain ? "production-worker" : "functor-pr-690",\n` +
+      `      zone_id: ${JSON.stringify(zoneId)},\n` +
+      `      cert_id: ${JSON.stringify(domainCertificateId)},\n` +
+      `    }] });\n` +
+      `  }\n` +
+      `  if (method === "GET" && url.pathname.endsWith("/ssl/certificate_packs")) {\n` +
+      `    return json({ success: true, result: [{\n` +
+      `      id: ${JSON.stringify(certificatePackId)}, status: "active",\n` +
+      `      hosts: [${JSON.stringify(previewHostname)}],\n` +
+      `      certificates: [{ id: ${JSON.stringify(packedCertificateId)}, hosts: [${JSON.stringify(previewHostname)}] }],\n` +
+      `    }], result_info: { total_pages: 1 } });\n` +
+      `  }\n` +
+      `  if (method === "DELETE" && url.pathname.endsWith("/workers/domains/domain-id") && failDomainDetach) {\n` +
+      `    return json({ success: false, errors: [{ message: "detach denied" }] }, 403);\n` +
+      `  }\n` +
+      `  if (method === "DELETE") return json({ success: true, result: null });\n` +
+      `  return json({ success: false, errors: [{ message: "unexpected request" }] }, 500);\n` +
+      `};\n`,
+  );
+  return { log, stub: pathToFileURL(stub).href };
+};
+
+const writeGitHubCommentStub = async (t, comments = []) => {
+  const root = await temporaryDirectory(t, "functor-pr-preview-comments-");
+  const stub = join(root, "fetch-stub.mjs");
+  const log = join(root, "requests.jsonl");
+  await writeFile(log, "");
+  await writeFile(
+    stub,
+    `import { appendFileSync } from "node:fs";\n` +
+      `const comments = ${JSON.stringify(comments)};\n` +
+      `const log = ${JSON.stringify(log)};\n` +
+      `const json = (body, status = 200) => new Response(JSON.stringify(body), {\n` +
+      `  status, headers: { "Content-Type": "application/json" },\n` +
+      `});\n` +
+      `globalThis.fetch = async (input, init = {}) => {\n` +
+      `  const url = new URL(String(input));\n` +
+      `  const method = init.method ?? "GET";\n` +
+      `  const body = init.body ? JSON.parse(init.body) : null;\n` +
+      `  appendFileSync(log, JSON.stringify({ method, path: url.pathname, body }) + "\\n");\n` +
+      `  if (method === "GET" && url.pathname.endsWith("/issues/690/comments")) return json(comments);\n` +
+      `  if (method === "POST" && url.pathname.endsWith("/issues/690/comments")) return json({ id: 1 });\n` +
+      `  if (method === "PATCH" && /\\/issues\\/comments\\/\\d+$/.test(url.pathname)) return json({ id: 1 });\n` +
+      `  return json({ message: "unexpected request" }, 500);\n` +
+      `};\n`,
+  );
+  return { log, stub: pathToFileURL(stub).href };
+};
+
+const validRun = () => ({
+  name: "Build PR Preview",
+  path: ".github/workflows/pr-preview-build.yml",
+  event: "pull_request",
+  status: "completed",
+  conclusion: "success",
+  actor: { login: "tommy-xr" },
+  triggering_actor: { login: "tommy-xr" },
+  head_repository: { full_name: repository },
+  head_sha: sha,
+  pull_requests: [{
+    number: 690,
+    base: { repo: { id: 800538382, name: "functor", url: repositoryApiUrl } },
+  }],
+});
+
+const validPull = () => ({
+  number: 690,
+  user: { login: "tommy-xr" },
+  head: { sha, repo: { full_name: repository } },
+  base: { repo: { full_name: repository } },
+  state: "open",
+});
+
+const authorizationEnvironment = (stub, output, summary) => ({
+  GITHUB_TOKEN: "test-token",
+  GITHUB_REPOSITORY: repository,
+  GITHUB_OUTPUT: output,
+  GITHUB_STEP_SUMMARY: summary,
+  NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${stub}`].filter(Boolean).join(" "),
+});
+
+const runAuthorization = async (
+  t,
+  {
+    run = validRun(),
+    pull = validPull(),
+    artifacts = validArtifacts(),
+    associated = [],
+  } = {},
+) => {
+  const root = await temporaryDirectory(t, "functor-pr-preview-authorization-");
+  const output = join(root, "output");
+  const summary = join(root, "summary");
+  const stub = await writeGitHubStub(t, run, pull, artifacts, associated);
+  const result = await runPreview(
+    ["authorize-run", "--run-id", "123"],
+    authorizationEnvironment(stub, output, summary),
+  );
+  return { output, result, summary };
+};
+
+const cloudflareEnvironment = (stub) => ({
+  CLOUDFLARE_API_TOKEN: "test-token",
+  CLOUDFLARE_ACCOUNT_ID: accountId,
+  NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${stub}`].filter(Boolean).join(" "),
+});
+
+const runCleanup = (stub) =>
+  runPreview(["cleanup", "--pr", "690"], cloudflareEnvironment(stub));
+
+test("accepts a complete static artifact with exact commit badges", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  const result = await validateArtifact(artifact);
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Validated 9 static preview assets/);
+});
+
+test("requires a full commit SHA", async () => {
+  const result = await validateArtifact(".", "deadbeef");
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /full 40-character Git commit SHA/);
+});
+
+test("requires positive, safe PR numbers", async () => {
+  const zero = await runPreview(["cleanup", "--pr", "0"]);
+  assert.notEqual(zero.code, 0);
+  assert.match(zero.stderr, /--pr must be a positive integer/);
+
+  const unsafe = await runPreview(["cleanup", "--pr", "99999999999999999"]);
+  assert.notEqual(unsafe.code, 0);
+  assert.match(unsafe.stderr, /--pr is too large/);
+});
+
+test("rejects an incomplete artifact", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  await rm(join(artifact, "pkg/functor_lang_wasm.js"));
+  const result = await validateArtifact(artifact);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /missing pkg\/functor_lang_wasm\.js/);
+});
+
+for (const control of [".assetsignore", "_headers", "_redirects"]) {
+  test(`rejects Cloudflare deployment control ${control}`, async (t) => {
+    const artifact = await makePreviewArtifact(t);
+    await writeFile(join(artifact, control), "/* fixture */");
+    const result = await validateArtifact(artifact);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr, /may not contain Cloudflare deployment controls/);
+    assert.match(result.stderr, new RegExp(control.replace(".", "\\.")));
+  });
+}
+
+test("rejects symbolic links", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  await symlink("index.html", join(artifact, "linked-index.html"));
+  const result = await validateArtifact(artifact);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /may not contain symbolic links/);
+});
+
+test("rejects files over Cloudflare's static-asset limit", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  const oversized = join(artifact, "oversized.bin");
+  await writeFile(oversized, "");
+  await truncate(oversized, 25 * 1024 * 1024 + 1);
+  const result = await validateArtifact(artifact);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /larger than Cloudflare's 25 MiB limit/);
+});
+
+test("rejects artifacts over the expanded-size limit", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  for (let index = 0; index < 5; index += 1) {
+    const file = join(artifact, `expanded-${index}.bin`);
+    await writeFile(file, "");
+    await truncate(file, 21 * 1024 * 1024);
+  }
+  const result = await validateArtifact(artifact);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /exceeds the 100 MiB expanded-size limit/);
+});
+
+test("rejects a spoofed commit badge", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  const sandbox = join(artifact, "sandbox.html");
+  const html = await readFile(sandbox, "utf8");
+  await writeFile(sandbox, html.replace(`${sha.slice(0, 7)} · preview`, "deadbee · preview"));
+  const result = await validateArtifact(artifact);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /sandbox\.html does not contain exactly one badge/);
+});
+
+test("rejects duplicate commit badges", async (t) => {
+  const artifact = await makePreviewArtifact(t);
+  const index = join(artifact, "index.html");
+  await writeFile(index, `${await readFile(index, "utf8")}\n${badge}`);
+  const result = await validateArtifact(artifact);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /index\.html does not contain exactly one badge/);
+});
+
+test("authorizes the exact allowlisted run and current PR head", async (t) => {
+  const { output, result } = await runAuthorization(t);
+  assert.equal(result.code, 0, result.stderr);
+  const values = await readFile(output, "utf8");
+  assert.match(values, /^authorized=true$/m);
+  assert.match(values, /^pr_number=690$/m);
+  assert.match(values, new RegExp(`^head_sha=${sha}$`, "m"));
+  assert.match(values, /^worker_name=functor-pr-690$/m);
+});
+
+test("resolves a PR through GitHub's associated-pulls fallback", async (t) => {
+  const { output, result } = await runAuthorization(t, {
+    run: { ...validRun(), pull_requests: [] },
+    associated: [validPull()],
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(await readFile(output, "utf8"), /^authorized=true$/m);
+});
+
+for (const [label, options, reason] of [
+  [
+    "source actor",
+    { run: { ...validRun(), actor: { login: "not-allowlisted" } } },
+    /source actor is not allowlisted/,
+  ],
+  [
+    "rerun actor",
+    { run: { ...validRun(), triggering_actor: { login: "not-allowlisted" } } },
+    /rerun actor is not allowlisted/,
+  ],
+  [
+    "source repository",
+    { run: { ...validRun(), head_repository: { full_name: "someone/fork" } } },
+    /source branch is not in the trusted repository/,
+  ],
+  [
+    "PR author",
+    { pull: { ...validPull(), user: { login: "not-allowlisted" } } },
+    /PR author is not allowlisted/,
+  ],
+  [
+    "closed PR",
+    { pull: { ...validPull(), state: "closed" } },
+    /PR is no longer open/,
+  ],
+  [
+    "stale head",
+    { run: { ...validRun(), head_sha: "f".repeat(40) } },
+    /source artifact is stale for the current PR head/,
+  ],
+]) {
+  test(`rejects a non-authorized ${label}`, async (t) => {
+    const { output, result, summary } = await runAuthorization(t, options);
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(await readFile(output, "utf8"), /^authorized=false$/m);
+    assert.match(await readFile(summary, "utf8"), reason);
+  });
+}
+
+test("rejects duplicate source artifacts", async (t) => {
+  const duplicate = { name: "pr-preview-site", expired: false, size_in_bytes: 1024 };
+  const { output, result, summary } = await runAuthorization(t, {
+    artifacts: {
+      total_count: 2,
+      artifacts: [duplicate, { ...duplicate, id: 2 }],
+    },
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(await readFile(output, "utf8"), /^authorized=false$/m);
+  assert.match(await readFile(summary, "utf8"), /must contain exactly one pr-preview-site artifact/);
+});
+
+test("rejects an oversized source artifact archive", async (t) => {
+  const { output, result, summary } = await runAuthorization(t, {
+    artifacts: {
+      total_count: 1,
+      artifacts: [{
+        name: "pr-preview-site",
+        expired: false,
+        size_in_bytes: 50 * 1024 * 1024 + 1,
+      }],
+    },
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(await readFile(output, "utf8"), /^authorized=false$/m);
+  assert.match(await readFile(summary, "utf8"), /archive exceeds the 50 MiB preview limit/);
+});
+
+test("records an authorization rejection in the step summary", async (t) => {
+  const { output, result, summary } = await runAuthorization(t, {
+    run: { ...validRun(), name: "Unexpected Workflow" },
+  });
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(await readFile(output, "utf8"), /^authorized=false$/m);
+  assert.match(await readFile(summary, "utf8"), /unexpected source workflow/);
+});
+
+test("creates a ready sticky comment with the preview URL and commit", async (t) => {
+  const { log, stub } = await writeGitHubCommentStub(t);
+  const result = await runPreview(
+    ["comment", "--pr", "690", "--sha", sha, "--state", "ready"],
+    {
+      GITHUB_TOKEN: "test-token",
+      GITHUB_REPOSITORY: repository,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${stub}`].filter(Boolean).join(" "),
+    },
+  );
+  assert.equal(result.code, 0, result.stderr);
+  const requests = (await readFile(log, "utf8")).trim().split("\n").map(JSON.parse);
+  const created = requests.find((request) => request.method === "POST");
+  assert.equal(created.path, `/repos/${repository}/issues/690/comments`);
+  assert.match(created.body.body, /<!-- functor-pr-preview -->/);
+  assert.match(created.body.body, new RegExp(`Deployed commit.*${sha.slice(0, 7)}`));
+  assert.match(created.body.body, /https:\/\/pr-690\.preview\.functor\.games\/sandbox\.html/);
+  assert.match(created.body.body, new RegExp(`Full commit: <code>${sha}</code>`));
+});
+
+test("cleans up the exact certificate despite Cloudflare's ID formatting", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t);
+  const result = await runCleanup(stub);
+  assert.equal(result.code, 0, result.stderr);
+  const requests = await readFile(log, "utf8");
+  assert.match(
+    requests,
+    new RegExp(`"method":"DELETE","path":"/client/v4/zones/${zoneId}/ssl/certificate_packs/${certificatePackId}"`),
+  );
+});
+
+test("refuses to replace a preview domain owned by another Worker", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t, { foreignDomain: true });
+  const result = await runPreview(
+    ["attach", "--pr", "690"],
+    cloudflareEnvironment(stub),
+  );
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /belongs to another Worker/);
+  assert.doesNotMatch(await readFile(log, "utf8"), /"method":"PUT"/);
+});
+
+test("does not delete the Worker when domain inventory fails", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t, { failDomainList: true });
+  const result = await runCleanup(stub);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /preview cleanup incomplete: list domain/);
+  assert.doesNotMatch(await readFile(log, "utf8"), /workers\/scripts\/functor-pr-690/);
+});
+
+test("does not delete the Worker when domain detach fails", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t, { failDomainDetach: true });
+  const result = await runCleanup(stub);
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /preview cleanup incomplete: detach domain/);
+  assert.doesNotMatch(await readFile(log, "utf8"), /workers\/scripts\/functor-pr-690/);
+});

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -88,25 +88,42 @@ await rm(dist, { recursive: true, force: true });
 await mkdir(`${dist}/pkg`, { recursive: true });
 await mkdir(`${dist}/examples`, { recursive: true });
 
-// The header version-badge names the build. A deploy (CI — the functor.games
-// build) names the release it ships from: the nearest reachable vX.Y.Z, walked
-// back from HEAD (hence the deploy's fetch-depth: 0). A local build is stricter
-// — only an exact, clean release tag counts; dev work, a commit ahead of a tag,
-// or a dirty tag checkout all read "v0.0.0 · dev", so a working copy never
-// mislabels itself as a release it merely descends from.
+// The header version-badge names the build. A PR preview receives its immutable
+// head SHA from the unprivileged build workflow and shows that identity directly
+// (the full SHA stays in the tooltip). A production deploy names the release it
+// ships from: the nearest reachable vX.Y.Z, walked back from HEAD (hence the
+// deploy's fetch-depth: 0). A local build is stricter — only an exact, clean
+// release tag counts; dev work, a commit ahead of a tag, or a dirty tag checkout
+// all read "v0.0.0 · dev", so a working copy never mislabels itself as a release
+// it merely descends from.
 let badge = "v0.0.0 · dev";
-try {
-  const describe = process.env.CI
-    ? "git describe --tags --abbrev=0 --match 'v[0-9]*'"
-    : "git describe --tags --exact-match --dirty --match 'v[0-9]*'";
-  const tag = execSync(describe, {
-    cwd: root,
-    stdio: ["ignore", "pipe", "ignore"],
-  })
-    .toString()
-    .trim();
-  if (/^v\d+\.\d+\.\d+$/.test(tag)) badge = `${tag} · alpha`;
-} catch {}
+let badgeTitle = "Local development build";
+const previewSha = process.env.FUNCTOR_SITE_PREVIEW_SHA;
+if (previewSha !== undefined) {
+  if (!/^[0-9a-f]{40}$/i.test(previewSha)) {
+    console.error("FUNCTOR_SITE_PREVIEW_SHA must be a full 40-character Git commit SHA");
+    process.exit(1);
+  }
+  const normalizedSha = previewSha.toLowerCase();
+  badge = `${normalizedSha.slice(0, 7)} · preview`;
+  badgeTitle = `PR preview for commit ${normalizedSha}`;
+} else {
+  try {
+    const describe = process.env.CI
+      ? "git describe --tags --abbrev=0 --match 'v[0-9]*'"
+      : "git describe --tags --exact-match --dirty --match 'v[0-9]*'";
+    const tag = execSync(describe, {
+      cwd: root,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    if (/^v\d+\.\d+\.\d+$/.test(tag)) {
+      badge = `${tag} · alpha`;
+      badgeTitle = "Functor is alpha software — everything may change between releases";
+    }
+  } catch {}
+}
 
 // The API reference is prerendered into its page (see src/api-reference-html.mjs):
 // a no-JS fetch of /docs/ must return the real signatures and docs, not a shell.
@@ -133,10 +150,12 @@ for (const page of PAGES) {
   await mkdir(dirname(target), { recursive: true });
   if (page.endsWith(".html")) {
     let html = await readFile(`${site}${page}`, "utf8");
-    // The shared header first (it carries the badge span), then stamp the badge.
+    // The shared header first (it carries the badge span), then stamp both its
+    // visible identity and tooltip. Badge values are either fixed copy, a
+    // validated tag, or a hex-only SHA, so they are safe to place in markup.
     html = injectHeader(html, page).replace(
-      /(<span class="version-badge"[^>]*>)[^<]*(<\/span>)/,
-      `$1${badge}$2`
+      /<span class="version-badge"[^>]*>[^<]*<\/span>/,
+      `<span class="version-badge" title="${badgeTitle}">${badge}</span>`
     );
     if (page === "docs/index.html") {
       for (const [marker, markup] of Object.entries(PRERENDER)) {

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -15,7 +15,7 @@ import { dirname } from "node:path";
 import esbuild from "esbuild";
 import { EXAMPLES, exampleEntryPath } from "./src/examples.ts";
 import { renderApiReference } from "./src/api-reference-html.mjs";
-import { injectHeader } from "./src/header.ts";
+import { ALPHA_BADGE_TITLE, injectHeader } from "./src/header.ts";
 
 const site = fileURLToPath(new URL(".", import.meta.url));
 const root = fileURLToPath(new URL("..", import.meta.url));
@@ -97,7 +97,7 @@ await mkdir(`${dist}/examples`, { recursive: true });
 // all read "v0.0.0 · dev", so a working copy never mislabels itself as a release
 // it merely descends from.
 let badge = "v0.0.0 · dev";
-let badgeTitle = "Local development build";
+let badgeTitle = process.env.CI ? "Unversioned build" : "Local development build";
 const previewSha = process.env.FUNCTOR_SITE_PREVIEW_SHA;
 if (previewSha !== undefined) {
   if (!/^[0-9a-f]{40}$/i.test(previewSha)) {
@@ -120,7 +120,7 @@ if (previewSha !== undefined) {
       .trim();
     if (/^v\d+\.\d+\.\d+$/.test(tag)) {
       badge = `${tag} · alpha`;
-      badgeTitle = "Functor is alpha software — everything may change between releases";
+      badgeTitle = ALPHA_BADGE_TITLE;
     }
   } catch {}
 }

--- a/site/src/header.ts
+++ b/site/src/header.ts
@@ -42,6 +42,8 @@ const NAV = [
 ];
 
 const GITHUB = "https://github.com/tommy-xr/functor";
+export const ALPHA_BADGE_TITLE =
+  "Functor is alpha software — everything may change between releases";
 
 /** The attributes a page may set on its `<!--@header-->` marker. */
 type HeaderKey = "prefix" | "suffix" | "active";
@@ -73,7 +75,7 @@ const renderHeader = ({
     `<a class="wordmark" href="${prefix || "./"}">${MARK}FUNCTOR${
       suffix ? `<span class="wordmark-accent">//${suffix}</span>` : ""
     }</a>`,
-    '<span class="version-badge" title="Functor is alpha software — everything may change between releases">alpha</span>',
+    `<span class="version-badge" title="${ALPHA_BADGE_TITLE}">alpha</span>`,
     BURGER,
     ...(controls ? [controls] : []),
     `<nav class="site-nav">\n        ${nav.join("\n        ")}\n      </nav>`,

--- a/site/src/header.ts
+++ b/site/src/header.ts
@@ -52,9 +52,9 @@ const NAV_IDS = new Set(NAV.map(({ id }) => id));
 
 type HeaderOptions = Partial<Record<HeaderKey, string>> & { controls?: string };
 
-// The badge ships as the literal "alpha"; build.mjs stamps the release tag
-// over it afterwards (one regex, unchanged by this module — which is why a
-// page may carry only ONE header block; injectHeader enforces that).
+// The badge ships as the literal "alpha"; build.mjs stamps the release tag or
+// PR head SHA over it afterwards (one regex — which is why a page may carry
+// only ONE header block; injectHeader enforces that).
 const renderHeader = ({
   prefix = "",
   suffix = "",


### PR DESCRIPTION
## Summary

- build `site/dist` in a secret-free `pull_request` workflow, currently limited to `tommy-xr` PRs from `tommy-xr/functor`
- independently re-authorize the completed run from trusted default-branch code before exposing Cloudflare credentials
- deploy one temporary static-assets Worker per PR at `pr-<number>.preview.functor.games` and maintain a sticky comment with Site, Sandbox, IDE, and API-reference links
- show the exact PR-head commit in the site version chip (`e368757 · preview`, with the full SHA in its tooltip)
- detach the custom domain and delete the Worker when the PR closes; artifacts expire after one day

## Security model

The PR build has read-only repository access and no secrets. The privileged `workflow_run` job checks the workflow identity, repository, PR author, run actor/rerun actor, open state, and current head SHA using code loaded from the default branch. It validates the downloaded artifact as static data and rejects Cloudflare deployment-control files (`.assetsignore`, `_headers`, and `_redirects`) before deployment.

The secret-bearing Wrangler action is pinned to an immutable commit. Deploy and cleanup runs share a queued, immutable PR-number concurrency group so a late build cannot evict close cleanup. Artifacts are bounded to 50 MiB compressed and 100 MiB expanded. The trusted sticky comment is the authoritative commit identity; the site chip provides the requested at-a-glance copy inside PR-controlled content.

## Verification

- `npm run test:pr-preview` — 28/28 lifecycle and security-boundary tests passed
- `FUNCTOR_SITE_PREVIEW_SHA=0123456789abcdef0123456789abcdef01234567 npm run site:build`
- `CI=true npm run site:build` — production badge remained `v0.1.2 · alpha`
- `node scripts/pr-preview.mjs validate-artifact --dir site/dist --sha 0123456789abcdef0123456789abcdef01234567` — validated 71 assets
- `npm run check:site`
- `node --check scripts/pr-preview.mjs` and `node --check scripts/pr-preview.test.mjs`
- YAML parsed successfully; `git diff --check` passed
- `actionlint v1.7.12` passed apart from its stale `concurrency.queue` diagnostic; [`queue: max` is supported by current GitHub Actions syntax](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
- live GitHub API payloads verified the workflow-run path and repository shapes used by authorization
- cross-engine review found no remaining actionable Critical/High/Medium findings; visual xreview passed with no findings
- GitHub CI at `e368757`: PR preview build, native and WebAssembly matrices, E2E, WASM golden, and the complete WASM/browser smoke suite passed

## Review findings disposition

- fixed: document the preview secret, least-privilege token scopes, lifecycle, limits, and first-merge rollout in `DEVELOPMENT.md` and workflow headers
- fixed: add a 28-case black-box test suite for authorization, artifact validation, identity, deployment comments, and safe cleanup; run it early in WASM smoke CI
- fixed: write authorization rejections to `$GITHUB_STEP_SUMMARY`
- fixed: remove hostname-based certificate deletion; cleanup now requires the exact normalized certificate-pack ID
- fixed: use an accurate `Unversioned build` tooltip for invalid CI version metadata
- fixed: preserve every pending deploy/cleanup lifecycle run with `queue: max` and a PR-number concurrency key
- fixed: preflight the exact artifact identity, expiry, archive size, and expanded size before deployment
- fixed: reject all static-assets deployment-control files from the untrusted artifact
- fixed: accept GitHub's production-shaped minimal repository payload without weakening exact repository checks
- fixed: avoid deleting the Worker when custom-domain inventory or detachment fails
- fixed: pin the secret-bearing Cloudflare action to a full commit SHA
- fixed: require one exact commit badge on every page using the shared header
- fixed: clarify first-deploy TLS timing in the sticky comment
- visual xreview: matching before/after framing, legible labels, and no chip collision, clipping, or layout regression
- not taken: extracting a shared site-build action would broaden this security-focused change; production and preview intentionally keep explicit build steps for now
- disproved with live API data: pull-request workflow runs report `run.path` as the bare `.github/workflows/<file>.yml` path in this repository

## Rollout note

GitHub requires these event workflows to exist on the default branch, so this PR cannot preview itself. Once merged, the next push to an eligible open PR will exercise the full deploy path.

## Visual evidence

![PR preview version chip demo](https://gist.githubusercontent.com/tommy-xr/45e042f48bbbebfe76a0c710eff07c43/raw/preview-version-chip-e368757.gif)

<sub>Preview builds show their exact commit SHA at a glance. Captured headlessly with Playwright from the production base and the committed PR head.</sub>

### Before → after

![Production and PR-preview version chips](https://gist.githubusercontent.com/tommy-xr/45e042f48bbbebfe76a0c710eff07c43/raw/preview-version-chip-before-after-e368757.png)
