### PR TITLE
fix(cli): fps template typechecks again — disambiguate clamp comparison

### DIFF
--- a/cli/templates/fps/game.fun
+++ b/cli/templates/fps/game.fun
@@ -33,7 +33,7 @@ let setHeld = (held, key, isDown) =>
 let input = (model, key, isDown) =>
   { model with held: setHeld(model.held, key, isDown) }
 
-let clamp = (value, low, high) =>
+let clamp = (value: float, low, high) =>
   match value < low with
   | true => low
   | false => (match high < value with | true => high | false => value)


### PR DESCRIPTION
`functor init fps` scaffolds a project that fails `functor build` — the `fps`
template's generic `clamp` trips the ambiguous-comparison rule now that the
prelude declares `<` on `Angle.t` and `Time.t`.

At `f4999ca`, `cargo test -p functor-cli fps_template` fails:

```
---- commands::init::tests::fps_template_creates_a_typechecked_project stdout ----
diagnostics: [
    CheckError {
        message: "`<` here could be float comparison or `Angle.t` comparison or `Time.t` comparison — annotate an operand (e.g. `(a: Angle.t)`) so the operator can be resolved",
        span: 1046..1057,
    },
]
```

## The fix

One character-level change in `cli/templates/fps/game.fun`:

```diff
-let clamp = (value, low, high) =>
+let clamp = (value: float, low, high) =>
   match value < low with
```

This is exactly the remedy the `functor-lang` skill prescribes for a brand-
ambiguous comparison: a comparison answers `bool` either way, so only an
*operand* can decide it, and annotating one settles the whole function
(`low`/`high` unify to `float` from there). `clamp` here only ever clamps a
pitch in radians-as-float, so `float` is the honest type — no behavior change,
no unnecessary annotations on the other two params.

## Verification

- `cargo test -p functor-cli fps_template` → `1 passed` (was FAILED).
- `cargo test -p functor-cli` → `140 passed; 0 failed` — no new failures.
- Real-binary smoke test with a debug `functor`:
  ```
  $ functor -d /tmp/fpsgame init fps
  initialized fps Functor Lang project in /tmp/fpsgame (functor.json, game.fun)
  $ functor -d /tmp/fpsgame build
  ✓ checked game.fun (+30 modules)
  ```

Based on `main`; does not overlap #701 (which moves template *storage* in
`init.rs` and leaves template `.fun` contents untouched). Trivial and
single-purpose, so no `/xreview` — the diff is one line.
