### PR TITLE
fix(ci): clean up PR preview certificates reliably

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,10 @@ Cloudflare deployment-control files. On close,
 `.github/workflows/pr-preview-cleanup.yml` detaches the domain and deletes the
 temporary Worker. A domain or Worker cleanup failure fails the job and marks the
 sticky PR comment with a warning; certificate cleanup is non-quota-critical and
-warns without failing the otherwise successful cleanup.
+warns without failing the otherwise successful cleanup. It resolves the
+certificate pack from Cloudflare's exact domain certificate ID, with bounded
+inventory retries, before detaching the domain; it never deletes a certificate
+using only a hostname match.
 
 These event workflows must already exist on the default branch, so the PR that
 introduces them cannot preview itself. After rollout, push a new commit to an

--- a/scripts/pr-preview.mjs
+++ b/scripts/pr-preview.mjs
@@ -35,6 +35,7 @@ const MAX_ASSET_BYTES = 25 * 1024 * 1024;
 const MAX_ASSET_TOTAL_BYTES = 100 * 1024 * 1024;
 const MAX_ARTIFACT_ARCHIVE_BYTES = 50 * 1024 * 1024;
 const FORBIDDEN_ASSET_FILES = new Set([".assetsignore", "_headers", "_redirects"]);
+const CERTIFICATE_PACK_LOOKUP_DELAYS_MS = [0, 1_000, 3_000, 7_000];
 
 const [, , command, ...rawArgs] = process.argv;
 
@@ -394,30 +395,50 @@ const packOnlyCovers = (pack, hostname) => {
   return hosts.length > 0 && hosts.every((host) => host === hostname);
 };
 
-const cleanupCertificate = async (domain) => {
-  if (!domain.zone_id || !domain.cert_id) return;
-  try {
-    const packs = (await listCertificatePacks(domain.zone_id)).filter(
-      (pack) => !["deleted", "pending_deletion"].includes(pack.status),
-    );
-    const domainCertificateId = String(domain.cert_id).replaceAll("-", "").toLowerCase();
-    const candidates = packs.filter((pack) =>
-      pack.certificates?.some(
-        (certificate) =>
-          String(certificate.id).replaceAll("-", "").toLowerCase() === domainCertificateId,
-      ),
-    );
-    // Never substitute a hostname-only guess: certificate cleanup is optional,
-    // and an exact ID miss is safer to leave for inventory review than delete.
-    if (candidates.length !== 1 || !packOnlyCovers(candidates[0], domain.hostname)) {
-      console.warn(
-        `Could not safely identify the generated certificate for ${domain.hostname}; ` +
-          "leaving it for manual review",
+const normalizeCloudflareId = (value) => String(value).replaceAll("-", "").toLowerCase();
+
+const resolveCertificatePack = async (domain) => {
+  if (!domain.zone_id || !domain.cert_id) return null;
+  const domainCertificateId = normalizeCloudflareId(domain.cert_id);
+  let lastInventoryError = null;
+  for (const delay of CERTIFICATE_PACK_LOOKUP_DELAYS_MS) {
+    if (delay > 0) await new Promise((resolveDelay) => setTimeout(resolveDelay, delay));
+    try {
+      const packs = await listCertificatePacks(domain.zone_id);
+      lastInventoryError = null;
+      const candidates = packs.filter(
+        (pack) =>
+          !["deleted", "pending_deletion"].includes(pack.status) &&
+          pack.certificates?.some(
+            (certificate) => normalizeCloudflareId(certificate.id) === domainCertificateId,
+          ),
       );
-      return;
+      if (candidates.length === 1 && packOnlyCovers(candidates[0], domain.hostname)) {
+        return candidates[0];
+      }
+    } catch (error) {
+      lastInventoryError = error;
     }
+  }
+  if (lastInventoryError) {
+    console.warn(
+      `Certificate inventory warning after retries: ${safeLog(lastInventoryError.message)}`,
+    );
+  }
+  // Never substitute a hostname-only guess: certificate cleanup is optional,
+  // and an exact ID miss is safer to leave for inventory review than delete.
+  console.warn(
+    `Could not safely identify the generated certificate for ${domain.hostname}; ` +
+      "leaving it for manual review",
+  );
+  return null;
+};
+
+const cleanupCertificate = async (domain, pack) => {
+  if (!pack) return;
+  try {
     await cloudflareRequest(
-      `/zones/${domain.zone_id}/ssl/certificate_packs/${candidates[0].id}`,
+      `/zones/${domain.zone_id}/ssl/certificate_packs/${pack.id}`,
       { method: "DELETE" },
       { allowNotFound: true },
     );
@@ -449,13 +470,17 @@ const cleanup = async () => {
       failures.push(`${target.hostname} belongs to unexpected Worker ${domain.service}`);
       continue;
     }
+    // Resolve the generated certificate while Cloudflare still exposes its
+    // Custom Domain record. Detaching first made the certificate-pack lookup
+    // race the provider's eventually consistent inventory.
+    const certificatePack = await resolveCertificatePack(domain);
     try {
       await cloudflareRequest(
         `/accounts/${account}/workers/domains/${domain.id}`,
         { method: "DELETE" },
         { allowNotFound: true },
       );
-      detached.push(domain);
+      detached.push({ domain, certificatePack });
       console.log(`Detached ${target.hostname}`);
     } catch (error) {
       failures.push(`detach domain: ${error.message}`);
@@ -479,7 +504,9 @@ const cleanup = async () => {
     failures.push(`delete Worker: ${error.message}`);
   }
 
-  for (const domain of detached) await cleanupCertificate(domain);
+  for (const { domain, certificatePack } of detached) {
+    await cleanupCertificate(domain, certificatePack);
+  }
 
   if (failures.length > 0) {
     throw new Error(`preview cleanup incomplete: ${failures.map(safeLog).join("; ")}`);

--- a/scripts/pr-preview.test.mjs
+++ b/scripts/pr-preview.test.mjs
@@ -118,7 +118,13 @@ const writeGitHubStub = async (
 
 const writeCloudflareStub = async (
   t,
-  { failDomainList = false, failDomainDetach = false, foreignDomain = false } = {},
+  {
+    certificateInventoryFailures = 0,
+    certificateInventoryMisses = 0,
+    failDomainList = false,
+    failDomainDetach = false,
+    foreignDomain = false,
+  } = {},
 ) => {
   const root = await temporaryDirectory(t, "functor-pr-preview-cloudflare-");
   const stub = join(root, "fetch-stub.mjs");
@@ -131,6 +137,10 @@ const writeCloudflareStub = async (
       `const failDomainList = ${JSON.stringify(failDomainList)};\n` +
       `const failDomainDetach = ${JSON.stringify(failDomainDetach)};\n` +
       `const foreignDomain = ${JSON.stringify(foreignDomain)};\n` +
+      `const certificateInventoryFailures = ${JSON.stringify(certificateInventoryFailures)};\n` +
+      `const certificateInventoryMisses = ${JSON.stringify(certificateInventoryMisses)};\n` +
+      `let certificateInventoryRequests = 0;\n` +
+      `globalThis.setTimeout = (callback) => { callback(); return 0; };\n` +
       `const json = (body, status = 200) => new Response(JSON.stringify(body), {\n` +
       `  status, headers: { "Content-Type": "application/json" },\n` +
       `});\n` +
@@ -148,6 +158,13 @@ const writeCloudflareStub = async (
       `    }] });\n` +
       `  }\n` +
       `  if (method === "GET" && url.pathname.endsWith("/ssl/certificate_packs")) {\n` +
+      `    certificateInventoryRequests += 1;\n` +
+      `    if (certificateInventoryRequests <= certificateInventoryFailures) {\n` +
+      `      return json({ success: false, errors: [{ message: "temporarily unavailable" }] }, 503);\n` +
+      `    }\n` +
+      `    if (certificateInventoryRequests <= certificateInventoryFailures + certificateInventoryMisses) {\n` +
+      `      return json({ success: true, result: [], result_info: { total_pages: 1 } });\n` +
+      `    }\n` +
       `    return json({ success: true, result: [{\n` +
       `      id: ${JSON.stringify(certificatePackId)}, status: "active",\n` +
       `      hosts: [${JSON.stringify(previewHostname)}],\n` +
@@ -464,11 +481,81 @@ test("cleans up the exact certificate despite Cloudflare's ID formatting", async
   const { log, stub } = await writeCloudflareStub(t);
   const result = await runCleanup(stub);
   assert.equal(result.code, 0, result.stderr);
-  const requests = await readFile(log, "utf8");
+  const requests = (await readFile(log, "utf8")).trim().split("\n").map(JSON.parse);
+  const inventoryIndex = requests.findIndex(
+    (request) => request.method === "GET" && request.path.includes("/ssl/certificate_packs?"),
+  );
+  const detachIndex = requests.findIndex(
+    (request) => request.method === "DELETE" && request.path.endsWith("/workers/domains/domain-id"),
+  );
+  const certificateDeleteIndex = requests.findIndex(
+    (request) => request.method === "DELETE" &&
+      request.path === `/client/v4/zones/${zoneId}/ssl/certificate_packs/${certificatePackId}`,
+  );
+  assert.ok(inventoryIndex >= 0 && inventoryIndex < detachIndex);
+  assert.ok(detachIndex < certificateDeleteIndex);
+});
+
+test("retries exact certificate inventory before detaching the domain", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t, { certificateInventoryMisses: 2 });
+  const result = await runCleanup(stub);
+  assert.equal(result.code, 0, result.stderr);
+  const requests = (await readFile(log, "utf8")).trim().split("\n").map(JSON.parse);
+  const inventoryIndexes = requests.flatMap((request, index) =>
+    request.method === "GET" && request.path.includes("/ssl/certificate_packs?") ? [index] : [],
+  );
+  const detachIndex = requests.findIndex(
+    (request) => request.method === "DELETE" && request.path.endsWith("/workers/domains/domain-id"),
+  );
+  assert.equal(inventoryIndexes.length, 3);
+  assert.ok(inventoryIndexes.every((index) => index < detachIndex));
   assert.match(
-    requests,
+    await readFile(log, "utf8"),
     new RegExp(`"method":"DELETE","path":"/client/v4/zones/${zoneId}/ssl/certificate_packs/${certificatePackId}"`),
   );
+});
+
+test("retries a transient certificate inventory error before detaching", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t, { certificateInventoryFailures: 1 });
+  const result = await runCleanup(stub);
+  assert.equal(result.code, 0, result.stderr);
+  const requests = (await readFile(log, "utf8")).trim().split("\n").map(JSON.parse);
+  const inventoryIndexes = requests.flatMap((request, index) =>
+    request.method === "GET" && request.path.includes("/ssl/certificate_packs?") ? [index] : [],
+  );
+  const detachIndex = requests.findIndex(
+    (request) => request.method === "DELETE" && request.path.endsWith("/workers/domains/domain-id"),
+  );
+  assert.equal(inventoryIndexes.length, 2);
+  assert.ok(inventoryIndexes.every((index) => index < detachIndex));
+  assert.match(
+    await readFile(log, "utf8"),
+    new RegExp(`"method":"DELETE","path":"/client/v4/zones/${zoneId}/ssl/certificate_packs/${certificatePackId}"`),
+  );
+});
+
+test("does not guess a certificate pack when the exact ID stays unavailable", async (t) => {
+  const { log, stub } = await writeCloudflareStub(t, { certificateInventoryMisses: 99 });
+  const result = await runCleanup(stub);
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stderr, /leaving it for manual review/);
+  const requests = await readFile(log, "utf8");
+  assert.match(requests, /"method":"DELETE","path":"\/client\/v4\/accounts\//);
+  assert.doesNotMatch(
+    requests,
+    new RegExp(`"method":"DELETE","path":"/client/v4/zones/${zoneId}/ssl/certificate_packs/`),
+  );
+});
+
+test("does not report a recovered inventory error as the final outcome", async (t) => {
+  const { stub } = await writeCloudflareStub(t, {
+    certificateInventoryFailures: 1,
+    certificateInventoryMisses: 99,
+  });
+  const result = await runCleanup(stub);
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stderr, /leaving it for manual review/);
+  assert.doesNotMatch(result.stderr, /inventory warning after retries/i);
 });
 
 test("refuses to replace a preview domain owned by another Worker", async (t) => {
@@ -495,5 +582,10 @@ test("does not delete the Worker when domain detach fails", async (t) => {
   const result = await runCleanup(stub);
   assert.notEqual(result.code, 0);
   assert.match(result.stderr, /preview cleanup incomplete: detach domain/);
-  assert.doesNotMatch(await readFile(log, "utf8"), /workers\/scripts\/functor-pr-690/);
+  const requests = await readFile(log, "utf8");
+  assert.doesNotMatch(requests, /workers\/scripts\/functor-pr-690/);
+  assert.doesNotMatch(
+    requests,
+    new RegExp(`"method":"DELETE","path":"/client/v4/zones/${zoneId}/ssl/certificate_packs/`),
+  );
 });


### PR DESCRIPTION
## Summary

- resolve a preview domain's certificate pack from Cloudflare's exact `cert_id` before detaching the Custom Domain
- retry bounded certificate-inventory misses and transient API failures, while retaining the exact pack identity across domain and Worker cleanup
- delete only the uniquely matched, preview-host-only certificate pack; never fall back to a hostname-only deletion
- document the cleanup invariant and add focused ordering, retry, failure, and no-guess regression coverage

## Why

The PR #700 smoke test successfully detached its domain and deleted its Worker, but certificate cleanup could no longer identify the generated certificate after detachment. Cloudflare documents `cert_id` on the Custom Domain record as the certificate identifier, while deleting a Custom Domain does not automatically remove its Advanced Certificate. This change captures that identity while the domain record still exists and preserves certificate deletion as best-effort/non-quota-critical.

References: [Workers Custom Domains](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/), [Workers Domains API](https://developers.cloudflare.com/api/resources/workers/subresources/domains/), [Certificate Packs API](https://developers.cloudflare.com/api/resources/ssl/subresources/certificate_packs/methods/list/)

## Verification

- `npm run test:pr-preview` — 32/32 passing
- `node --check scripts/pr-preview.mjs`
- `node --check scripts/pr-preview.test.mjs`
- `git diff --check`
- duplication review — no actionable duplication
- xreview — Codex found no actionable issue; Claude's transient-error retry finding was fixed and regression-tested

## Review dispositions

- Fixed: transient Cloudflare inventory errors now remain inside the bounded retry loop.
- Fixed: a recovered API error is cleared so it is not misreported as the final inventory outcome.
- Kept intentionally: successful inventory misses use the same bounded retry window. The certificate inventory is eventually consistent, and this one-time teardown can safely spend up to 11 seconds to avoid leaving certificate inventory behind.
- Not applicable: no visible site output changes, so visual captures are unnecessary.
