### PR TITLE
feat(scene): rigid model templates for Scene.instanced

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1072,9 +1072,11 @@ each combinator composes within its own channel (rotations multiply with the
 outer pipe applying last; scales and tints multiply componentwise). The
 renderer hardware-instances a recognized template — one
 cube/sphere/cylinder/quad/plane leaf under transforms and at most one solid
-`Scene.color`/`Scene.lit`/`Scene.emissive` material — in ONE draw call;
-anything else (models, textured materials, groups, bare leaves) still renders
-correctly via CPU expansion with a once-per-topology `[functor]` perf note.
+`Scene.color`/`Scene.lit`/`Scene.emissive` material (ONE draw call), or a
+rigid `Scene.model` leaf under transforms (one draw call per mesh primitive,
+textured like the ordinary model draw); anything else (skinned or animated
+models, textured materials, groups, bare leaves) still renders correctly via
+CPU expansion with a once-per-topology `[functor]` perf note.
 `Scene.opacity` inside a template is a teaching error — wrap the whole
 instanced node instead. `Scene.equals` compares instanced nodes structurally
 (template + every instance's channels).

--- a/functor-prelude/prelude/instance.funi
+++ b/functor-prelude/prelude/instance.funi
@@ -44,5 +44,7 @@ let trs : (Vec3.t, Angle.t, float, float, float) => t
 /// Multiply the copy's material colors by `color` — a per-instance tint over
 /// the template's material, not a second material system. Tints compose by
 /// multiplying; white is the identity. The tint is RGB only — a copy's alpha
-/// always comes from the template's material.
+/// always comes from the template's material. A bare `Scene.model` template
+/// has no material colors to multiply, so tint has no effect there (exactly
+/// as in the stamped group).
 let tint : (Color.t, t) => t

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -101,12 +101,16 @@ let opacity : (float, t) => t
 /// come FROM the template: `Scene.cube() |> Scene.lit(color)` instanced is
 /// lit and shadowed exactly like its copies would be.
 ///
-/// The renderer draws recognized templates as ONE hardware-instanced call —
-/// a single cube/sphere/cylinder/quad/plane leaf, under any transforms and at
-/// most one solid `Scene.color` / `Scene.lit` / `Scene.emissive` material.
+/// The renderer draws recognized templates with hardware instancing — a
+/// single cube/sphere/cylinder/quad/plane leaf under any transforms and at
+/// most one solid `Scene.color` / `Scene.lit` / `Scene.emissive` material
+/// (one draw call), or a rigid `Scene.model` leaf under transforms (one draw
+/// call per mesh primitive, textured exactly like the ordinary model draw).
 /// Any other template still renders correctly, expanded copy-by-copy on the
-/// CPU with a once-per-topology `[functor]` perf note — never worse than
-/// writing the group by hand, but not faster either.
+/// CPU with a once-per-topology `[functor]` perf note — comparable to
+/// writing the group by hand, but not faster. A SKINNED model template also
+/// expands (per-copy skinning, exact semantics, with the same note); the
+/// shared-pose instanced path for animated templates is the next rung.
 ///
 /// An empty list draws nothing. `Scene.opacity` inside the template is a
 /// teaching error — wrap the whole instanced node instead

--- a/runtime/functor-runtime-common/examples/instancing_probe.rs
+++ b/runtime/functor-runtime-common/examples/instancing_probe.rs
@@ -101,6 +101,55 @@ let draw = (m: float, tts: float) =>
 "#
 }
 
+/// Model path A: one `Scene.model` pipeline per copy.
+fn per_node_model(side: u32) -> String {
+    shared_header(side)
+        + r#"
+let barrel = Asset.model("barrel.glb")
+
+let cell = (ix, iz, tts) =>
+  let fx = ix / side in
+  let fz = iz / side in
+  let h = height(fx, fz, tts) in
+  Scene.model(barrel)
+    |> Scene.scale(0.02 * h)
+    |> Scene.rotateY(Angle.degrees(120.0 * fx))
+    |> Scene.translate(Vec3.make((ix - side / 2.0) * 1.4, h / 2.0, (iz - side / 2.0) * 1.4))
+
+let draw = (m: float, tts: float) =>
+  let copies =
+    List.range(side)
+      |> List.concatMap((ix) => List.range(side) |> List.map((iz) => cell(ix, iz, tts))) in
+  Frame.create(
+    Camera3D.lookAt(Vec3.make(30.0, 24.0, 30.0), Vec3.make(0.0, 1.0, 0.0)),
+    Scene.group(copies))
+"#
+}
+
+/// Model path B: `Instance.trs` chains into one instanced model node.
+fn instanced_model(side: u32) -> String {
+    shared_header(side)
+        + r#"
+let barrel = Asset.model("barrel.glb")
+
+let cell = (ix, iz, tts) =>
+  let fx = ix / side in
+  let fz = iz / side in
+  let h = height(fx, fz, tts) in
+  Instance.trs(
+      Vec3.make((ix - side / 2.0) * 1.4, h / 2.0, (iz - side / 2.0) * 1.4),
+      Angle.degrees(120.0 * fx), 0.02 * h, 0.02 * h, 0.02 * h)
+
+let draw = (m: float, tts: float) =>
+  let copies =
+    List.range(side)
+      |> List.concatMap((ix) => List.range(side) |> List.map((iz) => cell(ix, iz, tts))) in
+  Frame.create(
+    Camera3D.lookAt(Vec3.make(30.0, 24.0, 30.0), Vec3.make(0.0, 1.0, 0.0)),
+    Scene.model(barrel) |> Scene.instanced(copies))
+"#
+}
+
 const WARMUP: Duration = Duration::from_millis(300);
 const SAMPLES: usize = 120;
 
@@ -164,6 +213,24 @@ fn main() {
             (1.0 - b / a) * 100.0,
             c,
             (1.0 - c / a) * 100.0
+        );
+    }
+
+    println!();
+    println!("model templates (construction only — GPU draw-call savings invisible here):");
+    println!(
+        "{:>7} {:>18} {:>18} {:>9}",
+        "models", "per-node ms", "instanced ms", "red%"
+    );
+    for side in [32u32, 64, 96] {
+        let a = bench(&per_node_model(side));
+        let b = bench(&instanced_model(side));
+        println!(
+            "{:>7} {:>18.3} {:>18.3} {:>8.1}%",
+            side * side,
+            a,
+            b,
+            (1.0 - b / a) * 100.0
         );
     }
 }

--- a/runtime/functor-runtime-common/src/geometry/indexed_mesh.rs
+++ b/runtime/functor-runtime-common/src/geometry/indexed_mesh.rs
@@ -18,8 +18,20 @@ pub struct IndexedMeshData<T: Vertex> {
 
 pub struct IndexedMeshRuntimeData {
     vao: VertexArray,
+    vbo: Buffer,
     ebo: Buffer,
     len: i32,
+}
+
+/// The hydrated GL handles of an [`IndexedMesh`], as plain `Copy` values —
+/// what the instanced-model path needs to build a SECOND VAO over the same
+/// vertex/index buffers (its per-instance attributes cannot live on the
+/// mesh's own VAO without changing every ordinary draw).
+#[derive(Clone, Copy)]
+pub struct MeshBufferHandles {
+    pub vbo: Buffer,
+    pub ebo: Buffer,
+    pub index_count: i32,
 }
 
 impl<T: Vertex> IndexedMesh<T> {
@@ -28,6 +40,16 @@ impl<T: Vertex> IndexedMesh<T> {
         let ora = RuntimeRenderableAsset::new(data, ());
 
         IndexedMesh { ora }
+    }
+
+    /// Hydrate (if needed) and hand back the mesh's GL buffer handles.
+    pub(crate) fn buffers(&self, gl: &glow::Context) -> MeshBufferHandles {
+        let data = self.ora.get(gl);
+        MeshBufferHandles {
+            vbo: data.vbo,
+            ebo: data.ebo,
+            index_count: data.len,
+        }
     }
 }
 
@@ -90,7 +112,7 @@ impl<T: Vertex> RenderableAsset for IndexedMeshData<T> {
             // VAOs requires a call to glBindVertexArray anyways so we generally don't unbind VAOs (nor VBOs) when it's not directly necessary.
             gl.bind_buffer(glow::ARRAY_BUFFER, None);
             gl.bind_vertex_array(None);
-            IndexedMeshRuntimeData { vao, ebo, len }
+            IndexedMeshRuntimeData { vao, vbo, ebo, len }
         }
     }
 }

--- a/runtime/functor-runtime-common/src/geometry/indexed_mesh.rs
+++ b/runtime/functor-runtime-common/src/geometry/indexed_mesh.rs
@@ -28,7 +28,7 @@ pub struct IndexedMeshRuntimeData {
 /// vertex/index buffers (its per-instance attributes cannot live on the
 /// mesh's own VAO without changing every ordinary draw).
 #[derive(Clone, Copy)]
-pub struct MeshBufferHandles {
+pub(crate) struct MeshBufferHandles {
     pub vbo: Buffer,
     pub ebo: Buffer,
     pub index_count: i32,

--- a/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
@@ -17,11 +17,12 @@ use glow::HasContext;
 use crate::fog::{FogUniforms, FOG_GLSL};
 use crate::geometry::{
     cube_mesh_data, cylinder_mesh_data, plane_mesh_data, quad_mesh_data, sphere_mesh_data,
+    MeshBufferHandles,
 };
 use crate::light::{lighting_glsl, LightingUniforms};
 use crate::math::normal_matrix;
 use crate::model::Model;
-use crate::render::vertex::{Vertex, VertexAttributeType};
+use crate::render::vertex::{BuiltInVertexChannel, Vertex, VertexAttributeType};
 use crate::render::{VertexPositionTexture, VertexPositionTextureSkinned};
 use crate::texture::RuntimeTexture;
 use crate::shader::{Shader, ShaderType};
@@ -193,32 +194,32 @@ struct MeshBuffers {
     instance_capacity: usize,
 }
 
-/// One model mesh primitive's instanced state: a SECOND VAO over the mesh's
-/// own vertex/index buffers (locations 0-3; the skinned joint/weight
-/// attributes at 4/5 are deliberately not enabled — instance channels live
-/// there) plus this primitive's instance buffer.
-struct ModelMeshBuffers {
-    vao: glow::VertexArray,
-    /// The mesh's own VBO the VAO reads vertices from — kept to detect a
-    /// stale entry when an Arc address is reused by a different model.
-    vertex_buffer: glow::Buffer,
-    index_buffer: glow::Buffer,
+/// One rigid model's instanced GPU state: ONE shared instance buffer
+/// (uploaded once per node) plus a second VAO per mesh primitive over the
+/// mesh's own vertex/index buffers.
+struct ModelInstancedState {
     instance_buffer: glow::Buffer,
-    index_count: i32,
     instance_capacity: usize,
+    meshes: Vec<ModelMeshVao>,
+}
+
+struct ModelMeshVao {
+    vao: glow::VertexArray,
+    /// The mesh's own VBO the VAO reads vertices from — compared against the
+    /// live handle each draw to detect a stale entry after an asset
+    /// evict/hot-reload replaced the model's GL buffers.
+    vertex_buffer: glow::Buffer,
 }
 
 /// Persistent GPU state for `Scene.instanced`'s hardware path.
 pub(super) struct InstancedRenderer {
     meshes: HashMap<InstancedPrimitive, MeshBuffers>,
-    // Keyed by the hydrated model's Arc pointer + mesh index. An asset evict/
-    // hot-reload produces a NEW Arc with new GL buffers — usually a new
-    // address too, but a dropped Arc's address CAN be reused by a later
-    // model (ABA), so each draw validates the entry against the mesh's live
-    // VBO/EBO handles and rebuilds on mismatch. Entries for dropped models
-    // are otherwise retained (bounded by the models a session actually
-    // instanced) like every other persistent cache.
-    model_meshes: HashMap<(usize, usize), ModelMeshBuffers>,
+    // Keyed by the model's asset locator, so the entry count is bounded by
+    // the model FILES a session actually instanced — a hot reload/evict
+    // replaces the entry in place (each draw validates the cached VAOs
+    // against the meshes' live vertex-buffer handles and rebuilds on
+    // mismatch) instead of stranding a dead generation.
+    model_meshes: HashMap<String, ModelInstancedState>,
     forward: ShaderProgram,
     forward_uniforms: ForwardUniforms,
     depth: ShaderProgram,
@@ -345,24 +346,7 @@ impl InstancedRenderer {
                 }
 
                 gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
-                let instance_stride = size_of::<InstanceData>() as i32;
-                for (location, size, offset) in [
-                    (4, 3, offset_of!(InstanceData, position)),
-                    (5, 4, offset_of!(InstanceData, rotation)),
-                    (6, 3, offset_of!(InstanceData, scale)),
-                    (7, 3, offset_of!(InstanceData, tint)),
-                ] {
-                    gl.enable_vertex_attrib_array(location);
-                    gl.vertex_attrib_pointer_f32(
-                        location,
-                        size,
-                        glow::FLOAT,
-                        false,
-                        instance_stride,
-                        offset as i32,
-                    );
-                    gl.vertex_attrib_divisor(location, 1);
-                }
+                instance_attrib_layout(gl, true);
 
                 gl.bind_vertex_array(None);
                 gl.bind_buffer(glow::ARRAY_BUFFER, None);
@@ -455,19 +439,8 @@ impl InstancedRenderer {
                 ctx.gl.bind_vertex_array(Some(mesh.vao));
                 ctx.gl
                     .bind_buffer(glow::ARRAY_BUFFER, Some(mesh.instance_buffer));
-                // Deliberately monotonic: capacity follows the high-water
-                // mark for the process lifetime (like every other persistent
-                // renderer cache here) rather than shrinking per frame.
-                if bytes.len() > mesh.instance_capacity {
-                    ctx.gl
-                        .buffer_data_u8_slice(glow::ARRAY_BUFFER, bytes, glow::DYNAMIC_DRAW);
-                    mesh.instance_capacity = bytes.len();
-                } else {
-                    ctx.gl
-                        .buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
-                }
+                upload_instances(ctx.gl, bytes, &mut mesh.instance_capacity);
             }
-            crate::gpu_counters::gpu_counters().uploaded(bytes.len());
             (mesh.index_buffer, mesh.index_count)
         };
         if depth_pass {
@@ -515,10 +488,13 @@ impl InstancedRenderer {
     ///
     /// The caller has already resolved the model and verified it is rigid
     /// (no skeleton); an unloaded/failed model resolves to zero meshes and
-    /// draws nothing here.
+    /// draws nothing here. The instance records upload ONCE per node — every
+    /// mesh primitive's VAO reads the model's one shared instance buffer.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn draw_model(
         &mut self,
         ctx: &RenderContext,
+        file: &str,
         model: &Arc<Model>,
         local: &Matrix4<f32>,
         instances: &[InstanceData],
@@ -526,126 +502,72 @@ impl InstancedRenderer {
         projection: &Matrix4<f32>,
         view: &Matrix4<f32>,
     ) {
+        if model.meshes.is_empty() {
+            return;
+        }
         let depth_pass = ctx.render_pass == RenderPass::DepthOnly;
         let bytes = crate::terrain_renderer::slice_bytes(instances);
-        let key_base = Arc::as_ptr(model) as usize;
-        for (mesh_index, mesh) in model.meshes.iter().enumerate() {
-            let handles = mesh.mesh.buffers(ctx.gl);
-            let key = (key_base, mesh_index);
-            // ABA guard: a dropped model Arc's address can be reused by a
-            // DIFFERENT model later. The mesh's live GL handles are the
-            // ground truth — a cached entry whose buffers don't match is
-            // stale (its VAO reads deleted/foreign buffers); rebuild it.
-            if let Some(entry) = self.model_meshes.get(&key) {
-                if entry.vertex_buffer != handles.vbo || entry.index_buffer != handles.ebo {
-                    let stale = self.model_meshes.remove(&key).expect("checked above");
-                    let counters = crate::gpu_counters::gpu_counters();
-                    counters.vao_deleted();
-                    counters.buffer_deleted();
-                    unsafe {
-                        ctx.gl.delete_vertex_array(stale.vao);
-                        ctx.gl.delete_buffer(stale.instance_buffer);
-                    }
-                }
-            }
-            // Scope the mutable cache borrow, carrying out only Copy handles.
-            let (index_buffer, index_count) = {
-                let entry = self
-                    .model_meshes
-                    .entry(key)
-                    .or_insert_with(|| unsafe {
-                        let vao = ctx.gl.create_vertex_array().expect("model instanced VAO");
-                        let instance_buffer =
-                            ctx.gl.create_buffer().expect("model instance data");
-                        let counters = crate::gpu_counters::gpu_counters();
-                        counters.vao_created();
-                        counters.buffer_created();
-
-                        ctx.gl.bind_vertex_array(Some(vao));
-                        ctx.gl.bind_buffer(glow::ARRAY_BUFFER, Some(handles.vbo));
-                        let stride = VertexPositionTextureSkinned::get_total_size() as i32;
-                        // Locations 0-3 (position/uv/normal/tangent) from the
-                        // mesh's own VBO; the skinned joints/weights at 4/5
-                        // stay DISABLED — those locations carry the instance
-                        // channels instead.
-                        for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
-                            .iter()
-                            .take(4)
-                            .enumerate()
-                        {
-                            ctx.gl.enable_vertex_attrib_array(location as u32);
-                            match attribute.attribute_type {
-                                VertexAttributeType::Float => ctx.gl.vertex_attrib_pointer_f32(
-                                    location as u32,
-                                    attribute.size,
-                                    glow::FLOAT,
-                                    false,
-                                    stride,
-                                    attribute.offset as i32,
-                                ),
-                            }
-                        }
-
-                        ctx.gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
-                        let instance_stride = size_of::<InstanceData>() as i32;
-                        // No tint attribute (location 7): a bare model
-                        // template has no material colors for the tint to
-                        // multiply, so the STAMP ignores it — the hardware
-                        // path must match. The generic attribute value is
-                        // pinned to white at draw time instead.
-                        for (location, size, offset) in [
-                            (4, 3, offset_of!(InstanceData, position)),
-                            (5, 4, offset_of!(InstanceData, rotation)),
-                            (6, 3, offset_of!(InstanceData, scale)),
-                        ] {
-                            ctx.gl.enable_vertex_attrib_array(location);
-                            ctx.gl.vertex_attrib_pointer_f32(
-                                location,
-                                size,
-                                glow::FLOAT,
-                                false,
-                                instance_stride,
-                                offset as i32,
-                            );
-                            ctx.gl.vertex_attrib_divisor(location, 1);
-                        }
-
-                        ctx.gl.bind_vertex_array(None);
-                        ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
-
-                        ModelMeshBuffers {
-                            vao,
-                            vertex_buffer: handles.vbo,
-                            index_buffer: handles.ebo,
-                            instance_buffer,
-                            index_count: handles.index_count,
-                            instance_capacity: 0,
-                        }
-                    });
-                unsafe {
-                    ctx.gl.bind_vertex_array(Some(entry.vao));
-                    ctx.gl
-                        .bind_buffer(glow::ARRAY_BUFFER, Some(entry.instance_buffer));
-                    if bytes.len() > entry.instance_capacity {
-                        ctx.gl
-                            .buffer_data_u8_slice(glow::ARRAY_BUFFER, bytes, glow::DYNAMIC_DRAW);
-                        entry.instance_capacity = bytes.len();
-                    } else {
-                        ctx.gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
-                    }
-                }
-                crate::gpu_counters::gpu_counters().uploaded(bytes.len());
-                (entry.index_buffer, entry.index_count)
-            };
-
-            // Location 7's array is disabled in the model VAO — pin the
-            // generic tint value to white (identity), matching the stamp's
-            // tint-ignoring semantics for bare model templates. Generic
-            // attribute values are context state, so set it per draw.
+        // Hydrate (if needed) and fetch the live GL handles fresh each draw —
+        // the cache stores only what staleness detection needs; index buffers
+        // and counts are read from here.
+        let handles: Vec<MeshBufferHandles> = model
+            .meshes
+            .iter()
+            .map(|mesh| mesh.mesh.buffers(ctx.gl))
+            .collect();
+        // Staleness guard: the cache is keyed by asset locator, so an asset
+        // evict/hot-reload (a NEW Arc with new GL buffers) shows up as a
+        // vertex-buffer mismatch — drop the whole entry and rebuild. Nothing
+        // else in the tree deletes mesh VBOs, so a handle mismatch is a
+        // reliable staleness signal (and entries stay bounded by the model
+        // files a session actually instanced).
+        let stale = self.model_meshes.get(file).is_some_and(|state| {
+            state.meshes.len() != handles.len()
+                || state
+                    .meshes
+                    .iter()
+                    .zip(handles.iter())
+                    .any(|(cached, live)| cached.vertex_buffer != live.vbo)
+        });
+        if stale {
+            let state = self.model_meshes.remove(file).expect("checked above");
+            let counters = crate::gpu_counters::gpu_counters();
             unsafe {
-                ctx.gl.vertex_attrib_3_f32(7, 1.0, 1.0, 1.0);
+                for cached in &state.meshes {
+                    ctx.gl.delete_vertex_array(cached.vao);
+                    counters.vao_deleted();
+                }
+                ctx.gl.delete_buffer(state.instance_buffer);
+                counters.buffer_deleted();
             }
-
+        }
+        // Build (or reuse) the per-model state, then upload the instance
+        // records ONCE into its shared buffer; carry out only Copy VAOs.
+        let vaos: Vec<glow::VertexArray> = {
+            let state = match self.model_meshes.get_mut(file) {
+                Some(state) => state,
+                None => {
+                    let state = unsafe { Self::create_model_state(ctx.gl, &handles) };
+                    self.model_meshes.entry(file.to_string()).or_insert(state)
+                }
+            };
+            unsafe {
+                ctx.gl
+                    .bind_buffer(glow::ARRAY_BUFFER, Some(state.instance_buffer));
+                upload_instances(ctx.gl, bytes, &mut state.instance_capacity);
+                ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            }
+            state.meshes.iter().map(|cached| cached.vao).collect()
+        };
+        // Location 7's array is disabled in the model VAOs — pin the generic
+        // tint value to white (identity), matching the stamp's tint-ignoring
+        // semantics for bare model templates (`tint_scene` leaves Model nodes
+        // untouched). Generic attribute values are context state, so once per
+        // node is enough.
+        unsafe {
+            ctx.gl.vertex_attrib_3_f32(7, 1.0, 1.0, 1.0);
+        }
+        for ((mesh, live), vao) in model.meshes.iter().zip(handles.iter()).zip(vaos.iter()) {
             // glTF: a static mesh composes its NODE transform under the
             // template-internal transform (skinned models never reach here).
             let mesh_local = local * mesh.transform;
@@ -665,11 +587,12 @@ impl InstancedRenderer {
                 );
             }
             unsafe {
+                ctx.gl.bind_vertex_array(Some(*vao));
                 ctx.gl
-                    .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buffer));
+                    .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(live.ebo));
                 ctx.gl.draw_elements_instanced(
                     glow::TRIANGLES,
-                    index_count,
+                    live.index_count,
                     glow::UNSIGNED_INT,
                     0,
                     instances.len() as i32,
@@ -679,5 +602,120 @@ impl InstancedRenderer {
         unsafe {
             ctx.gl.bind_vertex_array(None);
         }
+    }
+
+    /// Create a rigid model's instanced GPU state: one shared instance
+    /// buffer, plus a VAO per mesh primitive — mesh attributes from the
+    /// mesh's own VBO (skipping the skinned joint/weight channels, whose
+    /// locations 4/5 carry the instance TRS instead) and the instance layout
+    /// from the shared buffer.
+    unsafe fn create_model_state(
+        gl: &glow::Context,
+        handles: &[MeshBufferHandles],
+    ) -> ModelInstancedState {
+        let counters = crate::gpu_counters::gpu_counters();
+        let instance_buffer = gl.create_buffer().expect("model instance data");
+        counters.buffer_created();
+        let meshes = handles
+            .iter()
+            .map(|live| {
+                let vao = gl.create_vertex_array().expect("model instanced VAO");
+                counters.vao_created();
+                gl.bind_vertex_array(Some(vao));
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(live.vbo));
+                let stride = VertexPositionTextureSkinned::get_total_size() as i32;
+                for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
+                    .iter()
+                    .enumerate()
+                {
+                    // Joints/weights sit at locations 4/5 — exactly where the
+                    // instance channels live — and rigid meshes never read
+                    // them, so leave those arrays disabled by CHANNEL (not by
+                    // positional prefix, which would silently mis-bind if the
+                    // attribute table were ever reordered).
+                    if matches!(
+                        attribute.attribute_channel,
+                        BuiltInVertexChannel::JointIndices | BuiltInVertexChannel::JointWeights
+                    ) {
+                        continue;
+                    }
+                    gl.enable_vertex_attrib_array(location as u32);
+                    match attribute.attribute_type {
+                        VertexAttributeType::Float => gl.vertex_attrib_pointer_f32(
+                            location as u32,
+                            attribute.size,
+                            glow::FLOAT,
+                            false,
+                            stride,
+                            attribute.offset as i32,
+                        ),
+                    }
+                }
+                // No tint attribute: a bare model template has no material
+                // colors for the tint to multiply, so the STAMP ignores it —
+                // the hardware path pins location 7's generic value instead.
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
+                instance_attrib_layout(gl, false);
+                gl.bind_vertex_array(None);
+                ModelMeshVao {
+                    vao,
+                    vertex_buffer: live.vbo,
+                }
+            })
+            .collect();
+        gl.bind_buffer(glow::ARRAY_BUFFER, None);
+        ModelInstancedState {
+            instance_buffer,
+            instance_capacity: 0,
+            meshes,
+        }
+    }
+}
+
+/// Upload the instance records into the currently bound `ARRAY_BUFFER`.
+/// Deliberately monotonic: capacity follows the high-water mark for the
+/// process lifetime (like every other persistent renderer cache here) rather
+/// than shrinking per frame.
+unsafe fn upload_instances(gl: &glow::Context, bytes: &[u8], capacity: &mut usize) {
+    if bytes.len() > *capacity {
+        gl.buffer_data_u8_slice(glow::ARRAY_BUFFER, bytes, glow::DYNAMIC_DRAW);
+        *capacity = bytes.len();
+    } else {
+        gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+    }
+    crate::gpu_counters::gpu_counters().uploaded(bytes.len());
+}
+
+/// Declare the per-instance attribute layout — TRS at locations 4/5/6, tint
+/// at 7 when `with_tint` — on the currently bound VAO, sourced from the
+/// currently bound `ARRAY_BUFFER`. Kept in ONE place so the primitive and
+/// model VAOs cannot drift from the shaders' shared location contract.
+unsafe fn instance_attrib_layout(gl: &glow::Context, with_tint: bool) {
+    let instance_stride = size_of::<InstanceData>() as i32;
+    let channels: &[(u32, i32, usize)] = if with_tint {
+        &[
+            (4, 3, offset_of!(InstanceData, position)),
+            (5, 4, offset_of!(InstanceData, rotation)),
+            (6, 3, offset_of!(InstanceData, scale)),
+            (7, 3, offset_of!(InstanceData, tint)),
+        ]
+    } else {
+        &[
+            (4, 3, offset_of!(InstanceData, position)),
+            (5, 4, offset_of!(InstanceData, rotation)),
+            (6, 3, offset_of!(InstanceData, scale)),
+        ]
+    };
+    for &(location, size, offset) in channels {
+        gl.enable_vertex_attrib_array(location);
+        gl.vertex_attrib_pointer_f32(
+            location,
+            size,
+            glow::FLOAT,
+            false,
+            instance_stride,
+            offset as i32,
+        );
+        gl.vertex_attrib_divisor(location, 1);
     }
 }

--- a/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
@@ -1,5 +1,6 @@
 //! The hardware half of `Scene.instanced`: one `draw_elements_instanced` call
-//! per recognized template, in both the forward pass (unlit or lit, fogged,
+//! per recognized primitive template — or per mesh primitive of a recognized
+//! rigid model template — in both the forward pass (unlit or lit, fogged,
 //! tinted per instance) and the depth pass (so instances cast shadows exactly
 //! like their stamped equivalent).
 //!
@@ -19,13 +20,17 @@ use crate::geometry::{
 };
 use crate::light::{lighting_glsl, LightingUniforms};
 use crate::math::normal_matrix;
+use crate::model::Model;
 use crate::render::vertex::{Vertex, VertexAttributeType};
-use crate::render::VertexPositionTexture;
+use crate::render::{VertexPositionTexture, VertexPositionTextureSkinned};
+use crate::texture::RuntimeTexture;
 use crate::shader::{Shader, ShaderType};
 use crate::shader_program::{ShaderProgram, UniformLocation};
 use crate::{DebugRenderMode, RenderContext, RenderPass};
 
-use super::instancing::{InstanceData, InstancedPrimitive, RecognizedTemplate};
+use std::sync::Arc;
+
+use super::instancing::{InstanceData, InstancedPrimitive, RecognizedPrimitive};
 use super::MaterialDescription;
 
 // The instance transform is `translate * rotate * scale` applied on top of
@@ -59,6 +64,7 @@ const INSTANCE_TRANSFORM_GLSL: &str = r#"
 // a flattened copy shades sanely instead of dividing to NaN.
 const VERTEX_SHADER_SOURCE: &str = r#"
         layout (location = 0) in vec3 inPos;
+        layout (location = 1) in vec2 inTex;
         layout (location = 2) in vec3 inNormal;
         layout (location = 3) in vec4 inTangent;
         layout (location = 7) in vec3 instanceTint;
@@ -68,6 +74,7 @@ const VERTEX_SHADER_SOURCE: &str = r#"
         uniform mat4 view;
         uniform mat4 projection;
 
+        out vec2 texCoord;
         out vec3 worldPos;
         out vec3 worldNormal;
         out vec3 worldTangent;
@@ -75,6 +82,7 @@ const VERTEX_SHADER_SOURCE: &str = r#"
 
         void main() {
             vec4 wp = world * vec4(instanceLocal(inPos), 1.0);
+            texCoord = inTex;
             worldPos = wp.xyz;
             tintColor = instanceTint;
             vec3 ln = localNormalMatrix * inNormal;
@@ -92,13 +100,16 @@ const VERTEX_SHADER_SOURCE: &str = r#"
 const FRAGMENT_SHADER_SOURCE: &str = r#"
         out vec4 fragColor;
 
+        in vec2 texCoord;
         in vec3 worldPos;
         in vec3 worldNormal;
         in vec3 worldTangent;
         in vec3 tintColor;
 
         uniform vec4 baseColor;
-        uniform int materialMode; // 0 = unlit (color/emissive), 1 = lit
+        uniform sampler2D texture1;
+        uniform int useTexture;   // model albedo on unit 0 (glTF base color)
+        uniform int materialMode; // 0 = unlit (color/emissive/model), 1 = lit
         uniform int debugMode;    // 0 = authored, 1 = normals, 2 = tangents
 
         void main() {
@@ -107,7 +118,11 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
             } else if (debugMode == 2) {
                 fragColor = vec4(normalize(worldTangent) * 0.5 + 0.5, 1.0);
             } else {
-                vec3 albedo = baseColor.rgb * tintColor;
+                vec4 base = baseColor;
+                if (useTexture == 1) {
+                    base = base * texture(texture1, texCoord);
+                }
+                vec3 albedo = base.rgb * tintColor;
                 vec3 shaded = albedo;
                 if (materialMode == 1) {
                     vec3 n = normalize(worldNormal);
@@ -116,7 +131,7 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
                     accumulateLights(n, worldPos, diffuseLight, specularLight);
                     shaded = albedo * diffuseLight + specularLight;
                 }
-                fragColor = vec4(applyFog(shaded, worldPos), baseColor.a);
+                fragColor = vec4(applyFog(shaded, worldPos), base.a);
             }
         }
 "#;
@@ -151,6 +166,8 @@ struct ForwardUniforms {
     view: UniformLocation,
     projection: UniformLocation,
     base_color: UniformLocation,
+    texture1: UniformLocation,
+    use_texture: UniformLocation,
     material_mode: UniformLocation,
     debug_mode: UniformLocation,
     lighting: LightingUniforms,
@@ -176,9 +193,32 @@ struct MeshBuffers {
     instance_capacity: usize,
 }
 
+/// One model mesh primitive's instanced state: a SECOND VAO over the mesh's
+/// own vertex/index buffers (locations 0-3; the skinned joint/weight
+/// attributes at 4/5 are deliberately not enabled — instance channels live
+/// there) plus this primitive's instance buffer.
+struct ModelMeshBuffers {
+    vao: glow::VertexArray,
+    /// The mesh's own VBO the VAO reads vertices from — kept to detect a
+    /// stale entry when an Arc address is reused by a different model.
+    vertex_buffer: glow::Buffer,
+    index_buffer: glow::Buffer,
+    instance_buffer: glow::Buffer,
+    index_count: i32,
+    instance_capacity: usize,
+}
+
 /// Persistent GPU state for `Scene.instanced`'s hardware path.
 pub(super) struct InstancedRenderer {
     meshes: HashMap<InstancedPrimitive, MeshBuffers>,
+    // Keyed by the hydrated model's Arc pointer + mesh index. An asset evict/
+    // hot-reload produces a NEW Arc with new GL buffers — usually a new
+    // address too, but a dropped Arc's address CAN be reused by a later
+    // model (ABA), so each draw validates the entry against the mesh's live
+    // VBO/EBO handles and rebuilds on mismatch. Entries for dropped models
+    // are otherwise retained (bounded by the models a session actually
+    // instanced) like every other persistent cache.
+    model_meshes: HashMap<(usize, usize), ModelMeshBuffers>,
     forward: ShaderProgram,
     forward_uniforms: ForwardUniforms,
     depth: ShaderProgram,
@@ -212,6 +252,8 @@ impl InstancedRenderer {
             view: forward.get_uniform_location(gl, "view"),
             projection: forward.get_uniform_location(gl, "projection"),
             base_color: forward.get_uniform_location(gl, "baseColor"),
+            texture1: forward.get_uniform_location(gl, "texture1"),
+            use_texture: forward.get_uniform_location(gl, "useTexture"),
             material_mode: forward.get_uniform_location(gl, "materialMode"),
             debug_mode: forward.get_uniform_location(gl, "debugMode"),
             lighting: LightingUniforms::get(&forward, gl),
@@ -245,6 +287,7 @@ impl InstancedRenderer {
 
         Self {
             meshes: HashMap::new(),
+            model_meshes: HashMap::new(),
             forward,
             forward_uniforms,
             depth,
@@ -336,13 +379,67 @@ impl InstancedRenderer {
         })
     }
 
-    /// Draw one recognized instanced node — in the depth pass with the
-    /// instanced depth program, otherwise with the forward program (unlit or
-    /// lit per the template's material, or a normals/tangents diagnostic).
-    pub(super) fn draw(
+    /// Set the depth program's uniforms for one instanced draw.
+    fn set_depth_uniforms(
+        &self,
+        ctx: &RenderContext,
+        world: &Matrix4<f32>,
+        local: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        let u = &self.depth_uniforms;
+        self.depth.use_program(ctx.gl);
+        self.depth.set_uniform_matrix4(ctx.gl, &u.world, world);
+        self.depth.set_uniform_matrix4(ctx.gl, &u.local, local);
+        self.depth.set_uniform_matrix4(ctx.gl, &u.view, view);
+        self.depth
+            .set_uniform_matrix4(ctx.gl, &u.projection, projection);
+    }
+
+    /// Set the forward program's uniforms for one instanced draw.
+    #[allow(clippy::too_many_arguments)]
+    fn set_forward_uniforms(
+        &self,
+        ctx: &RenderContext,
+        world: &Matrix4<f32>,
+        local: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+        color: &cgmath::Vector4<f32>,
+        use_texture: bool,
+        lit: bool,
+    ) {
+        let u = &self.forward_uniforms;
+        let p = &self.forward;
+        p.use_program(ctx.gl);
+        p.set_uniform_matrix4(ctx.gl, &u.world, world);
+        p.set_uniform_matrix4(ctx.gl, &u.local, local);
+        p.set_uniform_matrix3(ctx.gl, &u.normal_matrix, &normal_matrix(world));
+        p.set_uniform_matrix3(ctx.gl, &u.local_normal_matrix, &normal_matrix(local));
+        p.set_uniform_matrix4(ctx.gl, &u.view, view);
+        p.set_uniform_matrix4(ctx.gl, &u.projection, projection);
+        p.set_uniform_vec4(ctx.gl, &u.base_color, color);
+        p.set_uniform_1i(ctx.gl, &u.texture1, 0);
+        p.set_uniform_1i(ctx.gl, &u.use_texture, use_texture as i32);
+        p.set_uniform_1i(ctx.gl, &u.material_mode, lit as i32);
+        let debug_mode = match ctx.debug_render_mode {
+            DebugRenderMode::Normals => 1,
+            DebugRenderMode::Tangents => 2,
+            DebugRenderMode::Default | DebugRenderMode::Transparent | DebugRenderMode::Physics => 0,
+        };
+        p.set_uniform_1i(ctx.gl, &u.debug_mode, debug_mode);
+        u.lighting.set(p, ctx, view);
+        u.fog.set(p, ctx.gl, ctx.fog, &ctx.camera_pos);
+    }
+
+    /// Draw one recognized PRIMITIVE instanced node — in the depth pass with
+    /// the instanced depth program, otherwise with the forward program (unlit
+    /// or lit per the template's material, or a normals/tangents diagnostic).
+    pub(super) fn draw_primitive(
         &mut self,
         ctx: &RenderContext,
-        template: &RecognizedTemplate<'_>,
+        template: &RecognizedPrimitive<'_>,
         instances: &[InstanceData],
         world: &Matrix4<f32>,
         projection: &Matrix4<f32>,
@@ -373,54 +470,31 @@ impl InstancedRenderer {
             crate::gpu_counters::gpu_counters().uploaded(bytes.len());
             (mesh.index_buffer, mesh.index_count)
         };
+        if depth_pass {
+            self.set_depth_uniforms(ctx, world, &template.local, projection, view);
+        } else {
+            let (color, lit) = match template.material {
+                MaterialDescription::Lit { color, .. } => (*color, true),
+                MaterialDescription::Color(color)
+                | MaterialDescription::Emissive { color, .. } => (*color, false),
+                // Recognition never accepts these; the arm exists only so
+                // the match stays exhaustive if the enum grows.
+                MaterialDescription::Texture(_) | MaterialDescription::SpriteTexture { .. } => {
+                    (cgmath::vec4(1.0, 1.0, 1.0, 1.0), false)
+                }
+            };
+            self.set_forward_uniforms(
+                ctx,
+                world,
+                &template.local,
+                projection,
+                view,
+                &color,
+                false,
+                lit,
+            );
+        }
         unsafe {
-            if depth_pass {
-                let u = &self.depth_uniforms;
-                self.depth.use_program(ctx.gl);
-                self.depth.set_uniform_matrix4(ctx.gl, &u.world, world);
-                self.depth
-                    .set_uniform_matrix4(ctx.gl, &u.local, &template.local);
-                self.depth.set_uniform_matrix4(ctx.gl, &u.view, view);
-                self.depth
-                    .set_uniform_matrix4(ctx.gl, &u.projection, projection);
-            } else {
-                let (color, lit) = match template.material {
-                    MaterialDescription::Lit { color, .. } => (*color, true),
-                    MaterialDescription::Color(color)
-                    | MaterialDescription::Emissive { color, .. } => (*color, false),
-                    // Recognition never accepts these; the arm exists only so
-                    // the match stays exhaustive if the enum grows.
-                    MaterialDescription::Texture(_) | MaterialDescription::SpriteTexture { .. } => {
-                        (cgmath::vec4(1.0, 1.0, 1.0, 1.0), false)
-                    }
-                };
-                let u = &self.forward_uniforms;
-                let p = &self.forward;
-                p.use_program(ctx.gl);
-                p.set_uniform_matrix4(ctx.gl, &u.world, world);
-                p.set_uniform_matrix4(ctx.gl, &u.local, &template.local);
-                p.set_uniform_matrix3(ctx.gl, &u.normal_matrix, &normal_matrix(world));
-                p.set_uniform_matrix3(
-                    ctx.gl,
-                    &u.local_normal_matrix,
-                    &normal_matrix(&template.local),
-                );
-                p.set_uniform_matrix4(ctx.gl, &u.view, view);
-                p.set_uniform_matrix4(ctx.gl, &u.projection, projection);
-                p.set_uniform_vec4(ctx.gl, &u.base_color, &color);
-                p.set_uniform_1i(ctx.gl, &u.material_mode, lit as i32);
-                let debug_mode = match ctx.debug_render_mode {
-                    DebugRenderMode::Normals => 1,
-                    DebugRenderMode::Tangents => 2,
-                    DebugRenderMode::Default
-                    | DebugRenderMode::Transparent
-                    | DebugRenderMode::Physics => 0,
-                };
-                p.set_uniform_1i(ctx.gl, &u.debug_mode, debug_mode);
-                u.lighting.set(p, ctx, view);
-                u.fog.set(p, ctx.gl, ctx.fog, &ctx.camera_pos);
-            }
-
             ctx.gl
                 .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buffer));
             ctx.gl.draw_elements_instanced(
@@ -430,6 +504,179 @@ impl InstancedRenderer {
                 0,
                 instances.len() as i32,
             );
+            ctx.gl.bind_vertex_array(None);
+        }
+    }
+
+    /// Draw one recognized rigid-MODEL instanced node: one instanced call per
+    /// mesh primitive, each with its glTF base-color texture on unit 0 and
+    /// its node transform composed into `local` — matching the unlit textured
+    /// shading (and shadow casting) of the model's stamped equivalent.
+    ///
+    /// The caller has already resolved the model and verified it is rigid
+    /// (no skeleton); an unloaded/failed model resolves to zero meshes and
+    /// draws nothing here.
+    pub(super) fn draw_model(
+        &mut self,
+        ctx: &RenderContext,
+        model: &Arc<Model>,
+        local: &Matrix4<f32>,
+        instances: &[InstanceData],
+        world: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        let depth_pass = ctx.render_pass == RenderPass::DepthOnly;
+        let bytes = crate::terrain_renderer::slice_bytes(instances);
+        let key_base = Arc::as_ptr(model) as usize;
+        for (mesh_index, mesh) in model.meshes.iter().enumerate() {
+            let handles = mesh.mesh.buffers(ctx.gl);
+            let key = (key_base, mesh_index);
+            // ABA guard: a dropped model Arc's address can be reused by a
+            // DIFFERENT model later. The mesh's live GL handles are the
+            // ground truth — a cached entry whose buffers don't match is
+            // stale (its VAO reads deleted/foreign buffers); rebuild it.
+            if let Some(entry) = self.model_meshes.get(&key) {
+                if entry.vertex_buffer != handles.vbo || entry.index_buffer != handles.ebo {
+                    let stale = self.model_meshes.remove(&key).expect("checked above");
+                    let counters = crate::gpu_counters::gpu_counters();
+                    counters.vao_deleted();
+                    counters.buffer_deleted();
+                    unsafe {
+                        ctx.gl.delete_vertex_array(stale.vao);
+                        ctx.gl.delete_buffer(stale.instance_buffer);
+                    }
+                }
+            }
+            // Scope the mutable cache borrow, carrying out only Copy handles.
+            let (index_buffer, index_count) = {
+                let entry = self
+                    .model_meshes
+                    .entry(key)
+                    .or_insert_with(|| unsafe {
+                        let vao = ctx.gl.create_vertex_array().expect("model instanced VAO");
+                        let instance_buffer =
+                            ctx.gl.create_buffer().expect("model instance data");
+                        let counters = crate::gpu_counters::gpu_counters();
+                        counters.vao_created();
+                        counters.buffer_created();
+
+                        ctx.gl.bind_vertex_array(Some(vao));
+                        ctx.gl.bind_buffer(glow::ARRAY_BUFFER, Some(handles.vbo));
+                        let stride = VertexPositionTextureSkinned::get_total_size() as i32;
+                        // Locations 0-3 (position/uv/normal/tangent) from the
+                        // mesh's own VBO; the skinned joints/weights at 4/5
+                        // stay DISABLED — those locations carry the instance
+                        // channels instead.
+                        for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
+                            .iter()
+                            .take(4)
+                            .enumerate()
+                        {
+                            ctx.gl.enable_vertex_attrib_array(location as u32);
+                            match attribute.attribute_type {
+                                VertexAttributeType::Float => ctx.gl.vertex_attrib_pointer_f32(
+                                    location as u32,
+                                    attribute.size,
+                                    glow::FLOAT,
+                                    false,
+                                    stride,
+                                    attribute.offset as i32,
+                                ),
+                            }
+                        }
+
+                        ctx.gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
+                        let instance_stride = size_of::<InstanceData>() as i32;
+                        // No tint attribute (location 7): a bare model
+                        // template has no material colors for the tint to
+                        // multiply, so the STAMP ignores it — the hardware
+                        // path must match. The generic attribute value is
+                        // pinned to white at draw time instead.
+                        for (location, size, offset) in [
+                            (4, 3, offset_of!(InstanceData, position)),
+                            (5, 4, offset_of!(InstanceData, rotation)),
+                            (6, 3, offset_of!(InstanceData, scale)),
+                        ] {
+                            ctx.gl.enable_vertex_attrib_array(location);
+                            ctx.gl.vertex_attrib_pointer_f32(
+                                location,
+                                size,
+                                glow::FLOAT,
+                                false,
+                                instance_stride,
+                                offset as i32,
+                            );
+                            ctx.gl.vertex_attrib_divisor(location, 1);
+                        }
+
+                        ctx.gl.bind_vertex_array(None);
+                        ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
+
+                        ModelMeshBuffers {
+                            vao,
+                            vertex_buffer: handles.vbo,
+                            index_buffer: handles.ebo,
+                            instance_buffer,
+                            index_count: handles.index_count,
+                            instance_capacity: 0,
+                        }
+                    });
+                unsafe {
+                    ctx.gl.bind_vertex_array(Some(entry.vao));
+                    ctx.gl
+                        .bind_buffer(glow::ARRAY_BUFFER, Some(entry.instance_buffer));
+                    if bytes.len() > entry.instance_capacity {
+                        ctx.gl
+                            .buffer_data_u8_slice(glow::ARRAY_BUFFER, bytes, glow::DYNAMIC_DRAW);
+                        entry.instance_capacity = bytes.len();
+                    } else {
+                        ctx.gl.buffer_sub_data_u8_slice(glow::ARRAY_BUFFER, 0, bytes);
+                    }
+                }
+                crate::gpu_counters::gpu_counters().uploaded(bytes.len());
+                (entry.index_buffer, entry.index_count)
+            };
+
+            // Location 7's array is disabled in the model VAO — pin the
+            // generic tint value to white (identity), matching the stamp's
+            // tint-ignoring semantics for bare model templates. Generic
+            // attribute values are context state, so set it per draw.
+            unsafe {
+                ctx.gl.vertex_attrib_3_f32(7, 1.0, 1.0, 1.0);
+            }
+
+            // glTF: a static mesh composes its NODE transform under the
+            // template-internal transform (skinned models never reach here).
+            let mesh_local = local * mesh.transform;
+            if depth_pass {
+                self.set_depth_uniforms(ctx, world, &mesh_local, projection, view);
+            } else {
+                mesh.base_color_texture.bind(0, ctx);
+                self.set_forward_uniforms(
+                    ctx,
+                    world,
+                    &mesh_local,
+                    projection,
+                    view,
+                    &cgmath::vec4(1.0, 1.0, 1.0, 1.0),
+                    true,
+                    false,
+                );
+            }
+            unsafe {
+                ctx.gl
+                    .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(index_buffer));
+                ctx.gl.draw_elements_instanced(
+                    glow::TRIANGLES,
+                    index_count,
+                    glow::UNSIGNED_INT,
+                    0,
+                    instances.len() as i32,
+                );
+            }
+        }
+        unsafe {
             ctx.gl.bind_vertex_array(None);
         }
     }

--- a/runtime/functor-runtime-common/src/scene3d/instancing.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instancing.rs
@@ -240,11 +240,20 @@ pub(crate) enum InstancedPrimitive {
     Plane,
 }
 
-/// A template the renderer can draw with one instanced call: a single
-/// primitive leaf, optionally under `Group` transform wrappers (folded into
-/// `local`) and at most one solid-color `Color`/`Emissive`/`Lit` material
-/// node.
-pub(crate) struct RecognizedTemplate<'a> {
+/// A template the renderer can draw with instanced calls.
+pub(crate) enum RecognizedTemplate<'a> {
+    /// A single primitive leaf, optionally under `Group` transform wrappers
+    /// (folded into `local`) and at most one solid-color
+    /// `Color`/`Emissive`/`Lit` material node.
+    Primitive(RecognizedPrimitive<'a>),
+    /// A rigid `Scene.model` leaf (no attached animation, no overrides),
+    /// optionally under `Group` transform wrappers. Whether the LOADED model
+    /// is actually rigid (no skeleton) is only known at render time — a
+    /// skinned model falls back to the stamp there.
+    Model(RecognizedModel<'a>),
+}
+
+pub(crate) struct RecognizedPrimitive<'a> {
     pub primitive: InstancedPrimitive,
     /// The material enclosing the leaf. `None` never reaches the hardware
     /// path — a bare-primitive template CPU-expands so it keeps rendering
@@ -255,15 +264,25 @@ pub(crate) struct RecognizedTemplate<'a> {
     pub local: Matrix4<f32>,
 }
 
+pub(crate) struct RecognizedModel<'a> {
+    pub description: &'a super::ModelDescription,
+    /// Group wrappers plus the leaf's own xform; each mesh primitive further
+    /// composes its glTF node transform on the right.
+    pub local: Matrix4<f32>,
+}
+
 /// Decide whether `template` is drawable by the instanced hardware path.
 ///
 /// Recognized: `Group` chains with exactly one child (their transforms
-/// compose into `local`), at most ONE material node — a solid
-/// `Color`, `Emissive` (no texture), or `Lit` (no texture, no normal map) —
-/// and a `Cube`/`Sphere`/`Cylinder`/`Quad`/`Plane` leaf. Everything else
-/// (models, terrain, multi-child groups, textured materials, bare leaves,
-/// nested instancing, opacity) answers `None` and renders through
-/// [`expand_instanced`].
+/// compose into `local`) ending in either a
+/// `Cube`/`Sphere`/`Cylinder`/`Quad`/`Plane` leaf under at most ONE material
+/// node — a solid `Color`, `Emissive` (no texture), or `Lit` (no texture, no
+/// normal map) — or a bare `Scene.model` leaf with no attached animation and
+/// no overrides (enclosing materials are ignored by the ordinary model draw,
+/// so a material-wrapped model falls back rather than pretending the wrapper
+/// does something). Everything else (terrain, multi-child groups, textured
+/// materials, bare primitive leaves, nested instancing, opacity) answers
+/// `None` and renders through [`expand_instanced`].
 pub(crate) fn recognize(template: &Scene3D) -> Option<RecognizedTemplate<'_>> {
     fn walk<'a>(
         node: &'a Scene3D,
@@ -280,11 +299,28 @@ pub(crate) fn recognize(template: &Scene3D) -> Option<RecognizedTemplate<'_>> {
                     Shape::Plane => InstancedPrimitive::Plane,
                     Shape::Heightmap { .. } | Shape::ConvexPolygon { .. } => return None,
                 };
-                Some(RecognizedTemplate {
+                Some(RecognizedTemplate::Primitive(RecognizedPrimitive {
                     primitive,
                     material: material?,
                     local: local * node.xform,
-                })
+                }))
+            }
+            SceneObject::Model(description) => {
+                // A pose-attached template is the shared-pose ladder rung
+                // (not yet instanced); overrides are legacy and untypical.
+                // An enclosing material would be IGNORED by the ordinary
+                // model draw — fall back so the stamp stays authoritative
+                // rather than encoding that quirk here too.
+                if material.is_some()
+                    || description.animation.is_some()
+                    || !description.overrides.is_empty()
+                {
+                    return None;
+                }
+                Some(RecognizedTemplate::Model(RecognizedModel {
+                    description,
+                    local: local * node.xform,
+                }))
             }
             SceneObject::Group(items) => match items.as_slice() {
                 [only] => walk(only, local * node.xform, material),
@@ -316,8 +352,7 @@ pub(crate) fn recognize(template: &Scene3D) -> Option<RecognizedTemplate<'_>> {
                     _ => None,
                 }
             }
-            SceneObject::Model(_)
-            | SceneObject::Terrain(_)
+            SceneObject::Terrain(_)
             | SceneObject::Opacity(..)
             | SceneObject::Instanced { .. } => None,
         }
@@ -477,7 +512,11 @@ mod tests {
             obj: SceneObject::Group(vec![lit_cube()]),
             xform: Matrix4::from_nonuniform_scale(2.0, 1.0, 1.0),
         };
-        let recognized = recognize(&template).expect("lit cube under a transform");
+        let RecognizedTemplate::Primitive(recognized) =
+            recognize(&template).expect("lit cube under a transform")
+        else {
+            panic!("expected a primitive template");
+        };
         assert_eq!(recognized.primitive, InstancedPrimitive::Cube);
         assert!(matches!(
             recognized.material,
@@ -501,16 +540,65 @@ mod tests {
                 ),
                 xform: Matrix4::from_scale(1.0),
             };
-            assert_eq!(
-                recognize(&template).expect("solid primitive").primitive,
-                primitive
-            );
+            let RecognizedTemplate::Primitive(recognized) =
+                recognize(&template).expect("solid primitive")
+            else {
+                panic!("expected a primitive template");
+            };
+            assert_eq!(recognized.primitive, primitive);
         }
+    }
+
+    /// Rigid model templates are recognized (transform wrappers fold into
+    /// `local`); animated, override-carrying, or material-wrapped models fall
+    /// back to the stamp.
+    #[test]
+    fn recognizer_accepts_rigid_model_templates() {
+        use crate::scene3d::{ModelDescription, ModelHandle};
+
+        let model = |animation| {
+            Scene3D::model(ModelDescription {
+                handle: ModelHandle::File("barrel.glb".into()),
+                overrides: vec![],
+                animation,
+                while_pending: vec![],
+            })
+        };
+        let template = Scene3D {
+            obj: SceneObject::Group(vec![model(None)]),
+            xform: Matrix4::from_scale(0.02),
+        };
+        let RecognizedTemplate::Model(recognized) =
+            recognize(&template).expect("rigid model under a transform")
+        else {
+            panic!("expected a model template");
+        };
+        assert!(matches!(
+            recognized.description.handle,
+            ModelHandle::File(ref f) if f == "barrel.glb"
+        ));
+        assert_eq!(recognized.local, Matrix4::from_scale(0.02));
+
+        // A pose-attached template is the (not yet instanced) shared-pose
+        // rung — stamped for now.
+        let animated = model(Some(crate::anim::AnimExpr::Rest));
+        assert!(recognize(&animated).is_none());
+
+        // A material wrapper is IGNORED by the ordinary model draw; fall
+        // back so the stamp stays authoritative.
+        let wrapped = Scene3D {
+            obj: SceneObject::Material(
+                MaterialDescription::color(1.0, 0.0, 0.0, 1.0),
+                vec![model(None)],
+            ),
+            xform: Matrix4::from_scale(1.0),
+        };
+        assert!(recognize(&wrapped).is_none());
     }
 
     #[test]
     fn recognizer_rejects_what_must_fall_back() {
-        use crate::scene3d::{ModelDescription, ModelHandle, TextureDescription};
+        use crate::scene3d::TextureDescription;
 
         // A bare primitive: correct only through the stamp (pass material).
         assert!(recognize(&Scene3D::cube()).is_none());
@@ -529,14 +617,6 @@ mod tests {
             xform: Matrix4::from_scale(1.0),
         };
         assert!(recognize(&pair).is_none());
-        // A model.
-        let model = Scene3D::model(ModelDescription {
-            handle: ModelHandle::File("m.glb".into()),
-            overrides: vec![],
-            animation: None,
-            while_pending: vec![],
-        });
-        assert!(recognize(&model).is_none());
         // Nested materials.
         let nested = Scene3D {
             obj: SceneObject::Material(

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1773,7 +1773,7 @@ so the reach is ignored"
                 }
                 let xform = world_matrix * self.xform;
                 match instancing::recognize(template) {
-                    Some(recognized) => {
+                    Some(instancing::RecognizedTemplate::Primitive(recognized)) => {
                         let mut renderer = scene_context.instanced.borrow_mut();
                         let renderer = renderer.get_or_insert_with(|| {
                             InstancedRenderer::new(
@@ -1781,9 +1781,67 @@ so the reach is ignored"
                                 render_context.shader_version,
                             )
                         });
-                        renderer.draw(
+                        renderer.draw_primitive(
                             render_context,
                             &recognized,
+                            instances,
+                            &xform,
+                            projection_matrix,
+                            view_matrix,
+                        );
+                    }
+                    Some(instancing::RecognizedTemplate::Model(recognized)) => {
+                        // Resolve exactly like the ordinary Model arm — this
+                        // is ALSO the liveness poll for `Asset.whilePending`
+                        // chains, so it must run every frame.
+                        let ModelHandle::File(file) = &recognized.description.handle;
+                        let model: Arc<AssetHandle<Model>> = render_context
+                            .asset_cache
+                            .load_asset_with_pipeline(scene_context.model_pipeline.clone(), file);
+                        let hydrated_model = crate::asset::resolve_while_pending(
+                            &render_context.asset_cache,
+                            &scene_context.model_pipeline,
+                            &model,
+                            &recognized.description.while_pending,
+                        );
+                        // Whether the model is rigid is only knowable now.
+                        // A skinned model stamps per copy (full per-copy
+                        // skinning — exact semantics); the shared-pose
+                        // instanced path is the next ladder rung.
+                        if hydrated_model.skeleton.get_joint_count() > 0 {
+                            if !depth_pass {
+                                let copies = instances.len();
+                                scene_context.warn_once_with(
+                                    &format!("instanced-skinned:{file}"),
+                                    || format!(
+                                        "[functor] Scene.instanced template model \"{file}\" is \
+skinned — rendering {copies} copies as a stamped group with per-copy skinning \
+(rigid models hardware-instance; a shared-pose instanced path for animated \
+templates is planned)"
+                                    ),
+                                );
+                            }
+                            expand_instanced(template, instances).render(
+                                render_context,
+                                scene_context,
+                                &xform,
+                                projection_matrix,
+                                view_matrix,
+                                current_material,
+                            );
+                            return;
+                        }
+                        let mut renderer = scene_context.instanced.borrow_mut();
+                        let renderer = renderer.get_or_insert_with(|| {
+                            InstancedRenderer::new(
+                                &render_context.gl,
+                                render_context.shader_version,
+                            )
+                        });
+                        renderer.draw_model(
+                            render_context,
+                            &hydrated_model,
+                            &recognized.local,
                             instances,
                             &xform,
                             projection_matrix,

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -208,6 +208,27 @@ struct CompositeUniforms {
     weight_loc: UniformLocation,
 }
 
+/// Resolve a model asset for drawing: the per-frame cache poll (which is ALSO
+/// the liveness poll for `Asset.whilePending` chains, so it must run every
+/// frame) followed by placeholder resolution. Shared by the ordinary Model
+/// draw arm and the instanced-model arm so the two cannot drift.
+fn resolve_model_for_draw(
+    render_context: &RenderContext,
+    scene_context: &SceneContext,
+    file: &str,
+    while_pending: &[String],
+) -> Arc<Model> {
+    let model: Arc<AssetHandle<Model>> = render_context
+        .asset_cache
+        .load_asset_with_pipeline(scene_context.model_pipeline.clone(), file);
+    crate::asset::resolve_while_pending(
+        &render_context.asset_cache,
+        &scene_context.model_pipeline,
+        &model,
+        while_pending,
+    )
+}
+
 impl SceneContext {
     /// Drop every cached decode of `path` so the next draw reloads it from
     /// disk — asset hot-reload (pair with `AssetCache::evict` for the bytes).
@@ -1401,18 +1422,14 @@ impl Scene3D {
             SceneObject::Model(model_description) => {
                 match &model_description.handle {
                     ModelHandle::File(str) => {
-                        let model: Arc<AssetHandle<Model>> = render_context
-                            .asset_cache
-                            .load_asset_with_pipeline(scene_context.model_pipeline.clone(), str);
-
                         // While the primary streams in, an `Asset.whilePending`
                         // chain renders its first loaded placeholder instead of
                         // the empty fallback (chainless models resolve exactly
                         // like the old `get()`).
-                        let hydrated_model = crate::asset::resolve_while_pending(
-                            &render_context.asset_cache,
-                            &scene_context.model_pipeline,
-                            &model,
+                        let hydrated_model = resolve_model_for_draw(
+                            render_context,
+                            scene_context,
+                            str,
                             &model_description.while_pending,
                         );
 
@@ -1791,17 +1808,11 @@ so the reach is ignored"
                         );
                     }
                     Some(instancing::RecognizedTemplate::Model(recognized)) => {
-                        // Resolve exactly like the ordinary Model arm — this
-                        // is ALSO the liveness poll for `Asset.whilePending`
-                        // chains, so it must run every frame.
                         let ModelHandle::File(file) = &recognized.description.handle;
-                        let model: Arc<AssetHandle<Model>> = render_context
-                            .asset_cache
-                            .load_asset_with_pipeline(scene_context.model_pipeline.clone(), file);
-                        let hydrated_model = crate::asset::resolve_while_pending(
-                            &render_context.asset_cache,
-                            &scene_context.model_pipeline,
-                            &model,
+                        let hydrated_model = resolve_model_for_draw(
+                            render_context,
+                            scene_context,
+                            file,
                             &recognized.description.while_pending,
                         );
                         // Whether the model is rigid is only knowable now.
@@ -1840,6 +1851,7 @@ templates is planned)"
                         });
                         renderer.draw_model(
                             render_context,
+                            file,
                             &hydrated_model,
                             &recognized.local,
                             instances,
@@ -1866,7 +1878,7 @@ templates is planned)"
 — rendering {copies} copies as a stamped group, comparable to writing \
 the group by hand (hardware templates are one cube/sphere/cylinder/quad/plane \
 leaf under transforms and at most one solid Scene.color / Scene.lit / \
-Scene.emissive material)"
+Scene.emissive material, or a bare rigid Scene.model leaf under transforms)"
                                     )
                                 },
                             );


### PR DESCRIPTION
## Why

PR 2 of the generalized-instancing stack (on #689): `Scene.instanced` recognizes **rigid `Scene.model` templates** and hardware-instances them — the tree-lined field / prop-crowd case, previously CPU-expanded with a perf note.

```functor
Scene.model(Assets.barrel) |> Scene.instanced(copies)   // one instanced draw per mesh primitive
```

## What the renderer recognizes now

- A **bare `Scene.model` leaf under `Group` transforms** — no attached animation, no overrides, no enclosing material (the ordinary model draw *ignores* enclosing materials, so a material-wrapped model falls back to the stamp rather than encoding that quirk into the instanced path too).
- Each mesh primitive draws with **one `draw_elements_instanced` call**: a second VAO over the mesh's own vertex/index buffers (locations 0–3), instance TRS channels at 4–6 (the skinned joint/weight locations, deliberately disabled — rigid meshes never use them), the glTF **base-color texture** on unit 0, and the mesh's **node transform** composed into the template-local matrix. Forward shading matches `BasicMaterial` exactly (unlit textured, fogged, alpha from the texture); the **depth pass instances too, so copies cast shadows**.
- **Whether a model is rigid is only knowable after load**, so recognition is two-phase: the recognizer accepts the shape, and the render arm checks `skeleton.get_joint_count()` on the hydrated model. A **skinned** model falls back to the stamp (exact per-copy skinning) with a once-per-model `[functor]` note naming the planned shared-pose path — the next PR.
- **Tint has no effect on bare model templates** — the stamp has no material colors to multiply, so the hardware path pins the tint attribute to white (documented in `instance.funi`).
- The per-model VAO cache is keyed by `(Arc pointer, mesh index)` with an **ABA guard**: a dropped model Arc's address can be reused by a different model after an asset evict/hot-reload, so each draw validates the entry against the mesh's live VBO/EBO handles and rebuilds a stale entry (deleting its VAO + instance buffer).

Semantics are unchanged: `Scene.instanced` remains stamp-equivalent; this only widens the set of templates the renderer optimizes. Serde/protocol/equality were all done in #689 — no wire change here.

## A/B construction probe (release, headless, 3 runs, min ms/frame)

`instancing_probe` gained model-template tables: a grid of `Scene.model` pipelines per copy vs `Instance.trs` chains into one instanced node (identical per-cell math, both rotate):

| models | per-node ms | instanced ms | reduction |
|---:|---:|---:|---:|
| 1,024 | 3.223 | 2.080 | 35.5% |
| 4,096 | 13.163 | 8.127 | 38.3% |
| 9,216 | 30.223 | 18.413 | 39.1% |

This is **construction only** — the probe is headless, so the GPU draw-call collapse (N model draws → meshes-per-model instanced draws) is additional and invisible here.

## frame_bench (unused-path neutrality)

Base `scene-instancing-core` (1e4817b3) vs this branch, release, back-to-back, 3 runs/side:

| cells | allocs/frame | bytes/frame |
|---:|---:|---:|
| 400 | 13,877 → 13,877 | 844,497 → 844,497 |
| 1,600 | 54,717 → 54,717 | 3,308,337 → 3,308,337 |
| 3,136 | 106,973 → 106,973 | 6,461,361 → 6,461,361 |

Deterministic allocs/bytes are **exactly identical** both sides. Wall-clock minima differed between sides (change measured *faster*: e.g. 3,560 vs 4,370 µs min at 3,136 cells) — that direction is DVFS/load noise across separate compile+run sessions, not a claimed win; the deterministic columns are the gate.

## Verification

- `cargo test -p functor_runtime_common` and `cargo test -p functor-lang` — green (includes a new recognizer test: rigid model accepted with folded transforms; animated / override-carrying / material-wrapped models fall back).
- `npm run check:docs` — green (`scene.funi` / `instance.funi` docs updated; functor-lang skill updated in this PR).
- Strict native build (`cargo build --features=strict` in `runtime/functor-runtime-desktop`, the CI invocation) — green.
- **Stamp parity**: a side-by-side scene (stamped `Scene.model` barrel vs the same model through `Scene.instanced`, same scale/camera) renders the two identically.
- **WebGL2 smoke**: the barrel-field demo served via `run wasm` renders in headless Chromium with **no page/console errors** (both producers share the prelude and renderer — no new externals, so no separate wasm wiring was needed; the embedded bundle was rebuilt).
- `npm run test:golden` — green (all scenarios within tolerance; goldens don't cover instanced models yet, so this pins no-regression on existing rendering).
- **Quest/device GPU benchmarking was NOT run** (no device attached) — instanced-model GPU cost on device is an explicit gap; the probe and frame_bench are CPU-only evidence.


## Demo

![Scene.instanced glTF barrels demo](https://gist.githubusercontent.com/tommy-xr/b46f6f34e6e06fb02e39b7ebdac67c86/raw/instanced-models.gif)

<sub>256 textured glTF barrels bobbing and spinning through one `Scene.instanced` node — one hardware-instanced draw per mesh primitive, each copy casting its own shadow. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![still at t=1.0](https://gist.githubusercontent.com/tommy-xr/b46f6f34e6e06fb02e39b7ebdac67c86/raw/instanced-models-t1.png)

![still at t=4.0](https://gist.githubusercontent.com/tommy-xr/b46f6f34e6e06fb02e39b7ebdac67c86/raw/instanced-models-t4.png)


## xreview dispositions

Two independent engines (Claude/Opus subagent + Codex CLI, both image-capable) plus a dedicated 4-strategy de-dup pass. **No Critical/High findings from any engine.** All fixes re-validated after applying: full test suites, strict build, goldens, a byte-identical side-by-side stamp-parity re-capture, the barrel-field demo re-capture, and a clean wasm headless-Chromium smoke.

- **[AGREED] Medium (Claude + Codex): the identical instance array uploaded once per mesh primitive** — **fixed**: one shared instance buffer per model, uploaded once per node; every mesh VAO points at it.
- **Medium (Codex): `model_meshes` grew a dead generation per asset hot-reload** (Arc-pointer keys were never swept; the ABA guard only fired on address reuse) — **fixed**: the cache is keyed by asset locator, so a reload replaces the entry in place after a live-VBO staleness check; entry count is bounded by the model files a session instanced.
- **[AGREED] Low (Claude + Codex): stale fallback perf note** omitted the new rigid-model hardware path — **fixed**: the message now names "a bare rigid Scene.model leaf under transforms".
- **[Codex Low + de-dup reuse] duplicated model-resolution preamble** in the two Model arms — **fixed**: shared `resolve_model_for_draw` (the `Asset.whilePending` liveness poll cannot drift).
- **[de-dup extract, multi-strategy] duplicated instance-buffer upload and attribute-layout blocks** — **fixed**: shared `upload_instances` + `instance_attrib_layout(gl, with_tint)` helpers; the primitive and model VAOs now share one location contract. (The de-dup pass's `merge ModelMeshBuffers into MeshBuffers` finding is superseded by this restructure — the two structs now genuinely differ.)
- **Low fixes (Claude) applied**: `.take(4)` replaced by channel-based skipping of joints/weights (reorder-safe), redundant cached `index_count`/`index_buffer` dropped (live handles are read fresh each draw), tint pin hoisted out of the mesh loop, `MeshBufferHandles` narrowed to `pub(crate)`.
- **Accepted, not fixed**: the probe extension measures construction only (stated in the PR; it extends the committed probe from #689 — the GPU draw-call collapse is structurally invisible to a headless probe); the generic 6-copy `bind_vertex_attributes` cleanup across heightmap/polygon/indexed_mesh is a pre-existing cross-file pattern deferred rather than grown into this PR; the probe's duplicated `.fun` scenario tail (de-dup weak finding, low value).
- **Visual verification (both engines)**: textured barrels, per-instance scale/rotation/height, per-copy cast shadows (the depth-pass claim), and real motion across frames all confirmed in the GIF + stills.

Quest/device GPU benchmarking was **not** run (no device attached).
