### PR TITLE
fix(e2e): walk the parked playhead back to the last packet before reading the wires

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -1269,14 +1269,31 @@ try {
     await page.focus("#mp-playhead");
     await page.keyboard.press("End");
     await sleep(400);
-    const head = await page.evaluate(() => ({
+    // Since impairment (#657) a parked frame shows exactly the packets in the
+    // air THEN — an unimpaired dot's drawn flight is only the ~2-frame
+    // visibility floor, and the pause can land a few frames after the last
+    // packet the coordinator routed (the panes lag the reference clock under
+    // load). The head itself may therefore legitimately be past every flight;
+    // walk back to the last frame that had traffic before reading the wires.
+    let head = await page.evaluate(() => ({
       ...window.__mpProbe.network(),
       label: window.__mpProbe.railFrame(),
     }));
+    let walked = 0;
+    while (head.replay === 0 && walked < 12) {
+      await page.keyboard.press("ArrowLeft");
+      walked += 1;
+      await sleep(150);
+      head = await page.evaluate(() => ({
+        ...window.__mpProbe.network(),
+        label: window.__mpProbe.railFrame(),
+      }));
+    }
     check(
       head.replay > 0 && head.live === 0,
       "parked at the head, every dot on the wires comes from the packet log",
-      `replay=${head.replay} live=${head.live} at #f ${head.label}`
+      `replay=${head.replay} live=${head.live} at #f ${head.label}` +
+        (walked > 0 ? ` (walked back ${walked})` : "")
     );
 
     // SCRUB-LOCKED: parked, the panel's viewport sits at the playhead and marks
@@ -1295,6 +1312,10 @@ try {
     // not happening. (From the head deliberately: resuming from a rewound frame
     // is a live session again, but the panes' connections do not survive the
     // rewind — a coordinator-barrier problem, not this view's.)
+    if (walked > 0) {
+      await page.keyboard.press("End");
+      await sleep(200);
+    }
     await page.evaluate(() => window.__mpProbe.pauseAll());
     const resumed = await page
       .waitForFunction(() => window.__mpProbe.network().live > 0, null, { timeout: 15000 })

--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -1272,34 +1272,33 @@ try {
     // Since impairment (#657) a parked frame shows exactly the packets in the
     // air THEN — an unimpaired dot's drawn flight is only the ~2-frame
     // visibility floor, and the pause can land a few frames after the last
-    // packet the coordinator routed (the panes lag the reference clock under
-    // load). The head itself may therefore legitimately be past every flight;
-    // walk back to the last frame that had traffic before reading the wires.
-    let head = await page.evaluate(() => ({
+    // packet the coordinator routed (Packet.frame is measured once per host
+    // rAF, so it lags the recorded head under load). The head may therefore
+    // legitimately be past every flight. The unconditional claim is that a
+    // parked wire carries no LIVE dot; replay dots are required exactly when
+    // the log actually has a packet in the air at the head — read off the
+    // pinned wire log, the product's own record.
+    const head = await page.evaluate(() => ({
       ...window.__mpProbe.network(),
+      log: window.__mpProbe.wireLog(),
       label: window.__mpProbe.railFrame(),
     }));
-    let walked = 0;
-    while (head.replay === 0 && walked < 12) {
-      await page.keyboard.press("ArrowLeft");
-      walked += 1;
-      await sleep(150);
-      head = await page.evaluate(() => ({
-        ...window.__mpProbe.network(),
-        label: window.__mpProbe.railFrame(),
-      }));
-    }
+    const playhead = Number(head.label.match(/-?\d+/)?.[0] ?? NaN);
+    const inFlightAtHead = head.log.rows.some(
+      (row) => Number.isFinite(row.frame) && playhead - row.frame >= 0 && playhead - row.frame <= 1
+    );
     check(
-      head.replay > 0 && head.live === 0,
+      head.live === 0 && (!inFlightAtHead || head.replay > 0),
       "parked at the head, every dot on the wires comes from the packet log",
       `replay=${head.replay} live=${head.live} at #f ${head.label}` +
-        (walked > 0 ? ` (walked back ${walked})` : "")
+        (inFlightAtHead
+          ? ""
+          : ` (nothing in flight at the head — last logged #f ${head.log.rows.at(-1)?.frame ?? "none"})`)
     );
 
     // SCRUB-LOCKED: parked, the panel's viewport sits at the playhead and marks
     // the nearest row — the rail and the log are one instrument.
-    const parkedLog = await page.evaluate(() => window.__mpProbe.wireLog());
-    const playhead = Number(head.label.match(/-?\d+/)?.[0] ?? NaN);
+    const parkedLog = head.log;
     const marked = parkedLog.rows.find((row) => row.at);
     check(
       !!marked && Math.abs(marked.frame - playhead) <= 60,
@@ -1312,10 +1311,6 @@ try {
     // not happening. (From the head deliberately: resuming from a rewound frame
     // is a live session again, but the panes' connections do not survive the
     // rewind — a coordinator-barrier problem, not this view's.)
-    if (walked > 0) {
-      await page.keyboard.press("End");
-      await sleep(200);
-    }
     await page.evaluate(() => window.__mpProbe.pauseAll());
     const resumed = await page
       .waitForFunction(() => window.__mpProbe.network().live > 0, null, { timeout: 15000 })


### PR DESCRIPTION
## The flake

The wasm-smoke suite has been failing intermittently across unrelated branches (and `main`), always on the same check:

```
FAIL  parked at the head, every dot on the wires comes from the packet log — replay=0 live=0 at #f 139 / 139
```

## Root cause

A race that #657 (link impairment — real flights) made possible:

- Since #657, a parked frame draws only the packets whose own **sent→delivered window contains the playhead**. For an unimpaired LAN link that window is just the 40 ms visibility floor (`FLOOR_FLIGHT_MS`, ≈2.4 frames).
- `Packet.frame` is **measured, not scheduled** (`net-coordinator.ts` says so): it's sampled from the reference pane's head once per host rAF, so under CI load packets are stamped a few frames behind the recorded head — while `End` seeks to the recorded head, which doesn't lag. In the failing runs the head was e.g. frame 139 while the last logged packet was frame 135.
- Nothing was in the air at the head frame, so zero dots is *correct rendering* — the check's assumption dates from #642, when the replay drew a fixed 30-frame lookback. Per the code comments, the gap itself resolves by construction when the step barrier lands; this is a test-side assumption fix, not a papered-over product bug.

## The fix

Test-side only — derive the expectation from the log instead of assuming the head always has traffic:

- Sample the **true head** (no playhead movement). Assert unconditionally that a parked wire carries no **live** dot — every dot's provenance is the packet log.
- Require `replay > 0` exactly when the pinned wire log shows a packet sent within a frame of the head (conservative against the ~2.4-frame drawn-flight boundary); otherwise the detail string reports the gap (`nothing in flight at the head — last logged #f N`).

An earlier revision walked the playhead back until dots appeared; cross-engine review (Claude + Codex `/xreview`) independently flagged that as masking-prone (a stale live dot at the true head would be cleared by the first seek's `clearDots`; a head-boundary indexing regression would be stepped past), so it was replaced with this deterministic oracle — which also leaves the later resume-from-head precondition untouched by construction.

## Verification

- `npm run test:sandbox-mp` × 3 locally on the walk-back revision, × 2 on the final oracle revision — **ALL CHECKS PASSED** every time; the oracle's detail string confirms it correctly classifies the boundary case (head #f 104, last logged #f 102, replay drawn but not required).
- `/xreview` (two engines + de-dup pass): no Critical/High; all four Mediums were against the walk-back loop and are resolved by this revision. No actionable duplication.
- `reliability` label applied for the 10× CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)