### PR TITLE
feat(scene): shared-pose animated templates for Scene.instanced

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1073,10 +1073,12 @@ outer pipe applying last; scales and tints multiply componentwise). The
 renderer hardware-instances a recognized template — one
 cube/sphere/cylinder/quad/plane leaf under transforms and at most one solid
 `Scene.color`/`Scene.lit`/`Scene.emissive` material (ONE draw call), or a
-rigid `Scene.model` leaf under transforms (one draw call per mesh primitive,
-textured like the ordinary model draw); anything else (skinned or animated
-models, textured materials, groups, bare leaves) still renders correctly via
-CPU expansion with a once-per-topology `[functor]` perf note.
+`Scene.model` leaf under transforms (one draw call per mesh primitive,
+textured like the ordinary model draw; a SKINNED model — via `Scene.animate`
+or the first-clip autoplay — instances at the SHARED pose, sampled and
+uploaded once for every copy); anything else (textured materials, groups,
+bare leaves) still renders correctly via CPU expansion with a
+once-per-topology `[functor]` perf note.
 `Scene.opacity` inside a template is a teaching error — wrap the whole
 instanced node instead. `Scene.equals` compares instanced nodes structurally
 (template + every instance's channels).

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -104,13 +104,15 @@ let opacity : (float, t) => t
 /// The renderer draws recognized templates with hardware instancing — a
 /// single cube/sphere/cylinder/quad/plane leaf under any transforms and at
 /// most one solid `Scene.color` / `Scene.lit` / `Scene.emissive` material
-/// (one draw call), or a rigid `Scene.model` leaf under transforms (one draw
-/// call per mesh primitive, textured exactly like the ordinary model draw).
-/// Any other template still renders correctly, expanded copy-by-copy on the
-/// CPU with a once-per-topology `[functor]` perf note — comparable to
-/// writing the group by hand, but not faster. A SKINNED model template also
-/// expands (per-copy skinning, exact semantics, with the same note); the
-/// shared-pose instanced path for animated templates is the next rung.
+/// (one draw call), or a `Scene.model` leaf under transforms (one draw call
+/// per mesh primitive, textured exactly like the ordinary model draw). A
+/// SKINNED model template — with an attached `Scene.animate` pose or the
+/// zero-config first-clip autoplay — instances at the SHARED pose: the pose
+/// is sampled and uploaded once, and every copy skins from it (a crowd in
+/// step; per-instance playheads are planned, not yet available). Any other
+/// template still renders correctly, expanded copy-by-copy on the CPU with
+/// a once-per-topology `[functor]` perf note — comparable to writing the
+/// group by hand, but not faster.
 ///
 /// An empty list draws nothing. `Scene.opacity` inside the template is a
 /// teaching error — wrap the whole instanced node instead

--- a/runtime/functor-runtime-common/src/material/skinned_depth_material.rs
+++ b/runtime/functor-runtime-common/src/material/skinned_depth_material.rs
@@ -115,12 +115,7 @@ impl Material for SkinnedDepthMaterial {
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
 
-                let num_joints = skinning_data.len();
-                let mut joint_matrices = Vec::with_capacity(num_joints * 16);
-                for i in 0..num_joints {
-                    let matrix_array: &[f32; 16] = skinning_data[i].as_ref();
-                    joint_matrices.extend_from_slice(matrix_array);
-                }
+                let joint_matrices = crate::model::flatten_joint_matrices(skinning_data);
                 p.set_uniform_matrix4fv(ctx.gl, &uniforms.joint_transforms_loc, &joint_matrices);
             }
         }

--- a/runtime/functor-runtime-common/src/material/skinned_material.rs
+++ b/runtime/functor-runtime-common/src/material/skinned_material.rs
@@ -173,12 +173,7 @@ impl Material for SkinnedMaterial {
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
                 p.set_uniform_1i(ctx.gl, &uniforms.texture_loc, 0);
 
-                let num_joints = skinning_data.len();
-                let mut joint_matrices = Vec::with_capacity(num_joints * 16);
-                for i in 0..num_joints {
-                    let matrix_array: &[f32; 16] = skinning_data[i].as_ref();
-                    joint_matrices.extend_from_slice(matrix_array);
-                }
+                let joint_matrices = crate::model::flatten_joint_matrices(skinning_data);
 
                 p.set_uniform_matrix4fv(ctx.gl, &uniforms.joint_transforms_loc, &joint_matrices);
                 uniforms.lighting.set(p, ctx, view_matrix);

--- a/runtime/functor-runtime-common/src/material/skinned_normal_debug_material.rs
+++ b/runtime/functor-runtime-common/src/material/skinned_normal_debug_material.rs
@@ -132,12 +132,7 @@ impl Material for SkinnedNormalDebugMaterial {
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
 
-                let num_joints = skinning_data.len();
-                let mut joint_matrices = Vec::with_capacity(num_joints * 16);
-                for i in 0..num_joints {
-                    let matrix_array: &[f32; 16] = skinning_data[i].as_ref();
-                    joint_matrices.extend_from_slice(matrix_array);
-                }
+                let joint_matrices = crate::model::flatten_joint_matrices(skinning_data);
 
                 p.set_uniform_matrix4fv(ctx.gl, &uniforms.joint_transforms_loc, &joint_matrices);
             }

--- a/runtime/functor-runtime-common/src/material/skinned_tangent_debug_material.rs
+++ b/runtime/functor-runtime-common/src/material/skinned_tangent_debug_material.rs
@@ -121,12 +121,7 @@ impl Material for SkinnedTangentDebugMaterial {
                 p.set_uniform_matrix4(ctx.gl, &uniforms.view_loc, view_matrix);
                 p.set_uniform_matrix4(ctx.gl, &uniforms.projection_loc, projection_matrix);
 
-                let num_joints = skinning_data.len();
-                let mut joint_matrices = Vec::with_capacity(num_joints * 16);
-                for i in 0..num_joints {
-                    let matrix_array: &[f32; 16] = skinning_data[i].as_ref();
-                    joint_matrices.extend_from_slice(matrix_array);
-                }
+                let joint_matrices = crate::model::flatten_joint_matrices(skinning_data);
 
                 p.set_uniform_matrix4fv(ctx.gl, &uniforms.joint_transforms_loc, &joint_matrices);
             }

--- a/runtime/functor-runtime-common/src/model/skeleton.rs
+++ b/runtime/functor-runtime-common/src/model/skeleton.rs
@@ -223,6 +223,19 @@ impl Skeleton {
     }
 }
 
+/// Flatten a joint palette into the column-major f32 stream
+/// `set_uniform_matrix4fv` expects — the one shared upload shape for every
+/// skinned program (the stamped materials and the instanced shared-pose
+/// path).
+pub fn flatten_joint_matrices(joints: &[Matrix4<f32>]) -> Vec<f32> {
+    let mut joint_matrices = Vec::with_capacity(joints.len() * 16);
+    for joint in joints {
+        let matrix_array: &[f32; 16] = joint.as_ref();
+        joint_matrices.extend_from_slice(matrix_array);
+    }
+    joint_matrices
+}
+
 /// One node of the full glTF document hierarchy (every node, not just skin
 /// joints) — enough to resolve joint parents and the ancestor chain above a
 /// skin's root joints.

--- a/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
@@ -36,23 +36,51 @@ use super::MaterialDescription;
 
 // The instance transform is `translate * rotate * scale` applied on top of
 // the template's internal `local` matrix, all under the node's accumulated
-// `world`. Shared by the forward and depth vertex shaders so the two passes'
-// instance placement is provably identical.
-const INSTANCE_TRANSFORM_GLSL: &str = r#"
-        layout (location = 4) in vec3 instancePosition;
-        layout (location = 5) in vec4 instanceRotation;
-        layout (location = 6) in vec3 instanceScale;
+// `world`. Shared by every instanced vertex shader so all passes' instance
+// placement is provably identical. `base` is the first instance-attribute
+// location: 4 for the primitive/rigid-model shaders, 6 for the skinned ones
+// (whose 4/5 carry the mesh's joint indices/weights).
+fn instance_transform_glsl(base: u32) -> String {
+    format!(
+        r#"
+        layout (location = {p}) in vec3 instancePosition;
+        layout (location = {r}) in vec4 instanceRotation;
+        layout (location = {s}) in vec3 instanceScale;
 
         uniform mat4 world;
         uniform mat4 local;
 
-        vec3 rotate(vec4 q, vec3 v) {
+        vec3 rotate(vec4 q, vec3 v) {{
             return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
-        }
+        }}
 
-        vec3 instanceLocal(vec3 pos) {
+        vec3 instanceLocal(vec3 pos) {{
             vec4 lp = local * vec4(pos, 1.0);
             return rotate(instanceRotation, lp.xyz * instanceScale) + instancePosition;
+        }}
+"#,
+        p = base,
+        r = base + 1,
+        s = base + 2
+    )
+}
+
+// The joint blend shared by the skinned instanced vertex shaders — the same
+// palette blend as `SkinnedMaterial` (200-joint uniform array), evaluated
+// ONCE per node and read by every copy (the shared-pose contract).
+const SKINNING_GLSL: &str = r#"
+        #define MAX_JOINTS 200
+
+        layout (location = 4) in vec4 inJointIndices;
+        layout (location = 5) in vec4 inWeights;
+
+        uniform mat4 jointTransforms[MAX_JOINTS];
+
+        mat4 skinMatrix() {
+            return inWeights.x * jointTransforms[int(inJointIndices.x)] +
+                   inWeights.y * jointTransforms[int(inJointIndices.y)] +
+                   inWeights.z * jointTransforms[int(inJointIndices.z)] +
+                   inWeights.w * jointTransforms[int(inJointIndices.w)];
         }
 "#;
 
@@ -159,6 +187,65 @@ const DEPTH_FRAGMENT_SHADER_SOURCE: &str = r#"
         }
 "#;
 
+// Skinned instanced forward vertex shader: skin in mesh space (the skeleton
+// carries the chain to the model root — glTF ignores a skinned mesh's node
+// transform), then the shared instance placement. Outputs match
+// `FRAGMENT_SHADER_SOURCE`, which draws lit+textured here (materialMode 1,
+// useTexture 1) — the same shading as `SkinnedMaterial`'s stamped copies.
+// Normals/tangents take the joint blend first (the `SkinnedMaterial`
+// convention, which assumes rigid joint transforms), then the same
+// per-stage inverse-transpose treatment as the primitive shader. The tint
+// attribute sits at location 9, pinned to white for bare model templates.
+const SKINNED_VERTEX_SHADER_SOURCE: &str = r#"
+        layout (location = 0) in vec3 inPos;
+        layout (location = 1) in vec2 inTex;
+        layout (location = 2) in vec3 inNormal;
+        layout (location = 3) in vec4 inTangent;
+        layout (location = 9) in vec3 instanceTint;
+
+        uniform mat3 normalMatrix;
+        uniform mat3 localNormalMatrix;
+        uniform mat4 view;
+        uniform mat4 projection;
+
+        out vec2 texCoord;
+        out vec3 worldPos;
+        out vec3 worldNormal;
+        out vec3 worldTangent;
+        out vec3 tintColor;
+
+        void main() {
+            mat4 skin = skinMatrix();
+            vec3 sp = (skin * vec4(inPos, 1.0)).xyz;
+            vec4 wp = world * vec4(instanceLocal(sp), 1.0);
+            texCoord = inTex;
+            worldPos = wp.xyz;
+            tintColor = instanceTint;
+            vec3 ln = localNormalMatrix * (mat3(skin) * inNormal);
+            vec3 safeScale = mix(instanceScale, vec3(1.0),
+                vec3(lessThan(abs(instanceScale), vec3(1e-8))));
+            worldNormal = normalMatrix * rotate(instanceRotation, ln / safeScale);
+            vec3 lt = mat3(local) * (mat3(skin) * inTangent.xyz);
+            worldTangent = mat3(world) * rotate(instanceRotation, lt * instanceScale);
+            gl_Position = projection * view * wp;
+        }
+"#;
+
+// Skinned depth-pass twin: skin, place, packDepth — so animated instanced
+// copies cast a correctly deforming shadow (the `SkinnedDepthMaterial`
+// contract).
+const SKINNED_DEPTH_VERTEX_SHADER_SOURCE: &str = r#"
+        layout (location = 0) in vec3 inPos;
+
+        uniform mat4 view;
+        uniform mat4 projection;
+
+        void main() {
+            vec3 sp = (skinMatrix() * vec4(inPos, 1.0)).xyz;
+            gl_Position = projection * view * world * vec4(instanceLocal(sp), 1.0);
+        }
+"#;
+
 struct ForwardUniforms {
     world: UniformLocation,
     local: UniformLocation,
@@ -220,79 +307,85 @@ pub(super) struct InstancedRenderer {
     // against the meshes' live vertex-buffer handles and rebuilds on
     // mismatch) instead of stranding a dead generation.
     model_meshes: HashMap<String, ModelInstancedState>,
+    // The skinned twin — same state shape, but its VAOs enable the joint
+    // channels and carry the instance layout at locations 6-8.
+    skinned_model_meshes: HashMap<String, ModelInstancedState>,
     forward: ShaderProgram,
     forward_uniforms: ForwardUniforms,
     depth: ShaderProgram,
     depth_uniforms: DepthUniforms,
+    skinned_forward: ShaderProgram,
+    skinned_forward_uniforms: ForwardUniforms,
+    skinned_forward_joints: UniformLocation,
+    skinned_depth: ShaderProgram,
+    skinned_depth_uniforms: DepthUniforms,
+    skinned_depth_joints: UniformLocation,
 }
 
 impl InstancedRenderer {
     pub(super) fn new(gl: &glow::Context, shader_version: &str) -> Self {
-        let forward_vertex_source =
-            format!("{}\n{}", INSTANCE_TRANSFORM_GLSL, VERTEX_SHADER_SOURCE);
-        let vertex_shader = Shader::build(
-            gl,
-            ShaderType::Vertex,
-            &forward_vertex_source,
-            shader_version,
-        );
-        let fragment_source = format!(
-            "{}\n{}\n{}",
-            FOG_GLSL,
-            lighting_glsl(),
-            FRAGMENT_SHADER_SOURCE
-        );
-        let fragment_shader =
-            Shader::build(gl, ShaderType::Fragment, &fragment_source, shader_version);
-        let forward = ShaderProgram::link(gl, &vertex_shader, &fragment_shader);
-        let forward_uniforms = ForwardUniforms {
-            world: forward.get_uniform_location(gl, "world"),
-            local: forward.get_uniform_location(gl, "local"),
-            normal_matrix: forward.get_uniform_location(gl, "normalMatrix"),
-            local_normal_matrix: forward.get_uniform_location(gl, "localNormalMatrix"),
-            view: forward.get_uniform_location(gl, "view"),
-            projection: forward.get_uniform_location(gl, "projection"),
-            base_color: forward.get_uniform_location(gl, "baseColor"),
-            texture1: forward.get_uniform_location(gl, "texture1"),
-            use_texture: forward.get_uniform_location(gl, "useTexture"),
-            material_mode: forward.get_uniform_location(gl, "materialMode"),
-            debug_mode: forward.get_uniform_location(gl, "debugMode"),
-            lighting: LightingUniforms::get(&forward, gl),
-            fog: FogUniforms::get(&forward, gl),
+        let build_program = |vertex_source: &str, fragment_source: &str| {
+            let vertex = Shader::build(gl, ShaderType::Vertex, vertex_source, shader_version);
+            let fragment = Shader::build(gl, ShaderType::Fragment, fragment_source, shader_version);
+            ShaderProgram::link(gl, &vertex, &fragment)
         };
-
-        let depth_vertex_source = format!(
-            "{}\n{}",
-            INSTANCE_TRANSFORM_GLSL, DEPTH_VERTEX_SHADER_SOURCE
-        );
-        let depth_vertex =
-            Shader::build(gl, ShaderType::Vertex, &depth_vertex_source, shader_version);
-        let depth_fragment_source = format!(
+        let forward_fragment = format!("{}\n{}\n{}", FOG_GLSL, lighting_glsl(), FRAGMENT_SHADER_SOURCE);
+        let depth_fragment = format!(
             "{}\n{}",
             crate::material::depth_material::PACK_DEPTH_GLSL,
             DEPTH_FRAGMENT_SHADER_SOURCE
         );
-        let depth_fragment = Shader::build(
-            gl,
-            ShaderType::Fragment,
-            &depth_fragment_source,
-            shader_version,
+
+        let forward = build_program(
+            &format!("{}\n{}", instance_transform_glsl(4), VERTEX_SHADER_SOURCE),
+            &forward_fragment,
         );
-        let depth = ShaderProgram::link(gl, &depth_vertex, &depth_fragment);
-        let depth_uniforms = DepthUniforms {
-            world: depth.get_uniform_location(gl, "world"),
-            local: depth.get_uniform_location(gl, "local"),
-            view: depth.get_uniform_location(gl, "view"),
-            projection: depth.get_uniform_location(gl, "projection"),
-        };
+        let forward_uniforms = forward_uniforms_of(&forward, gl);
+
+        let depth = build_program(
+            &format!("{}\n{}", instance_transform_glsl(4), DEPTH_VERTEX_SHADER_SOURCE),
+            &depth_fragment,
+        );
+        let depth_uniforms = depth_uniforms_of(&depth, gl);
+
+        let skinned_forward = build_program(
+            &format!(
+                "{}\n{}\n{}",
+                instance_transform_glsl(6),
+                SKINNING_GLSL,
+                SKINNED_VERTEX_SHADER_SOURCE
+            ),
+            &forward_fragment,
+        );
+        let skinned_forward_uniforms = forward_uniforms_of(&skinned_forward, gl);
+        let skinned_forward_joints = skinned_forward.get_uniform_location(gl, "jointTransforms");
+
+        let skinned_depth = build_program(
+            &format!(
+                "{}\n{}\n{}",
+                instance_transform_glsl(6),
+                SKINNING_GLSL,
+                SKINNED_DEPTH_VERTEX_SHADER_SOURCE
+            ),
+            &depth_fragment,
+        );
+        let skinned_depth_uniforms = depth_uniforms_of(&skinned_depth, gl);
+        let skinned_depth_joints = skinned_depth.get_uniform_location(gl, "jointTransforms");
 
         Self {
             meshes: HashMap::new(),
             model_meshes: HashMap::new(),
+            skinned_model_meshes: HashMap::new(),
             forward,
             forward_uniforms,
             depth,
             depth_uniforms,
+            skinned_forward,
+            skinned_forward_uniforms,
+            skinned_forward_joints,
+            skinned_depth,
+            skinned_depth_uniforms,
+            skinned_depth_joints,
         }
     }
 
@@ -346,7 +439,7 @@ impl InstancedRenderer {
                 }
 
                 gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
-                instance_attrib_layout(gl, true);
+                instance_attrib_layout(gl, 4, true);
 
                 gl.bind_vertex_array(None);
                 gl.bind_buffer(glow::ARRAY_BUFFER, None);
@@ -363,59 +456,7 @@ impl InstancedRenderer {
         })
     }
 
-    /// Set the depth program's uniforms for one instanced draw.
-    fn set_depth_uniforms(
-        &self,
-        ctx: &RenderContext,
-        world: &Matrix4<f32>,
-        local: &Matrix4<f32>,
-        projection: &Matrix4<f32>,
-        view: &Matrix4<f32>,
-    ) {
-        let u = &self.depth_uniforms;
-        self.depth.use_program(ctx.gl);
-        self.depth.set_uniform_matrix4(ctx.gl, &u.world, world);
-        self.depth.set_uniform_matrix4(ctx.gl, &u.local, local);
-        self.depth.set_uniform_matrix4(ctx.gl, &u.view, view);
-        self.depth
-            .set_uniform_matrix4(ctx.gl, &u.projection, projection);
-    }
 
-    /// Set the forward program's uniforms for one instanced draw.
-    #[allow(clippy::too_many_arguments)]
-    fn set_forward_uniforms(
-        &self,
-        ctx: &RenderContext,
-        world: &Matrix4<f32>,
-        local: &Matrix4<f32>,
-        projection: &Matrix4<f32>,
-        view: &Matrix4<f32>,
-        color: &cgmath::Vector4<f32>,
-        use_texture: bool,
-        lit: bool,
-    ) {
-        let u = &self.forward_uniforms;
-        let p = &self.forward;
-        p.use_program(ctx.gl);
-        p.set_uniform_matrix4(ctx.gl, &u.world, world);
-        p.set_uniform_matrix4(ctx.gl, &u.local, local);
-        p.set_uniform_matrix3(ctx.gl, &u.normal_matrix, &normal_matrix(world));
-        p.set_uniform_matrix3(ctx.gl, &u.local_normal_matrix, &normal_matrix(local));
-        p.set_uniform_matrix4(ctx.gl, &u.view, view);
-        p.set_uniform_matrix4(ctx.gl, &u.projection, projection);
-        p.set_uniform_vec4(ctx.gl, &u.base_color, color);
-        p.set_uniform_1i(ctx.gl, &u.texture1, 0);
-        p.set_uniform_1i(ctx.gl, &u.use_texture, use_texture as i32);
-        p.set_uniform_1i(ctx.gl, &u.material_mode, lit as i32);
-        let debug_mode = match ctx.debug_render_mode {
-            DebugRenderMode::Normals => 1,
-            DebugRenderMode::Tangents => 2,
-            DebugRenderMode::Default | DebugRenderMode::Transparent | DebugRenderMode::Physics => 0,
-        };
-        p.set_uniform_1i(ctx.gl, &u.debug_mode, debug_mode);
-        u.lighting.set(p, ctx, view);
-        u.fog.set(p, ctx.gl, ctx.fog, &ctx.camera_pos);
-    }
 
     /// Draw one recognized PRIMITIVE instanced node — in the depth pass with
     /// the instanced depth program, otherwise with the forward program (unlit
@@ -444,7 +485,15 @@ impl InstancedRenderer {
             (mesh.index_buffer, mesh.index_count)
         };
         if depth_pass {
-            self.set_depth_uniforms(ctx, world, &template.local, projection, view);
+            set_depth_uniforms(
+                &self.depth,
+                &self.depth_uniforms,
+                ctx,
+                world,
+                &template.local,
+                projection,
+                view,
+            );
         } else {
             let (color, lit) = match template.material {
                 MaterialDescription::Lit { color, .. } => (*color, true),
@@ -456,7 +505,9 @@ impl InstancedRenderer {
                     (cgmath::vec4(1.0, 1.0, 1.0, 1.0), false)
                 }
             };
-            self.set_forward_uniforms(
+            set_forward_uniforms(
+                &self.forward,
+                &self.forward_uniforms,
                 ctx,
                 world,
                 &template.local,
@@ -572,10 +623,20 @@ impl InstancedRenderer {
             // template-internal transform (skinned models never reach here).
             let mesh_local = local * mesh.transform;
             if depth_pass {
-                self.set_depth_uniforms(ctx, world, &mesh_local, projection, view);
+                set_depth_uniforms(
+                    &self.depth,
+                    &self.depth_uniforms,
+                    ctx,
+                    world,
+                    &mesh_local,
+                    projection,
+                    view,
+                );
             } else {
                 mesh.base_color_texture.bind(0, ctx);
-                self.set_forward_uniforms(
+                set_forward_uniforms(
+                    &self.forward,
+                    &self.forward_uniforms,
                     ctx,
                     world,
                     &mesh_local,
@@ -655,7 +716,200 @@ impl InstancedRenderer {
                 // colors for the tint to multiply, so the STAMP ignores it —
                 // the hardware path pins location 7's generic value instead.
                 gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
-                instance_attrib_layout(gl, false);
+                instance_attrib_layout(gl, 4, false);
+                gl.bind_vertex_array(None);
+                ModelMeshVao {
+                    vao,
+                    vertex_buffer: live.vbo,
+                }
+            })
+            .collect();
+        gl.bind_buffer(glow::ARRAY_BUFFER, None);
+        ModelInstancedState {
+            instance_buffer,
+            instance_capacity: 0,
+            meshes,
+        }
+    }
+
+    /// Draw one recognized SKINNED instanced node at the SHARED pose: the
+    /// pose's joint palette uploads once, then one instanced call per mesh
+    /// primitive — lit and textured like `SkinnedMaterial`'s stamped copies
+    /// in the forward pass, skinning in the depth pass too (so animated
+    /// copies cast a correctly deforming shadow).
+    ///
+    /// Per glTF, a skinned mesh's node transform is ignored (the skeleton
+    /// carries the chain), so every primitive shares the template-local
+    /// matrix unmodified.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn draw_skinned_model(
+        &mut self,
+        ctx: &RenderContext,
+        file: &str,
+        model: &Arc<Model>,
+        joints: &[Matrix4<f32>],
+        local: &Matrix4<f32>,
+        instances: &[InstanceData],
+        world: &Matrix4<f32>,
+        projection: &Matrix4<f32>,
+        view: &Matrix4<f32>,
+    ) {
+        if model.meshes.is_empty() {
+            return;
+        }
+        let depth_pass = ctx.render_pass == RenderPass::DepthOnly;
+        let bytes = crate::terrain_renderer::slice_bytes(instances);
+        let handles: Vec<MeshBufferHandles> = model
+            .meshes
+            .iter()
+            .map(|mesh| mesh.mesh.buffers(ctx.gl))
+            .collect();
+        // Same staleness rule as the rigid path (see `draw_model`).
+        let stale = self.skinned_model_meshes.get(file).is_some_and(|state| {
+            state.meshes.len() != handles.len()
+                || state
+                    .meshes
+                    .iter()
+                    .zip(handles.iter())
+                    .any(|(cached, live)| cached.vertex_buffer != live.vbo)
+        });
+        if stale {
+            let state = self.skinned_model_meshes.remove(file).expect("checked above");
+            let counters = crate::gpu_counters::gpu_counters();
+            unsafe {
+                for cached in &state.meshes {
+                    ctx.gl.delete_vertex_array(cached.vao);
+                    counters.vao_deleted();
+                }
+                ctx.gl.delete_buffer(state.instance_buffer);
+                counters.buffer_deleted();
+            }
+        }
+        let vaos: Vec<glow::VertexArray> = {
+            let state = match self.skinned_model_meshes.get_mut(file) {
+                Some(state) => state,
+                None => {
+                    let state = unsafe { Self::create_skinned_model_state(ctx.gl, &handles) };
+                    self.skinned_model_meshes
+                        .entry(file.to_string())
+                        .or_insert(state)
+                }
+            };
+            unsafe {
+                ctx.gl
+                    .bind_buffer(glow::ARRAY_BUFFER, Some(state.instance_buffer));
+                upload_instances(ctx.gl, bytes, &mut state.instance_capacity);
+                ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
+            }
+            state.meshes.iter().map(|cached| cached.vao).collect()
+        };
+        // The tint attribute (location 9) has no array in the skinned VAOs —
+        // pin the generic value to white, matching the stamp's tint-ignoring
+        // semantics for model templates.
+        unsafe {
+            ctx.gl.vertex_attrib_3_f32(9, 1.0, 1.0, 1.0);
+        }
+        // ONE palette upload per node per pass — the shared-pose contract.
+        let program = if depth_pass {
+            &self.skinned_depth
+        } else {
+            &self.skinned_forward
+        };
+        let joints_loc = if depth_pass {
+            &self.skinned_depth_joints
+        } else {
+            &self.skinned_forward_joints
+        };
+        program.use_program(ctx.gl);
+        let mut joint_matrices = Vec::with_capacity(joints.len() * 16);
+        for joint in joints {
+            let matrix_array: &[f32; 16] = joint.as_ref();
+            joint_matrices.extend_from_slice(matrix_array);
+        }
+        program.set_uniform_matrix4fv(ctx.gl, joints_loc, &joint_matrices);
+        for ((mesh, live), vao) in model.meshes.iter().zip(handles.iter()).zip(vaos.iter()) {
+            if depth_pass {
+                set_depth_uniforms(
+                    &self.skinned_depth,
+                    &self.skinned_depth_uniforms,
+                    ctx,
+                    world,
+                    local,
+                    projection,
+                    view,
+                );
+            } else {
+                mesh.base_color_texture.bind(0, ctx);
+                set_forward_uniforms(
+                    &self.skinned_forward,
+                    &self.skinned_forward_uniforms,
+                    ctx,
+                    world,
+                    local,
+                    projection,
+                    view,
+                    &cgmath::vec4(1.0, 1.0, 1.0, 1.0),
+                    true,
+                    true,
+                );
+            }
+            unsafe {
+                ctx.gl.bind_vertex_array(Some(*vao));
+                ctx.gl
+                    .bind_buffer(glow::ELEMENT_ARRAY_BUFFER, Some(live.ebo));
+                ctx.gl.draw_elements_instanced(
+                    glow::TRIANGLES,
+                    live.index_count,
+                    glow::UNSIGNED_INT,
+                    0,
+                    instances.len() as i32,
+                );
+            }
+        }
+        unsafe {
+            ctx.gl.bind_vertex_array(None);
+        }
+    }
+
+    /// Create a skinned model's instanced GPU state: like
+    /// [`Self::create_model_state`], but every mesh channel is enabled
+    /// (joints/weights at 4/5 feed the palette blend) and the instance
+    /// layout sits at locations 6-8.
+    unsafe fn create_skinned_model_state(
+        gl: &glow::Context,
+        handles: &[MeshBufferHandles],
+    ) -> ModelInstancedState {
+        let counters = crate::gpu_counters::gpu_counters();
+        let instance_buffer = gl.create_buffer().expect("skinned model instance data");
+        counters.buffer_created();
+        let meshes = handles
+            .iter()
+            .map(|live| {
+                let vao = gl
+                    .create_vertex_array()
+                    .expect("skinned model instanced VAO");
+                counters.vao_created();
+                gl.bind_vertex_array(Some(vao));
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(live.vbo));
+                let stride = VertexPositionTextureSkinned::get_total_size() as i32;
+                for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
+                    .iter()
+                    .enumerate()
+                {
+                    gl.enable_vertex_attrib_array(location as u32);
+                    match attribute.attribute_type {
+                        VertexAttributeType::Float => gl.vertex_attrib_pointer_f32(
+                            location as u32,
+                            attribute.size,
+                            glow::FLOAT,
+                            false,
+                            stride,
+                            attribute.offset as i32,
+                        ),
+                    }
+                }
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
+                instance_attrib_layout(gl, 6, false);
                 gl.bind_vertex_array(None);
                 ModelMeshVao {
                     vao,
@@ -672,6 +926,90 @@ impl InstancedRenderer {
     }
 }
 
+
+/// Look up the shared forward-uniform set on a freshly linked program (the
+/// plain and skinned forward programs share one uniform contract).
+fn forward_uniforms_of(program: &ShaderProgram, gl: &glow::Context) -> ForwardUniforms {
+    ForwardUniforms {
+        world: program.get_uniform_location(gl, "world"),
+        local: program.get_uniform_location(gl, "local"),
+        normal_matrix: program.get_uniform_location(gl, "normalMatrix"),
+        local_normal_matrix: program.get_uniform_location(gl, "localNormalMatrix"),
+        view: program.get_uniform_location(gl, "view"),
+        projection: program.get_uniform_location(gl, "projection"),
+        base_color: program.get_uniform_location(gl, "baseColor"),
+        texture1: program.get_uniform_location(gl, "texture1"),
+        use_texture: program.get_uniform_location(gl, "useTexture"),
+        material_mode: program.get_uniform_location(gl, "materialMode"),
+        debug_mode: program.get_uniform_location(gl, "debugMode"),
+        lighting: LightingUniforms::get(program, gl),
+        fog: FogUniforms::get(program, gl),
+    }
+}
+
+/// Look up the shared depth-uniform set (plain and skinned depth programs).
+fn depth_uniforms_of(program: &ShaderProgram, gl: &glow::Context) -> DepthUniforms {
+    DepthUniforms {
+        world: program.get_uniform_location(gl, "world"),
+        local: program.get_uniform_location(gl, "local"),
+        view: program.get_uniform_location(gl, "view"),
+        projection: program.get_uniform_location(gl, "projection"),
+    }
+}
+
+/// Set a depth program's uniforms for one instanced draw.
+fn set_depth_uniforms(
+    program: &ShaderProgram,
+    u: &DepthUniforms,
+    ctx: &RenderContext,
+    world: &Matrix4<f32>,
+    local: &Matrix4<f32>,
+    projection: &Matrix4<f32>,
+    view: &Matrix4<f32>,
+) {
+    program.use_program(ctx.gl);
+    program.set_uniform_matrix4(ctx.gl, &u.world, world);
+    program.set_uniform_matrix4(ctx.gl, &u.local, local);
+    program.set_uniform_matrix4(ctx.gl, &u.view, view);
+    program.set_uniform_matrix4(ctx.gl, &u.projection, projection);
+}
+
+/// Set a forward program's uniforms for one instanced draw.
+#[allow(clippy::too_many_arguments)]
+fn set_forward_uniforms(
+    program: &ShaderProgram,
+    u: &ForwardUniforms,
+    ctx: &RenderContext,
+    world: &Matrix4<f32>,
+    local: &Matrix4<f32>,
+    projection: &Matrix4<f32>,
+    view: &Matrix4<f32>,
+    color: &cgmath::Vector4<f32>,
+    use_texture: bool,
+    lit: bool,
+) {
+    let p = program;
+    p.use_program(ctx.gl);
+    p.set_uniform_matrix4(ctx.gl, &u.world, world);
+    p.set_uniform_matrix4(ctx.gl, &u.local, local);
+    p.set_uniform_matrix3(ctx.gl, &u.normal_matrix, &normal_matrix(world));
+    p.set_uniform_matrix3(ctx.gl, &u.local_normal_matrix, &normal_matrix(local));
+    p.set_uniform_matrix4(ctx.gl, &u.view, view);
+    p.set_uniform_matrix4(ctx.gl, &u.projection, projection);
+    p.set_uniform_vec4(ctx.gl, &u.base_color, color);
+    p.set_uniform_1i(ctx.gl, &u.texture1, 0);
+    p.set_uniform_1i(ctx.gl, &u.use_texture, use_texture as i32);
+    p.set_uniform_1i(ctx.gl, &u.material_mode, lit as i32);
+    let debug_mode = match ctx.debug_render_mode {
+        DebugRenderMode::Normals => 1,
+        DebugRenderMode::Tangents => 2,
+        DebugRenderMode::Default | DebugRenderMode::Transparent | DebugRenderMode::Physics => 0,
+    };
+    p.set_uniform_1i(ctx.gl, &u.debug_mode, debug_mode);
+    u.lighting.set(p, ctx, view);
+    u.fog.set(p, ctx.gl, ctx.fog, &ctx.camera_pos);
+}
+
 /// Upload the instance records into the currently bound `ARRAY_BUFFER`.
 /// Deliberately monotonic: capacity follows the high-water mark for the
 /// process lifetime (like every other persistent renderer cache here) rather
@@ -686,27 +1024,22 @@ unsafe fn upload_instances(gl: &glow::Context, bytes: &[u8], capacity: &mut usiz
     crate::gpu_counters::gpu_counters().uploaded(bytes.len());
 }
 
-/// Declare the per-instance attribute layout — TRS at locations 4/5/6, tint
-/// at 7 when `with_tint` — on the currently bound VAO, sourced from the
-/// currently bound `ARRAY_BUFFER`. Kept in ONE place so the primitive and
-/// model VAOs cannot drift from the shaders' shared location contract.
-unsafe fn instance_attrib_layout(gl: &glow::Context, with_tint: bool) {
+/// Declare the per-instance attribute layout — TRS at locations
+/// `base`/`base+1`/`base+2` (matching `instance_transform_glsl(base)`), tint
+/// at `base+3` when `with_tint` — on the currently bound VAO, sourced from
+/// the currently bound `ARRAY_BUFFER`. Kept in ONE place so the primitive
+/// and model VAOs cannot drift from the shaders' shared location contract.
+unsafe fn instance_attrib_layout(gl: &glow::Context, base: u32, with_tint: bool) {
     let instance_stride = size_of::<InstanceData>() as i32;
-    let channels: &[(u32, i32, usize)] = if with_tint {
-        &[
-            (4, 3, offset_of!(InstanceData, position)),
-            (5, 4, offset_of!(InstanceData, rotation)),
-            (6, 3, offset_of!(InstanceData, scale)),
-            (7, 3, offset_of!(InstanceData, tint)),
-        ]
-    } else {
-        &[
-            (4, 3, offset_of!(InstanceData, position)),
-            (5, 4, offset_of!(InstanceData, rotation)),
-            (6, 3, offset_of!(InstanceData, scale)),
-        ]
-    };
-    for &(location, size, offset) in channels {
+    let mut channels: Vec<(u32, i32, usize)> = vec![
+        (base, 3, offset_of!(InstanceData, position)),
+        (base + 1, 4, offset_of!(InstanceData, rotation)),
+        (base + 2, 3, offset_of!(InstanceData, scale)),
+    ];
+    if with_tint {
+        channels.push((base + 3, 3, offset_of!(InstanceData, tint)));
+    }
+    for (location, size, offset) in channels {
         gl.enable_vertex_attrib_array(location);
         gl.vertex_attrib_pointer_f32(
             location,

--- a/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
@@ -298,6 +298,60 @@ struct ModelMeshVao {
     vertex_buffer: glow::Buffer,
 }
 
+/// The skinned program pair (forward + depth) with their uniform sets and
+/// palette locations — built lazily on the FIRST skinned instanced draw, so
+/// a scene that only instances primitives or rigid models never pays their
+/// compile/link.
+struct SkinnedPrograms {
+    forward: ShaderProgram,
+    forward_uniforms: ForwardUniforms,
+    forward_joints: UniformLocation,
+    depth: ShaderProgram,
+    depth_uniforms: DepthUniforms,
+    depth_joints: UniformLocation,
+}
+
+impl SkinnedPrograms {
+    fn new(gl: &glow::Context, shader_version: &str) -> Self {
+        let forward = build_program(
+            gl,
+            shader_version,
+            &format!(
+                "{}\n{}\n{}",
+                instance_transform_glsl(6),
+                SKINNING_GLSL,
+                SKINNED_VERTEX_SHADER_SOURCE
+            ),
+            &forward_fragment_source(),
+        );
+        let forward_uniforms = forward_uniforms_of(&forward, gl);
+        let forward_joints = forward.get_uniform_location(gl, "jointTransforms");
+
+        let depth = build_program(
+            gl,
+            shader_version,
+            &format!(
+                "{}\n{}\n{}",
+                instance_transform_glsl(6),
+                SKINNING_GLSL,
+                SKINNED_DEPTH_VERTEX_SHADER_SOURCE
+            ),
+            &depth_fragment_source(),
+        );
+        let depth_uniforms = depth_uniforms_of(&depth, gl);
+        let depth_joints = depth.get_uniform_location(gl, "jointTransforms");
+
+        Self {
+            forward,
+            forward_uniforms,
+            forward_joints,
+            depth,
+            depth_uniforms,
+            depth_joints,
+        }
+    }
+}
+
 /// Persistent GPU state for `Scene.instanced`'s hardware path.
 pub(super) struct InstancedRenderer {
     meshes: HashMap<InstancedPrimitive, MeshBuffers>,
@@ -314,63 +368,32 @@ pub(super) struct InstancedRenderer {
     forward_uniforms: ForwardUniforms,
     depth: ShaderProgram,
     depth_uniforms: DepthUniforms,
-    skinned_forward: ShaderProgram,
-    skinned_forward_uniforms: ForwardUniforms,
-    skinned_forward_joints: UniformLocation,
-    skinned_depth: ShaderProgram,
-    skinned_depth_uniforms: DepthUniforms,
-    skinned_depth_joints: UniformLocation,
+    // Lazily built (see `SkinnedPrograms`); needs the shader version kept.
+    skinned: Option<SkinnedPrograms>,
+    shader_version: String,
 }
 
 impl InstancedRenderer {
     pub(super) fn new(gl: &glow::Context, shader_version: &str) -> Self {
-        let build_program = |vertex_source: &str, fragment_source: &str| {
-            let vertex = Shader::build(gl, ShaderType::Vertex, vertex_source, shader_version);
-            let fragment = Shader::build(gl, ShaderType::Fragment, fragment_source, shader_version);
-            ShaderProgram::link(gl, &vertex, &fragment)
-        };
-        let forward_fragment = format!("{}\n{}\n{}", FOG_GLSL, lighting_glsl(), FRAGMENT_SHADER_SOURCE);
-        let depth_fragment = format!(
-            "{}\n{}",
-            crate::material::depth_material::PACK_DEPTH_GLSL,
-            DEPTH_FRAGMENT_SHADER_SOURCE
-        );
-
         let forward = build_program(
+            gl,
+            shader_version,
             &format!("{}\n{}", instance_transform_glsl(4), VERTEX_SHADER_SOURCE),
-            &forward_fragment,
+            &forward_fragment_source(),
         );
         let forward_uniforms = forward_uniforms_of(&forward, gl);
 
         let depth = build_program(
-            &format!("{}\n{}", instance_transform_glsl(4), DEPTH_VERTEX_SHADER_SOURCE),
-            &depth_fragment,
+            gl,
+            shader_version,
+            &format!(
+                "{}\n{}",
+                instance_transform_glsl(4),
+                DEPTH_VERTEX_SHADER_SOURCE
+            ),
+            &depth_fragment_source(),
         );
         let depth_uniforms = depth_uniforms_of(&depth, gl);
-
-        let skinned_forward = build_program(
-            &format!(
-                "{}\n{}\n{}",
-                instance_transform_glsl(6),
-                SKINNING_GLSL,
-                SKINNED_VERTEX_SHADER_SOURCE
-            ),
-            &forward_fragment,
-        );
-        let skinned_forward_uniforms = forward_uniforms_of(&skinned_forward, gl);
-        let skinned_forward_joints = skinned_forward.get_uniform_location(gl, "jointTransforms");
-
-        let skinned_depth = build_program(
-            &format!(
-                "{}\n{}\n{}",
-                instance_transform_glsl(6),
-                SKINNING_GLSL,
-                SKINNED_DEPTH_VERTEX_SHADER_SOURCE
-            ),
-            &depth_fragment,
-        );
-        let skinned_depth_uniforms = depth_uniforms_of(&skinned_depth, gl);
-        let skinned_depth_joints = skinned_depth.get_uniform_location(gl, "jointTransforms");
 
         Self {
             meshes: HashMap::new(),
@@ -380,12 +403,8 @@ impl InstancedRenderer {
             forward_uniforms,
             depth,
             depth_uniforms,
-            skinned_forward,
-            skinned_forward_uniforms,
-            skinned_forward_joints,
-            skinned_depth,
-            skinned_depth_uniforms,
-            skinned_depth_joints,
+            skinned: None,
+            shader_version: shader_version.to_string(),
         }
     }
 
@@ -455,8 +474,6 @@ impl InstancedRenderer {
             }
         })
     }
-
-
 
     /// Draw one recognized PRIMITIVE instanced node — in the depth pass with
     /// the instanced depth program, otherwise with the forward program (unlit
@@ -566,49 +583,8 @@ impl InstancedRenderer {
             .iter()
             .map(|mesh| mesh.mesh.buffers(ctx.gl))
             .collect();
-        // Staleness guard: the cache is keyed by asset locator, so an asset
-        // evict/hot-reload (a NEW Arc with new GL buffers) shows up as a
-        // vertex-buffer mismatch — drop the whole entry and rebuild. Nothing
-        // else in the tree deletes mesh VBOs, so a handle mismatch is a
-        // reliable staleness signal (and entries stay bounded by the model
-        // files a session actually instanced).
-        let stale = self.model_meshes.get(file).is_some_and(|state| {
-            state.meshes.len() != handles.len()
-                || state
-                    .meshes
-                    .iter()
-                    .zip(handles.iter())
-                    .any(|(cached, live)| cached.vertex_buffer != live.vbo)
-        });
-        if stale {
-            let state = self.model_meshes.remove(file).expect("checked above");
-            let counters = crate::gpu_counters::gpu_counters();
-            unsafe {
-                for cached in &state.meshes {
-                    ctx.gl.delete_vertex_array(cached.vao);
-                    counters.vao_deleted();
-                }
-                ctx.gl.delete_buffer(state.instance_buffer);
-                counters.buffer_deleted();
-            }
-        }
-        // Build (or reuse) the per-model state, then upload the instance
-        // records ONCE into its shared buffer; carry out only Copy VAOs.
-        let vaos: Vec<glow::VertexArray> = {
-            let state = match self.model_meshes.get_mut(file) {
-                Some(state) => state,
-                None => {
-                    let state = unsafe { Self::create_model_state(ctx.gl, &handles) };
-                    self.model_meshes.entry(file.to_string()).or_insert(state)
-                }
-            };
-            unsafe {
-                ctx.gl
-                    .bind_buffer(glow::ARRAY_BUFFER, Some(state.instance_buffer));
-                upload_instances(ctx.gl, bytes, &mut state.instance_capacity);
-                ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
-            }
-            state.meshes.iter().map(|cached| cached.vao).collect()
+        let vaos = unsafe {
+            acquire_model_vaos(ctx.gl, &mut self.model_meshes, file, &handles, bytes, false)
         };
         // Location 7's array is disabled in the model VAOs — pin the generic
         // tint value to white (identity), matching the stamp's tint-ignoring
@@ -665,73 +641,6 @@ impl InstancedRenderer {
         }
     }
 
-    /// Create a rigid model's instanced GPU state: one shared instance
-    /// buffer, plus a VAO per mesh primitive — mesh attributes from the
-    /// mesh's own VBO (skipping the skinned joint/weight channels, whose
-    /// locations 4/5 carry the instance TRS instead) and the instance layout
-    /// from the shared buffer.
-    unsafe fn create_model_state(
-        gl: &glow::Context,
-        handles: &[MeshBufferHandles],
-    ) -> ModelInstancedState {
-        let counters = crate::gpu_counters::gpu_counters();
-        let instance_buffer = gl.create_buffer().expect("model instance data");
-        counters.buffer_created();
-        let meshes = handles
-            .iter()
-            .map(|live| {
-                let vao = gl.create_vertex_array().expect("model instanced VAO");
-                counters.vao_created();
-                gl.bind_vertex_array(Some(vao));
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(live.vbo));
-                let stride = VertexPositionTextureSkinned::get_total_size() as i32;
-                for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
-                    .iter()
-                    .enumerate()
-                {
-                    // Joints/weights sit at locations 4/5 — exactly where the
-                    // instance channels live — and rigid meshes never read
-                    // them, so leave those arrays disabled by CHANNEL (not by
-                    // positional prefix, which would silently mis-bind if the
-                    // attribute table were ever reordered).
-                    if matches!(
-                        attribute.attribute_channel,
-                        BuiltInVertexChannel::JointIndices | BuiltInVertexChannel::JointWeights
-                    ) {
-                        continue;
-                    }
-                    gl.enable_vertex_attrib_array(location as u32);
-                    match attribute.attribute_type {
-                        VertexAttributeType::Float => gl.vertex_attrib_pointer_f32(
-                            location as u32,
-                            attribute.size,
-                            glow::FLOAT,
-                            false,
-                            stride,
-                            attribute.offset as i32,
-                        ),
-                    }
-                }
-                // No tint attribute: a bare model template has no material
-                // colors for the tint to multiply, so the STAMP ignores it —
-                // the hardware path pins location 7's generic value instead.
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
-                instance_attrib_layout(gl, 4, false);
-                gl.bind_vertex_array(None);
-                ModelMeshVao {
-                    vao,
-                    vertex_buffer: live.vbo,
-                }
-            })
-            .collect();
-        gl.bind_buffer(glow::ARRAY_BUFFER, None);
-        ModelInstancedState {
-            instance_buffer,
-            instance_capacity: 0,
-            meshes,
-        }
-    }
-
     /// Draw one recognized SKINNED instanced node at the SHARED pose: the
     /// pose's joint palette uploads once, then one instanced call per mesh
     /// primitive — lit and textured like `SkinnedMaterial`'s stamped copies
@@ -764,44 +673,21 @@ impl InstancedRenderer {
             .iter()
             .map(|mesh| mesh.mesh.buffers(ctx.gl))
             .collect();
-        // Same staleness rule as the rigid path (see `draw_model`).
-        let stale = self.skinned_model_meshes.get(file).is_some_and(|state| {
-            state.meshes.len() != handles.len()
-                || state
-                    .meshes
-                    .iter()
-                    .zip(handles.iter())
-                    .any(|(cached, live)| cached.vertex_buffer != live.vbo)
-        });
-        if stale {
-            let state = self.skinned_model_meshes.remove(file).expect("checked above");
-            let counters = crate::gpu_counters::gpu_counters();
-            unsafe {
-                for cached in &state.meshes {
-                    ctx.gl.delete_vertex_array(cached.vao);
-                    counters.vao_deleted();
-                }
-                ctx.gl.delete_buffer(state.instance_buffer);
-                counters.buffer_deleted();
-            }
+        // The programs compile on the first skinned draw (see
+        // `SkinnedPrograms`).
+        if self.skinned.is_none() {
+            self.skinned = Some(SkinnedPrograms::new(ctx.gl, &self.shader_version));
         }
-        let vaos: Vec<glow::VertexArray> = {
-            let state = match self.skinned_model_meshes.get_mut(file) {
-                Some(state) => state,
-                None => {
-                    let state = unsafe { Self::create_skinned_model_state(ctx.gl, &handles) };
-                    self.skinned_model_meshes
-                        .entry(file.to_string())
-                        .or_insert(state)
-                }
-            };
-            unsafe {
-                ctx.gl
-                    .bind_buffer(glow::ARRAY_BUFFER, Some(state.instance_buffer));
-                upload_instances(ctx.gl, bytes, &mut state.instance_capacity);
-                ctx.gl.bind_buffer(glow::ARRAY_BUFFER, None);
-            }
-            state.meshes.iter().map(|cached| cached.vao).collect()
+        let programs = self.skinned.as_ref().expect("just built");
+        let vaos = unsafe {
+            acquire_model_vaos(
+                ctx.gl,
+                &mut self.skinned_model_meshes,
+                file,
+                &handles,
+                bytes,
+                true,
+            )
         };
         // The tint attribute (location 9) has no array in the skinned VAOs —
         // pin the generic value to white, matching the stamp's tint-ignoring
@@ -810,28 +696,19 @@ impl InstancedRenderer {
             ctx.gl.vertex_attrib_3_f32(9, 1.0, 1.0, 1.0);
         }
         // ONE palette upload per node per pass — the shared-pose contract.
-        let program = if depth_pass {
-            &self.skinned_depth
+        let (program, joints_loc) = if depth_pass {
+            (&programs.depth, &programs.depth_joints)
         } else {
-            &self.skinned_forward
-        };
-        let joints_loc = if depth_pass {
-            &self.skinned_depth_joints
-        } else {
-            &self.skinned_forward_joints
+            (&programs.forward, &programs.forward_joints)
         };
         program.use_program(ctx.gl);
-        let mut joint_matrices = Vec::with_capacity(joints.len() * 16);
-        for joint in joints {
-            let matrix_array: &[f32; 16] = joint.as_ref();
-            joint_matrices.extend_from_slice(matrix_array);
-        }
+        let joint_matrices = crate::model::flatten_joint_matrices(joints);
         program.set_uniform_matrix4fv(ctx.gl, joints_loc, &joint_matrices);
         for ((mesh, live), vao) in model.meshes.iter().zip(handles.iter()).zip(vaos.iter()) {
             if depth_pass {
                 set_depth_uniforms(
-                    &self.skinned_depth,
-                    &self.skinned_depth_uniforms,
+                    &programs.depth,
+                    &programs.depth_uniforms,
                     ctx,
                     world,
                     local,
@@ -841,8 +718,8 @@ impl InstancedRenderer {
             } else {
                 mesh.base_color_texture.bind(0, ctx);
                 set_forward_uniforms(
-                    &self.skinned_forward,
-                    &self.skinned_forward_uniforms,
+                    &programs.forward,
+                    &programs.forward_uniforms,
                     ctx,
                     world,
                     local,
@@ -870,62 +747,162 @@ impl InstancedRenderer {
             ctx.gl.bind_vertex_array(None);
         }
     }
-
-    /// Create a skinned model's instanced GPU state: like
-    /// [`Self::create_model_state`], but every mesh channel is enabled
-    /// (joints/weights at 4/5 feed the palette blend) and the instance
-    /// layout sits at locations 6-8.
-    unsafe fn create_skinned_model_state(
-        gl: &glow::Context,
-        handles: &[MeshBufferHandles],
-    ) -> ModelInstancedState {
-        let counters = crate::gpu_counters::gpu_counters();
-        let instance_buffer = gl.create_buffer().expect("skinned model instance data");
-        counters.buffer_created();
-        let meshes = handles
-            .iter()
-            .map(|live| {
-                let vao = gl
-                    .create_vertex_array()
-                    .expect("skinned model instanced VAO");
-                counters.vao_created();
-                gl.bind_vertex_array(Some(vao));
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(live.vbo));
-                let stride = VertexPositionTextureSkinned::get_total_size() as i32;
-                for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
-                    .iter()
-                    .enumerate()
-                {
-                    gl.enable_vertex_attrib_array(location as u32);
-                    match attribute.attribute_type {
-                        VertexAttributeType::Float => gl.vertex_attrib_pointer_f32(
-                            location as u32,
-                            attribute.size,
-                            glow::FLOAT,
-                            false,
-                            stride,
-                            attribute.offset as i32,
-                        ),
-                    }
-                }
-                gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
-                instance_attrib_layout(gl, 6, false);
-                gl.bind_vertex_array(None);
-                ModelMeshVao {
-                    vao,
-                    vertex_buffer: live.vbo,
-                }
-            })
-            .collect();
-        gl.bind_buffer(glow::ARRAY_BUFFER, None);
-        ModelInstancedState {
-            instance_buffer,
-            instance_capacity: 0,
-            meshes,
-        }
-    }
 }
 
+/// Compile and link one instanced program.
+fn build_program(
+    gl: &glow::Context,
+    shader_version: &str,
+    vertex_source: &str,
+    fragment_source: &str,
+) -> ShaderProgram {
+    let vertex = Shader::build(gl, ShaderType::Vertex, vertex_source, shader_version);
+    let fragment = Shader::build(gl, ShaderType::Fragment, fragment_source, shader_version);
+    ShaderProgram::link(gl, &vertex, &fragment)
+}
+
+/// The forward fragment source shared by the plain and skinned programs.
+fn forward_fragment_source() -> String {
+    format!(
+        "{}\n{}\n{}",
+        FOG_GLSL,
+        lighting_glsl(),
+        FRAGMENT_SHADER_SOURCE
+    )
+}
+
+/// The depth fragment source shared by the plain and skinned programs.
+fn depth_fragment_source() -> String {
+    format!(
+        "{}\n{}",
+        crate::material::depth_material::PACK_DEPTH_GLSL,
+        DEPTH_FRAGMENT_SHADER_SOURCE
+    )
+}
+
+/// Acquire one model's per-file instanced GPU state — apply the staleness
+/// guard, build the state on miss, upload the instance records ONCE into the
+/// shared buffer — and return the per-mesh VAOs (Copy handles, so no borrow
+/// is carried into the draw loop).
+///
+/// Staleness: the cache is keyed by asset locator, so an asset
+/// evict/hot-reload (a NEW Arc with new GL buffers) shows up as a
+/// vertex-buffer mismatch — drop the whole entry and rebuild. Nothing else
+/// in the tree deletes mesh VBOs, so a handle mismatch is a reliable
+/// staleness signal (and entries stay bounded by the model files a session
+/// actually instanced).
+unsafe fn acquire_model_vaos(
+    gl: &glow::Context,
+    cache: &mut HashMap<String, ModelInstancedState>,
+    file: &str,
+    handles: &[MeshBufferHandles],
+    bytes: &[u8],
+    skinned: bool,
+) -> Vec<glow::VertexArray> {
+    let stale = cache.get(file).is_some_and(|state| {
+        state.meshes.len() != handles.len()
+            || state
+                .meshes
+                .iter()
+                .zip(handles.iter())
+                .any(|(cached, live)| cached.vertex_buffer != live.vbo)
+    });
+    if stale {
+        let state = cache.remove(file).expect("checked above");
+        let counters = crate::gpu_counters::gpu_counters();
+        for cached in &state.meshes {
+            gl.delete_vertex_array(cached.vao);
+            counters.vao_deleted();
+        }
+        gl.delete_buffer(state.instance_buffer);
+        counters.buffer_deleted();
+    }
+    let state = match cache.get_mut(file) {
+        Some(state) => state,
+        None => {
+            let state = create_model_state(gl, handles, skinned);
+            cache.entry(file.to_string()).or_insert(state)
+        }
+    };
+    gl.bind_buffer(glow::ARRAY_BUFFER, Some(state.instance_buffer));
+    upload_instances(gl, bytes, &mut state.instance_capacity);
+    gl.bind_buffer(glow::ARRAY_BUFFER, None);
+    state.meshes.iter().map(|cached| cached.vao).collect()
+}
+
+/// Create a model's instanced GPU state: one shared instance buffer, plus a
+/// VAO per mesh primitive — mesh attributes from the mesh's own VBO and the
+/// instance layout from the shared buffer.
+///
+/// Rigid (`skinned == false`): the joint/weight channels are skipped —
+/// their locations 4/5 carry the instance TRS instead (base 4). Skinned:
+/// every mesh channel is enabled (joints/weights at 4/5 feed the palette
+/// blend) and the instance layout sits at locations 6-8.
+///
+/// No tint attribute either way: a bare model template has no material
+/// colors for the tint to multiply, so the STAMP ignores it — the hardware
+/// paths pin the tint location's generic value instead.
+unsafe fn create_model_state(
+    gl: &glow::Context,
+    handles: &[MeshBufferHandles],
+    skinned: bool,
+) -> ModelInstancedState {
+    let counters = crate::gpu_counters::gpu_counters();
+    let instance_buffer = gl.create_buffer().expect("model instance data");
+    counters.buffer_created();
+    let meshes = handles
+        .iter()
+        .map(|live| {
+            let vao = gl.create_vertex_array().expect("model instanced VAO");
+            counters.vao_created();
+            gl.bind_vertex_array(Some(vao));
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(live.vbo));
+            let stride = VertexPositionTextureSkinned::get_total_size() as i32;
+            for (location, attribute) in VertexPositionTextureSkinned::get_vertex_attributes()
+                .iter()
+                .enumerate()
+            {
+                // On the rigid path, joints/weights sit at locations 4/5 —
+                // exactly where the instance channels live — and rigid
+                // meshes never read them, so leave those arrays disabled by
+                // CHANNEL (not by positional prefix, which would silently
+                // mis-bind if the attribute table were ever reordered).
+                if !skinned
+                    && matches!(
+                        attribute.attribute_channel,
+                        BuiltInVertexChannel::JointIndices | BuiltInVertexChannel::JointWeights
+                    )
+                {
+                    continue;
+                }
+                gl.enable_vertex_attrib_array(location as u32);
+                match attribute.attribute_type {
+                    VertexAttributeType::Float => gl.vertex_attrib_pointer_f32(
+                        location as u32,
+                        attribute.size,
+                        glow::FLOAT,
+                        false,
+                        stride,
+                        attribute.offset as i32,
+                    ),
+                }
+            }
+            gl.bind_buffer(glow::ARRAY_BUFFER, Some(instance_buffer));
+            instance_attrib_layout(gl, if skinned { 6 } else { 4 }, false);
+            gl.bind_vertex_array(None);
+            ModelMeshVao {
+                vao,
+                vertex_buffer: live.vbo,
+            }
+        })
+        .collect();
+    gl.bind_buffer(glow::ARRAY_BUFFER, None);
+    ModelInstancedState {
+        instance_buffer,
+        instance_capacity: 0,
+        meshes,
+    }
+}
 
 /// Look up the shared forward-uniform set on a freshly linked program (the
 /// plain and skinned forward programs share one uniform contract).

--- a/runtime/functor-runtime-common/src/scene3d/instancing.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instancing.rs
@@ -246,10 +246,11 @@ pub(crate) enum RecognizedTemplate<'a> {
     /// (folded into `local`) and at most one solid-color
     /// `Color`/`Emissive`/`Lit` material node.
     Primitive(RecognizedPrimitive<'a>),
-    /// A rigid `Scene.model` leaf (no attached animation, no overrides),
-    /// optionally under `Group` transform wrappers. Whether the LOADED model
-    /// is actually rigid (no skeleton) is only known at render time — a
-    /// skinned model falls back to the stamp there.
+    /// A `Scene.model` leaf (no overrides; an attached `Scene.animate` pose
+    /// is allowed — every copy shows the same sampled pose), optionally under
+    /// `Group` transform wrappers. Whether the LOADED model is rigid or
+    /// skinned is only known at render time; each gets its own instanced
+    /// draw path there.
     Model(RecognizedModel<'a>),
 }
 
@@ -277,9 +278,10 @@ pub(crate) struct RecognizedModel<'a> {
 /// compose into `local`) ending in either a
 /// `Cube`/`Sphere`/`Cylinder`/`Quad`/`Plane` leaf under at most ONE material
 /// node — a solid `Color`, `Emissive` (no texture), or `Lit` (no texture, no
-/// normal map) — or a bare `Scene.model` leaf with no attached animation and
-/// no overrides (enclosing materials are ignored by the ordinary model draw,
-/// so a material-wrapped model falls back rather than pretending the wrapper
+/// normal map) — or a `Scene.model` leaf with no overrides, with or without
+/// an attached `Scene.animate` pose (every copy shows the same sampled pose;
+/// enclosing materials are ignored by the ordinary model draw, so a
+/// material-wrapped model falls back rather than pretending the wrapper
 /// does something). Everything else (terrain, multi-child groups, textured
 /// materials, bare primitive leaves, nested instancing, opacity) answers
 /// `None` and renders through [`expand_instanced`].
@@ -306,15 +308,14 @@ pub(crate) fn recognize(template: &Scene3D) -> Option<RecognizedTemplate<'_>> {
                 }))
             }
             SceneObject::Model(description) => {
-                // A pose-attached template is the shared-pose ladder rung
-                // (not yet instanced); overrides are legacy and untypical.
-                // An enclosing material would be IGNORED by the ordinary
-                // model draw — fall back so the stamp stays authoritative
-                // rather than encoding that quirk here too.
-                if material.is_some()
-                    || description.animation.is_some()
-                    || !description.overrides.is_empty()
-                {
+                // A pose-attached (`Scene.animate`) model is recognized too —
+                // every copy shows the SAME sampled pose (the stamp of a
+                // shared-tts group is exactly that), drawn by the skinned
+                // instanced path. Overrides are legacy and untypical. An
+                // enclosing material would be IGNORED by the ordinary model
+                // draw — fall back so the stamp stays authoritative rather
+                // than encoding that quirk here too.
+                if material.is_some() || !description.overrides.is_empty() {
                     return None;
                 }
                 Some(RecognizedTemplate::Model(RecognizedModel {
@@ -579,10 +580,15 @@ mod tests {
         ));
         assert_eq!(recognized.local, Matrix4::from_scale(0.02));
 
-        // A pose-attached template is the (not yet instanced) shared-pose
-        // rung — stamped for now.
+        // A pose-attached template is recognized too — the shared-pose rung:
+        // every copy renders the same sampled pose.
         let animated = model(Some(crate::anim::AnimExpr::Rest));
-        assert!(recognize(&animated).is_none());
+        let RecognizedTemplate::Model(recognized) =
+            recognize(&animated).expect("pose-attached model template")
+        else {
+            panic!("expected a model template");
+        };
+        assert!(recognized.description.animation.is_some());
 
         // A material wrapper is IGNORED by the ordinary model draw; fall
         // back so the stamp stays authoritative.

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -287,7 +287,10 @@ so the reach is ignored"
                     Skeleton::animate(&hydrated_model.skeleton, animation, time);
                 animated_skeleton.get_skinning_transforms()
             }
-            None => vec![Matrix4::identity(); 50],
+            // A skeleton with no clips: identity for EVERY joint (sized by
+            // the model, not a fixed count — an undersized palette would
+            // leave the tail joints reading a previous upload's leftovers).
+            None => vec![Matrix4::identity(); hydrated_model.skeleton.get_joint_count() as usize],
         },
     }
 }
@@ -1884,7 +1887,7 @@ impl Scene3D {
 — rendering {copies} copies as a stamped group, comparable to writing \
 the group by hand (hardware templates are one cube/sphere/cylinder/quad/plane \
 leaf under transforms and at most one solid Scene.color / Scene.lit / \
-Scene.emissive material, or a bare rigid Scene.model leaf under transforms)"
+Scene.emissive material, or a bare Scene.model leaf under transforms)"
                                     )
                                 },
                             );

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -229,6 +229,69 @@ fn resolve_model_for_draw(
     )
 }
 
+/// Evaluate a skinned model's pose ONCE — the declarative `Scene.animate`
+/// expression when attached (unknown clip/joint names warn once; a missing
+/// clip contributes the bind pose, a missing joint is ignored), else the
+/// zero-config default (the first clip auto-plays, looping on the game
+/// clock). Shared by the ordinary Model draw arm and the instanced
+/// shared-pose path, which uploads the result once for every copy.
+fn model_pose_joints(
+    render_context: &RenderContext,
+    scene_context: &SceneContext,
+    hydrated_model: &Arc<Model>,
+    animation: &Option<crate::anim::AnimExpr>,
+    file: &str,
+) -> Vec<Matrix4<f32>> {
+    match animation {
+        Some(expr) => crate::anim::skinning_transforms(hydrated_model, expr, &mut |warning| {
+            let (key, message) = match warning {
+                crate::anim::AnimWarning::MissingClip(name) => (
+                    format!("anim-clip:{file}:{name}"),
+                    format!(
+                        "[anim] model \"{file}\" has no clip \
+named \"{name}\" — rendering the bind pose (functor inspect lists a model's clips)"
+                    ),
+                ),
+                crate::anim::AnimWarning::MissingJoint(name) => (
+                    format!("anim-joint:{file}:{name}"),
+                    format!(
+                        "[anim] model \"{file}\" has no joint \
+named \"{name}\" — ignoring it (functor inspect lists a model's joints)"
+                    ),
+                ),
+                crate::anim::AnimWarning::InvalidChain { root, middle, end } => (
+                    format!("anim-chain:{file}:{root}:{middle}:{end}"),
+                    format!(
+                        "[anim] model \"{file}\" joints \
+\"{root}\" -> \"{middle}\" -> \"{end}\" are not a direct, non-degenerate \
+two-bone chain — ignoring Anim.reach"
+                    ),
+                ),
+                crate::anim::AnimWarning::NonUniformRootScale { root } => (
+                    format!("anim-reach-scale:{file}:{root}"),
+                    format!(
+                        "[anim] model \"{file}\" root joint \
+\"{root}\" has non-uniform scale — Anim.reach requires uniform root scale, \
+so the reach is ignored"
+                    ),
+                ),
+            };
+            scene_context.warn_once(&key, &message);
+        }),
+        // Zero-config default: the first clip auto-plays, looping on the
+        // game clock.
+        None => match hydrated_model.animations.first() {
+            Some(animation) => {
+                let time = render_context.frame_time.tts % animation.duration;
+                let animated_skeleton =
+                    Skeleton::animate(&hydrated_model.skeleton, animation, time);
+                animated_skeleton.get_skinning_transforms()
+            }
+            None => vec![Matrix4::identity(); 50],
+        },
+    }
+}
+
 impl SceneContext {
     /// Drop every cached decode of `path` so the next draw reloads it from
     /// disk — asset hot-reload (pair with `AssetCache::evict` for the bytes).
@@ -1478,80 +1541,17 @@ impl Scene3D {
                         };
                         model_material.initialize(&render_context);
 
-                        let animation_index = 0;
-
                         // The pose depends only on the model + expression, so
                         // evaluate it once per model (a blend samples every
                         // clip in the expression) and share it across meshes.
                         let joints = if is_skinned {
-                            match &model_description.animation {
-                                // The declarative path: game code chose the
-                                // pose (clip playheads, blend weights,
-                                // per-joint rotations) — evaluate it. An
-                                // unknown clip/joint name warns once; a
-                                // missing clip contributes the bind pose, a
-                                // missing joint is ignored.
-                                Some(expr) => crate::anim::skinning_transforms(
-                                    &hydrated_model,
-                                    expr,
-                                    &mut |warning| {
-                                        let (key, message) = match warning {
-                                            crate::anim::AnimWarning::MissingClip(name) => (
-                                                format!("anim-clip:{str}:{name}"),
-                                                format!(
-                                                    "[anim] model \"{str}\" has no clip \
-named \"{name}\" — rendering the bind pose (functor inspect lists a model's clips)"
-                                                ),
-                                            ),
-                                            crate::anim::AnimWarning::MissingJoint(name) => (
-                                                format!("anim-joint:{str}:{name}"),
-                                                format!(
-                                                    "[anim] model \"{str}\" has no joint \
-named \"{name}\" — ignoring it (functor inspect lists a model's joints)"
-                                                ),
-                                            ),
-                                            crate::anim::AnimWarning::InvalidChain {
-                                                root,
-                                                middle,
-                                                end,
-                                            } => (
-                                                format!("anim-chain:{str}:{root}:{middle}:{end}"),
-                                                format!(
-                                                    "[anim] model \"{str}\" joints \
-\"{root}\" -> \"{middle}\" -> \"{end}\" are not a direct, non-degenerate \
-two-bone chain — ignoring Anim.reach"
-                                                ),
-                                            ),
-                                            crate::anim::AnimWarning::NonUniformRootScale {
-                                                root,
-                                            } => (
-                                                format!("anim-reach-scale:{str}:{root}"),
-                                                format!(
-                                                    "[anim] model \"{str}\" root joint \
-\"{root}\" has non-uniform scale — Anim.reach requires uniform root scale, \
-so the reach is ignored"
-                                                ),
-                                            ),
-                                        };
-                                        scene_context.warn_once(&key, &message);
-                                    },
-                                ),
-                                // Zero-config default: the first clip
-                                // auto-plays, looping on the game clock.
-                                None => match hydrated_model.animations.get(animation_index) {
-                                    Some(animation) => {
-                                        let time =
-                                            render_context.frame_time.tts % animation.duration;
-                                        let animated_skeleton = Skeleton::animate(
-                                            &hydrated_model.skeleton,
-                                            animation,
-                                            time,
-                                        );
-                                        animated_skeleton.get_skinning_transforms()
-                                    }
-                                    None => vec![Matrix4::identity(); 50],
-                                },
-                            }
+                            model_pose_joints(
+                                render_context,
+                                scene_context,
+                                &hydrated_model,
+                                &model_description.animation,
+                                str,
+                            )
                         } else {
                             vec![]
                         };
@@ -1815,33 +1815,25 @@ so the reach is ignored"
                             file,
                             &recognized.description.while_pending,
                         );
-                        // Whether the model is rigid is only knowable now.
-                        // A skinned model stamps per copy (full per-copy
-                        // skinning — exact semantics); the shared-pose
-                        // instanced path is the next ladder rung.
-                        if hydrated_model.skeleton.get_joint_count() > 0 {
-                            if !depth_pass {
-                                let copies = instances.len();
-                                scene_context.warn_once_with(
-                                    &format!("instanced-skinned:{file}"),
-                                    || format!(
-                                        "[functor] Scene.instanced template model \"{file}\" is \
-skinned — rendering {copies} copies as a stamped group with per-copy skinning \
-(rigid models hardware-instance; a shared-pose instanced path for animated \
-templates is planned)"
-                                    ),
-                                );
-                            }
-                            expand_instanced(template, instances).render(
+                        // Whether the model is rigid or skinned is only
+                        // knowable now. A SKINNED model instances at the
+                        // SHARED pose: the stamp of a group of same-tts
+                        // copies is exactly one sampled pose repeated, so
+                        // the pose evaluates and uploads once and every
+                        // copy skins from it. (Per-instance playheads are
+                        // the next ladder rung.)
+                        let is_skinned = hydrated_model.skeleton.get_joint_count() > 0;
+                        let joints = if is_skinned {
+                            model_pose_joints(
                                 render_context,
                                 scene_context,
-                                &xform,
-                                projection_matrix,
-                                view_matrix,
-                                current_material,
-                            );
-                            return;
-                        }
+                                &hydrated_model,
+                                &recognized.description.animation,
+                                file,
+                            )
+                        } else {
+                            vec![]
+                        };
                         let mut renderer = scene_context.instanced.borrow_mut();
                         let renderer = renderer.get_or_insert_with(|| {
                             InstancedRenderer::new(
@@ -1849,16 +1841,30 @@ templates is planned)"
                                 render_context.shader_version,
                             )
                         });
-                        renderer.draw_model(
-                            render_context,
-                            file,
-                            &hydrated_model,
-                            &recognized.local,
-                            instances,
-                            &xform,
-                            projection_matrix,
-                            view_matrix,
-                        );
+                        if is_skinned {
+                            renderer.draw_skinned_model(
+                                render_context,
+                                file,
+                                &hydrated_model,
+                                &joints,
+                                &recognized.local,
+                                instances,
+                                &xform,
+                                projection_matrix,
+                                view_matrix,
+                            );
+                        } else {
+                            renderer.draw_model(
+                                render_context,
+                                file,
+                                &hydrated_model,
+                                &recognized.local,
+                                instances,
+                                &xform,
+                                projection_matrix,
+                                view_matrix,
+                            );
+                        }
                     }
                     // The honest fallback: render the stamp-equivalent group
                     // (the semantics itself), with a once-per-topology perf


### PR DESCRIPTION
## Why

PR 3 of the generalized-instancing stack (on #691) — the design's animation-ladder **v2, shared pose**: a `Scene.model` template with an attached `Scene.animate` pose (or the zero-config first-clip autoplay) now hardware-instances instead of CPU-expanding with a perf note.

```functor
Scene.model(Assets.xbot)
  |> Scene.animate(Anim.clip("walk", tts))
  |> Scene.instanced(copies)      // every copy shows the SAME sampled pose
```

## How

- **Semantics were already shared-pose.** The stamp of a group of same-tts copies is one sampled pose repeated, so instancing it changes no semantics — the recognizer now accepts pose-attached model leaves (overrides and enclosing materials still fall back), and whether the loaded model is rigid or skinned picks the draw path at render time.
- **One pose evaluation, one palette upload, instanced draws.** `model_pose_joints` (extracted from the ordinary Model draw arm and shared with it, so the two cannot drift — same declarative-expression evaluation, same once-per-issue anim warnings, same first-clip autoplay default) evaluates the pose once per node; the joint palette uploads once per node per pass; every copy skins from it in the vertex shader. One `draw_elements_instanced` per mesh primitive.
- **Shading parity with the stamp.** Skinned stamped copies draw with `SkinnedMaterial` (lit + textured + fog), so the skinned instanced forward shader is lit + textured (the rigid path stays unlit like `BasicMaterial` — each matches its own stamp). The depth pass skins too (`SkinnedDepthMaterial` contract), so animated copies cast correctly deforming shadows. Per glTF, a skinned mesh's node transform is ignored — the skeleton carries the chain — so primitives share the template-local matrix, exactly like the stamp.
- **Locations.** Joints/weights own 4/5 in the mesh vertex layout, so the skinned VAOs carry the instance TRS at 6–8 (tint generic at 9, pinned white — model templates ignore tint, like the stamp). `instance_transform_glsl(base)` and `instance_attrib_layout(gl, base, with_tint)` are parameterized so all four programs (plain/skinned × forward/depth) share one location contract.
- **Out of scope (unchanged from the design):** per-instance playheads / bone-palette textures (ladder v3) and the identity-keyed instance-buffer cache. The palette-upload seam (one uniform array per node) does not preclude them.

## Perf evidence

**frame_bench** — base `scene-instancing-models` vs this branch, release, 3 runs/side: `allocs/frame` and `bytes/frame` **exactly identical** at all sizes (13,877 / 844,497 · 54,717 / 3,308,337 · 106,973 / 6,461,361); wall-clock min columns overlap within run-to-run spread (no delta claimed).

**Construction cost** is the same shape as #691's model-template probe (35–39% reduction at 1k–9k copies) — the animated case adds one `Scene.animate` host call per NODE, not per instance, so the probe table carries over. The wins specific to this PR are render-side and structurally invisible to a headless probe: pose evaluation N→1, skinning-palette uploads N→1, and draw calls N→meshes-per-model. Stated honestly rather than benchmarked on CPU.

## Verification

- `cargo test -p functor_runtime_common` / `-p functor-lang` — green (recognizer test updated: pose-attached model templates are recognized; material-wrapped and override-carrying models still fall back).
- `npm run check:docs` — green (`scene.funi` updated; functor-lang skill updated in this PR).
- Strict native build (CI invocation) — green.
- `npm run test:golden` — green (goldens pin no-regression on existing rendering).
- **Stamp parity**: a side-by-side scene — one stamped `Scene.animate` Xbot vs the same model/pose through `Scene.instanced` — renders identical pose and shading at a fixed time.
- **WebGL2 smoke**: the 96-Xbot crowd served via `run wasm` renders in headless Chromium with no page/console errors (shared renderer — no separate producer wiring needed; the embedded bundle was rebuilt).
- **Quest/device GPU benchmarking was NOT run** (no device attached) — skinned instanced GPU cost on device is an explicit gap.


## xreview dispositions

Two independent engines (Claude/Opus subagent + Codex CLI, both image-capable) plus a dedicated 4-strategy de-dup pass. **No Critical/High findings from any engine** — the Claude reviewer explicitly verified the attribute-location math (the skinned vertex format ends at location 5, so instance TRS 6–8 + tint 9 collide with nothing) and shading parity with `SkinnedMaterial`; Codex verified the stills show the claimed behavior (shared pose per frame, deforming shadows, stride reversal between t=0.2 and t=0.7). All fixes re-validated after applying: full test suites, strict build, goldens, docs check, a rebuilt-bundle headless-Chromium wasm crowd smoke, and a **byte-identical pre-fix vs post-fix A/B capture** of both the stamp-parity scene and the 96-copy crowd at a fixed time (0 differing pixels each).

- **[AGREED Claude + Codex + de-dup (S1+S2+S4, multi-strategy)] Medium: `draw_skinned_model`/`create_skinned_model_state` duplicated ~140 lines of the rigid path** (identical staleness rule, teardown, cache-miss create, upload) — **fixed**: one `create_model_state(gl, handles, skinned)` and one `acquire_model_vaos` (staleness + rebuild + one-shot upload) shared by both draw paths; the eviction rule can no longer drift.
- **Medium (Claude): both skinned programs compiled eagerly in `InstancedRenderer::new`** — a first-frame compile/link hitch (including the full lighting/shadow GLSL) paid by every instancing scene, even ones that never instance a skinned model — **fixed**: `SkinnedPrograms` builds lazily on the first skinned instanced draw.
- **Medium (Codex): >200-joint models overflow the `jointTransforms[200]` palette without validation** — **accepted**: a pre-existing, engine-wide limitation of every skinned material (the instanced path reuses the same `SKINNING_GLSL` convention, so the two cannot disagree); centralizing MAX_JOINTS validation at model hydration is a follow-up that belongs with the stamped path, not this PR.
- **Medium (Claude): no golden/example pixel coverage for the two new shaders** — **accepted with evidence**: the embedded GIF + stills are deterministic `--fixed-time` captures both engines visually verified, the stamp-parity scene pins the instanced output against the stamped `SkinnedMaterial` ground truth at a fixed time (re-captured byte-identical after the fixes), and goldens pin no-regression on all existing scenarios. An `examples/` crowd scene + golden scenario for the whole instancing ladder is queued as stack-level follow-up rather than added to PR 3 of 3.
- **[AGREED Claude + Codex] Low: the fallback perf note still said "a bare rigid `Scene.model` leaf"**, contradicting this PR's own `.funi`/skill text — **fixed**: "a bare `Scene.model` leaf under transforms".
- **Low (Claude): the no-clip skinned fallback uploaded a fixed 50-identity palette** — under-filling >50-joint skeletons, with new cross-model blast radius now that one shared program serves every instanced skinned model — **fixed**: sized by the model's joint count.
- **De-dup (S4+S3): the joint-palette flatten loop was a 5th verbatim copy** across the four skinned materials — **fixed**: `model::flatten_joint_matrices` is the one shared flatten, called by all five.
- **De-dup (S4+S3), accepted: promoting `SKINNING_GLSL` into the four stamped skinned materials** — this change is the first to *name* the snippet; retrofitting the stamped materials' inline shaders is deferred rather than growing this PR into the stamped path (the palette-blend convention is pinned by the parity capture either way).
- **Low (Claude): rustfmt strays introduced by this change** — **fixed** (double blank lines, overlong `format!` lines; the file's 2 pre-existing fmt deviations were left untouched to keep the diff surgical).

Quest/device GPU benchmarking was **not** run (no device attached).

## Demo

![instanced skinned crowd demo](https://gist.githubusercontent.com/tommy-xr/29941297755e688b6618ae9b226b749d/raw/crowd.gif)

<sub>96 skinned Xbot copies marching in step through one `Scene.instanced` node — the pose is sampled and uploaded once per frame, every copy skins from it in hardware-instanced draws, and the depth pass skins too (deforming shadows). Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![still t=0.2](https://gist.githubusercontent.com/tommy-xr/29941297755e688b6618ae9b226b749d/raw/still-t02.png)

![still t=0.7](https://gist.githubusercontent.com/tommy-xr/29941297755e688b6618ae9b226b749d/raw/still-t07.png)

