### PR TITLE
refactor(site): remove the "+ add client" seat from the multiplayer pane grid

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -25,8 +25,8 @@
 //      full-width strip below them — and switching layout reloads no pane;
 //   6. switching to a single-role example removes the server pane again;
 //   7. every pane CARD letterboxes to a 16:9 body inside its cell in the grid
-//      and network views, the "+" seat is last in reading order, and the
-//      network wires anchor to the cards rather than to the cells;
+//      and network views, and the network wires anchor to the cards rather
+//      than to the cells;
 //   8. parked, the wires and the pinned wire log replay the packet LOG at the
 //      playhead rather than showing a frozen live feed;
 //   9. the WIRE TAB — the same traffic monitor docked in the status bar — is
@@ -56,13 +56,12 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
  * Wait for the view transition to finish. Switching layout FLIPs the cards
  * (mp-panes.ts, 420ms), and a transform moves a card's measured box without
  * resizing anything — so geometry read mid-flight is the card's *animated*
- * box, not its laid-out one. The "+" seat FLIPs alongside the cards and its
- * band geometry is asserted too, so it has to be waited on as well.
+ * box, not its laid-out one.
  */
 const settle = (page) =>
   page.waitForFunction(
     () =>
-      [...document.querySelectorAll(".mp-pane, .mp-add-tile")].every(
+      [...document.querySelectorAll(".mp-pane")].every(
         (node) => node.getAnimations().length === 0
       ),
     null,
@@ -366,20 +365,6 @@ const installProbe = (page) =>
           frame: shown(".mp-pf"),
         };
       },
-      // The "+" affordances (tile in tiled/grid, tab in tabs).
-      addTile: () => {
-        const tile = document.querySelector(".mp-add-tile");
-        return {
-          present: !!tile,
-          hidden: !tile || tile.hidden,
-          display: tile ? getComputedStyle(tile).display : "none",
-          tag: tile?.tagName,
-          // Addendum 5b.1: the seat is the LAST thing in the arrangement.
-          last: !!tile && tile.parentElement.lastElementChild === tile,
-          tabDisplay: getComputedStyle(document.querySelector(".mp-tab.add")).display,
-        };
-      },
-      clickAddTile: () => document.querySelector(".mp-add-tile").click(),
       // Click a view button and read back, IN THE SAME TASK, how many pane
       // cards are mid-animation — the FLIP has to have started before the
       // browser has painted anything.
@@ -504,63 +489,43 @@ try {
       await sleep(200);
     }
 
-    // The "+" tile: the spatial way to add a client, same path as the dropdown.
-    const tile = await page.evaluate(() => window.__mpProbe.addTile());
+    // The "+" affordances are retired: the CLIENTS dropdown is the one way to
+    // change the count, and no ghost seat/tab renders in any view.
+    const addAffordances = await page.evaluate(() => ({
+      tile: !!document.querySelector(".mp-add-tile"),
+      tab: !!document.querySelector(".mp-tab.add"),
+    }));
     check(
-      tile.present && !tile.hidden && tile.display !== "none" && tile.tag === "BUTTON",
-      "a + tile sits after the client panes, as a real button",
-      JSON.stringify(tile)
+      !addAffordances.tile && !addAffordances.tab,
+      "no + tile or + tab renders (the CLIENTS dropdown is the only count control)",
+      JSON.stringify(addAffordances)
     );
-    check(
-      tile.last,
-      "the seat is LAST in reading order, after every occupied cell"
-    );
-    await page.evaluate(() => window.__mpProbe.clickAddTile());
+    await page.selectOption("#client-count", "2");
     await sleep(2500);
     const afterAdd = await page.evaluate(() => ({
       roles: window.__mpProbe.roles(),
       hash: window.location.hash,
-      control: document.getElementById("client-count").value,
     }));
     check(
       afterAdd.roles.join(", ") === "client 1, client 2, server" &&
-        afterAdd.control === "2" &&
         afterAdd.hash.includes("clients=2"),
-      "clicking + adds a client through the same path as the CLIENTS dropdown",
+      "the CLIENTS dropdown adds a client (roles + hash follow)",
       JSON.stringify(afterAdd)
-    );
-    await page.selectOption("#client-count", "3");
-    await sleep(2500);
-    const atMax = await page.evaluate(() => window.__mpProbe.addTile());
-    // The ATTRIBUTE is not the picture: the seat sets its own `display`, which
-    // outranks the UA's `[hidden]` rule — so assert what is painted.
-    check(
-      atMax.hidden && atMax.display === "none",
-      "the + tile is hidden at MAX_CLIENTS",
-      JSON.stringify(atMax)
     );
     await page.selectOption("#client-count", "1");
     await sleep(1500);
 
-    // Grid with a LONE client: the client takes the whole row (no peer to match)
-    // and the open seat closes the layout as a band UNDER everything — never
-    // between the client and the authority (Addendum 5b.1).
+    // Grid with a LONE client: the client takes the whole row (no peer to
+    // match), over the authority strip.
     await page.click("#mp-view-grid");
     await settle(page);
     const [client, server] = await page.evaluate(() => window.__mpProbe.boxes());
-    const seat = await page.evaluate(() => {
-      const box = document.querySelector(".mp-add-tile").getBoundingClientRect();
-      return { x: Math.round(box.x), y: Math.round(box.y), w: Math.round(box.width), h: Math.round(box.height) };
-    });
     check(
-      seat.y >= server.y + server.h &&
-        Math.abs(seat.w - client.cell.w) < 2 &&
-        seat.h < client.h &&
-        server.gridColumn === "1 / -1" &&
+      server.gridColumn === "1 / -1" &&
         server.y >= client.y + client.h &&
         server.h < client.h,
-      "grid closes with the open seat as a band under the client and the strip",
-      JSON.stringify([client, seat, server])
+      "grid keeps the lone client over the authority strip",
+      JSON.stringify([client, server])
     );
     await page.close();
   }
@@ -882,6 +847,13 @@ try {
         three[3].cell.w > three[2].cell.w * 1.8,
       "a third client keeps its half-width cell above the full-width strip",
       JSON.stringify(three.map((b) => [b.role, b.x, b.y, b.w, b.h]))
+    );
+    // The strip stays a STRIP at max count: shorter than a client card (the
+    // data-clients="3" span override in styles.css exists for exactly this).
+    check(
+      three[3].h < three[0].h,
+      "the server strip stays shorter than a client card at three clients",
+      `server ${three[3].h} vs client ${three[0].h}`
     );
     await page.close();
   }

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -198,13 +198,6 @@ export interface MultiplayerPanesOptions {
   setPill: (state: PaneState, text: string, detail: string) => void;
   /** The current editor buffer, so a mirror added mid-session catches up. */
   getSource: () => string;
-  /**
-   * Ask the PAGE for a client count — the "+" tile's one job. It routes through
-   * the host rather than calling `setCount` directly so that the spatial
-   * affordance and the CLIENTS dropdown are the same path: the same clamp, the
-   * same `#clients=` hash write, the same control re-render.
-   */
-  requestCount: (n: number) => void;
 }
 
 export interface MultiplayerPanes {
@@ -283,7 +276,6 @@ export function initMultiplayerPanes({
   statusBar,
   setPill,
   getSource,
-  requestCount,
 }: MultiplayerPanesOptions): MultiplayerPanes {
   const previewPane = frame.closest(".preview-pane") as HTMLElement;
   previewPane.classList.add("mp");
@@ -362,38 +354,10 @@ export function initMultiplayerPanes({
   grid.className = "mp-grid";
   grid.dataset.view = "tiled";
 
-  // The "+" tile (Addendum 5a.7): the SPATIAL way to add a client — the CLIENTS
-  // dropdown stays the numeric one, and both go through the same host call. It
-  // is always the LAST grid child (Addendum 5b.1): an open seat placed in "the
-  // cell the next client takes" can land mid-layout, where it reads as a hole
-  // rather than an invitation, so it lives at the EDGE of the arrangement,
-  // after every occupied cell. It is a real <button>, so it is
-  // tab-reachable and answers to Enter/Space for free; it is
-  // a grid child so it takes a slot in tiled/grid, and CSS hides it in tabs
-  // (which has its own "+" tab) and in network. NETWORK gets no ghost spoke: a
-  // wire is measured between two panes that are actually talking, and drawing
-  // one to a card that is not a participant would be the one lie this view
-  // cannot afford.
-  const addTile = document.createElement("button");
-  addTile.type = "button";
-  addTile.className = "mp-add-tile";
-  addTile.title = "Add a client";
-  addTile.innerHTML = `<span class="mp-add-plus" aria-hidden="true">+</span>
-    <span class="mp-add-label">add a client</span>`;
-  grid.appendChild(addTile);
-
-  const addTab = document.createElement("button");
-  addTab.type = "button";
-  addTab.className = "mp-tab add";
-  addTab.title = "Add a client";
-  addTab.textContent = "+";
-  addTab.setAttribute("aria-label", "Add a client");
-  tabsStrip.appendChild(addTab);
-
   // The stage holds the grid plus the layers the NETWORK view adds (mounted by
   // the graph itself: the wires under the cards, the chips over them). They are
   // siblings of the grid, never children of it — the grid's children are the
-  // pane cells and the "+" tile, and another child would shift the
+  // pane cells, and another child would shift the
   // `:nth-child` rules the grid and network views lay out with.
   const stage = document.createElement("div");
   stage.className = "mp-stage";
@@ -556,12 +520,12 @@ export function initMultiplayerPanes({
     const cell = document.createElement("div");
     cell.className = client ? "mp-cell" : "mp-cell server";
     cell.appendChild(shell);
-    // A client cell is INSERTED BEFORE the server's (and both before the "+"
-    // seat, which is always last — Addendum 5b.1), never appended after them:
+    // A client cell is INSERTED BEFORE the server's (which is always last),
+    // never appended after it:
     // re-appending a mounted node is a remove + insert, and that reloads an
     // iframe — the same invariant that keeps pane 1 in place would be broken
     // for the authority, wiping the world every time the count changed.
-    grid.insertBefore(cell, (client && serverPane?.pane.cell) || addTile);
+    grid.insertBefore(cell, (client && serverPane?.pane.cell) || null);
 
     const tab = document.createElement("button");
     tab.className = client ? "mp-tab" : "mp-tab server";
@@ -569,9 +533,8 @@ export function initMultiplayerPanes({
     tab.innerHTML = `${client ? `<span class="mp-digit">${index + 1}</span> client` : "SERVER"}
       <span class="mp-pf"><b>#f</b> <span class="mp-pf-n">—</span></span>
       <span class="mp-st" data-state="busy"></span>`;
-    // Same rule in the tab strip, with the "+" tab pinned last: a client's tab
-    // goes before the server's, and both go before the "+".
-    tabsStrip.insertBefore(tab, (client && serverPane?.pane.tab) || addTab);
+    // Same rule in the tab strip: a client's tab goes before the server's.
+    tabsStrip.insertBefore(tab, (client && serverPane?.pane.tab) || null);
 
     const pane: Pane = {
       role,
@@ -878,7 +841,7 @@ export function initMultiplayerPanes({
   const inFlight = new Map<HTMLElement, Animation>();
 
   const flipViews = (apply: () => void) => {
-    const nodes = [...allPanes().map((pane) => pane.shell), addTile];
+    const nodes = allPanes().map((pane) => pane.shell);
     // Reduced motion: the layout still changes, it just arrives instantly.
     if (reduceMotion.matches) {
       apply();
@@ -963,9 +926,6 @@ export function initMultiplayerPanes({
     network.title = viewAvailable("network")
       ? "Network: the server as the hub, with live packet flow along each link (f cycles)"
       : "Network needs an authority — this example declares no server role, so there is no hub to arrange the clients around";
-    // The "+" affordances: hidden at MAX_CLIENTS (there is nothing to add), and
-    // hidden in the single-pane layout, which drops every other piece of
-    // multiplayer chrome with it.
     // The strip carries the pane readouts in EVERY multi-pane view, not just
     // network: the headers clip by their own width (a tiled row of four is
     // thumbnails too), so the frame counters need a home wherever that happens.
@@ -976,9 +936,6 @@ export function initMultiplayerPanes({
     // so the tab is absent rather than empty (the NETWORK view's gate, and the
     // CLIENTS control's discipline).
     statusBar.setWirePresent(serverPane !== null);
-    const canAdd = !single && panes.length < MAX_CLIENTS;
-    addTile.hidden = !canAdd;
-    addTab.hidden = !canAdd;
     // Grid's odd-last-client rule needs "is there an authority" as data: the
     // strip is a cell like any other, so no structural selector answers it.
     grid.dataset.server = serverPane ? "yes" : "no";
@@ -1014,10 +971,6 @@ export function initMultiplayerPanes({
       })
     );
   }
-
-  const requestAnotherClient = () => requestCount(panes.length + 1);
-  addTile.addEventListener("click", requestAnotherClient);
-  addTab.addEventListener("click", requestAnotherClient);
 
   // Live client-count change: grow or shrink the mirror set in place. Pane 1
   // is untouched, so its model (and the editor session) survive.

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -142,9 +142,6 @@ mp = initMultiplayerPanes({
   statusBar,
   setPill: (state, text, detail) => pill.set({ state, text, detail }),
   getSource: () => view.state.doc.toString(),
-  // The pane grid's "+" tile asks for a count the same way the CLIENTS
-  // dropdown does — `selectClients` is the one path (clamp, hash, control).
-  requestCount: (n) => selectClients(n),
 });
 
 // The CLIENTS control only appears for multiplayer-structured samples (the

--- a/site/styles.css
+++ b/site/styles.css
@@ -3235,9 +3235,7 @@ a:hover {
 
 /* TILED is one row, and says so: a flex row rather than auto-fit columns, which
    wrapped into a second row as soon as a fourth cell existed (three clients and
-   an authority, or two and the open seat) — the one thing "tiled" promises not
-   to do. The seat rides the end of the row as a slim rail instead of taking a
-   pane's worth of it. */
+   an authority) — the one thing "tiled" promises not to do. */
 .mp-grid[data-view="tiled"] {
   display: flex;
 }
@@ -3271,14 +3269,6 @@ a:hover {
    context, so the cell has to be raised, not just the menu. */
 .mp-cell:has(.mp-link-menu:not([hidden])) {
   z-index: 20;
-}
-
-.mp-grid[data-view="tiled"] .mp-add-tile {
-  flex: 0 0 clamp(44px, 5%, 68px);
-}
-
-.mp-grid[data-view="tiled"] .mp-add-label {
-  display: none;
 }
 
 .mp-grid[data-view="tabs"] {
@@ -3379,10 +3369,10 @@ a:hover {
    players are peers of equal size, and the one full-width band belongs to the
    authority — the SHAPE says which is which before you read a label.
 
-   The strip is half a client row tall, expressed as spans over one set of
-   equal implicit rows rather than per-count track sizes: a client takes two
-   rows, the server one. It stays a thumbnail at every count with no CSS that
-   knows how many panes there are.
+   The strip stays a thumbnail at every count, expressed as spans over one set
+   of equal implicit rows rather than per-count track sizes: a client takes
+   three rows (two when a third client adds a second client row), the server
+   one.
 
    An odd LAST client under an authority (three of them: 2 + 1) keeps its
    half-width cell instead of stretching: it has peers on the row above, and
@@ -3396,16 +3386,22 @@ a:hover {
 
    Each card then letterboxes inside the cell it is given, centred across it
    and anchored towards the layout's middle (see the aspect block); the cells
-   themselves are what this section places.
-
-   The open SEAT is not one of these cells: it rides the bottom edge as a band
-   (Addendum 5b.1, and see its own block below). */
+   themselves are what this section places. */
 
 .mp-grid[data-view="grid"] {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+/* Client cells take three row-shares to the server strip's one, so the
+   authority reads as a STRIP under the gameplay — never a peer-sized pane. */
 .mp-grid[data-view="grid"] .mp-cell {
+  grid-row: span 3;
+}
+
+/* At three clients the second client row would compound that share (3+3+1
+   leaves the strip a 1/7 sliver), so each client backs off to two rows and
+   the strip keeps the proportion it has at every other count. */
+.mp-grid[data-view="grid"][data-clients="3"] .mp-cell {
   grid-row: span 2;
 }
 
@@ -3415,8 +3411,8 @@ a:hover {
 }
 
 /* Three clients and no authority: nothing closes the bottom row (no server
-   strip, and the seat is full at MAX_CLIENTS), so the odd last client stretches
-   rather than leaving a whole empty quadrant. */
+   strip), so the odd last client stretches rather than leaving a whole empty
+   quadrant. */
 .mp-grid[data-view="grid"][data-clients="3"][data-server="no"] .mp-cell:nth-child(3) {
   grid-column: 1 / -1;
 }
@@ -4660,7 +4656,7 @@ button.mp-vt-row:focus-visible {
   }
 
   /* Tiled's flex row becomes a flex column — the same stack the grid views
-     collapse to, with the seat as a short band at the end of it. */
+     collapse to. */
   .preview-pane.mp .mp-grid[data-view="tiled"] {
     flex-direction: column;
   }
@@ -4693,87 +4689,8 @@ button.mp-vt-row:focus-visible {
   }
 }
 
-/* ---- the "+" seat: add a client at the edge of the arrangement ----
-
-   Addendum 5a.7, revised by 5b.1. The CLIENTS dropdown is the numeric control;
-   this is the spatial one — an empty seat at the table. It sits AFTER every
-   occupied cell, never between them: a seat placed in "the cell the next
-   client takes" lands mid-layout and reads as a hole in the arrangement, and
-   an invitation should sit at the edge you would reach for. So it is the last
-   grid child (mp-panes.ts) and takes an edge shape rather than a pane's: a
-   slim rail at the end of the tiled row, a short band under the grid.
-   Hidden at MAX_CLIENTS, and in TABS (which has its own "+" tab) and NETWORK
-   (a topology of real participants only — see mp-panes.ts). */
-
-.mp-add-tile {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-width: 0;
-  min-height: 0;
-  cursor: pointer;
-  color: var(--text-dim);
-  background: transparent;
-  border: 1px dashed color-mix(in srgb, var(--cyan) 22%, rgba(43, 37, 66, 0.9));
-  border-radius: 5px;
-  font: 10px/1 var(--font-mono);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  transition: border-color 0.18s, color 0.18s, background 0.18s;
-}
-
-.mp-add-tile:hover,
-.mp-add-tile:focus-visible {
-  color: var(--cyan);
-  border-color: color-mix(in srgb, var(--cyan) 55%, transparent);
-  background: rgba(65, 216, 230, 0.05);
-}
-
-.mp-add-plus {
-  font-size: 30px;
-  line-height: 1;
-  font-weight: 300;
-  opacity: 0.8;
-}
-
-/* In GRID the seat closes the layout as a band across the bottom — under the
-   clients, under the authority strip, last in reading order at every count. It
-   opts out of the row's stretch, so an empty seat never outweighs the panes
-   that are actually running. */
-.mp-grid[data-view="grid"] .mp-add-tile {
-  grid-column: 1 / -1;
-  grid-row: span 1;
-  align-self: center;
-  height: clamp(56px, 100%, 96px);
-}
-
-.mp-grid[data-view="tabs"] .mp-add-tile,
-.mp-grid[data-view="network"] .mp-add-tile {
-  display: none;
-}
-
-/* The tab-strip twin: the same action, at the size the tab strip allows. */
-.mp-tab.add {
-  --pc: var(--cyan);
-  font-size: 13px;
-  line-height: 1;
-  padding: 6px 12px;
-  filter: none;
-  background: transparent;
-  border-style: dashed;
-}
-
-.mp-tab.add:hover {
-  color: var(--cyan);
-  border-color: color-mix(in srgb, var(--cyan) 55%, transparent);
-}
-
 /* `hidden` must win over the display rules above. */
 .mp-tabs[hidden],
-.mp-add-tile[hidden],
-.mp-tab.add[hidden],
 .mp-link-menu[hidden] {
   display: none;
 }


### PR DESCRIPTION
Removes the "+ add client" affordance from the sandbox multiplayer pane grid — the **CLIENTS dropdown is now the one way to change the client count**. Drops the "+" tile (tiled/grid views), its tab-strip twin, their click handlers, and the `requestCount` seam that existed only as their path to the page's count control.

## Before / after (grid view, one client + server)

| Before | After |
| --- | --- |
| ![before](https://gist.githubusercontent.com/tommy-xr/4ddbb809ad7be178604e620cc270ef8a/raw/before-grid.png) | ![after](https://gist.githubusercontent.com/tommy-xr/4ddbb809ad7be178604e620cc270ef8a/raw/after-grid.png) |

## The load-bearing seat row

The seat wasn't just chrome: its grid row held a 1fr share, and removing it made the server strip inherit that share and render **taller than a client pane** (caught by `test:sandbox-mp`). Client cells now take three row-shares to the strip's one, backing off to two at three clients (where a second client row would compound the share into a 1/7 sliver) — the strip keeps its shipped proportion at every count. A new e2e assertion pins strip-shorter-than-a-client at max count, which was previously uncovered (the 3-client block only asserted widths).

## Verification

- `npm run check:site` clean; `npm run test:sandbox-mp` **98/98** (the "+"-tile assertions replaced with an absence check + the dropdown path, plus the new strip-height pin).
- Review: xreview (Claude + Codex) — the Claude reviewer verified no `mp-add*`/`mp-tab.add`/`requestCount` reference survives anywhere in the repo. [AGREED] findings (3-client ratio, stale seat comments) fixed as above; the pre-existing 8232 port collision between two demo scripts was noted and left alone.
