### PR TITLE
feat(site): route sandbox edits through the multi-file set-project seam

### DIFF
--- a/e2e/sandbox-mp.mjs
+++ b/e2e/sandbox-mp.mjs
@@ -36,7 +36,10 @@
 //  10. LINK IMPAIRMENT: a pane's link chip really delays that client's packets
 //      (sent → delivered on every row), only that client's, never out of order,
 //      and without breaking convergence — while loss stays a labelled datagram
-//      setting (design Addendum 8.2).
+//      setting (design Addendum 8.2);
+//  11. an EDIT reaches every role: the sandbox pushes the whole file set, so a
+//      netpong session (roles as separate FILES) hot-reloads its clients AND
+//      its authority — each at its own entry file, each model preserved.
 //
 // Run manually (needs the web-runtime wasm bundle):
 //
@@ -573,12 +576,16 @@ try {
         params[1].get("module") === "Client" &&
         params[2].get("module") === "Server",
       "every pane boots its role as a MODULE — clients Client, authority Server",
-      params.map((p) => `${p.get("game")}?module=${p.get("module")}`).join(" | ")
+      params.map((p) => `${p.get("project")}?module=${p.get("module")}`).join(" | ")
     );
+    // The sources are PUSHED now (project=inline — the page owns every file and
+    // delivers it over `functor-lang-set-project`), so no pane names a `?game=`
+    // to fetch: they all boot the one file set the sandbox pushes, and only the
+    // `?module=` above tells the two roles of orbs' single buffer apart.
     check(
-      params.every((p) => p.get("game") === params[0].get("game")),
-      "all three panes boot the same file",
-      params.map((p) => p.get("game")).join(" | ")
+      params.every((p) => p.get("project") === "inline" && !p.has("game") && !p.has("file")),
+      "every pane boots the pushed project rather than fetching a file",
+      params.map((p) => p.toString()).join(" | ")
     );
 
     // The link indicator: every pane linked through the coordinator.
@@ -1686,6 +1693,63 @@ try {
         .map((row) => `${row.link} ${row.frame}→${row.delivered}`)
         .join(", ")}`
     );
+    await page.close();
+  }
+
+  // --- 4i. An EDIT reaches every role — netpong, whose roles are FILES. -------
+  // The sandbox pushes the whole file set (`functor-lang-set-project`), so a
+  // role is the file it is entered at rather than "whatever the buffer holds":
+  // the authority hot-reloads with its clients instead of being left on the
+  // served build (which is what the single-buffer set-source seam forced).
+  {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+    const consoleLog = [];
+    page.on("console", (m) => consoleLog.push(m.text()));
+    page.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+    await page.goto(`${BASE}/sandbox.html?example=netpong#clients=2`);
+    await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+      timeout: 40000,
+    });
+    await installProbe(page);
+    const roles = await page.evaluate(() => window.__mpProbe.roles());
+    check(
+      roles.join(", ") === "client 1, client 2, server",
+      "netpong (roles as files) runs two clients under one authority",
+      roles.join(", ")
+    );
+    await page.evaluate(() =>
+      window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// pushed-project marker\n`)
+    );
+    // Each pane's own reload line, prefixed with the pane id by the console
+    // relay, names the file that pane was entered at.
+    const reloads = await page
+      .waitForFunction(
+        () => {
+          const lines = [...document.querySelectorAll(".output-line")].map((n) => n.textContent);
+          return ["[client 1]", "[client 2]", "[server]"].every((who) =>
+            lines.some((line) => line.includes(who) && line.includes("model preserved"))
+          );
+        },
+        null,
+        { timeout: 30000 }
+      )
+      .then(() => true)
+      .catch(() => false);
+    const lines = await page.locator(".output-line").allTextContents();
+    check(
+      reloads,
+      "one edit hot-reloads both clients AND the authority, each model preserved",
+      lines.filter((line) => line.includes("model preserved")).slice(-3).join(" / ")
+    );
+    check(
+      lines.some(
+        (line) => line.includes("[server]") && line.includes("examples/netpong/server.fun")
+      ),
+      "the authority reloads at its OWN entry file, not the client's",
+      lines.filter((line) => line.includes("[server]")).slice(-2).join(" / ")
+    );
+    const errors = consoleLog.filter((line) => /unknown external|panic|pageerror/i.test(line));
+    check(errors.length === 0, "no pane reported a load error", errors.slice(0, 2).join(" | "));
     await page.close();
   }
 

--- a/e2e/site-sandbox.mjs
+++ b/e2e/site-sandbox.mjs
@@ -1024,6 +1024,44 @@ check("picker exposes the expanded example set", examples.length >= 10, examples
 // Duplicate ids would silently overwrite each other's dist/examples/<id>.fun and
 // under-test the set — a unique-count mismatch is a real drift bug, not a nit.
 check("picker example ids are unique", new Set(examples).size === examples.length, examples.join(", "));
+// An IN-PLACE example switch, between two examples whose player URLs are now
+// byte-identical (the sources are pushed, so nothing distinguishes them in the
+// query). The switch must still replace the player document — a fresh model, the
+// new program — rather than leave the old one running or hang on "reloading…".
+{
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${BASE}/sandbox.html?example=hero`);
+  await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+    timeout: 30000,
+  });
+  const before = await page.evaluate(() => {
+    // Mark the live document so a surviving one is detectable.
+    document.getElementById("player").contentWindow.__docMark = "first";
+    return document.getElementById("player").getAttribute("src");
+  });
+  await page.selectOption("#example-picker", "orbit");
+  const switched = await page
+    .waitForFunction(
+      () =>
+        window.__sandbox.status().state === "live" &&
+        window.__sandbox.getSource().includes("orbit"),
+      null,
+      { timeout: 30000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  const after = await page.evaluate(() => ({
+    src: document.getElementById("player").getAttribute("src"),
+    mark: document.getElementById("player").contentWindow.__docMark ?? "(fresh)",
+    status: window.__sandbox.status(),
+  }));
+  check(
+    "an in-place switch between same-URL examples reboots the player",
+    switched && after.mark === "(fresh)" && before === after.src,
+    JSON.stringify({ before, ...after })
+  );
+  await page.close();
+}
 for (const example of examples) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
   const consoleLog = [];
@@ -2146,13 +2184,16 @@ for (const example of examples) {
 
   await problemsTab.click();
   const row = page.locator(".problem-row");
+  // The row names the file being edited — the loaded example's REAL entry path
+  // (the sandbox pushes it as part of a multi-file project), not a `game.fun`
+  // no example is called.
   const rowText = await waitFor(
     async () => ((await row.count()) ? await row.first().textContent() : ""),
-    (t) => t.includes("game.fun")
+    (t) => t.includes("examples/hero.fun")
   );
   check(
     "problems panel lists the diagnostic with its location",
-    rowText.includes("float") && rowText.includes("game.fun"),
+    rowText.includes("float") && rowText.includes("examples/hero.fun"),
     rowText
   );
 

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -237,9 +237,9 @@ fn net_transport() -> NetTransport {
 
 /// The project's full file list (entry FIRST, then siblings), as the CLI's Functor Lang
 /// index page injects it (`window.__functorLangProjectFiles`, mirroring `__functorLangGamePath`
-/// — see `wasm_dev_server.rs`). Absent (a page that only set the single entry,
-/// e.g. the site sandbox) → `None`, and the caller falls back to the entry
-/// alone.
+/// — see `wasm_dev_server.rs`). Absent (a page that sets only the single entry,
+/// or one that pushes its sources in memory instead) → `None`, and the caller
+/// falls back to the entry alone.
 fn functor_lang_project_files() -> Option<Vec<String>> {
     use wasm_bindgen::JsCast;
     let value =
@@ -251,8 +251,8 @@ fn functor_lang_project_files() -> Option<Vec<String>> {
 
 /// In-memory project sources (`window.__functorLangProjectSources`, an array of
 /// `{path, source}` objects, entry FIRST) — set by a page that holds the
-/// whole project in memory instead of serving it (the IDE's inline boot,
-/// see `player.html?project=inline`). Absent or malformed → `None`, and the
+/// whole project in memory instead of serving it (the site sandbox's and IDE's
+/// inline boot, see `player.html?project=inline`). Absent or malformed → `None`, and the
 /// caller uses the fetch path.
 fn functor_lang_project_sources() -> Option<Vec<(String, String)>> {
     let value =
@@ -351,9 +351,9 @@ pub fn functor_lang_uses_captured_mouse_input() -> bool {
     })
 }
 
-/// A queued push: the classic single-buffer text push (the sandbox / VSCode
-/// preview editing the entry over served siblings), or the whole-project
-/// push (the IDE, which owns every file in memory).
+/// A queued push: the classic single-buffer text push (the VSCode preview panel
+/// editing the entry over served siblings), or the whole-project push (the
+/// site's sandbox and IDE, which own every file in memory).
 enum PendingPush {
     Source(String),
     Project(Vec<(String, String)>),

--- a/site/README.md
+++ b/site/README.md
@@ -19,10 +19,15 @@ npm run test:editor-keybindings # headless e2e — opt-in Vim in the sandbox and
 
 - `player.html` — the runtime host page; the sibling of the CLI dev server's
   `index-functor-lang.html`, but the `.fun` entry comes from `?game=` (one file) or
-  `?project=inline` (the IDE pushes the whole file set by postMessage). Keep its
+  `?project=inline` (the sandbox and the IDE push the whole file set by
+  postMessage). Keep its
   input mapping and set-source/set-project seam in sync with that page.
-- `sandbox.html` / `src/sandbox.tsx` — the single-buffer editor over a served
-  example (pushes `functor-lang-set-source`).
+- `sandbox.html` / `src/sandbox.tsx` — the example editor: it fetches the
+  selected example's whole file set and pushes it as a project
+  (`functor-lang-set-project` via `src/project-bridge.ts`, to a
+  `player.html?project=inline` preview), while editing ONE buffer — the entry.
+  A file switcher is a follow-up. Binary assets are still served by the site and
+  resolved as URLs against `player.html`.
 - `ide.html` / `src/ide.tsx` — the multi-file IDE: a file sidebar, per-file
   editing, a live preview fed the whole project via `functor-lang-set-project`
   (`src/project-bridge.ts`), localStorage persistence, and project download as a

--- a/site/player.html
+++ b/site/player.html
@@ -201,9 +201,9 @@
       const requestedFiles = params
         .getAll("file")
         .filter((path) => path && !path.startsWith("/") && !path.includes(":"));
-      // ?project=inline: the HOSTING page owns the whole file set (the IDE)
-      // and delivers it by postMessage — nothing is fetched. The boot is
-      // deferred until the first `functor-lang-set-project` arrives (see the
+      // ?project=inline: the HOSTING page owns the whole file set (the sandbox
+      // and the IDE) and delivers it by postMessage — nothing is fetched. The
+      // boot is deferred until the first `functor-lang-set-project` arrives (see the
       // bottom of this script), so no game path is set here.
       const inlineProject = params.get("project") === "inline";
       // Same-origin relative paths only: reject absolute/protocol-relative
@@ -708,8 +708,9 @@
       };
 
       // The live-edit seam: the hosting page (the sandbox / the IDE) posts
-      // .fun source (`functor-lang-set-source`) or a whole file set
-      // (`functor-lang-set-project`, the IDE) and the runtime hot-swaps it,
+      // .fun source (`functor-lang-set-source`, the VSCode preview panel) or a
+      // whole file set (`functor-lang-set-project`, the site's sandbox and IDE)
+      // and the runtime hot-swaps it,
       // model preserved. ONE listener, installed synchronously below, so no
       // push is lost in the async init() → producer-ready window (a
       // fast-typing IDE pushes exactly there); pushes that arrive before the

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -31,8 +31,9 @@
 // OUTSIDE the React islands (like CodeMirror owns #editor), and publishes to
 // the page through the injected `setPill` / `statusBar` seams.
 
-import { PlayerBridge } from "./player-bridge.js";
+import { ProjectBridge } from "./project-bridge.js";
 import { asPlayerMessage } from "./protocol.js";
+import type { ProjectFile } from "./protocol.js";
 import type { StatusBar } from "./status-bar-store.js";
 import type { PillState } from "./components/StatusPill.js";
 import { NetCoordinator, TIMELINE_FPS } from "./net-coordinator.js";
@@ -196,18 +197,30 @@ export interface MultiplayerPanesOptions {
   statusBar: StatusBar;
   /** Writes the header pill (the page's pill store). */
   setPill: (state: PaneState, text: string, detail: string) => void;
-  /** The current editor buffer, so a mirror added mid-session catches up. */
-  getSource: () => string;
+  /**
+   * The editor's whole file set (entry first) — every pane is booted BY a
+   * project push, so this is both a new pane's program and how one added
+   * mid-session catches up to the edited buffer.
+   */
+  getProject: () => ProjectFile[];
+}
+
+/** A pane's program: its `player.html?project=inline` URL plus its ENTRY file. */
+export interface PaneProgram {
+  src: string;
+  /** The project path this role enters at — hoisted to the front of the push. */
+  entry: string;
 }
 
 export interface MultiplayerPanes {
   /**
-   * Load a fresh program into every pane. `serverSrc` is the player URL of the
-   * example's SERVER role (examples.ts `server`), or null for a sample that
-   * declares none — passing it mounts the server pane, passing null removes it.
+   * Load a fresh program into every pane. `server` is the example's SERVER role
+   * (examples.ts `server`) — its player URL and its entry file — or null for a
+   * sample that declares none: passing it mounts the server pane, passing null
+   * removes it.
    */
-  setSrc(src: string, serverSrc?: string | null): void;
-  push(source: string): void;
+  setSrc(src: string, server?: PaneProgram | null): void;
+  push(files: ProjectFile[]): void;
   reset(): void;
   aggregateStatus(state: PaneState, text: string, detail: string): void;
   setCount(n: number): void;
@@ -275,7 +288,7 @@ export function initMultiplayerPanes({
   count,
   statusBar,
   setPill,
-  getSource,
+  getProject,
 }: MultiplayerPanesOptions): MultiplayerPanes {
   const previewPane = frame.closest(".preview-pane") as HTMLElement;
   previewPane.classList.add("mp");
@@ -437,7 +450,10 @@ export function initMultiplayerPanes({
   // about "every running pane" — the scrub broadcasts, the aggregate pill, the
   // frame labels, the coordinator's routing table — goes through `allPanes()`,
   // with the server always LAST so client indices (and their digits) never move.
-  let serverPane: { pane: Pane; bridge: PlayerBridge } | null = null;
+  let serverPane: { pane: Pane; bridge: ProjectBridge } | null = null;
+  // The project path the server pane enters at (its role's file), from the
+  // example's declaration — see `serverFiles`.
+  let serverEntry: string | null = null;
   const allPanes = (): Pane[] => (serverPane ? [...panes, serverPane.pane] : panes);
 
   // The NETWORK view's wires and packet dots. It measures the pane cards the
@@ -592,13 +608,13 @@ export function initMultiplayerPanes({
   // added and removed LIVE — pane 1's iframe never moves again after this
   // wrap, so its running model survives every count change.
   makePane("client", 0, frame);
-  const mirrors: { pane: Pane; bridge: PlayerBridge }[] = [];
+  const mirrors: { pane: Pane; bridge: ProjectBridge }[] = [];
 
   // Everything a pane the module created itself needs: its own status bridge
   // and its own prefixed console relay. Pane 1 is excluded by construction —
   // the PAGE owns its bridge (see `aggregateStatus`).
-  const attachBridge = (pane: Pane): PlayerBridge => {
-    const bridge = new PlayerBridge(pane.iframe, {
+  const attachBridge = (pane: Pane): ProjectBridge => {
+    const bridge = new ProjectBridge(pane.iframe, {
       onReloading: () => setPaneState(pane, "busy"),
       onLive: () => setPaneState(pane, "live"),
       onResult: (ok, message) => {
@@ -620,7 +636,11 @@ export function initMultiplayerPanes({
     return bridge;
   };
 
-  const addMirror = (pushCurrent: boolean) => {
+  // `bootProgram` is false for the panes created during THIS call (below): the
+  // page has not loaded a program yet, and its `getProject` closes over state
+  // declared after this module is initialized — the `setSrc` that follows a load
+  // is what arms every mirror. A pane added mid-session passes true.
+  const addMirror = (bootProgram: boolean) => {
     const index = panes.length;
     const iframe = document.createElement("iframe");
     iframe.title = `client ${index + 1} preview`;
@@ -628,11 +648,12 @@ export function initMultiplayerPanes({
     const pane = makePane("client", index, iframe);
     const bridge = attachBridge(pane);
     mirrors.push({ pane, bridge });
-    // A mirror added mid-session boots the served program, then catches up to
-    // the (possibly edited) buffer; the bridge holds the push until ready.
+    // A mirror boots FROM the project push (`?project=inline` fetches nothing),
+    // so it starts on the edited buffer rather than on a served build it then
+    // has to catch up to; the bridge holds the push until the pane is armed.
     if (frame.getAttribute("src")) {
       iframe.src = frame.src; // already carries ?scrubber=hidden (the page adds it)
-      if (pushCurrent) bridge.push(getSource());
+      if (bootProgram) bridge.setProject(getProject());
     }
   };
 
@@ -642,20 +663,44 @@ export function initMultiplayerPanes({
   // not a client's. It runs the same project files with the server file as the
   // entry, and its packets reach the clients through the same coordinator.
   //
-  // It does NOT take editor pushes: `functor-lang-set-source` replaces the
-  // ENTRY module's source, and the sandbox's buffer is the client entry —
-  // pushing it here would swap the server's program for the client's. So an
-  // edit hot-reloads the clients live while the server keeps running the
-  // served build. Editing server.fun needs the multi-file `set-project` path
-  // (the IDE already speaks it); until the sandbox grows a file switcher,
-  // `↺ reset` reboots both roles from disk.
-  const mountServer = (src: string) => {
+  // It DOES take editor pushes, because the seam is now the multi-file one:
+  // every pane receives the whole project, and a role is the file it enters at
+  // (plus its `?module=`), so pushing the client's edit no longer overwrites
+  // the server's program — an edit hot-reloads the authority and its clients
+  // together, each with its own model preserved. The editor still shows one
+  // buffer (the client entry); editing server.fun itself waits on a file
+  // switcher, and `↺ reset` still reboots every role from the served sources.
+  // The authority's view of the project: the SAME files, re-entered at its own
+  // role's file (the runtime takes `files[0]` as the entry module). A sample
+  // whose roles share one file (orbs) hoists nothing — the entry is already
+  // that file, and `?module=` alone tells the two roles apart.
+  const serverFiles = (files: ProjectFile[]): ProjectFile[] => {
+    if (!serverEntry) return files;
+    const role = files.find((file) => file.path === serverEntry);
+    // A declared server file that isn't IN the pushed set is a sample bug (the
+    // `server?:` note in examples.ts). Under the fetch path it was a visible
+    // 404; say so loudly here rather than booting the CLIENT entry as the
+    // authority (its role params are already gone), which would look like a
+    // working session that quietly has no server.
+    if (!role) {
+      console.error(
+        `[mp] the server role's file ${serverEntry} is not in the pushed project; ` +
+          "the authority has no entry to boot (add it to the example's siblings)"
+      );
+      return files;
+    }
+    return [role, ...files.filter((file) => file !== role)];
+  };
+
+  const mountServer = (program: PaneProgram, files: ProjectFile[]) => {
     const iframe = document.createElement("iframe");
     iframe.title = "server preview";
     iframe.allow = "pointer-lock";
     const pane = makePane("server", panes.length, iframe);
-    serverPane = { pane, bridge: attachBridge(pane) };
-    iframe.src = src;
+    const bridge = attachBridge(pane);
+    serverPane = { pane, bridge };
+    iframe.src = program.src;
+    bridge.setProject(serverFiles(files));
   };
 
   const unmountServer = () => {
@@ -1755,19 +1800,25 @@ export function initMultiplayerPanes({
   return {
     // Mirror a fresh program load into the extra panes, and mount/remove the
     // server pane to match what the newly loaded example declares.
-    setSrc(src, serverSrc = null) {
+    setSrc(src, server = null) {
+      const files = getProject();
       for (const { pane, bridge } of mirrors) {
         bridge.reset();
         setPaneState(pane, "busy");
         pane.iframe.src = src;
+        // The push IS the boot under `?project=inline`, so re-arm it after the
+        // reset: the fresh document announces project-waiting and gets this.
+        bridge.setProject(files);
       }
-      if (!serverSrc) unmountServer();
+      serverEntry = server?.entry ?? null;
+      if (!server) unmountServer();
       else if (serverPane) {
         serverPane.bridge.reset();
         setPaneState(serverPane.pane, "busy");
-        serverPane.pane.iframe.src = serverSrc;
+        serverPane.pane.iframe.src = server.src;
+        serverPane.bridge.setProject(serverFiles(files));
       } else {
-        mountServer(serverSrc);
+        mountServer(server, files);
       }
       // A different program is a different session: the packet log, and the
       // per-link totals the reduced-motion badge shows, start over with it —
@@ -1780,18 +1831,20 @@ export function initMultiplayerPanes({
       paintAggregate();
     },
     // Mirror a debounced hot-reload push. EVERY pane is a target, the
-    // authority included: a same-file project (`module Client` / `module
-    // Server`) boots both roles from the buffer being edited, and the runtime
-    // re-resolves each pane's own role on reload (`load_source(.., &self.role)`
-    // in the embedded producer), so the server swaps its Server module while
-    // the clients swap theirs — one edit, one atomic session-wide reload, every
-    // model preserved.
-    push(source) {
-      for (const { bridge } of mirrors) bridge.push(source);
-      serverPane?.bridge.push(source);
+    // authority included: each role gets the same file set entered at its own
+    // file (see mountServer), and the runtime re-resolves each pane's own role
+    // on reload (`load_source(.., &self.role)` in the embedded producer), so
+    // the server swaps its Server module while the clients swap theirs — one
+    // edit, one atomic session-wide reload, every model preserved.
+    push(files) {
+      for (const { bridge } of mirrors) bridge.setProject(files);
+      serverPane?.bridge.setProject(serverFiles(files));
     },
     reset() {
+      // Every pane the module owns, authority included — it takes pushes now,
+      // so leaving its bridge armed across a program change is an asymmetry.
       for (const { bridge } of mirrors) bridge.reset();
+      serverPane?.bridge.reset();
     },
     // The page's own status writer delegates here. It has ALREADY written the
     // pill (its single-client wording); with more than one pane the aggregate

--- a/site/src/project-bridge.ts
+++ b/site/src/project-bridge.ts
@@ -1,8 +1,9 @@
 // The multi-file editor ↔ player bridge — the whole-project sibling of
-// player-bridge.ts (which pushes a single source buffer). The IDE owns every
-// .fun in memory, so it pushes the full file set over `functor-lang-set-project`
-// to a `player.html?project=inline` iframe: the player boots from memory (no
-// fetch) on the first push, then hot-swaps (model preserved) on each edit.
+// player-bridge.ts (which pushes a single source buffer). The IDE and the
+// sandbox both own every .fun in memory, so they push the full file set over
+// `functor-lang-set-project` to a `player.html?project=inline` iframe: the
+// player boots from memory (no fetch) on the first push, then hot-swaps (model
+// preserved) on each edit.
 //
 // The boot handshake: the player announces `functor-lang-project-waiting` when
 // its listener is armed; only then may we push. It replies
@@ -28,6 +29,9 @@ export class ProjectBridge {
   private readonly errorGraceMs: number;
 
   private waiting = false; // player announced project-waiting (safe to push)
+  // Has a push already BOOTED the current document? The boot push is a load,
+  // not a reload — the host's "loading…" stands until the player reports in.
+  private booted = false;
   private files: ProjectFile[] | null = null; // latest full file set
   private pushTimer: ReturnType<typeof setTimeout> | undefined;
   private errorTimer: ReturnType<typeof setTimeout> | undefined;
@@ -43,6 +47,7 @@ export class ProjectBridge {
       onResult,
       debounceMs = PUSH_DEBOUNCE_MS,
       errorGraceMs = ERROR_GRACE_MS,
+      signal,
     }: BridgeOptions
   ) {
     this.iframe = iframe;
@@ -52,7 +57,13 @@ export class ProjectBridge {
     this.debounceMs = debounceMs;
     this.errorGraceMs = errorGraceMs;
 
-    window.addEventListener("message", (event) => this.#onMessage(event));
+    // `signal` detaches the listener with a disposable pane (the sandbox's
+    // mirror/server panes), exactly as PlayerBridge's does.
+    window.addEventListener(
+      "message",
+      (event) => this.#onMessage(event),
+      signal !== undefined ? { signal } : undefined
+    );
   }
 
   // Debounced whole-project push: swap in the file set once edits settle.
@@ -68,6 +79,7 @@ export class ProjectBridge {
     clearTimeout(this.pushTimer);
     clearTimeout(this.errorTimer);
     this.waiting = false;
+    this.booted = false;
   }
 
   // Surface a hot-swap result — but hold errors back. A rejected edit keeps the
@@ -86,11 +98,18 @@ export class ProjectBridge {
 
   #send(): void {
     clearTimeout(this.pushTimer); // an early flush cancels the pending timer
-    if (!this.iframe.contentWindow || !this.files) return;
+    // An EMPTY set is rejected by the player as a malformed push, whose error
+    // arrives as "live now, error in 4s" — so never send one; a bridge with
+    // nothing to push simply waits for a real project.
+    if (!this.iframe.contentWindow || !this.files?.length) return;
     // The player drops anything sent before it announces `project-waiting`;
     // hold the push and flush it on that signal (below).
     if (!this.waiting) return;
-    this.onReloading();
+    // The BOOT push is this document's load — the host already says "loading…",
+    // and calling it a reload would report a program that has never run as one
+    // being swapped. Every later push is a real hot-swap.
+    if (this.booted) this.onReloading();
+    else this.booted = true;
     this.pushId += 1;
     const message: SetProject = {
       type: "functor-lang-set-project",

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -49,14 +49,15 @@ export interface SetSource {
 }
 
 /**
- * Boot from / hot-swap a whole in-memory project (the IDE's push).
+ * Boot from / hot-swap a whole in-memory project (the sandbox's and the IDE's
+ * push).
  *
  * `files` must be non-empty and every `path` non-blank — the player rejects
  * anything else as a "malformed project push" (player.html). That is a runtime
- * precondition rather than a type: the only producer is ide.ts, which builds
- * this list from user-editable localStorage, so a non-empty-tuple type here
- * would be an unchecked assertion at the boundary rather than a real
- * guarantee.
+ * precondition rather than a type: the producers build this list from
+ * user-editable localStorage (ide.tsx) or fetched example sources
+ * (sandbox.tsx), so a non-empty-tuple type here would be an unchecked
+ * assertion at the boundary rather than a real guarantee.
  */
 export interface SetProject {
   type: "functor-lang-set-project";

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -1,8 +1,15 @@
 // The sandbox page: a CodeMirror editor wired to the runtime iframe over the
-// editor↔player postMessage seam (player-bridge.ts — the same protocol the
-// VSCode live-preview panel uses). Edits are debounced and pushed as
-// `functor-lang-set-source`; the runtime hot-swaps the program with the model
-// preserved and replies `functor-lang-set-source-result`.
+// editor↔player postMessage seam. It speaks the IDE's MULTI-FILE seam
+// (project-bridge.ts): the page owns every source of the loaded example, boots
+// the player as `player.html?project=inline`, and pushes the whole file set as
+// `functor-lang-set-project` — the runtime hot-swaps the program with the model
+// preserved and replies `functor-lang-set-source-result`. The editor still
+// edits ONE buffer (the entry); a file switcher is a separate concern.
+//
+// Binary assets are NOT part of that push: the runtime resolves an `Asset.*`
+// locator as a URL against player.html, so an example's png/glb/ogg is served
+// from the built site (examples.ts `assets` copies them) exactly as before.
+// Only `.fun` sources travel over the seam.
 //
 // The page shell is static HTML; the CHROME around the editor (the picker, the
 // pill, the external-runtime panel, the status bar) renders as React islands
@@ -33,7 +40,7 @@ import {
   currentCoverage,
   currentExpects,
 } from "./lang-intel.js";
-import { PlayerBridge } from "./player-bridge.js";
+import { ProjectBridge } from "./project-bridge.js";
 import { createStatusBarStore } from "./status-bar-store.js";
 import { createRuntimeTargetCore } from "./runtime-target-core.js";
 import type { RuntimeTargetState } from "./runtime-target-core.js";
@@ -41,10 +48,11 @@ import { createStore } from "./store.js";
 import { SandboxControls } from "./components/SandboxControls.js";
 import type { PickerState, ClientsState } from "./components/SandboxControls.js";
 import { initMultiplayerPanes, MAX_CLIENTS } from "./mp-panes.js";
-import type { MultiplayerPanes } from "./mp-panes.js";
+import type { MultiplayerPanes, PaneProgram } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { asPlayerMessage } from "./protocol.js";
+import type { ProjectFile } from "./protocol.js";
 import { EXAMPLES, exampleEntryPath } from "./examples.js";
 
 /** The sandbox's e2e seam (driven by e2e/site-sandbox.mjs). */
@@ -76,8 +84,8 @@ interface LangSeam {
 const frame = document.getElementById("player") as HTMLIFrameElement;
 
 // An inline program from the URL fragment (the docs' "try it" buttons):
-// #src=<base64url> becomes the editor buffer and the player's ?src= data:
-// URL, so it starts with a fresh init — no served file involved.
+// #src=<base64url> becomes the editor buffer and a ONE-FILE project pushed to a
+// fresh player, so it starts with a fresh init — no served file involved.
 const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
 const pageParams = new URLSearchParams(window.location.search);
 const requested = pageParams.get("example");
@@ -133,15 +141,15 @@ const statusBar = createStatusBarStore();
 
 // One instrument at every client count: the chrono bar is the transport UI
 // for a single client and for N — the players mount their __scrub seam with
-// no bar of their own (?scrubber=hidden). `getSource` lets a mirror added
-// mid-session catch up to the edited buffer (`view` exists by the time any
-// pane is added).
+// no bar of their own (?scrubber=hidden). `getProject` is how a pane added
+// mid-session BOOTS (the project push is the boot) already carrying the edited
+// buffer (`view` exists by the time any pane is added).
 mp = initMultiplayerPanes({
   frame,
   count: requestedClients,
   statusBar,
   setPill: (state, text, detail) => pill.set({ state, text, detail }),
-  getSource: () => view.state.doc.toString(),
+  getProject: () => projectFiles(),
 });
 
 // The CLIENTS control only appears for multiplayer-structured samples (the
@@ -190,14 +198,27 @@ window.addEventListener("hashchange", () => {
     updateClientsStore();
   }
 });
-// The sandbox edits only the entry buffer, but some examples also load sibling
-// modules (for example the platformer's generated assets.fun manifest). Keep those
-// fetched sources so an external runtime receives the same complete project as
-// the in-page wasm preview.
-let siblingSources: [string, string][] = [];
+// The loaded example's whole file set, ENTRY FIRST — the paths are the ones the
+// built site serves, so `file = module` derives the same module names the
+// player used to get by fetching them. The editor's buffer is the entry's
+// source (the only file it edits for now); every push carries the rest
+// unchanged, so a multi-entry example's other roles keep resolving.
+let project: ProjectFile[] = [];
+// Binary assets stay a fetched, page-relative concern (see the header note);
+// they are only forwarded to an external runtime target, which has no site to
+// fetch them from.
 let assetSources: [string, Uint8Array][] = [];
 
-const bridge = new PlayerBridge(frame, {
+/** The file the editor is showing — the entry, until a file switcher lands. */
+const activePath = () => project[0]?.path ?? "";
+
+// Mirror the live buffer into the entry and hand back the file set to push.
+const projectFiles = (): ProjectFile[] => {
+  if (project[0]) project[0].source = view.state.doc.toString();
+  return project;
+};
+
+const bridge = new ProjectBridge(frame, {
   onReloading: () => setStatus("busy", "◌ reloading…"),
   onLive: () => {
     dismissBootLoader();
@@ -235,8 +256,16 @@ window.addEventListener("message", (event) => {
 
 // Created once, outside React: this controller carries the live link's queued
 // pushes and its `/state` poll chain, so a re-render must never restart it.
+// The external runtime target keeps its own FLAT naming: the entry is pushed as
+// `game.fun` and siblings by basename, as it was before the preview moved to the
+// multi-file seam (the device push has no site paths to mirror).
 const runtimeTarget = createRuntimeTargetCore({
-  getProject: () => [["game.fun", view.state.doc.toString()], ...siblingSources],
+  getProject: () =>
+    projectFiles().map((file, index): [string, string] => [
+      // Every path has at least one segment, so `pop` always yields one.
+      index === 0 ? "game.fun" : file.path.split("/").pop()!,
+      file.source,
+    ]),
   getAssets: () => assetSources,
   onOutput: (level, message) => statusBar.appendOutput(level, message),
 });
@@ -257,8 +286,9 @@ const view = new EditorView({
     synthwaveEditorTheme,
     EditorView.updateListener.of((update) => {
       if (update.docChanged && !programmaticEdit) {
-        bridge.push(view.state.doc.toString());
-        mp?.push(view.state.doc.toString());
+        const files = projectFiles();
+        bridge.setProject(files);
+        mp?.push(files);
         runtimeTarget.projectChanged();
       }
     }),
@@ -283,13 +313,17 @@ wireLiveTrace(view, statusBar, frame, langReady);
 // Each lint pass refreshes the Problems panel; clicking a problem jumps the
 // editor to it. Positions re-clamp at click time (the doc may have moved on).
 onDiagnostics((diags) => {
+  // The lint pass is of the file the editor is showing — name it, rather than
+  // asserting a `game.fun` no example is actually called (the IDE's rule, with
+  // the entry standing in for its `project.active`).
+  const file = activePath();
   statusBar.setProblems(
     diags.map((d) => {
       const line = view.state.doc.lineAt(Math.min(d.from, view.state.doc.length));
       return {
         severity: d.severity,
         message: d.message,
-        loc: `game.fun ${line.number}:${d.from - line.from + 1}`,
+        loc: `${file} ${line.number}:${d.from - line.from + 1}`,
         jump: () => {
           const len = view.state.doc.length;
           const from = Math.min(d.from, len);
@@ -313,20 +347,18 @@ onDiagnostics((diags) => {
   expects: () => currentExpects(view),
 };
 
-const setDoc = (
-  source: string,
-  siblings: [string, string][] = [],
-  assets: [string, Uint8Array][] = []
-) => {
+// Load a fresh file set (example switch, inline load, reset): `files[0]` is the
+// entry and becomes the editor's buffer.
+const setDoc = (files: ProjectFile[], assets: [string, Uint8Array][] = []) => {
   bridge.reset();
   mp?.reset();
   // Wholesale document replacement (example switch, inline load, reset): drop
   // the wasm completion cache so the previous program's candidates can't leak.
   resetIntel();
-  siblingSources = siblings;
+  project = files;
   assetSources = assets;
   programmaticEdit = true;
-  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: source } });
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: files[0].source } });
   programmaticEdit = false;
   // …and drop the outgoing program's decorations (the IDE's setDoc does the
   // same): if the incoming source doesn't analyze cleanly, the keep-stale
@@ -341,6 +373,29 @@ const fromBase64Url = (b64u: string) =>
   );
 
 let inlineB64: string | null = null;
+
+// An inline (#src=) program is a one-file project; `main.fun` is module `Main`,
+// which is what the old `?src=` data: URL boot derived for it.
+const INLINE_ENTRY = "main.fun";
+
+// The player iframe's boot params, common to every load:
+//   project=inline — the PAGE owns every source and delivers it by postMessage
+//     (project-bridge.ts); the player fetches no `.fun` at all;
+//   scrubber=hidden — the page's chrono bar is the transport UI, so the player
+//     mounts the __scrub seam with no bar of its own;
+//   net=embedder, UNCONDITIONALLY — this host always routes pane networking
+//     through its own coordinator (net-coordinator.ts) rather than letting a
+//     pane open browser sockets. A program that declares no `Sub.connect` /
+//     `Sub.listen` posts nothing, so the declaration costs it nothing.
+const playerParams = (
+  cursorPolicy: "visible" | null = pageCursorPolicy,
+  mouseCapture: false | null = pageMouseCapture
+) => {
+  const params = new URLSearchParams({ project: "inline", scrubber: "hidden", net: "embedder" });
+  if (mouseCapture === false) params.set("mouseCapture", "false");
+  if (cursorPolicy) params.set("cursor", cursorPolicy);
+  return params;
+};
 
 // A monotonically increasing load token: each picker change / reset / inline
 // load claims a new one, and a fetch that finishes after a newer load started
@@ -366,21 +421,13 @@ const loadInline = (b64u: string) => {
     selected: "__inline",
   });
   loadToken += 1; // supersede any in-flight example fetch
-  setDoc(source);
+  setDoc([{ path: INLINE_ENTRY, source }]);
   setStatus("busy", "◌ loading…");
-  // A fresh iframe on a `?src=` data: URL, so the inline program runs its OWN
-  // `init` (a set-source push would preserve the default entry's model). The
-  // loader derives module `Main` for a non-identifier entry label.
-  // scrubber=hidden: the page's chrono bar is the transport UI; the player
-  // mounts the __scrub seam with no bar of its own.
-  // net=embedder, UNCONDITIONALLY: this host always routes pane networking
-  // through its own coordinator (net-coordinator.ts) rather than letting a
-  // pane open browser sockets. A program that declares no `Sub.connect`/
-  // `Sub.listen` posts nothing, so the declaration costs it nothing.
-  const params = new URLSearchParams({ src: b64u, scrubber: "hidden", net: "embedder" });
-  if (pageMouseCapture === false) params.set("mouseCapture", "false");
-  if (pageCursorPolicy) params.set("cursor", pageCursorPolicy);
-  frame.src = `player.html?${params}`;
+  // A fresh iframe, booted BY the initial project push, so the inline program
+  // runs its OWN `init` (a hot-swap push would preserve the previous program's
+  // model). `main.fun` keeps the module the old `?src=` data: URL derived.
+  frame.src = `player.html?${playerParams()}`;
+  bridge.setProject(project);
   mp?.setSrc(frame.src);
   return true;
 };
@@ -415,28 +462,18 @@ const loadExample = async (id: string) => {
     ])
   );
   if (token !== loadToken) return;
-  const url = files[0];
-  const source = sources[0];
-  const siblings = files.slice(1).map((path, index): [string, string] => [
-    // Every path here has at least one segment, so `pop` always yields one.
-    path.split("/").pop()!,
-    sources[index + 1],
-  ]);
-  // A fresh iframe (fresh model: init runs) rather than a source push, so
-  // switching examples resets state; the ready announcement re-arms pushes.
-  setDoc(source, siblings, assets);
+  // A fresh iframe (fresh model: init runs) rather than a hot-swap push, so
+  // switching examples resets state; the project-waiting handshake boots it.
+  setDoc(
+    files.map((path, index): ProjectFile => ({ path, source: sources[index] })),
+    assets
+  );
   setStatus("busy", "◌ loading…");
-  // scrubber=hidden / net=embedder: as in loadInline above.
-  const params = new URLSearchParams({ game: url, scrubber: "hidden", net: "embedder" });
   const cursorPolicy = example?.cursor ?? pageCursorPolicy;
   const mouseCapture = cursorPolicy
     ? null
     : example?.mouseCapture ?? pageMouseCapture;
-  if (mouseCapture === false) params.set("mouseCapture", "false");
-  if (cursorPolicy) {
-    params.set("cursor", cursorPolicy);
-  }
-  for (const file of files) params.append("file", file);
+  const params = playerParams(cursorPolicy, mouseCapture);
   // A same-file-entries sample plays its declared role: in the preferred form
   // the role's inline module (e.g. orbs' Client.init/Client.tick/…)…
   if (example?.module) params.set("module", example.module);
@@ -444,19 +481,18 @@ const loadExample = async (id: string) => {
   // player takes one of the two.
   if (example?.prefix) params.set("prefix", example.prefix);
   frame.src = `player.html?${params}`;
+  bridge.setProject(project);
   // A sample with a SERVER role (examples.ts `server`) also boots a server
-  // pane: the SAME file list re-entered at the server file. `?file=` is the
-  // whole project with the ENTRY FIRST, so the two roles differ only in which
-  // module the runtime looks the entry points up in.
+  // pane: the SAME file set re-entered at the server file. The pushed project
+  // is entry-first, so the pane grid hoists that file to the front — the two
+  // roles differ only in their entry and (for a same-file sample) their module.
   const serverFile = example?.server?.file;
-  let serverSrc: string | null = null;
+  let server: PaneProgram | null = null;
   if (serverFile) {
     // Derived from the client's params, so every project setting the sample
     // declares (cursor, mouseCapture) reaches the server pane too — only the
-    // entry, the file ORDER, and the ROLE differ.
+    // entry and the ROLE differ.
     const serverParams = new URLSearchParams(params);
-    serverParams.set("game", serverFile);
-    serverParams.delete("file");
     // The client's ROLE must not leak into the server pane — neither form, so
     // both are dropped before the server's own is applied. A same-file sample
     // (orbs) has both roles in the one entry and differs only here; absent a
@@ -465,12 +501,9 @@ const loadExample = async (id: string) => {
     serverParams.delete("prefix");
     if (example?.server?.module) serverParams.set("module", example.server.module);
     if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
-    for (const file of [serverFile, ...files.filter((f) => f !== serverFile)]) {
-      serverParams.append("file", file);
-    }
-    serverSrc = `player.html?${serverParams}`;
+    server = { src: `player.html?${serverParams}`, entry: serverFile };
   }
-  mp?.setSrc(frame.src, serverSrc);
+  mp?.setSrc(frame.src, server);
 };
 
 const selectExample = (value: string) => {


### PR DESCRIPTION
Track A step 1 of the sandbox/IDE reconciliation: the sandbox now speaks the
**multi-file** editor↔player seam the IDE already uses, instead of pushing one
buffer over served files.

## What changed

- **`site/src/sandbox.tsx`** — the page now owns the loaded example's whole file
  set (`ProjectFile[]`, entry first, paths exactly as the built site serves
  them), boots the preview as **`player.html?project=inline`**, and pushes every
  edit as **`functor-lang-set-project`** through `ProjectBridge`. The editor
  still edits ONE buffer — the entry — which is mirrored into `files[0]` on each
  change. `?game=` / `?file=` are gone from the player URL; the initial project
  push *is* the boot (model preservation on later pushes is unchanged).
- **`site/src/mp-panes.ts`** — the pane grid moved to the same seam
  (`ProjectBridge` per pane). **The server pane now takes editor pushes**: a role
  is the file it is *entered at*, so the authority receives the same file set
  with its own file hoisted to the front (`serverFiles`). One edit hot-reloads
  every client *and* the authority, each with its own model preserved — the
  limitation the old comment at `mp-panes.ts:645` explicitly said needed
  `set-project`. `setSrc` now takes `{ src, entry }` for the server role instead
  of a URL that carried `?game=`/`?file=`; `push` takes files.
- **`site/src/project-bridge.ts`** — accepts the `signal` option (parity with
  `PlayerBridge`) so a disposable pane's listener detaches with it.
- **Problems panel** — rows use the real path of the file being edited
  (`activePath()`, mirroring the IDE's `project.active`) instead of a hardcoded
  `game.fun`.
- Preserved as-is: `?example=` deep links, `#src=` inline programs (a one-file
  project, entry `main.fun` → module `Main`, same as the old `?src=` data: URL),
  `#clients=N` live growth, roles via `?module=`/`?prefix=`, `?cursor=` /
  `?mouseCapture=`, scene picker + reset, and the external runtime target's flat
  push naming (`game.fun` + sibling basenames).

## Asset-resolution decision: nothing to change

The web runtime resolves an `Asset.*` locator as a **URL against `player.html`**,
not against the entry's directory — which is why `examples.ts` already copies
example assets to the **site root** (`ground.png`, `heightmap.png`, …). Asset
loading is therefore independent of how *sources* arrive, and `?project=inline`
needs no `?file=`/`?game=` companion for it. Verified empirically: every example
in the picker (including `platformer` with two local PNGs, `glove` with a checked-in
`.glb`, and `terrain`) passes the site e2e's per-example smoke test on the inline
path. Only `.fun` sources travel over the seam; binary assets keep being served
by the site (and, separately, uploaded to an external runtime target as before).

## Deliberately deferred

- **The file sidebar / file switcher** for the sandbox (next PR) — that is what
  makes `server.fun` and sibling modules editable, and what will converge the
  sandbox's implicit "active = entry" with the IDE's explicit `active`.
- **Sandbox language analysis is still single-buffer** (`setLangContext` remains
  IDE-only), so diagnostics for a multi-file example do not yet see its siblings.
  Unchanged by this PR; natural to fix alongside the switcher.
- Cross-file extraction opportunities the de-dup reviewer flagged (the
  status-bridge option block, the `onDiagnostics`→Problems mapping, and the
  `project=inline` param builder are now near-identical in `sandbox.tsx` and
  `ide.tsx`) — left alone here to keep the diff scoped; they are the natural
  cleanup once the switcher lands and the two pages' file models converge.

## Verification

```
npm run check:site          # tsc clean
npm run site:build          # ok
npm run test:site           # ALL CHECKS PASSED (e2e/site-sandbox.mjs — incl. every example's smoke test)
npm run test:sandbox-mp     # ALL CHECKS PASSED (e2e/sandbox-mp.mjs, + the new netpong case)
npm run test:runtime-target # ALL CHECKS PASSED (external-runtime pushes unchanged: "game.fun,assets.fun")
npm run test:net-coordinator# ALL CHECKS PASSED
npm run test:ide / test:ide-page / test:editor-keybindings # PASS
```

**e2e updates** (both because the seam changed, asserting the equivalent new behavior):

- `e2e/site-sandbox.mjs` — the Problems row now expects the loaded example's real
  entry path (`examples/hero.fun`) instead of `game.fun`.
- `e2e/site-sandbox.mjs` — **added** the in-place same-URL example switch check
  (see review finding 1 below).
- `e2e/sandbox-mp.mjs` — the pane-role assertion no longer reads `?game=`; it
  asserts every pane boots `project=inline` with no `?game=`/`?file=` (roles still
  asserted via `?module=`). **Added claim 11**: netpong (roles as separate FILES)
  in the sandbox — one edit produces a `model preserved` reload line for
  `[client 1]`, `[client 2]` **and** `[server]`, the authority reloading at
  `examples/netpong/server.fun`, i.e. the new capability is now covered by a test.

**Manual headless checks** (scratch script, not committed):

1. single-file example (`orbit`) boots `?project=inline` and an edit reports
   `reloaded examples/orbit.fun (1 file(s)) from pushed project … (model preserved)`;
2. `netpong#clients=2` runs client/client/server, and one edit hot-reloads all
   three (`[server] … reloaded examples/netpong/server.fun (4 file(s)) … model preserved`),
   no console errors;
3. `#src=<base64url>` still lands in the editor, flips the picker to “docs
   snippet”, and renders (center pixel `rgb(255,51,153)`).

**Pre-existing failure, unrelated:** `npm run test:detached-camera` times out at
`e2e/detached-camera.mjs:692` — reproduced identically on `main` (stashed
changes, rebuilt, same failure), so it is not caused by this change.

## Review dispositions

`/xreview` — Claude subagent + Codex CLI + a dedicated de-dup pass. Codex: *"clean
within the requested scope … ship as-is."* The Claude reviewer's findings, all
dispositioned (everything below was applied and the suites re-run):

| # | Finding | Disposition |
| --- | --- | --- |
| 1 | Every example now boots an *identical* player URL, so an in-place switch relies on same-URL `iframe.src` reassignment navigating — and no e2e covered it | **Verified empirically** rather than papered over with a cache-busting param: the switch does replace the document (marked the live document, switched hero→orbit, the mark is gone and `examples/orbit.fun` loads live). Added that as a committed check in `e2e/site-sandbox.mjs` ("an in-place switch between same-URL examples reboots the player") so the assumption is now pinned |
| 2 | `serverFiles` silently fell back to the CLIENT entry when the declared server file isn't in the pushed set — a second client booting as the authority, where the fetch path used to 404 loudly | **Fixed**: `console.error` naming the missing file (`mp-panes.ts`) |
| 3 | `setProject([])` passed `#send`'s `!this.files` guard, and an empty push is reported "live now, error in 4s" | **Fixed**: guard on `!this.files?.length` |
| 4 | Dropping the `pushCurrent` flag made the module-init mirror loop call `getProject()` — a latent TDZ dereference in the sandbox, surviving only because `#player` has no `src` attribute | **Fixed**: the flag is back as `addMirror(bootProgram)`, false for the boot loop (the following `setSrc` arms every mirror), true mid-session |
| 5 | The boot push called `onReloading()`, so the pill said "◌ reloading…" for a program that had never run | **Fixed** in `ProjectBridge` (a per-document `booted` flag) — this restores the old `PlayerBridge` wording and fixes the IDE the same way |
| 6/7 | `mp.reset()` reset only the mirror bridges, not the authority's | **Fixed** by making it symmetric (kept rather than deleted: it is the defensive half of `setDoc`) |
| 8 | `mountServer` re-called `getProject()` although `setSrc` had just computed the files | **Fixed**: files passed in |
| 9 | The sandbox re-declared `{ src, entry }` inline instead of importing the new `PaneProgram` | **Fixed** |
| 10 | Stale comments in `site/player.html` and `runtime/functor-runtime-web/src/lib.rs` still called set-project "the IDE's" and set-source "the sandbox's" | **Fixed** (comments only; `cargo check -p functor-runtime-web` clean) |
| 11 | The Problems label now names the real project path while analysis is still single-buffer (`setLangContext` is IDE-only) | **Deferred, noted above** — it belongs with the file switcher |
| 12 | Pre-existing: the external-runtime push renames the entry to `game.fun`, so netpong pushes two `game.fun` files | **Out of scope** — byte-identical to `main`'s behavior |

De-dup pass: one newly-introduced item, applied — the buffer→entry mirror existed
twice in `sandbox.tsx`, so `runtimeTarget.getProject` now maps `projectFiles()`
instead of re-reading the doc itself. Its other findings are the cross-file
extractions listed under "deferred" (pre-existing near-clones with `ide.tsx` that
this diff made exact).

No visual change, so no GIF.
