### PR TITLE
refactor(cli): template files as a slice — unblock N-file templates

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -30,25 +30,17 @@ impl Template {
 
     /// The file names this template writes — the scaffolder's own answer, so
     /// callers that report them (the `init_game` MCP tool) cannot drift.
-    pub fn file_names(&self) -> [&'static str; 2] {
-        self.files().map(|file| file.name)
+    pub fn file_names(&self) -> Vec<&'static str> {
+        self.files().iter().map(|file| file.name).collect()
     }
 
-    fn files(&self) -> [TemplateFile; 2] {
-        let (manifest, game) = match self {
-            Self::ThreeD => (MANIFEST_3D, GAME_3D),
-            Self::Fps => (MANIFEST_FPS, GAME_FPS),
-        };
-        [
-            TemplateFile {
-                name: "functor.json",
-                contents: manifest,
-            },
-            TemplateFile {
-                name: "game.fun",
-                contents: game,
-            },
-        ]
+    /// Every file this template writes, in write order. A template may ship any
+    /// number of files (siblings like `protocol.fun` or `assets.fun`).
+    fn files(&self) -> &'static [TemplateFile] {
+        match self {
+            Self::ThreeD => FILES_3D,
+            Self::Fps => FILES_FPS,
+        }
     }
 }
 
@@ -57,7 +49,32 @@ struct TemplateFile {
     contents: &'static str,
 }
 
-/// Create a project in `directory` without overwriting either scaffolded file.
+static FILES_3D: &[TemplateFile] = &[
+    TemplateFile {
+        name: "functor.json",
+        contents: MANIFEST_3D,
+    },
+    TemplateFile {
+        name: "game.fun",
+        contents: GAME_3D,
+    },
+];
+
+static FILES_FPS: &[TemplateFile] = &[
+    TemplateFile {
+        name: "functor.json",
+        contents: MANIFEST_FPS,
+    },
+    TemplateFile {
+        name: "game.fun",
+        contents: GAME_FPS,
+    },
+];
+
+/// Create a project in `directory` without overwriting any scaffolded file: if
+/// even one of the template's files already exists the whole call aborts before
+/// writing anything (no per-file skipping — a partially scaffolded project is
+/// worse than a refusal).
 /// Unrelated existing files are left alone. If a write fails, files created by
 /// this call are removed so the directory is not left half-initialized.
 pub fn execute(directory: &Path, template: &Template) -> io::Result<()> {
@@ -171,36 +188,46 @@ mod tests {
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:#?}");
     }
 
-    #[test]
-    fn three_d_template_creates_a_typechecked_project() {
-        let directory = TestDir::new("3d");
-        execute(&directory.0, &Template::ThreeD).unwrap();
+    /// The template writes exactly `expected` — each name, each byte — and the
+    /// result typechecks. `expected` is spelled out independently of `files()`
+    /// so a template mapped to the wrong source still fails; comparing the whole
+    /// name list (rather than a fixed pair) is what generalizes to N files.
+    fn assert_template_scaffolds(
+        name: &str,
+        template: Template,
+        expected: &[(&str, &'static str)],
+    ) {
+        let directory = TestDir::new(name);
+        execute(&directory.0, &template).unwrap();
 
-        assert_eq!(
-            fs::read_to_string(directory.0.join("functor.json")).unwrap(),
-            MANIFEST_3D
-        );
-        assert_eq!(
-            fs::read_to_string(directory.0.join("game.fun")).unwrap(),
-            GAME_3D
-        );
+        let expected_names: Vec<&str> = expected.iter().map(|(name, _)| *name).collect();
+        assert_eq!(template.file_names(), expected_names);
+        for (name, contents) in expected {
+            assert_eq!(
+                fs::read_to_string(directory.0.join(name)).unwrap(),
+                *contents,
+                "{name} should be written verbatim"
+            );
+        }
         assert_project_typechecks(&directory.0);
     }
 
     #[test]
-    fn fps_template_creates_a_typechecked_project() {
-        let directory = TestDir::new("fps");
-        execute(&directory.0, &Template::Fps).unwrap();
+    fn three_d_template_creates_a_typechecked_project() {
+        assert_template_scaffolds(
+            "3d",
+            Template::ThreeD,
+            &[("functor.json", MANIFEST_3D), ("game.fun", GAME_3D)],
+        );
+    }
 
-        assert_eq!(
-            fs::read_to_string(directory.0.join("functor.json")).unwrap(),
-            MANIFEST_FPS
+    #[test]
+    fn fps_template_creates_a_typechecked_project() {
+        assert_template_scaffolds(
+            "fps",
+            Template::Fps,
+            &[("functor.json", MANIFEST_FPS), ("game.fun", GAME_FPS)],
         );
-        assert_eq!(
-            fs::read_to_string(directory.0.join("game.fun")).unwrap(),
-            GAME_FPS
-        );
-        assert_project_typechecks(&directory.0);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -347,9 +347,10 @@ async fn run(args: &Args) -> io::Result<()> {
         commands::init::execute(&working_directory, template)?;
         emit(Event::Info {
             message: format!(
-                "initialized {} Functor Lang project in {} (functor.json, game.fun)",
+                "initialized {} Functor Lang project in {} ({})",
                 template.as_str(),
-                working_directory.display()
+                working_directory.display(),
+                template.file_names().join(", ")
             ),
         });
         return Ok(());


### PR DESCRIPTION
PR 1 of the templates track: make the `init` scaffolder's file set **N-ary** so follow-up templates (`multiplayer`, `2d`) can ship siblings (`protocol.fun`, `assets.fun`) without touching the mechanism again. No new templates here.

## What changed

- `Template::files()` now returns `&'static [TemplateFile]` (two `static FILES_3D` / `FILES_FPS` tables) instead of `[TemplateFile; 2]`, and `file_names()` returns `Vec<&'static str>`.
- `cli/src/main.rs` no longer hard-codes the success line's file list — it prints `template.file_names().join(", ")`. For `3d`/`fps` that renders the same text as before (`(functor.json, game.fun)`).
- `cli/src/commands/mcp.rs` (`init_game`) needed no change: `"files": template.file_names()` serializes the `Vec` to the same JSON array as the old `[_; 2]`.
- The template tests iterate the declared file set instead of a fixed pair, while still pinning each name and its bytes against independently-spelled expectations (see review below).

Pure refactor: same files, same order, same bytes, same behavior.

## No-overwrite semantics

Unchanged, and it already generalized cleanly: `execute` pre-scans **all** of the template's files, and if **any** already exists it aborts with `AlreadyExists` listing every conflict — before creating the directory or writing anything. So the choice is **abort-all, not per-file skip**: a partially scaffolded project (half the template's files from the template, half the user's) is worse than a refusal, and this is exactly what the 2-file case did. The rollback-on-write-failure path is untouched and still only removes paths this call created.

## Verification

- `cargo test -p functor-cli` → **139 passed, 1 failed**. The one failure, `init::tests::fps_template_creates_a_typechecked_project`, is **pre-existing on `main`** (verified by stashing the change and re-running at `f4999ca`): the `fps` template's generic `clamp` has an ambiguous `<`, so the template no longer typechecks —
  ```
  `<` here could be float comparison or `Angle.t` comparison or `Time.t` comparison
  — annotate an operand (e.g. `(a: Angle.t)`) so the operator can be resolved
  ```
  at `cli/templates/fps/game.fun:37` (`match value < low with`). Out of scope here — fixing it changes emitted template bytes, which this PR is required to keep identical — so it should land as its own small `fix(cli):` PR. The name/content assertions in that test pass; only the typecheck assertion fails.
- Binary smoke test (debug CLI, built with the web bundle present): `functor -d <tmp> init` and `init fps` both emit `functor.json` + `game.fun` and nothing else, and `diff` against `cli/templates/{functor.json,3d/game.fun,fps/*}` is empty — **byte-identical**. `diff -r` of the pre-change vs post-change output directories is also empty, and the console line is unchanged.
- Conflict path exercised live: with a user-written `game.fun` in place, `functor init` exits 1 with `refusing to overwrite game.fun`, leaves `game.fun` untouched, and writes no `functor.json`.

## Review dispositions (`/xreview`: Claude subagent + Codex CLI)

- **[AGREED, Low] The refactored tests were self-referential** — they compared each emitted file against `file.contents` from the very table under test, so mapping `fps`'s `game.fun` at `GAME_3D` would still pass. **Fixed**: `assert_template_scaffolds` now takes an independent `&[(name, contents)]` expectation, asserts `file_names()` equals the whole expected name list (so an extra/renamed file fails too), and compares bytes against the named consts. Tests re-run after the fix.
- (Codex, Low) Nothing else; no Critical/High/Medium from either engine. Both explicitly confirmed parity of file order/bytes, the conflict check, the rollback path, the CLI message, and the MCP `files` field.
- Duplication pass: `dupfinder names --base main` → no actionable duplication (the change adds no new concepts; `files()`/`file_names()` already existed). Strategies run: S1-names (3 queries / 7770 candidates), S4-read. Not run: S2-clones, S3-index — the diff adds no new functions, only re-shapes two existing ones.
