### PR TITLE
feat(site): share-link codec — deflate+base64url project fragments

### DIFF
--- a/.github/workflows/reliability.yml
+++ b/.github/workflows/reliability.yml
@@ -204,6 +204,9 @@ jobs:
       - name: Run scrubber model tests
         run: npm run test:scrubber
 
+      - name: Run share-link codec tests
+        run: npm run test:share-link
+
       - name: Run detached-camera browser test
         run: npm run test:detached-camera
 

--- a/.github/workflows/wasm-smoke.yml
+++ b/.github/workflows/wasm-smoke.yml
@@ -134,6 +134,9 @@ jobs:
       - name: Run scrubber model tests
         run: npm run test:scrubber
 
+      - name: Run share-link codec tests
+        run: npm run test:share-link
+
       - name: Run detached-camera browser test
         run: npm run test:detached-camera
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:scrubber": "node --test runtime/functor-runtime-web/timeline-model.test.js",
     "test:wire-value": "node --test site/src/wire-value.test.ts",
     "test:pr-preview": "node --test scripts/pr-preview.test.mjs",
+    "test:share-link": "node --test site/src/share-link.test.ts",
     "test:vscode-e2e": "playwright test -c tools/functor-lang-vscode/tests-integration/playwright.config.mjs",
     "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",

--- a/site/src/ide.tsx
+++ b/site/src/ide.tsx
@@ -46,6 +46,10 @@ import type { PillState } from "./components/StatusPill.js";
 import { asPlayerMessage } from "./protocol.js";
 import type { ProjectFile } from "./protocol.js";
 import { zipFiles } from "./zip.js";
+// The project-file rule lives with the share-link codec, which enforces the
+// same thing on a decoded fragment — one definition for both entrances into
+// the IDE's flat module space.
+import { MODULE_FILE } from "./share-link.js";
 
 /** The in-memory project: a flat module space plus the open file's path. */
 interface Project {
@@ -106,11 +110,6 @@ const playerUrl = () => {
   if (cursorPolicy) params.set("cursor", cursorPolicy);
   return `player.html?${params}`;
 };
-// A valid project file: a bare module name + `.fun` (the project is a flat
-// module space — no path separators). Enforced on BOTH created and loaded
-// files, so a hand-edited/corrupt localStorage can't smuggle in a `../x.fun`
-// (which would be a zip-slip entry on download and a bad module at load).
-const MODULE_FILE = /^[A-Za-z][A-Za-z0-9_]*\.fun$/;
 
 // A two-file starter: game.fun draws using constants from palette.fun (a
 // sibling module — file = module, so palette.fun is module `Palette`), to show

--- a/site/src/share-link.test.ts
+++ b/site/src/share-link.test.ts
@@ -1,0 +1,235 @@
+// The share-link codec's contract: every real project round-trips losslessly
+// and small enough to fit in a URL, and NOTHING an attacker can put in a
+// fragment gets through as a project (or throws).
+//
+// The size half is a regression guard with teeth: a share link has to survive
+// being pasted into a chat client, so the encoded fragment for every example in
+// the repo is asserted under a cap. A payload-format change that stops
+// compressing — or starts carrying something it shouldn't — fails here.
+//
+//   node --test site/src/share-link.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { encodeShare, decodeShare } from "./share-link.ts";
+import type { ShareProject } from "./share-link.ts";
+
+const EXAMPLES = new URL("../../examples", import.meta.url).pathname;
+/** A share link must stay pasteable; the biggest example sets the bar. */
+const MAX_ENCODED_CHARS = 24_000;
+
+const roundTrip = async (project: ShareProject) => {
+  const hash = await encodeShare(project);
+  const back = await decodeShare(hash);
+  return { hash, back };
+};
+
+test("round-trips a multi-file project with entries config and options", async () => {
+  const project: ShareProject = {
+    files: [
+      { path: "game.fun", source: "let init = { t: 0.0 }\n" },
+      { path: "protocol.fun", source: "let hello = \"hi\"\n" },
+    ],
+    entry: "game.fun",
+    config: {
+      entries: {
+        client: { file: "game.fun", module: "Client" },
+        server: "protocol.fun",
+      },
+    },
+    options: { mouseCapture: false },
+  };
+  const { hash, back } = await roundTrip(project);
+  assert.match(hash, /^#code=[A-Za-z0-9_-]+$/);
+  assert.deepEqual(back, {
+    // `entry` is dropped on the wire when it is the default, so it comes back absent.
+    files: project.files,
+    config: project.config,
+    options: { mouseCapture: false },
+  });
+});
+
+test("carries a non-default entry and a cursor policy", async () => {
+  const { back } = await roundTrip({
+    files: [{ path: "main.fun", source: "let init = 0\n" }],
+    entry: "main.fun",
+    options: { cursor: "visible" },
+  });
+  assert.equal(back?.entry, "main.fun");
+  assert.deepEqual(back?.options, { cursor: "visible" });
+});
+
+// --- the real projects -------------------------------------------------------
+
+interface ExampleConfig {
+  entry?: string;
+  entries?: Record<string, unknown>;
+  cursor?: string;
+  mouseCapture?: boolean;
+}
+
+/** Read an `examples/<name>/` directory the way a Share button would. */
+const readExample = (name: string): ShareProject => {
+  const dir = join(EXAMPLES, name);
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".fun"))
+    .sort()
+    .map((f) => ({ path: f, source: readFileSync(join(dir, f), "utf8") }));
+  const config: ExampleConfig = JSON.parse(readFileSync(join(dir, "functor.json"), "utf8"));
+  const project: ShareProject = { files };
+  // `game.fun` is the codec's default and never rides on the wire, so a project
+  // built for comparison must not claim it either.
+  if (config.entry && config.entry !== "game.fun") project.entry = config.entry;
+  if (config.entries) project.config = { entries: config.entries as never };
+  const options: ShareProject["options"] = {};
+  if (config.cursor === "visible") options.cursor = "visible";
+  if (config.mouseCapture === false) options.mouseCapture = false;
+  if (Object.keys(options).length > 0) project.options = options;
+  return project;
+};
+
+// Every example that is a PROJECT — `examples/replay` is a bare scene fixture
+// with no functor.json, so it has nothing to share.
+const exampleNames = readdirSync(EXAMPLES, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && existsSync(join(EXAMPLES, e.name, "functor.json")))
+  .map((e) => e.name)
+  .sort();
+
+test("round-trips every example project, and each stays pasteable", async (t) => {
+  assert.ok(exampleNames.length > 10, "expected the examples/ tree to be populated");
+  for (const name of exampleNames) {
+    const project = readExample(name);
+    const raw = project.files.reduce((n, f) => n + f.source.length, 0);
+    const { hash, back } = await roundTrip(project);
+    const encoded = hash.length - "#code=".length;
+    // One line per project: the size table a size regression shows up in.
+    t.diagnostic(
+      `${name.padEnd(20)} ${String(project.files.length).padStart(2)} files ` +
+        `${String(raw).padStart(7)} raw ${String(encoded).padStart(6)} encoded`
+    );
+    assert.deepEqual(back, project, `${name} did not round-trip losslessly`);
+    assert.ok(
+      encoded <= MAX_ENCODED_CHARS,
+      `${name} encodes to ${encoded} chars, over the ${MAX_ENCODED_CHARS} cap`
+    );
+  }
+});
+
+// --- the legacy docs fragment ------------------------------------------------
+
+// Exactly what site/src/docs.ts writes into a "▶ try it" href.
+const docsToBase64Url = (s: string): string =>
+  btoa(String.fromCharCode(...new TextEncoder().encode(s)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+test("decodes the docs' legacy #src= fragment as a single game.fun", async () => {
+  const source = "let init = 0\nlet draw = (model, tts: float) => Frame.create()\n// ünïcode ✦\n";
+  const project = await decodeShare(`#src=${docsToBase64Url(source)}`);
+  assert.deepEqual(project, { files: [{ path: "game.fun", source }] });
+});
+
+// --- hostile input -----------------------------------------------------------
+
+test("rejects everything that is not a valid fragment", async () => {
+  const hostile = [
+    "",
+    "#",
+    "#code=",
+    "#src=",
+    "#nope=abc",
+    "#code=!!!not base64!!!",
+    "#code=" + "AAAA", // valid base64url, not a deflate stream
+    "#src=%%%",
+  ];
+  for (const hash of hostile) {
+    assert.equal(await decodeShare(hash), null, `expected ${JSON.stringify(hash)} to be rejected`);
+  }
+});
+
+/** Encode an arbitrary envelope, bypassing `encodeShare`'s well-formed input. */
+const rawCode = async (envelope: unknown): Promise<string> => {
+  const json = new TextEncoder().encode(JSON.stringify(envelope));
+  const stream = new Blob([json]).stream().pipeThrough(new CompressionStream("deflate-raw"));
+  const bytes = new Uint8Array(await new Response(stream).arrayBuffer());
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return `#code=${btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")}`;
+};
+
+test("rejects a wrong or missing version", async () => {
+  const files = { "game.fun": "let init = 0\n" };
+  assert.equal(await decodeShare(await rawCode({ v: 2, f: files })), null);
+  assert.equal(await decodeShare(await rawCode({ f: files })), null);
+  assert.equal(await decodeShare(await rawCode({ v: "1", f: files })), null);
+  // …and accepts the one version it knows, so the cases above fail on `v` alone.
+  assert.ok(await decodeShare(await rawCode({ v: 1, f: files })));
+});
+
+test("rejects file names outside the flat module space", async () => {
+  const bad = [
+    "../x.fun",
+    "a/b.fun",
+    "/etc/passwd",
+    "..%2Fx.fun",
+    "game.js",
+    "game.fun.bak",
+    "1game.fun",
+    "",
+    ".fun",
+  ];
+  for (const path of bad) {
+    const hash = await rawCode({ v: 1, f: { [path]: "let init = 0\n" } });
+    assert.equal(await decodeShare(hash), null, `expected ${JSON.stringify(path)} to be rejected`);
+  }
+});
+
+test("rejects a malformed envelope shape", async () => {
+  const bad: unknown[] = [
+    { v: 1 }, // no files
+    { v: 1, f: {} }, // empty module space
+    { v: 1, f: [] }, // files as an array
+    { v: 1, f: { "game.fun": 7 } }, // source not a string
+    { v: 1, f: { "game.fun": "x" }, e: "missing.fun" }, // entry not in the project
+    { v: 1, f: { "game.fun": "x" }, e: 3 },
+    { v: 1, f: { "game.fun": "x" }, c: 7 },
+    { v: 1, f: { "game.fun": "x" }, c: { entries: { client: "missing.fun" } } },
+    { v: 1, f: { "game.fun": "x" }, c: { entries: { "../c": "game.fun" } } },
+    // a role declares at most one of module / prefix
+    { v: 1, f: { "game.fun": "x" }, c: { entries: { c: { file: "game.fun", module: "C", prefix: "c" } } } },
+    { v: 1, f: { "game.fun": "x" }, c: { entries: { c: { file: "game.fun", module: "not an ident" } } } },
+    { v: 1, f: { "game.fun": "x" }, o: { cursor: "hidden" } },
+    { v: 1, f: { "game.fun": "x" }, o: { mouseCapture: true } },
+    { v: 1, f: { "game.fun": "x" }, o: "nope" },
+    "just a string",
+    42,
+    null,
+    [1, 2, 3],
+  ];
+  for (const envelope of bad) {
+    const hash = await rawCode(envelope);
+    assert.equal(
+      await decodeShare(hash),
+      null,
+      `expected ${JSON.stringify(envelope)} to be rejected`
+    );
+  }
+});
+
+test("rejects an oversize payload without inflating all of it", async () => {
+  // Highly compressible: ~4MB of source in a tiny fragment — the deflate-bomb
+  // shape. It must come back null, not as a 4MB project.
+  const files: Record<string, string> = {};
+  for (let i = 0; i < 8; i++) files[`m${i}.fun` as const] = "a".repeat(512 * 1024);
+  const hash = await rawCode({ v: 1, f: files });
+  assert.ok(hash.length < 20_000, "the bomb should be small on the wire");
+  assert.equal(await decodeShare(hash), null);
+});
+
+test("rejects too many files", async () => {
+  const files: Record<string, string> = {};
+  for (let i = 0; i < 200; i++) files[`m${i}.fun`] = "let x = 0\n";
+  assert.equal(await decodeShare(await rawCode({ v: 1, f: files })), null);
+});

--- a/site/src/share-link.test.ts
+++ b/site/src/share-link.test.ts
@@ -131,6 +131,19 @@ test("decodes the docs' legacy #src= fragment as a single game.fun", async () =>
   assert.deepEqual(project, { files: [{ path: "game.fun", source }] });
 });
 
+test("finds its param anywhere in a multi-param hash", async () => {
+  // The sandbox writes `#clients=2&src=…` (site/src/sandbox.tsx), so a share
+  // param is not necessarily the first thing after the `#`.
+  const source = "let init = 0\n";
+  const legacy = await decodeShare(`#clients=2&src=${docsToBase64Url(source)}`);
+  assert.deepEqual(legacy, { files: [{ path: "game.fun", source }] });
+
+  const code = (await encodeShare({ files: [{ path: "game.fun", source }] })).slice("#".length);
+  assert.deepEqual(await decodeShare(`#clients=3&${code}`), {
+    files: [{ path: "game.fun", source }],
+  });
+});
+
 // --- hostile input -----------------------------------------------------------
 
 test("rejects everything that is not a valid fragment", async () => {
@@ -200,6 +213,15 @@ test("rejects a malformed envelope shape", async () => {
     // a role declares at most one of module / prefix
     { v: 1, f: { "game.fun": "x" }, c: { entries: { c: { file: "game.fun", module: "C", prefix: "c" } } } },
     { v: 1, f: { "game.fun": "x" }, c: { entries: { c: { file: "game.fun", module: "not an ident" } } } },
+    // inherited object properties are not project files
+    { v: 1, f: { "game.fun": "x" }, e: "__proto__" },
+    { v: 1, f: { "game.fun": "x" }, e: "constructor" },
+    { v: 1, f: { "game.fun": "x" }, c: { entries: { s: "toString" } } },
+    { v: 1, f: { "game.fun": "x" }, c: { entries: { s: { file: "constructor" } } } },
+    // nothing to boot: no roles, and no (default) entry file
+    { v: 1, f: { "main.fun": "x" } },
+    // a module space that could not exist on a case-insensitive filesystem
+    { v: 1, f: { "game.fun": "x", "Game.fun": "y" } },
     { v: 1, f: { "game.fun": "x" }, o: { cursor: "hidden" } },
     { v: 1, f: { "game.fun": "x" }, o: { mouseCapture: true } },
     { v: 1, f: { "game.fun": "x" }, o: "nope" },
@@ -221,15 +243,33 @@ test("rejects a malformed envelope shape", async () => {
 test("rejects an oversize payload without inflating all of it", async () => {
   // Highly compressible: ~4MB of source in a tiny fragment — the deflate-bomb
   // shape. It must come back null, not as a 4MB project.
-  const files: Record<string, string> = {};
-  for (let i = 0; i < 8; i++) files[`m${i}.fun` as const] = "a".repeat(512 * 1024);
+  const files: Record<string, string> = { "game.fun": "let init = 0\n" };
+  for (let i = 0; i < 8; i++) files[`m${i}.fun`] = "a".repeat(512 * 1024);
   const hash = await rawCode({ v: 1, f: files });
   assert.ok(hash.length < 20_000, "the bomb should be small on the wire");
   assert.equal(await decodeShare(hash), null);
 });
 
 test("rejects too many files", async () => {
-  const files: Record<string, string> = {};
+  const files: Record<string, string> = { "game.fun": "let init = 0\n" };
   for (let i = 0; i < 200; i++) files[`m${i}.fun`] = "let x = 0\n";
   assert.equal(await decodeShare(await rawCode({ v: 1, f: files })), null);
+});
+
+test("refuses to mint a link that would not decode", async () => {
+  const source = "let init = 0\n";
+  const unshareable: ShareProject[] = [
+    { files: [{ path: "game.fun", source }, { path: "game.fun", source }] }, // dupe
+    { files: [{ path: "../x.fun", source }] },
+    { files: [] },
+    { files: [{ path: "main.fun", source }] }, // no boot target
+    { files: [{ path: "game.fun", source }], config: { entries: { c: "missing.fun" } } },
+  ];
+  for (const project of unshareable) {
+    await assert.rejects(
+      () => encodeShare(project),
+      /share-link/,
+      `expected ${JSON.stringify(project)} to be refused`
+    );
+  }
 });

--- a/site/src/share-link.ts
+++ b/site/src/share-link.ts
@@ -1,0 +1,294 @@
+// The share-link codec: a whole Functor project ⇄ a URL fragment.
+//
+// A share link carries the project itself, not a reference to one — there is no
+// server, so the fragment IS the storage. `#code=<base64url>` is a
+// deflate-raw'd JSON envelope:
+//
+//   { v: 1,
+//     e?: "main.fun",                      // entry; omitted when "game.fun"
+//     f: { "game.fun": "…", … },           // the flat module space
+//     c?: { entries: { … } },              // functor.json subset (roles)
+//     o?: { cursor?: "visible", mouseCapture?: false } }
+//
+// Everything a decoder sees is attacker-controlled: the fragment is whatever
+// was in the URL. So `decodeShare` NEVER throws and never trusts — bad base64,
+// a truncated deflate stream, a `../x.fun` path, a deflate bomb, and a future
+// `v` all come back as `null` rather than as a half-applied project.
+//
+// The legacy `#src=<base64url>` fragment (an uncompressed single program, what
+// the docs' "▶ try it" buttons emit — site/src/docs.ts) decodes through the
+// same entry point, so callers have exactly one path to handle.
+import type { ProjectFile } from "./protocol.js";
+
+/**
+ * A valid project file: a bare module name + `.fun` (the project is a flat
+ * module space — no path separators). This is the site's one definition of the
+ * rule, shared by the IDE (which enforces it on created and localStorage-loaded
+ * files) and by this codec — a share link must not be able to smuggle in a
+ * `../x.fun`, which would be a zip-slip entry on download and a bad module at
+ * load.
+ */
+export const MODULE_FILE = /^[A-Za-z][A-Za-z0-9_]*\.fun$/;
+
+/** The default entry, omitted from the payload to keep short links short. */
+const DEFAULT_ENTRY = "game.fun";
+
+// Caps. Generous next to the real projects (the largest example encodes to a
+// few KB) but far below what a browser will hand back from a URL, so a hostile
+// fragment is rejected before it costs anything.
+const MAX_FILES = 64;
+/** Total UTF-8 bytes of source across all files. */
+const MAX_SOURCE_BYTES = 512 * 1024;
+/** Encoded fragment length, checked before any inflation. */
+const MAX_CODE_CHARS = 256 * 1024;
+/** Inflated envelope bytes — the guard against a deflate bomb. */
+const MAX_JSON_BYTES = 1024 * 1024;
+
+const ROLE_NAME = /^[A-Za-z][A-Za-z0-9_-]*$/;
+const IDENT = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+/**
+ * One role of a multi-entry project: an entry file, or a file plus the inline
+ * `module` (preferred) or binding `prefix` (transitional) that names the role's
+ * contract inside it. Mirrors `functor.json`'s `entries`.
+ */
+export type ShareRole = string | { file: string; module?: string; prefix?: string };
+
+/** The `functor.json` subset a share link carries. `language` is implied. */
+export interface ShareConfig {
+  entries?: Record<string, ShareRole>;
+}
+
+/** Player options that live in the URL rather than in the project files. */
+export interface ShareOptions {
+  cursor?: "visible";
+  mouseCapture?: false;
+}
+
+/** A shareable project: the module space plus how to boot it. */
+export interface ShareProject {
+  files: ProjectFile[];
+  /** Defaults to `game.fun` when absent. */
+  entry?: string;
+  config?: ShareConfig;
+  options?: ShareOptions;
+}
+
+// --- base64url ---------------------------------------------------------------
+
+const toBase64Url = (bytes: Uint8Array): string => {
+  // Chunked: `String.fromCharCode(...bytes)` blows the argument limit somewhere
+  // north of ~100KB, which real projects reach.
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const BASE64URL = /^[A-Za-z0-9_-]*$/;
+
+const fromBase64Url = (code: string): Uint8Array<ArrayBuffer> | null => {
+  if (!BASE64URL.test(code)) return null; // atob is lenient about whitespace; we are not
+  try {
+    const binary = atob(code.replace(/-/g, "+").replace(/_/g, "/"));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+};
+
+// --- deflate ----------------------------------------------------------------
+
+/**
+ * Push `bytes` through a (de)compression stream and read it back whole, giving
+ * up if the output passes `limit`. Returns null on a stream error — which for
+ * decompression means "not a deflate-raw stream", the common hostile case.
+ */
+const pump = async (
+  bytes: Uint8Array,
+  transform: GenericTransformStream,
+  limit: number
+): Promise<Uint8Array<ArrayBuffer> | null> => {
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  const reader = source.pipeThrough(transform).getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > limit) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return null;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+};
+
+// --- encode -----------------------------------------------------------------
+
+/** The wire envelope. Field names are short because they ride in a URL. */
+interface Envelope {
+  v: 1;
+  e?: string;
+  f: Record<string, string>;
+  c?: ShareConfig;
+  o?: ShareOptions;
+}
+
+/**
+ * Serialize a project into the URL fragment that reproduces it — the full hash
+ * including the leading `#`, so a caller can assign it straight to
+ * `location.hash` or append it to a page URL.
+ */
+export async function encodeShare(project: ShareProject): Promise<string> {
+  const f: Record<string, string> = {};
+  for (const file of project.files) f[file.path] = file.source;
+  const envelope: Envelope = { v: 1, f };
+  if (project.entry && project.entry !== DEFAULT_ENTRY) envelope.e = project.entry;
+  if (project.config && project.config.entries) envelope.c = { entries: project.config.entries };
+  if (project.options && Object.keys(project.options).length > 0) envelope.o = project.options;
+
+  const json = new TextEncoder().encode(JSON.stringify(envelope));
+  const deflated = await pump(json, new CompressionStream("deflate-raw"), Infinity);
+  // CompressionStream cannot fail on a valid input; the null branch is the type.
+  if (!deflated) throw new Error("share-link: compression failed");
+  return `#code=${toBase64Url(deflated)}`;
+}
+
+// --- decode -----------------------------------------------------------------
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const validRole = (role: unknown, files: Record<string, string>): ShareRole | null => {
+  if (typeof role === "string") return files[role] === undefined ? null : role;
+  if (!isRecord(role)) return null;
+  const { file, module, prefix } = role;
+  if (typeof file !== "string" || files[file] === undefined) return null;
+  if (module !== undefined && prefix !== undefined) return null; // a role declares at most one
+  if (module !== undefined && (typeof module !== "string" || !IDENT.test(module))) return null;
+  if (prefix !== undefined && (typeof prefix !== "string" || !IDENT.test(prefix))) return null;
+  const out: { file: string; module?: string; prefix?: string } = { file };
+  if (typeof module === "string") out.module = module;
+  if (typeof prefix === "string") out.prefix = prefix;
+  return out;
+};
+
+const validConfig = (c: unknown, files: Record<string, string>): ShareConfig | null => {
+  if (!isRecord(c)) return null;
+  if (c.entries === undefined) return {};
+  if (!isRecord(c.entries)) return null;
+  const entries: Record<string, ShareRole> = {};
+  for (const [name, role] of Object.entries(c.entries)) {
+    if (!ROLE_NAME.test(name)) return null;
+    const valid = validRole(role, files);
+    if (!valid) return null;
+    entries[name] = valid;
+  }
+  return Object.keys(entries).length > 0 ? { entries } : {};
+};
+
+const validOptions = (o: unknown): ShareOptions | null => {
+  if (!isRecord(o)) return null;
+  const options: ShareOptions = {};
+  if (o.cursor !== undefined) {
+    if (o.cursor !== "visible") return null;
+    options.cursor = "visible";
+  }
+  if (o.mouseCapture !== undefined) {
+    if (o.mouseCapture !== false) return null;
+    options.mouseCapture = false;
+  }
+  return options;
+};
+
+/** An envelope, validated field by field. Null means "reject the whole link". */
+const validEnvelope = (parsed: unknown): ShareProject | null => {
+  if (!isRecord(parsed)) return null;
+  if (parsed.v !== 1) return null;
+  if (!isRecord(parsed.f)) return null;
+
+  const files: Record<string, string> = {};
+  let bytes = 0;
+  for (const [path, source] of Object.entries(parsed.f)) {
+    if (!MODULE_FILE.test(path)) return null;
+    if (typeof source !== "string") return null;
+    files[path] = source;
+    bytes += source.length; // a char-count lower bound on UTF-8 bytes; exact for the ASCII norm
+    if (bytes > MAX_SOURCE_BYTES) return null;
+  }
+  const paths = Object.keys(files);
+  if (paths.length === 0 || paths.length > MAX_FILES) return null;
+
+  const project: ShareProject = { files: paths.map((path) => ({ path, source: files[path] })) };
+
+  if (parsed.e !== undefined) {
+    if (typeof parsed.e !== "string" || files[parsed.e] === undefined) return null;
+    project.entry = parsed.e;
+  }
+  if (parsed.c !== undefined) {
+    const config = validConfig(parsed.c, files);
+    if (!config) return null;
+    if (config.entries) project.config = config;
+  }
+  if (parsed.o !== undefined) {
+    const options = validOptions(parsed.o);
+    if (!options) return null;
+    if (Object.keys(options).length > 0) project.options = options;
+  }
+  return project;
+};
+
+/** Pull `name`'s value out of a hash, with or without its leading `#`. */
+const fragment = (hash: string, name: string): string | null => {
+  const body = hash.startsWith("#") ? hash.slice(1) : hash;
+  const prefix = `${name}=`;
+  return body.startsWith(prefix) ? body.slice(prefix.length) : null;
+};
+
+/**
+ * Decode a share fragment back into a project, or null if it is not a valid
+ * one. Accepts `#code=…` (this codec) and the legacy `#src=…` of the docs'
+ * "try it" links (an uncompressed single program, loaded as `game.fun`).
+ */
+export async function decodeShare(hash: string): Promise<ShareProject | null> {
+  const legacy = fragment(hash, "src");
+  if (legacy !== null) {
+    if (legacy.length > MAX_CODE_CHARS) return null;
+    const bytes = fromBase64Url(legacy);
+    if (!bytes || bytes.length === 0) return null;
+    return { files: [{ path: DEFAULT_ENTRY, source: new TextDecoder().decode(bytes) }] };
+  }
+
+  const code = fragment(hash, "code");
+  if (code === null || code.length === 0 || code.length > MAX_CODE_CHARS) return null;
+  const deflated = fromBase64Url(code);
+  if (!deflated) return null;
+  const json = await pump(deflated, new DecompressionStream("deflate-raw"), MAX_JSON_BYTES);
+  if (!json) return null;
+  try {
+    return validEnvelope(JSON.parse(new TextDecoder().decode(json)));
+  } catch {
+    return null; // inflated to something that isn't JSON
+  }
+}

--- a/site/src/share-link.ts
+++ b/site/src/share-link.ts
@@ -37,8 +37,9 @@ const DEFAULT_ENTRY = "game.fun";
 // few KB) but far below what a browser will hand back from a URL, so a hostile
 // fragment is rejected before it costs anything.
 const MAX_FILES = 64;
-/** Total UTF-8 bytes of source across all files. */
-const MAX_SOURCE_BYTES = 512 * 1024;
+/** Total source characters across all files (the total BYTES are capped by
+ * MAX_JSON_BYTES below, so this is the "sane project" bound, not the memory one). */
+const MAX_SOURCE_CHARS = 512 * 1024;
 /** Encoded fragment length, checked before any inflation. */
 const MAX_CODE_CHARS = 256 * 1024;
 /** Inflated envelope bytes — the guard against a deflate bomb. */
@@ -102,26 +103,37 @@ const fromBase64Url = (code: string): Uint8Array<ArrayBuffer> | null => {
 
 // --- deflate ----------------------------------------------------------------
 
-/**
- * Push `bytes` through a (de)compression stream and read it back whole, giving
- * up if the output passes `limit`. Returns null on a stream error — which for
- * decompression means "not a deflate-raw stream", the common hostile case.
- */
-const pump = async (
-  bytes: Uint8Array,
-  transform: GenericTransformStream,
-  limit: number
-): Promise<Uint8Array<ArrayBuffer> | null> => {
-  const source = new ReadableStream<Uint8Array>({
+// Typed as BufferSource — what a (De)CompressionStream's writable end accepts.
+const oneChunk = (bytes: Uint8Array<ArrayBuffer>): ReadableStream<BufferSource> =>
+  new ReadableStream<BufferSource>({
     start(controller) {
       controller.enqueue(bytes);
       controller.close();
     },
   });
-  const reader = source.pipeThrough(transform).getReader();
+
+const deflate = async (bytes: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayBuffer>> => {
+  const stream = oneChunk(bytes).pipeThrough(new CompressionStream("deflate-raw"));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+};
+
+/**
+ * Inflate `bytes`, or null if they are not a deflate-raw stream — or if they
+ * expand past `limit`, which is what stops a deflate bomb: the read is
+ * incremental and abandoned mid-stream, so a fragment claiming gigabytes never
+ * allocates them. Constructing the stream is inside the `try` too: an engine
+ * without `deflate-raw` must yield null, not throw at a URL.
+ */
+const inflate = async (
+  bytes: Uint8Array<ArrayBuffer>,
+  limit: number
+): Promise<Uint8Array<ArrayBuffer> | null> => {
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
+    const reader = oneChunk(bytes)
+      .pipeThrough(new DecompressionStream("deflate-raw"))
+      .getReader();
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -159,20 +171,28 @@ interface Envelope {
  * Serialize a project into the URL fragment that reproduces it — the full hash
  * including the leading `#`, so a caller can assign it straight to
  * `location.hash` or append it to a page URL.
+ *
+ * Throws if the project cannot round-trip: the envelope is run through the
+ * DECODER's validation first, so an unshareable project fails here (where a
+ * caller can say so) rather than becoming a link that opens to nothing.
  */
 export async function encodeShare(project: ShareProject): Promise<string> {
-  const f: Record<string, string> = {};
-  for (const file of project.files) f[file.path] = file.source;
+  const f: Record<string, string> = Object.create(null);
+  for (const file of project.files) {
+    // A record would silently collapse two same-named files into one.
+    if (f[file.path] !== undefined) {
+      throw new Error(`share-link: duplicate file ${file.path}`);
+    }
+    f[file.path] = file.source;
+  }
   const envelope: Envelope = { v: 1, f };
   if (project.entry && project.entry !== DEFAULT_ENTRY) envelope.e = project.entry;
   if (project.config && project.config.entries) envelope.c = { entries: project.config.entries };
   if (project.options && Object.keys(project.options).length > 0) envelope.o = project.options;
+  if (!validEnvelope(envelope)) throw new Error("share-link: unshareable project");
 
   const json = new TextEncoder().encode(JSON.stringify(envelope));
-  const deflated = await pump(json, new CompressionStream("deflate-raw"), Infinity);
-  // CompressionStream cannot fail on a valid input; the null branch is the type.
-  if (!deflated) throw new Error("share-link: compression failed");
-  return `#code=${toBase64Url(deflated)}`;
+  return `#code=${toBase64Url(await deflate(json))}`;
 }
 
 // --- decode -----------------------------------------------------------------
@@ -228,14 +248,23 @@ const validEnvelope = (parsed: unknown): ShareProject | null => {
   if (parsed.v !== 1) return null;
   if (!isRecord(parsed.f)) return null;
 
-  const files: Record<string, string> = {};
-  let bytes = 0;
+  // Prototype-free: on a plain `{}`, `files["__proto__"]` and
+  // `files["toString"]` are inherited truthy values, so every `!== undefined`
+  // membership test below would wave through a file the project doesn't have.
+  const files: Record<string, string> = Object.create(null);
+  const lowered = new Set<string>();
+  let chars = 0;
   for (const [path, source] of Object.entries(parsed.f)) {
     if (!MODULE_FILE.test(path)) return null;
     if (typeof source !== "string") return null;
+    // The IDE's module space is case-INsensitively unique (a mac/Windows
+    // checkout of the same project could not hold both), so a link carrying
+    // game.fun AND Game.fun describes a project that can't exist.
+    if (lowered.has(path.toLowerCase())) return null;
+    lowered.add(path.toLowerCase());
     files[path] = source;
-    bytes += source.length; // a char-count lower bound on UTF-8 bytes; exact for the ASCII norm
-    if (bytes > MAX_SOURCE_BYTES) return null;
+    chars += source.length;
+    if (chars > MAX_SOURCE_CHARS) return null;
   }
   const paths = Object.keys(files);
   if (paths.length === 0 || paths.length > MAX_FILES) return null;
@@ -251,6 +280,10 @@ const validEnvelope = (parsed: unknown): ShareProject | null => {
     if (!config) return null;
     if (config.entries) project.config = config;
   }
+  // Something has to be bootable: either named roles, or an entry file (the
+  // explicit one, or the default) that the project actually contains. A
+  // roles-only project need not have a `game.fun` at all (examples/lobby).
+  if (!project.config && files[project.entry ?? DEFAULT_ENTRY] === undefined) return null;
   if (parsed.o !== undefined) {
     const options = validOptions(parsed.o);
     if (!options) return null;
@@ -259,12 +292,15 @@ const validEnvelope = (parsed: unknown): ShareProject | null => {
   return project;
 };
 
-/** Pull `name`'s value out of a hash, with or without its leading `#`. */
-const fragment = (hash: string, name: string): string | null => {
-  const body = hash.startsWith("#") ? hash.slice(1) : hash;
-  const prefix = `${name}=`;
-  return body.startsWith(prefix) ? body.slice(prefix.length) : null;
-};
+/**
+ * Pull `name`'s value out of a hash, with or without its leading `#`.
+ *
+ * A hash is a query string, not one parameter: the sandbox already writes
+ * `#clients=2&src=…` (sandbox.tsx), so a share param can arrive anywhere in it.
+ * base64url has no `+`, so URLSearchParams' space rewriting can't corrupt one.
+ */
+const fragment = (hash: string, name: string): string | null =>
+  new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash).get(name);
 
 /**
  * Decode a share fragment back into a project, or null if it is not a valid
@@ -272,23 +308,33 @@ const fragment = (hash: string, name: string): string | null => {
  * "try it" links (an uncompressed single program, loaded as `game.fun`).
  */
 export async function decodeShare(hash: string): Promise<ShareProject | null> {
-  const legacy = fragment(hash, "src");
-  if (legacy !== null) {
-    if (legacy.length > MAX_CODE_CHARS) return null;
-    const bytes = fromBase64Url(legacy);
-    if (!bytes || bytes.length === 0) return null;
-    return { files: [{ path: DEFAULT_ENTRY, source: new TextDecoder().decode(bytes) }] };
-  }
+  // Strict UTF-8: mojibake in a program is worse than a rejected link.
+  const text = new TextDecoder("utf-8", { fatal: true });
 
   const code = fragment(hash, "code");
-  if (code === null || code.length === 0 || code.length > MAX_CODE_CHARS) return null;
-  const deflated = fromBase64Url(code);
-  if (!deflated) return null;
-  const json = await pump(deflated, new DecompressionStream("deflate-raw"), MAX_JSON_BYTES);
-  if (!json) return null;
-  try {
-    return validEnvelope(JSON.parse(new TextDecoder().decode(json)));
-  } catch {
-    return null; // inflated to something that isn't JSON
+  if (code !== null) {
+    if (code.length === 0 || code.length > MAX_CODE_CHARS) return null;
+    const deflated = fromBase64Url(code);
+    if (!deflated) return null;
+    const json = await inflate(deflated, MAX_JSON_BYTES);
+    if (!json) return null;
+    try {
+      return validEnvelope(JSON.parse(text.decode(json)));
+    } catch {
+      return null; // inflated to something that isn't UTF-8 JSON
+    }
   }
+
+  const legacy = fragment(hash, "src");
+  if (legacy !== null) {
+    if (legacy.length === 0 || legacy.length > MAX_CODE_CHARS) return null;
+    const bytes = fromBase64Url(legacy);
+    if (!bytes || bytes.length === 0) return null;
+    try {
+      return { files: [{ path: DEFAULT_ENTRY, source: text.decode(bytes) }] };
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
PR 1 of the shareable-links track: **the codec only**. A whole Functor project ⇄ a URL fragment, with no server — the fragment *is* the storage. Share buttons, the sandbox/IDE wiring, and retiring the sandbox's own `#src=` decoder all land in follow-up PRs; nothing on the site calls this yet.

`site/src/share-link.ts` exports `encodeShare(project) → "#code=…"` and `decodeShare(hash) → ShareProject | null`.

## Payload schema

`#code=<base64url(deflate-raw(JSON))>`, field names short because they ride in a URL:

```jsonc
{
  "v": 1,                                     // version; anything else is rejected
  "e": "main.fun",                            // entry; OMITTED when it is "game.fun"
  "f": { "game.fun": "…", "palette.fun": "…" }, // the flat module space (file = module)
  "c": { "entries": {                          // functor.json subset — roles
           "client": { "file": "game.fun", "module": "Client" },
           "server": "server.fun" } },
  "o": { "cursor": "visible", "mouseCapture": false } // player options that live in the URL
}
```

`language` never travels (always `functor-lang`), and `e` is dropped at its default so single-file links stay short.

The legacy **`#src=<base64url>`** fragment — an uncompressed single program, what the docs' "▶ try it" buttons emit (`site/src/docs.ts`) — decodes through the same entry point as `{ f: { "game.fun": … } }`, so callers have exactly one path to handle. Both params are read with `URLSearchParams`, because a hash is a query string: the sandbox already writes `#clients=2&src=…`.

## Size table (every example project, from the test)

The encoded fragment for each real project, asserted under a **24,000-char cap** so a payload-format change that stops compressing fails the test.

| project | files | raw chars | encoded | | project | files | raw chars | encoded |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| animation | 2 | 15732 | 5683 | | physics | 1 | 7617 | 4171 |
| asteroids | 4 | 23084 | 10167 | | physics-controller | 3 | 31133 | **14498** |
| atmosphere | 1 | 2047 | 1331 | | platformer | 2 | 7924 | 4256 |
| breakout | 1 | 12881 | 5026 | | pointer-2d | 1 | 3052 | 1626 |
| code-garden | 1 | 20428 | 9758 | | primitives | 1 | 2376 | 1371 |
| counter | 1 | 1704 | 1254 | | roguelike | 1 | 19577 | 6992 |
| crossfade | 2 | 4386 | 2575 | | shapes2d | 1 | 4311 | 2407 |
| glove | 2 | 7722 | 3158 | | shooting-range | 2 | 35505 | **16172** |
| hello | 2 | 10722 | 5599 | | synthwave | 1 | 5027 | 2983 |
| hello-cubes | 2 | 2398 | 1522 | | terrain | 1 | 9517 | 5074 |
| inspector | 1 | 1454 | 1023 | | tetris | 1 | 16659 | 5992 |
| lighting | 2 | 13491 | 6722 | | text2d | 1 | 4096 | 2371 |
| loading | 1 | 8383 | 4306 | | ui | 1 | 2613 | 1563 |
| lobby | 5 | 9881 | 4263 | | webview | 1 | 3952 | 2388 |
| monitor | 1 | 3978 | 2040 | | webview-animated | 1 | 4694 | 2646 |
| netdemo | 1 | 2316 | 1542 | | wsdemo | 1 | 1915 | 1254 |
| netpong | 4 | 27670 | 12207 | | wsserverdemo | 1 | 2030 | 1268 |
| orbs | 1 | 16841 | 8196 | | xr-controllers | 1 | 5011 | 2095 |

Compression runs ~40% of raw; the largest example in the repo (`shooting-range`, 35.5 KB of source across 2 files) fits in a **16 KB** fragment.

## Validation rules (decode)

Everything the decoder sees is attacker-controlled URL text, so it **never throws** and returns `null` on:

- `v !== 1`
- a file name that isn't `/^[A-Za-z][A-Za-z0-9_]*\.fun$/` (the IDE's `MODULE_FILE`, hoisted out of `ide.tsx` into this module so both entrances into the flat module space share one rule) — `../x.fun`, `a/b.fun`, `game.js` all rejected
- case-insensitively duplicate modules (`game.fun` + `Game.fun` describes a project that can't exist on disk)
- a non-string source, an empty module space, `> 64` files, `> 512K` source chars
- an encoded fragment `> 256K` chars, or one that inflates past **1 MiB** — the deflate-bomb guard, enforced incrementally so a fragment claiming gigabytes never allocates them
- bad base64url (alphabet-checked before `atob`), bytes that aren't a deflate-raw stream, non-UTF-8 or non-JSON output (`TextDecoder` is `fatal: true` — mojibake in a program is worse than a rejected link)
- an `e` / role `file` that isn't in `f` — checked on a **prototype-free** record, so `__proto__` / `constructor` / `toString` are not files
- nothing bootable: no roles and no (default) entry file. A roles-only project needs no `game.fun` (`examples/lobby`)
- a role declaring both `module` and `prefix`, a non-identifier `module`/`prefix`, a bad role name, `cursor` other than `"visible"`, `mouseCapture` other than `false`

`encodeShare` runs the envelope through that **same** validation and throws instead of minting a link that would decode to nothing (also rejecting duplicate paths, which a record would silently collapse).

## Verification

```
npm run test:share-link   # 12/12 pass — round-trip synthetic + all 36 example projects, size caps,
                          # legacy #src=, multi-param hashes, and the rejection table
npm run test:wire-value   # 8/8 pass (unchanged)
npm run check:site        # clean
```

Wired into CI in `wasm-smoke.yml` (the PR gate) next to `test:scrubber`, and into its `reliability.yml` mirror.

## Review

`/xreview` (Claude + Codex + a de-dup pass) ran on the first commit; the second commit is the fixes:

- **Fixed** — prototype-chain membership admitted `__proto__`/`toString` as project files (proven by both reviewers' repro); hash parsed as a single param, which would have broken the sandbox's real `#clients=2&src=…` links; `encodeShare` could mint permanently-dead links (now gated on the decoder's own validation); case-insensitive duplicate modules and no-boot-target projects accepted; `DecompressionStream` constructed outside the `try` (an engine without `deflate-raw` would throw at a URL instead of returning `null`); non-fatal `TextDecoder` silently produced mojibake; the byte-cap constant counted UTF-16 units (renamed to `MAX_SOURCE_CHARS`, with `MAX_JSON_BYTES` documented as the real memory bound); the unreachable "compression failed" branch removed; the CI step moved to the workflow that actually gates PRs.
- **Deferred, deliberately** — the de-dup pass wants one shared `base64url` module (`docs.ts` and `sandbox.tsx` have string-level twins) and wants `sandbox.tsx`'s inline-load path to call `decodeShare` and delete its own decoder. Both are the *UI* PR's job; doing them here would mean touching the sandbox in a codec-only change. The legacy `#src=` branch is intentionally callerless for one PR so the switch-over is a pure deletion. Similarly, sharing a `validateModuleSpace` with `ide.tsx`'s loader belongs with the PR that feeds decoded projects into the IDE — this PR only makes the codec's guarantee a superset of the loader's on file names.
