### PR TITLE
feat(ui): Frame.withUiTarget — egui views on render targets

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1462,6 +1462,13 @@ let soundScape = (model) => AudioScene.create([source, …])  // OPTIONAL; conti
                                             // frame (needs no `update`)
 ```
 
+**UI on world screens**: `frame |> Frame.withUiTarget(target, view)` paints a
+`Ui.*` tree into a render target (declared once with
+`RenderTarget.named("id") |> RenderTarget.sized(w, h)`) before the main pass;
+read it back with `Scene.quad() |> Scene.screen(target)` — a monitor mesh, a
+cockpit panel. Display-only for now: interactive widgets render, but their
+handlers are ignored (a one-time warning says so).
+
 The three mouse hooks receive captured shell input by default. Set
 `"mouseCapture":false` to disable that path, or use `"cursor":"visible"` for
 absolute pointer input (which also disables capture). Programs without

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1467,7 +1467,8 @@ let soundScape = (model) => AudioScene.create([source, …])  // OPTIONAL; conti
 `RenderTarget.named("id") |> RenderTarget.sized(w, h)`) before the main pass;
 read it back with `Scene.quad() |> Scene.screen(target)` — a monitor mesh, a
 cockpit panel. Display-only for now: interactive widgets render, but their
-handlers are ignored (a one-time warning says so).
+handlers are ignored (a one-time warning says so). Native + web; the VR
+runtime doesn't paint ui targets yet (fallback texture + warning there).
 
 The three mouse hooks receive captured shell input by default. Set
 `"mouseCapture":false` to disable that path, or use `"cursor":"visible"` for

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1467,8 +1467,8 @@ let soundScape = (model) => AudioScene.create([source, …])  // OPTIONAL; conti
 `RenderTarget.named("id") |> RenderTarget.sized(w, h)`) before the main pass;
 read it back with `Scene.quad() |> Scene.screen(target)` — a monitor mesh, a
 cockpit panel. Display-only for now: interactive widgets render, but their
-handlers are ignored (a one-time warning says so). Native + web; the VR
-runtime doesn't paint ui targets yet (fallback texture + warning there).
+handlers are ignored (a one-time warning says so). Runs on every shell —
+native, web, and VR.
 
 The three mouse hooks receive captured shell input by default. Set
 `"mouseCapture":false` to disable that path, or use `"cursor":"visible"` for

--- a/examples/monitor-ui/functor.json
+++ b/examples/monitor-ui/functor.json
@@ -1,0 +1,4 @@
+{
+  "language": "functor-lang",
+  "entry": "game.fun"
+}

--- a/examples/monitor-ui/game.fun
+++ b/examples/monitor-ui/game.fun
@@ -1,0 +1,72 @@
+// examples/monitor-ui — UI on a render target (the scoreboard demo).
+//
+// A Ui.* tree renders into the "scoreboard" render target each frame
+// (Frame.withUiTarget), and a monitor mesh in the world shows it live
+// (Scene.screen) — a world-space screen driven by the model. The view is
+// display-only: buttons/sliders on a target render but their handlers are
+// inert. All animation derives from tts, so captures are deterministic
+// under --fixed-time.
+
+// The branded target: declared ONCE, used at the writer (draw's
+// Frame.withUiTarget) and the reader (the monitor's Scene.screen).
+let board = RenderTarget.named("scoreboard") |> RenderTarget.sized(512.0, 256.0)
+
+// The scoreboard content — an ordinary Ui view, laid out by the same egui
+// pass as the `ui` hook, but sized to the TARGET (512x256), not the window.
+let scoreboard = (score: float, tts: float) =>
+  Ui.column([
+    Ui.textColor(Color.rgb(0.3, 1.0, 0.9), "== ARENA SCOREBOARD =="),
+    Ui.text(""),
+    Ui.row([Ui.text("home"), Ui.textColor(Color.rgb(1.0, 0.8, 0.2), $"  {score}")]),
+    Ui.row([Ui.text("away"), Ui.textColor(Color.rgb(1.0, 0.4, 0.4), $"  {Math.floor(score / 2.0)}")]),
+    Ui.text(""),
+    Ui.text($"match clock {Math.floor(tts)}s"),
+  ])
+
+// A little arena for the monitor to overlook.
+let arena = (tts: float) =>
+  Scene.group([
+    Scene.plane() |> Scene.scale(18.0) |> Scene.lit(Color.rgb(0.5, 0.55, 0.5)),
+    Scene.sphere()
+      |> Scene.scale(0.5)
+      |> Scene.emissive(Color.rgb(1.0, 0.55, 0.15))
+      |> Scene.translate(Vec3.make(Math.cos(tts) * 2.5, 0.5, 2.0 + Math.sin(tts) * 1.5)),
+    Scene.cube() |> Scene.lit(Color.rgb(0.3, 0.5, 0.9)) |> Scene.translate(Vec3.make(-2.5, 0.5, 2.5)),
+  ])
+
+// The monitor: a dark bezel block with the screen on its camera-facing side.
+// A quad's front is +Z and the main camera looks down +Z, so the screen is
+// rotated 180° to face the viewer. The screen is 2:1, matching the target.
+let monitor = () =>
+  Scene.group([
+    Scene.cube() |> Scene.scaleXYZ(4.6, 2.5, 0.4) |> Scene.lit(Color.rgb(0.08, 0.08, 0.09)),
+    Scene.quad()
+      |> Scene.screen(board)
+      |> Scene.rotateY(Angle.degrees(180.0))
+      |> Scene.scaleXYZ(4.2, 2.1, 1.0)
+      |> Scene.translate(Vec3.make(0.0, 0.0, -0.25)),
+  ])
+    |> Scene.translate(Vec3.make(0.0, 2.6, 2.0))
+
+let lights = () => [
+  Light.ambient(Color.rgb(0.15, 0.15, 0.18)),
+  Light.directional(Vec3.make(0.4, -1.0, 0.3), Color.rgb(1.0, 0.97, 0.9), 0.9) |> Light.castShadows,
+]
+
+let init = { score: 0.0 }
+
+// The home side scores every 4 seconds of match time — the screen is a pure
+// function of the model, so it rewinds with the scrubber like everything else.
+let tick = (m, dt, tts: float) => { score: Math.floor(tts / 4.0) }
+
+let draw = (m, tts: float) =>
+  Frame.createLit(
+    Camera3D.lookAt(Vec3.make(0.0, 3.0, -8.5), Vec3.make(0.0, 1.8, 0.0)),
+    Scene.group([arena(tts), monitor()]),
+    lights())
+  |> Frame.withUiTarget(board, scoreboard(m.score, tts))
+
+expect (
+  let frame = draw(init, 0.0) in
+  Frame.equals(frame, draw(init, 0.0))
+)

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -22,7 +22,12 @@ let withRenderTarget : (RenderTarget.t, t, t) => t
 /// back like any render target (`Scene.quad() |> Scene.screen(target)`) — a
 /// monitor mesh, a cockpit panel. Views on targets are display-only for now:
 /// interactive widgets (buttons, sliders, text inputs) render, but their
-/// handlers are ignored. The main frame is last for piping.
+/// handlers are ignored. The screen clears to the engine's default
+/// background. Like `withRenderTarget`, the FIRST declaration of a target id
+/// wins; one id must not be declared by both writers. Supported on native
+/// and web; the VR runtime does not paint ui targets yet (screens show the
+/// fallback texture there, with a warning). The main frame is last for
+/// piping.
 let withUiTarget : (RenderTarget.t, Ui.view, t) => t
 /// Attach fog to a frame; the frame is last for piping.
 let withFog : (Fog.t, t) => t

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -24,10 +24,8 @@ let withRenderTarget : (RenderTarget.t, t, t) => t
 /// interactive widgets (buttons, sliders, text inputs) render, but their
 /// handlers are ignored. The screen clears to the engine's default
 /// background. Like `withRenderTarget`, the FIRST declaration of a target id
-/// wins; one id must not be declared by both writers. Supported on native
-/// and web; the VR runtime does not paint ui targets yet (screens show the
-/// fallback texture there, with a warning). The main frame is last for
-/// piping.
+/// wins; one id must not be declared by both writers. Runs on every shell —
+/// native, web, and VR. The main frame is last for piping.
 let withUiTarget : (RenderTarget.t, Ui.view, t) => t
 /// Attach fog to a frame; the frame is last for piping.
 let withFog : (Fog.t, t) => t

--- a/functor-prelude/prelude/frame.funi
+++ b/functor-prelude/prelude/frame.funi
@@ -16,6 +16,14 @@ let create2D : (Camera2D.t, Sprite.t) => t
 /// `Light.castShadows` there. A scene that samples the very target it is drawn
 /// into sees the previous frame's image. The main frame is last for piping.
 let withRenderTarget : (RenderTarget.t, t, t) => t
+/// Paint a UI view into a target before rendering the main frame.
+///
+/// The view is a `Ui.*` tree painted at the target's declared size and read
+/// back like any render target (`Scene.quad() |> Scene.screen(target)`) — a
+/// monitor mesh, a cockpit panel. Views on targets are display-only for now:
+/// interactive widgets (buttons, sliders, text inputs) render, but their
+/// handlers are ignored. The main frame is last for piping.
+let withUiTarget : (RenderTarget.t, Ui.view, t) => t
 /// Attach fog to a frame; the frame is last for piping.
 let withFog : (Fog.t, t) => t
 /// Attach a cubemap skybox to a frame; the frame is last for piping.

--- a/runtime/functor-runtime-common/src/frame.rs
+++ b/runtime/functor-runtime-common/src/frame.rs
@@ -2,8 +2,8 @@ use cgmath::{Matrix4, SquareMatrix};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    fog::Fog, render_target::RenderTargetDescriptor, skybox::SkyboxDescription, Camera, Light,
-    Scene3D, SceneObject, SpriteLayer,
+    fog::Fog, render_target::RenderTargetDescriptor, skybox::SkyboxDescription, ui::View, Camera,
+    Light, Scene3D, SceneObject, SpriteLayer,
 };
 
 fn is_false(value: &bool) -> bool {
@@ -19,12 +19,23 @@ pub struct RenderTargetPass {
     pub frame: Frame,
 }
 
+/// A named UI pass: `view` (a `Ui.*` tree) is painted into `target`'s texture
+/// before the owning frame's main pass, and sampled via `Scene.screen` like
+/// any render target. Display-only for now: interactive widgets render in
+/// their resting state and their handlers are inert.
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct UiTargetPass {
+    pub target: RenderTargetDescriptor,
+    pub view: View,
+}
+
 /// What a game's `draw` returns each frame: a 3D pass plus any ordered 2D
 /// sprite layers. Intentionally a growable record (post-processing etc. can be
 /// added later) so the render boundary signature doesn't churn.
 ///
 /// `PartialEq` is the structural walk behind `Frame.equals`: every field —
-/// camera, scene, lights (ordered), render-target passes (ordered), fog,
+/// camera, scene, lights (ordered), render-target passes (ordered), ui-target
+/// passes (ordered), fog,
 /// skybox, clear color, 2D layers (ordered), and the `pure_2d` marker. It
 /// inherits [`Scene3D`]'s rules: floats compare exactly, assets compare by
 /// locator, and animation compares as declared.
@@ -38,6 +49,11 @@ pub struct Frame {
     /// targets inside a target's own frame are ignored (depth 1 for now).
     #[serde(default)]
     pub render_targets: Vec<RenderTargetPass>,
+    /// UI views painted into render targets (in order) before the main pass
+    /// (`Frame.withUiTarget`). Skipped when empty so older wire frames — and
+    /// frames that never use the feature — serialize unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ui_targets: Vec<UiTargetPass>,
     /// Frame-level distance fog; its color also drives the pass's clear color.
     #[serde(default)]
     pub fog: Option<Fog>,
@@ -69,6 +85,7 @@ impl Frame {
             scene,
             lights: vec![],
             render_targets: vec![],
+            ui_targets: vec![],
             fog: None,
             skybox: None,
             clear_color: None,
@@ -116,6 +133,15 @@ impl Frame {
             target,
             frame: target_frame,
         });
+        frame
+    }
+
+    /// Paint `view` (a `Ui.*` tree) into `target` each frame, before this
+    /// frame's main pass, at the target's declared size. Subject-first so it
+    /// pipes (`frame |> Frame.withUiTarget(…)`); declaration order is paint
+    /// order, so a later write to the same id wins.
+    pub fn with_ui_target(mut frame: Frame, target: RenderTargetDescriptor, view: View) -> Frame {
+        frame.ui_targets.push(UiTargetPass { target, view });
         frame
     }
 

--- a/runtime/functor-runtime-common/src/frame.rs
+++ b/runtime/functor-runtime-common/src/frame.rs
@@ -139,7 +139,8 @@ impl Frame {
     /// Paint `view` (a `Ui.*` tree) into `target` each frame, before this
     /// frame's main pass, at the target's declared size. Subject-first so it
     /// pipes (`frame |> Frame.withUiTarget(…)`); declaration order is paint
-    /// order, so a later write to the same id wins.
+    /// order, and — matching `withRenderTarget` — the FIRST declaration of an
+    /// id wins (duplicates warn once and are skipped).
     pub fn with_ui_target(mut frame: Frame, target: RenderTargetDescriptor, view: View) -> Frame {
         frame.ui_targets.push(UiTargetPass { target, view });
         frame
@@ -201,11 +202,7 @@ mod tests {
             obj: SceneObject::Group(vec![]),
             xform: Matrix4::identity(),
         };
-        assert!(!Frame::with_2d(
-            Frame::new(Camera::default(), empty_3d),
-            layer
-        )
-        .is_pure_2d());
+        assert!(!Frame::with_2d(Frame::new(Camera::default(), empty_3d), layer).is_pure_2d());
     }
 
     #[test]

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -27,8 +27,8 @@ use functor_lang::{Session, Value};
 
 use crate::functor_lang_prelude::{
     audio_scene_of, clear_audio_completions, clear_http_taggers, clear_preload_completions,
-    frame_value, html_node_value, now_ms, take_ui_handlers, view_value, EffectLog,
-    EffectRunner, EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
+    frame_value, html_node_value, now_ms, take_ui_handlers, view_value, EffectLog, EffectRunner,
+    EffectTree, FunctorHost, NetEventKind, RealEffects, UiHandler,
 };
 use crate::functor_lang_producer::{
     journal_arm, journal_swap, rebase_connect_retry_deadlines, validate_contract,
@@ -1006,16 +1006,11 @@ impl GameProducer for FunctorLangEmbeddedGame {
                 self.reporter.report_once(rendered);
             }
         }
-        // Handlers registered during the `draw` eval (interactive widgets in
-        // `Frame.withUiTarget` trees) are display-only for now: drop them so
-        // they neither accumulate across frames nor pollute the `ui`/`webview`
-        // tables adopted below.
-        if !take_ui_handlers().is_empty() {
-            self.reporter.report_once(
-                "[functor-lang] interactive Ui widgets in a draw-eval tree (e.g. \
-Frame.withUiTarget) are display-only for now; their handlers are ignored"
-                    .to_string(),
-            );
+        // Draw-eval handlers are display-only: drop them so they neither
+        // accumulate across frames nor pollute the ui/webview tables below.
+        if crate::functor_lang_prelude::drop_draw_eval_ui_handlers() {
+            self.reporter
+                .report_once(crate::functor_lang_prelude::DRAW_EVAL_HANDLERS_WARNING.to_string());
         }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `ui()` is a `&self` accessor, and errors need `&mut`
@@ -1263,6 +1258,39 @@ let draw = (model, tts) =>
         FrameTime { tts, dts }
     }
 
+    // The draw-eval drain: a `Frame.withUiTarget` button's handler must never
+    // reach the `ui` hook's adopted table — otherwise every HUD slot shifts
+    // and clicks resolve against the wrong handlers.
+    #[test]
+    fn draw_eval_ui_target_handlers_never_reach_the_ui_table() {
+        const SRC: &str = r#"
+let hud = RenderTarget.named("hud")
+type Msg = | FromScreen | FromHud
+let init = { n: 0.0 }
+let tick = (model, dt, tts) => model
+let update = (model, msg) => model
+let draw = (model, tts) =>
+  Frame.create(
+    Camera3D.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),
+    Scene.quad() |> Scene.screen(hud))
+  |> Frame.withUiTarget(hud, Ui.button("screen", FromScreen))
+let ui = (model) => Ui.button("hud", FromHud)
+"#;
+        let mut game = FunctorLangEmbeddedGame::create(
+            vec![("game.fun".to_string(), SRC.to_string())],
+            Box::new(NativePlatform),
+        )
+        .expect("boot scene loads");
+        let ft = frame_time(0.016, 0.016);
+        game.tick(ft.clone());
+        let frame = game.render(ft);
+        assert_eq!(frame.ui_targets.len(), 1);
+        // The adopted table holds ONLY the ui hook's button, and the view's
+        // slot numbering starts at 0 — the draw eval's handler was dropped.
+        assert_eq!(game.ui_handlers.len(), 1);
+        assert!(matches!(game.ui(), View::Button { slot: 0, .. }));
+    }
+
     #[test]
     fn boots_ticks_renders_and_reloads_preserving_the_model() {
         let mut game = FunctorLangEmbeddedGame::create(
@@ -1329,7 +1357,10 @@ let draw = (model, tts) =>
             !matches!(&frame.scene.obj, crate::SceneObject::Group(children) if children.is_empty()),
             "serverDraw produced the game's scene, not the empty fallback"
         );
-        assert!(game.state_debug().contains("spin"), "serverTick advanced the model");
+        assert!(
+            game.state_debug().contains("spin"),
+            "serverTick advanced the model"
+        );
 
         // The prefixed sibling of the broken-push case below: a push missing
         // the role's tick names `serverTick`, never the canonical `tick`.
@@ -1476,7 +1507,11 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
         )
         .expect("the declared role boots on the push");
         assert_eq!(game.names.tick, "Server.tick");
-        assert!(game.state_debug().contains("n: 7"), "{}", game.state_debug());
+        assert!(
+            game.state_debug().contains("n: 7"),
+            "{}",
+            game.state_debug()
+        );
 
         // A re-push re-resolves the same role and preserves the model.
         crate::protocol::reload_with_role(
@@ -1487,7 +1522,10 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
         .expect("the re-push reloads");
         assert_eq!(game.names.tick, "Server.tick");
         assert_eq!(
-            game.session.global("Server.probe").expect("probe").to_string(),
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
             "2",
             "the edit landed"
         );
@@ -1504,14 +1542,15 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
         assert!(err.contains("module Server"), "{err}");
         assert_eq!(game.names.tick, "Server.tick", "the role is intact");
         assert_eq!(
-            game.session.global("Server.probe").expect("probe").to_string(),
+            game.session
+                .global("Server.probe")
+                .expect("probe")
+                .to_string(),
             "2",
             "the old program keeps running"
         );
-        crate::protocol::reload_with_role(&mut game, None, |game| {
-            game.reload_project(&files(3.0))
-        })
-        .expect("a role-less push runs the role already in force");
+        crate::protocol::reload_with_role(&mut game, None, |game| game.reload_project(&files(3.0)))
+            .expect("a role-less push runs the role already in force");
         assert_eq!(game.names.tick, "Server.tick");
 
         // A DIFFERENT role on the model-preserving route is refused: adopting
@@ -1747,10 +1786,10 @@ let draw = (model, tts) =>
         .expect("sampled-input game loads");
         let snapshot = |x| crate::InputSnapshot {
             mouse: crate::MouseSnapshot {
-                    x,
-                    y: 0,
-                    ..Default::default()
-                },
+                x,
+                y: 0,
+                ..Default::default()
+            },
             ..crate::InputSnapshot::default()
         };
 
@@ -1880,7 +1919,8 @@ let draw = (model, tts) =>
             .expect("re-adding the hook reloads");
         assert!(readded.contains("history recomputed"), "{readded}");
 
-        game.seek_scene_to(2).expect("rebuilt future remains seekable");
+        game.seek_scene_to(2)
+            .expect("rebuilt future remains seekable");
         let model = game.state_debug();
         assert!(model.contains("sum: 6"), "{model}");
     }
@@ -1927,7 +1967,8 @@ let draw = (model, tts) =>
         game.seek_scene_to(0).expect("frame zero is seekable");
         let status = game.reload_source(sampled).expect("later reload succeeds");
         assert!(status.contains("history recomputed"), "{status}");
-        game.seek_scene_to(1).expect("rebuilt future remains seekable");
+        game.seek_scene_to(1)
+            .expect("rebuilt future remains seekable");
         let model = game.state_debug();
         assert!(model.contains("sum: 3"), "{model}");
     }
@@ -1982,7 +2023,8 @@ let draw = (model, tts) =>
             .reload_source(sampled)
             .expect("same-hook reload revalidates the current branch");
         assert!(status.contains("history recomputed"), "{status}");
-        game.seek_scene_to(2).expect("rebuilt future remains seekable");
+        game.seek_scene_to(2)
+            .expect("rebuilt future remains seekable");
         let model = game.state_debug();
         assert!(model.contains("sum: 6"), "{model}");
     }

--- a/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_game_embedded.rs
@@ -1006,6 +1006,17 @@ impl GameProducer for FunctorLangEmbeddedGame {
                 self.reporter.report_once(rendered);
             }
         }
+        // Handlers registered during the `draw` eval (interactive widgets in
+        // `Frame.withUiTarget` trees) are display-only for now: drop them so
+        // they neither accumulate across frames nor pollute the `ui`/`webview`
+        // tables adopted below.
+        if !take_ui_handlers().is_empty() {
+            self.reporter.report_once(
+                "[functor-lang] interactive Ui widgets in a draw-eval tree (e.g. \
+Frame.withUiTarget) are display-only for now; their handlers are ignored"
+                    .to_string(),
+            );
+        }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `ui()` is a `&self` accessor, and errors need `&mut`
         // dedupe. A bad `ui` keeps the last good view (the last_frame rule).

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -4993,6 +4993,21 @@ pub fn take_ui_handlers() -> Vec<UiHandler> {
     UI_HANDLERS.with(|h| std::mem::take(&mut *h.borrow_mut()))
 }
 
+/// Drop whatever handlers the just-finished `draw` evaluation registered
+/// (interactive widgets in `Frame.withUiTarget` trees — display-only for
+/// now), so they neither accumulate across frames nor pollute the
+/// `ui`/`webview` tables the producer adopts next. Returns whether anything
+/// was dropped, so the caller can report [`DRAW_EVAL_HANDLERS_WARNING`] once.
+pub fn drop_draw_eval_ui_handlers() -> bool {
+    !take_ui_handlers().is_empty()
+}
+
+/// The one-time warning both producers report when
+/// [`drop_draw_eval_ui_handlers`] drops something.
+pub const DRAW_EVAL_HANDLERS_WARNING: &str =
+    "[functor-lang] interactive Ui widgets in a draw-eval tree (e.g. \
+Frame.withUiTarget) are display-only for now; their handlers are ignored";
+
 /// Put a saved handler table back — the inspector-replay bracket: replaying a
 /// journaled call (or draw) that evaluates `Ui.*` pushes handlers the NEXT
 /// real `ui` pass would take as its own, shifting every slot. The replay

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2723,6 +2723,7 @@ fn register_frame(reg: &mut crate::host_registry::Registry) {
                 scene: scene.0,
                 lights: lights.into_iter().map(|l| l.0).collect(),
                 render_targets: vec![],
+                ui_targets: vec![],
                 fog: None,
                 skybox: None,
                 clear_color: None,
@@ -2740,6 +2741,15 @@ is a Frame.create/createLit(…) rendered into the target each frame, before \
 frame's main pass",
         |target: FunctorLangRenderTarget, target_frame: FunctorLangFrame, frame: FunctorLangFrame| {
             FunctorLangFrame(Frame::with_render_target(frame.0, target.0, target_frame.0))
+        },
+    );
+    reg.fn3(
+        "Frame.withUiTarget",
+        "Frame.withUiTarget(target, view, frame) — view is a Ui.* tree \
+painted into the target each frame, before frame's main pass. Display-only: \
+interactive widgets render but their handlers are inert",
+        |target: FunctorLangRenderTarget, view: FunctorLangView, frame: FunctorLangFrame| {
+            FunctorLangFrame(Frame::with_ui_target(frame.0, target.0, view.0))
         },
     );
     reg.fn2(
@@ -8834,6 +8844,54 @@ Scene.cube() |> Scene.rotateY(Angle.radians(1.5707964)))",
         // And the whole frame round-trips through the protocol.
         let back: Frame = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // The ui-target vocabulary: a branded target declared once, written by a
+    // Ui.* tree (Frame.withUiTarget) and read by Scene.screen — the frame
+    // carries the (target, view) pass and it all speaks the protocol.
+    #[test]
+    fn functor_lang_snippet_declares_a_ui_target_frame() {
+        let frame = frame_of(
+            "let hud = RenderTarget.named(\"hud\") |> RenderTarget.sized(256.0, 128.0)\n\
+             let main = () =>\n\
+             Frame.create(\n\
+               Camera3D.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.quad() |> Scene.screen(hud))\n\
+             |> Frame.withUiTarget(hud, Ui.column([Ui.text(\"score 3\")]))",
+        );
+        assert_eq!(frame.ui_targets.len(), 1);
+        let pass = &frame.ui_targets[0];
+        assert_eq!(pass.target.id, "hud");
+        assert_eq!((pass.target.width, pass.target.height), (256, 128));
+        assert!(matches!(&pass.view, View::Column(items) if items.len() == 1));
+        // The whole frame round-trips through the protocol.
+        let json = serde_json::to_string(&frame).expect("serialize");
+        let back: Frame = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
+    // Interactive widgets in a ui-target tree are display-only: the draw eval
+    // pushes their handlers into the thread-local table, and the producers
+    // drop that table right after the draw eval (with a one-time warning) so
+    // it neither leaks across frames nor pollutes the `ui` hook's table.
+    // This pins WHERE those handlers land — the draw eval's table.
+    #[test]
+    fn ui_target_button_handlers_land_in_the_draw_eval_table() {
+        let _ = take_ui_handlers(); // isolate from other tests on this thread
+        let frame = frame_of(
+            "let hud = RenderTarget.named(\"hud\")\n\
+             let main = () =>\n\
+             Frame.create(\n\
+               Camera3D.lookAt(Vec3.make(0.0, 0.0, -5.0), Vec3.make(0.0, 0.0, 0.0)),\n\
+               Scene.quad() |> Scene.screen(hud))\n\
+             |> Frame.withUiTarget(hud, Ui.button(\"go\", 1))",
+        );
+        assert!(matches!(
+            &frame.ui_targets[0].view,
+            View::Button { slot: 0, .. }
+        ));
+        let handlers = take_ui_handlers();
+        assert_eq!(handlers.len(), 1, "the button registered one handler");
     }
 
     // Scene.screen is an emissive (fullbright) white surface over the target's

--- a/runtime/functor-runtime-common/src/functor_lang_producer.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_producer.rs
@@ -2256,6 +2256,9 @@ pub fn ghost_frames(
                 frames.push((frame.clone(), FrameTime { dts: 0.0, tts }));
             }
         }
+        // Draw-eval handlers (Frame.withUiTarget widgets) are display-only;
+        // an auxiliary draw must not leave them for the next live drain.
+        let _ = take_ui_handlers();
     }
     frames
 }
@@ -2390,6 +2393,9 @@ pub fn history_frames(
                 ));
             }
         }
+        // Draw-eval handlers (Frame.withUiTarget widgets) are display-only;
+        // an auxiliary draw must not leave them for the next live drain.
+        let _ = take_ui_handlers();
     }
     frames
 }

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -843,6 +843,14 @@ mod tests {
                 target: RenderTargetDescriptor::new("feed"),
                 frame: Frame::new(Camera::default(), Scene3D::cube()),
             }],
+            ui_targets: vec![crate::UiTargetPass {
+                target: RenderTargetDescriptor::new("hud"),
+                view: crate::ui::View::Column(vec![crate::ui::View::Text {
+                    text: "score 3".to_string(),
+                    color: [255, 255, 255],
+                    font: None,
+                }]),
+            }],
             fog: Some(crate::fog::Fog::linear(4.0, 30.0, 0.5, 0.6, 0.7)),
             skybox: Some(crate::skybox::SkyboxDescription::new(
                 "px.jpg", "nx.jpg", "py.jpg", "ny.jpg", "pz.jpg", "nz.jpg",
@@ -862,6 +870,7 @@ mod tests {
                 .expect("frame without lights decodes");
         assert!(legacy.lights.is_empty());
         assert!(legacy.render_targets.is_empty());
+        assert!(legacy.ui_targets.is_empty());
         assert!(legacy.fog.is_none());
         assert!(legacy.skybox.is_none());
         assert!(legacy.clear_color.is_none());
@@ -882,6 +891,19 @@ mod tests {
         assert_wire(
             &RenderTargetDescriptor::new("feed"),
             r#"{"id":"feed","width":512,"height":512}"#,
+        );
+        // A ui-target pass: the same descriptor plus the View painted into it
+        // (`Frame.withUiTarget`).
+        assert_wire(
+            &crate::UiTargetPass {
+                target: RenderTargetDescriptor::new("hud"),
+                view: crate::ui::View::Text {
+                    text: "score 3".to_string(),
+                    color: [255, 255, 255],
+                    font: None,
+                },
+            },
+            r#"{"target":{"id":"hud","width":512,"height":512},"view":{"Text":{"text":"score 3","color":[255,255,255],"font":null}}}"#,
         );
     }
 

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -178,6 +178,11 @@ fn render_frame_inner(
 ) {
     scene_context.begin_terrain_frame(gl, terrain_frame_id);
 
+    // The caller's render target, restored after every target pass below.
+    // Captured BEFORE the ensure phase — (re)allocating buffers leaves the
+    // binding on `None`.
+    let previous_fbo = ambient_framebuffer(gl);
+
     // Allocate buffers for EVERY declared target up front, so a target whose
     // scene samples a later-declared target reads last frame's image (initially
     // the clear color) rather than the magenta fallback. A duplicate id is a
@@ -285,7 +290,7 @@ are ignored — declare Frame.withUiTarget on the main frame",
             None,
         );
         unsafe {
-            gl.bind_framebuffer(glow::FRAMEBUFFER, None);
+            gl.bind_framebuffer(glow::FRAMEBUFFER, previous_fbo);
         }
         scene_context.finish_render_target_write(&pass.target.id);
     }
@@ -531,6 +536,10 @@ pub fn render_composited_frames_with_view(
     let weights = normalize_weights(&weights[..n]);
     scene_context.begin_terrain_frame(gl, None);
 
+    // The caller's render target, restored after every offscreen pass below
+    // (captured before any buffer allocation can reset the binding).
+    let previous_fbo = ambient_framebuffer(gl);
+
     // 1. Render each input frame into its own full-viewport offscreen target,
     //    at its own frame time.
     let mut textures: Vec<glow::Texture> = Vec::with_capacity(n);
@@ -599,7 +608,7 @@ pub fn render_composited_frames_with_view(
             sprite_cameras.filter(|cameras| cameras.len() == frame.sprite_layers.len()),
         );
         unsafe {
-            gl.bind_framebuffer(glow::FRAMEBUFFER, None);
+            gl.bind_framebuffer(glow::FRAMEBUFFER, previous_fbo);
         }
         scene_context.finish_render_target_write(&id);
         textures.push(
@@ -668,6 +677,25 @@ fn shadow_pass(
                 light_index: light_index as i32,
             }
         })
+}
+
+/// The framebuffer currently bound — captured before an offscreen section and
+/// restored after it (the shadow-pass rule): XR shells render into per-eye
+/// swapchain FBOs, so resetting to the default would send the rest of the
+/// frame into an invisible pbuffer. Reconstructing the key from the GL query
+/// is native-only (glow's web backend uses opaque slotmap keys); on wasm the
+/// canvas default framebuffer IS the target, so `None` is exact there.
+pub(crate) fn ambient_framebuffer(gl: &glow::Context) -> Option<glow::Framebuffer> {
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe {
+        std::num::NonZeroU32::new(gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32)
+            .map(glow::NativeFramebuffer)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = gl;
+        None
+    }
 }
 
 /// Turn on the constant-alpha over-blend with depth writes off — the state both

--- a/runtime/functor-runtime-common/src/renderer.rs
+++ b/runtime/functor-runtime-common/src/renderer.rs
@@ -214,6 +214,16 @@ target frame are ignored (depth 1 only)",
                 ),
             );
         }
+        if !pass.frame.ui_targets.is_empty() {
+            scene_context.warn_once(
+                &format!("nested-ui:{}", pass.target.id),
+                &format!(
+                    "[render-target] \"{}\": ui targets inside a target frame \
+are ignored — declare Frame.withUiTarget on the main frame",
+                    pass.target.id
+                ),
+            );
+        }
 
         let shadow = shadow_pass(
             gl,

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -45,7 +45,7 @@ impl Label {
 /// *bytes* live in the shell's font registry; a `View` only ever names a font, so
 /// the tree stays serializable/inspectable. Only the default font is wired today —
 /// the family is carried for forward-compatibility and unknown names fall back.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FontRef {
     pub family: String,
     pub size: f32,
@@ -53,7 +53,7 @@ pub struct FontRef {
 
 /// Which screen position a [`View::Panel`] pins its subtree to — the four
 /// corners, or the screen center (for menus).
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Anchor {
     TopLeft,
     TopRight,
@@ -66,7 +66,7 @@ pub enum Anchor {
 /// API (`ui : 'model -> View`). It carries only text, layout, colors and *names*
 /// (e.g. fonts), never bytes, so it round-trips as JSON across the wasm boundary
 /// and stays introspectable. [`View::lower`] flattens it to absolute [`Label`]s.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum View {
     /// Renders nothing — the default `ui` for games that don't draw a HUD.
     Empty,
@@ -609,6 +609,139 @@ impl TextOverlay {
         // DEPTH_TEST as-is) and does not restore it. The shared 3D path enables
         // DEPTH_TEST only once at startup and re-arms SCISSOR per frame, so reset
         // to the slate the next 3D frame expects.
+        restore_gl_after_egui(&self.gl);
+    }
+}
+
+/// Paints `Frame.withUiTarget` passes: each declared [`View`] is rendered into
+/// its render target's texture — at the target's declared size, with
+/// `pixels_per_point` 1.0 — so the main pass can sample it via `Scene.screen`.
+/// Call [`Self::render`] BEFORE the frame's main pass; like a 3D target pass,
+/// the write is published with `swap()`, so readers see this frame's image.
+///
+/// Owns its own egui context rather than sharing [`TextOverlay`]'s: an egui
+/// context retains the last pointer position across runs, so reusing the
+/// overlay's would replay window-space hover state onto target widgets. This
+/// context never receives an input event — target views are display-only for
+/// now (interactive widgets render in their resting state; their handlers are
+/// dropped by the producer).
+pub struct UiTargetRenderer {
+    ctx: egui::Context,
+    painter: egui_glow::Painter,
+    gl: Arc<glow::Context>,
+}
+
+impl UiTargetRenderer {
+    pub fn new(gl: Arc<glow::Context>) -> Self {
+        let painter = egui_glow::Painter::new(gl.clone(), "", None, false)
+            .expect("failed to create egui_glow painter");
+        Self {
+            ctx: egui::Context::default(),
+            painter,
+            gl,
+        }
+    }
+
+    /// Render every `Frame.withUiTarget` pass, in declaration order (a later
+    /// write to the same id wins, matching `Frame.withRenderTarget`).
+    pub fn render(
+        &mut self,
+        scene_context: &crate::SceneContext,
+        passes: &[crate::frame::UiTargetPass],
+    ) {
+        for pass in passes {
+            self.render_pass(scene_context, pass);
+        }
+    }
+
+    fn render_pass(&mut self, scene_context: &crate::SceneContext, pass: &crate::frame::UiTargetPass) {
+        // UI targets clear to the engine default backdrop — there is no target
+        // frame to take a fog/clear color from.
+        let clear = crate::fog::clear_color(None);
+        scene_context.ensure_render_target(&self.gl, &pass.target, clear);
+        let Some((fbo, width, height)) = scene_context.render_target_write(&pass.target.id)
+        else {
+            return;
+        };
+        let gl = &self.gl;
+        let previous_fbo = unsafe {
+            // Remember the caller's render target and restore it after the
+            // pass (the shadow-pass rule, shadow.rs): XR shells render into
+            // per-eye swapchain FBOs, so resetting to the default would send
+            // the forward pass into an invisible pbuffer. Reconstructing the
+            // key from the GL query is native-only; on wasm the canvas default
+            // framebuffer IS the target, so `None` is exact there.
+            #[cfg(not(target_arch = "wasm32"))]
+            let previous_fbo = std::num::NonZeroU32::new(
+                gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32,
+            )
+            .map(glow::NativeFramebuffer);
+            #[cfg(target_arch = "wasm32")]
+            let previous_fbo: Option<glow::Framebuffer> = None;
+            gl.bind_framebuffer(glow::FRAMEBUFFER, Some(fbo));
+            // The forward pass may have left SCISSOR_TEST clipped to a window
+            // pane; the target owns its whole texture.
+            gl.disable(glow::SCISSOR_TEST);
+            gl.viewport(0, 0, width as i32, height as i32);
+            gl.clear_color(clear[0], clear[1], clear[2], 1.0);
+            gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
+            previous_fbo
+        };
+        self.paint(width, height, &pass.view);
+        unsafe {
+            self.gl.bind_framebuffer(glow::FRAMEBUFFER, previous_fbo);
+        }
+        scene_context.finish_render_target_write(&pass.target.id);
+    }
+
+    /// One display-only egui pass into the bound framebuffer. Interaction
+    /// state is fresh locals: no events are ever fed, so no `UiEvent` can
+    /// arise and the stateful-widget buffers have nothing to reconcile.
+    fn paint(&mut self, width: u32, height: u32, view: &View) {
+        if matches!(view, View::Empty) || width == 0 || height == 0 {
+            return;
+        }
+        self.ctx.set_pixels_per_point(1.0);
+        let raw_input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(width as f32, height as f32),
+            )),
+            ..Default::default()
+        };
+        let mut events = Vec::new();
+        let mut sliders = std::collections::HashMap::new();
+        let mut seen_sliders = std::collections::HashSet::new();
+        let mut texts = std::collections::HashMap::new();
+        let mut seen_texts = std::collections::HashSet::new();
+        let output = self.ctx.run_ui(raw_input, |ui| {
+            let mut state = UiFrameState {
+                events: &mut events,
+                sliders: &mut sliders,
+                seen_sliders: &mut seen_sliders,
+                texts: &mut texts,
+                seen_texts: &mut seen_texts,
+            };
+            match view {
+                // A panel anchors itself (to the TARGET's rect); a bare root
+                // sits at the top-left with a margin, like the overlay.
+                View::Panel { .. } => render_view(ui, view, &mut state),
+                other => {
+                    let ctx = ui.ctx().clone();
+                    egui::Area::new(egui::Id::new("functor_ui_target_root"))
+                        .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
+                        .interactable(false)
+                        .show(&ctx, |ui| render_view(ui, other, &mut state));
+                }
+            }
+        });
+        let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
+        self.painter.paint_and_update_textures(
+            [width, height],
+            output.pixels_per_point,
+            &primitives,
+            &output.textures_delta,
+        );
         restore_gl_after_egui(&self.gl);
     }
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -264,6 +264,11 @@ struct UiFrameState<'a> {
     seen_sliders: &'a mut std::collections::HashSet<u32>,
     texts: &'a mut std::collections::HashMap<u32, TextBuffer>,
     seen_texts: &'a mut std::collections::HashSet<u32>,
+    /// Namespaces every `Area` id this pass creates (panels included), so
+    /// passes sharing one egui context — the window overlay, and each ui
+    /// render target — never share retained Area state (egui remembers an
+    /// Area's size, which right/bottom/center anchoring reads back).
+    salt: egui::Id,
 }
 
 /// Render a declarative [`View`] into `ui` using egui's own layout (vertical /
@@ -305,7 +310,7 @@ fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
         View::Panel { anchor, child } => {
             let (align, offset) = anchor_align(*anchor);
             let ctx = ui.ctx().clone();
-            egui::Area::new(egui::Id::new(("functor_ui_panel", anchor_id(*anchor))))
+            egui::Area::new(state.salt.with(("functor_ui_panel", anchor_id(*anchor))))
                 .anchor(align, offset)
                 .interactable(contains_interactive(child))
                 .show(&ctx, |ui| render_view(ui, child, state));
@@ -376,6 +381,69 @@ fn render_view(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState) {
             }
         }
     }
+}
+
+/// Lay out a [`View`]'s root: a `Panel` anchors itself (to the pass's screen
+/// rect), any other root sits at the top-left with a margin. Shared by the
+/// window overlay and the ui-target passes; `allow_interaction` is false for
+/// display-only passes (target views), which never receive input.
+fn render_root(ui: &mut egui::Ui, view: &View, state: &mut UiFrameState, allow_interaction: bool) {
+    match view {
+        View::Panel { .. } => render_view(ui, view, state),
+        other => {
+            let ctx = ui.ctx().clone();
+            egui::Area::new(state.salt.with("functor_ui_root"))
+                .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
+                .interactable(allow_interaction && contains_interactive(other))
+                .show(&ctx, |ui| render_view(ui, other, state));
+        }
+    }
+}
+
+/// Run one egui frame (building the UI with `build`), tessellate, and paint to
+/// the bound framebuffer, restoring the GL state the 3D path expects. egui's
+/// fonts only exist *during* the run, so all layout/measurement happens in
+/// here. Shared by [`TextOverlay`] and [`UiTargetRenderer`], which each own a
+/// (context, painter) pair.
+fn run_and_paint_with(
+    ctx: &egui::Context,
+    painter: &mut egui_glow::Painter,
+    gl: &glow::Context,
+    width: u32,
+    height: u32,
+    pixels_per_point: f32,
+    events: Vec<egui::Event>,
+    build: impl FnMut(&mut egui::Ui),
+) {
+    if width == 0 || height == 0 {
+        return;
+    }
+    ctx.set_pixels_per_point(pixels_per_point);
+    let screen_points = egui::vec2(
+        width as f32 / pixels_per_point,
+        height as f32 / pixels_per_point,
+    );
+    let raw_input = egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+        events,
+        ..Default::default()
+    };
+
+    let output = ctx.run_ui(raw_input, build);
+
+    let primitives = ctx.tessellate(output.shapes, output.pixels_per_point);
+    painter.paint_and_update_textures(
+        [width, height],
+        output.pixels_per_point,
+        &primitives,
+        &output.textures_delta,
+    );
+
+    // egui_glow mutates global GL state (enables BLEND + SCISSOR, leaves
+    // DEPTH_TEST as-is) and does not restore it. The shared 3D path enables
+    // DEPTH_TEST only once at startup and re-arms SCISSOR per frame, so reset
+    // to the slate the next 3D frame expects.
+    restore_gl_after_egui(gl);
 }
 
 /// egui alignment + inset offset for an [`Anchor`]. Center pins to the middle
@@ -544,18 +612,9 @@ impl TextOverlay {
                 seen_sliders: &mut seen_sliders,
                 texts: &mut texts,
                 seen_texts: &mut seen_texts,
+                salt: egui::Id::new("functor_overlay"),
             };
-            match view {
-                // A panel anchors itself; a bare root sits at the top-left with a margin.
-                View::Panel { .. } => render_view(ui, view, &mut state),
-                other => {
-                    let ctx = ui.ctx().clone();
-                    egui::Area::new(egui::Id::new("functor_ui_root"))
-                        .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
-                        .interactable(contains_interactive(other))
-                        .show(&ctx, |ui| render_view(ui, other, &mut state));
-                }
-            }
+            render_root(ui, view, &mut state, true);
         });
         // A slot that left the view is a different widget if it ever returns
         // (positional identity) — drop its buffer rather than resurrect it.
@@ -570,9 +629,7 @@ impl TextOverlay {
         }
     }
 
-    /// Run one egui frame (building the UI with `build`), tessellate, paint to the
-    /// bound framebuffer, and restore the GL state the 3D path expects. egui's
-    /// fonts only exist *during* `run`, so all layout/measurement happens in here.
+    /// One egui frame into the bound framebuffer — see [`run_and_paint_with`].
     fn run_and_paint(
         &mut self,
         width: u32,
@@ -581,35 +638,16 @@ impl TextOverlay {
         events: Vec<egui::Event>,
         build: impl FnMut(&mut egui::Ui),
     ) {
-        if width == 0 || height == 0 {
-            return;
-        }
-        self.ctx.set_pixels_per_point(pixels_per_point);
-        let screen_points = egui::vec2(
-            width as f32 / pixels_per_point,
-            height as f32 / pixels_per_point,
-        );
-        let raw_input = egui::RawInput {
-            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, screen_points)),
+        run_and_paint_with(
+            &self.ctx,
+            &mut self.painter,
+            &self.gl,
+            width,
+            height,
+            pixels_per_point,
             events,
-            ..Default::default()
-        };
-
-        let output = self.ctx.run_ui(raw_input, build);
-
-        let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
-        self.painter.paint_and_update_textures(
-            [width, height],
-            output.pixels_per_point,
-            &primitives,
-            &output.textures_delta,
+            build,
         );
-
-        // egui_glow mutates global GL state (enables BLEND + SCISSOR, leaves
-        // DEPTH_TEST as-is) and does not restore it. The shared 3D path enables
-        // DEPTH_TEST only once at startup and re-arms SCISSOR per frame, so reset
-        // to the slate the next 3D frame expects.
-        restore_gl_after_egui(&self.gl);
     }
 }
 
@@ -642,42 +680,71 @@ impl UiTargetRenderer {
         }
     }
 
-    /// Render every `Frame.withUiTarget` pass, in declaration order (a later
-    /// write to the same id wins, matching `Frame.withRenderTarget`).
-    pub fn render(
-        &mut self,
-        scene_context: &crate::SceneContext,
-        passes: &[crate::frame::UiTargetPass],
-    ) {
-        for pass in passes {
+    /// Render a frame's `Frame.withUiTarget` passes, in declaration order.
+    /// Duplicate ids: the FIRST declaration wins, with a one-time warning —
+    /// matching `Frame.withRenderTarget`. An id also declared as a 3D target
+    /// pass (`Frame.withRenderTarget`) is skipped here with a warning: the two
+    /// writers would otherwise fight over one texture every frame (and a size
+    /// mismatch would delete/recreate the GPU buffers per frame).
+    pub fn render(&mut self, scene_context: &crate::SceneContext, frame: &crate::Frame) {
+        let mut rendered: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for pass in &frame.ui_targets {
+            let id = pass.target.id.as_str();
+            if frame
+                .render_targets
+                .iter()
+                .any(|rt| rt.target.id == pass.target.id)
+            {
+                scene_context.warn_once_with(&format!("ui-vs-3d:{id}"), || {
+                    format!(
+                        "[functor] render target \"{id}\" is declared by both \
+Frame.withUiTarget and Frame.withRenderTarget; the ui pass is skipped — use \
+two target ids"
+                    )
+                });
+                continue;
+            }
+            if !rendered.insert(id) {
+                scene_context.warn_once_with(&format!("duplicate-ui:{id}"), || {
+                    format!(
+                        "[functor] ui target \"{id}\" is declared more than once \
+in this frame; only the first declaration is rendered"
+                    )
+                });
+                continue;
+            }
             self.render_pass(scene_context, pass);
         }
     }
 
-    fn render_pass(&mut self, scene_context: &crate::SceneContext, pass: &crate::frame::UiTargetPass) {
-        // UI targets clear to the engine default backdrop — there is no target
-        // frame to take a fog/clear color from.
+    fn render_pass(
+        &mut self,
+        scene_context: &crate::SceneContext,
+        pass: &crate::frame::UiTargetPass,
+    ) {
+        let gl = &self.gl;
+        // Remember the caller's render target BEFORE ensure_render_target —
+        // (re)allocating buffers leaves the FBO binding on `None` — and
+        // restore it after the pass (the shadow-pass rule, shadow.rs): XR
+        // shells render into per-eye swapchain FBOs, so resetting to the
+        // default would send the forward pass into an invisible pbuffer.
+        // Reconstructing the key from the GL query is native-only; on wasm
+        // the canvas default framebuffer IS the target, so `None` is exact.
+        #[cfg(not(target_arch = "wasm32"))]
+        let previous_fbo = std::num::NonZeroU32::new(unsafe {
+            gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32
+        })
+        .map(glow::NativeFramebuffer);
+        #[cfg(target_arch = "wasm32")]
+        let previous_fbo: Option<glow::Framebuffer> = None;
+        // UI targets clear to the engine default backdrop for now — there is
+        // no target frame to take a fog/clear color from.
         let clear = crate::fog::clear_color(None);
-        scene_context.ensure_render_target(&self.gl, &pass.target, clear);
-        let Some((fbo, width, height)) = scene_context.render_target_write(&pass.target.id)
-        else {
+        scene_context.ensure_render_target(gl, &pass.target, clear);
+        let Some((fbo, width, height)) = scene_context.render_target_write(&pass.target.id) else {
             return;
         };
-        let gl = &self.gl;
-        let previous_fbo = unsafe {
-            // Remember the caller's render target and restore it after the
-            // pass (the shadow-pass rule, shadow.rs): XR shells render into
-            // per-eye swapchain FBOs, so resetting to the default would send
-            // the forward pass into an invisible pbuffer. Reconstructing the
-            // key from the GL query is native-only; on wasm the canvas default
-            // framebuffer IS the target, so `None` is exact there.
-            #[cfg(not(target_arch = "wasm32"))]
-            let previous_fbo = std::num::NonZeroU32::new(
-                gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32,
-            )
-            .map(glow::NativeFramebuffer);
-            #[cfg(target_arch = "wasm32")]
-            let previous_fbo: Option<glow::Framebuffer> = None;
+        unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, Some(fbo));
             // The forward pass may have left SCISSOR_TEST clipped to a window
             // pane; the target owns its whole texture.
@@ -685,64 +752,40 @@ impl UiTargetRenderer {
             gl.viewport(0, 0, width as i32, height as i32);
             gl.clear_color(clear[0], clear[1], clear[2], 1.0);
             gl.clear(glow::COLOR_BUFFER_BIT | glow::DEPTH_BUFFER_BIT);
-            previous_fbo
-        };
-        self.paint(width, height, &pass.view);
-        unsafe {
-            self.gl.bind_framebuffer(glow::FRAMEBUFFER, previous_fbo);
         }
-        scene_context.finish_render_target_write(&pass.target.id);
-    }
-
-    /// One display-only egui pass into the bound framebuffer. Interaction
-    /// state is fresh locals: no events are ever fed, so no `UiEvent` can
-    /// arise and the stateful-widget buffers have nothing to reconcile.
-    fn paint(&mut self, width: u32, height: u32, view: &View) {
-        if matches!(view, View::Empty) || width == 0 || height == 0 {
-            return;
-        }
-        self.ctx.set_pixels_per_point(1.0);
-        let raw_input = egui::RawInput {
-            screen_rect: Some(egui::Rect::from_min_size(
-                egui::Pos2::ZERO,
-                egui::vec2(width as f32, height as f32),
-            )),
-            ..Default::default()
-        };
+        // A display-only egui pass: interaction state is fresh locals — no
+        // events are ever fed, so no UiEvent can arise and the stateful-widget
+        // buffers have nothing to reconcile. Area ids are salted by target id
+        // so two targets sharing this context never share retained Area state.
         let mut events = Vec::new();
         let mut sliders = std::collections::HashMap::new();
         let mut seen_sliders = std::collections::HashSet::new();
         let mut texts = std::collections::HashMap::new();
         let mut seen_texts = std::collections::HashSet::new();
-        let output = self.ctx.run_ui(raw_input, |ui| {
-            let mut state = UiFrameState {
-                events: &mut events,
-                sliders: &mut sliders,
-                seen_sliders: &mut seen_sliders,
-                texts: &mut texts,
-                seen_texts: &mut seen_texts,
-            };
-            match view {
-                // A panel anchors itself (to the TARGET's rect); a bare root
-                // sits at the top-left with a margin, like the overlay.
-                View::Panel { .. } => render_view(ui, view, &mut state),
-                other => {
-                    let ctx = ui.ctx().clone();
-                    egui::Area::new(egui::Id::new("functor_ui_target_root"))
-                        .anchor(egui::Align2::LEFT_TOP, egui::vec2(MARGIN, MARGIN))
-                        .interactable(false)
-                        .show(&ctx, |ui| render_view(ui, other, &mut state));
-                }
-            }
-        });
-        let primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
-        self.painter.paint_and_update_textures(
-            [width, height],
-            output.pixels_per_point,
-            &primitives,
-            &output.textures_delta,
+        run_and_paint_with(
+            &self.ctx,
+            &mut self.painter,
+            gl,
+            width,
+            height,
+            1.0,
+            Vec::new(),
+            |ui| {
+                let mut state = UiFrameState {
+                    events: &mut events,
+                    sliders: &mut sliders,
+                    seen_sliders: &mut seen_sliders,
+                    texts: &mut texts,
+                    seen_texts: &mut seen_texts,
+                    salt: egui::Id::new(("functor_ui_target", &pass.target.id)),
+                };
+                render_root(ui, &pass.view, &mut state, false);
+            },
         );
-        restore_gl_after_egui(&self.gl);
+        unsafe {
+            gl.bind_framebuffer(glow::FRAMEBUFFER, previous_fbo);
+        }
+        scene_context.finish_render_target_write(&pass.target.id);
     }
 }
 
@@ -1090,26 +1133,20 @@ impl Scrubber {
                                             };
                                             // Pink = future, cyan = past —
                                             // the trail's own two colors.
-                                            let future_band =
-                                                egui::Color32::from_rgba_unmultiplied(
-                                                    232, 88, 184, 200,
-                                                );
-                                            let future_cap =
-                                                egui::Color32::from_rgba_unmultiplied(
-                                                    232, 88, 184, 230,
-                                                );
-                                            let future_hot =
-                                                egui::Color32::from_rgb(255, 208, 238);
-                                            let past_band =
-                                                egui::Color32::from_rgba_unmultiplied(
-                                                    64, 217, 255, 200,
-                                                );
-                                            let past_cap =
-                                                egui::Color32::from_rgba_unmultiplied(
-                                                    64, 217, 255, 230,
-                                                );
-                                            let past_hot =
-                                                egui::Color32::from_rgb(150, 236, 255);
+                                            let future_band = egui::Color32::from_rgba_unmultiplied(
+                                                232, 88, 184, 200,
+                                            );
+                                            let future_cap = egui::Color32::from_rgba_unmultiplied(
+                                                232, 88, 184, 230,
+                                            );
+                                            let future_hot = egui::Color32::from_rgb(255, 208, 238);
+                                            let past_band = egui::Color32::from_rgba_unmultiplied(
+                                                64, 217, 255, 200,
+                                            );
+                                            let past_cap = egui::Color32::from_rgba_unmultiplied(
+                                                64, 217, 255, 230,
+                                            );
+                                            let past_hot = egui::Color32::from_rgb(150, 236, 255);
                                             // Start at the handle's edges so
                                             // neither band paints over the
                                             // handle itself.
@@ -1122,10 +1159,9 @@ impl Scrubber {
                                             // band is simply shorter there
                                             // (the trail clips the same way).
                                             let back_x1 = x_of(f) - 5.0;
-                                            let back_x0 = x_of(
-                                                f.saturating_sub(future_frames).max(lo),
-                                            )
-                                            .min(back_x1);
+                                            let back_x0 =
+                                                x_of(f.saturating_sub(future_frames).max(lo))
+                                                    .min(back_x1);
                                             band(ui, back_x0, back_x1, past_band);
                                             if let Some(a) = cap(
                                                 ui,
@@ -1195,10 +1231,8 @@ impl Scrubber {
                             // Same two colors as the rail's bands: cyan for
                             // the recorded past, pink for the projected
                             // future.
-                            let cyan =
-                                egui::Color32::from_rgba_unmultiplied(64, 217, 255, 190);
-                            let pink =
-                                egui::Color32::from_rgba_unmultiplied(232, 88, 184, 190);
+                            let cyan = egui::Color32::from_rgba_unmultiplied(64, 217, 255, 190);
+                            let pink = egui::Color32::from_rgba_unmultiplied(232, 88, 184, 190);
                             let mut segments: Vec<(String, egui::Color32)> = Vec::new();
                             match state.range {
                                 Some((lo, hi)) => {
@@ -1208,8 +1242,8 @@ impl Scrubber {
                                         // frame — report what actually exists,
                                         // matching where the rail's cyan band
                                         // stops.
-                                        let past_frames = future_frames
-                                            .min(state.frame.saturating_sub(lo));
+                                        let past_frames =
+                                            future_frames.min(state.frame.saturating_sub(lo));
                                         segments.push((format!("-{past_frames} "), cyan));
                                     }
                                     segments.push((format!("{}", state.frame), weak));
@@ -1250,10 +1284,7 @@ impl Scrubber {
                                                 crate::viewer::DebugCameraMode::Orbit,
                                             ] {
                                                 if ui
-                                                    .selectable_label(
-                                                        current == mode,
-                                                        mode.label(),
-                                                    )
+                                                    .selectable_label(current == mode, mode.label())
                                                     .clicked()
                                                 {
                                                     action = Some(
@@ -1275,8 +1306,7 @@ impl Scrubber {
                                             )
                                             .changed()
                                         {
-                                            action =
-                                                Some(ScrubberAction::SetDebugCameraFov(value));
+                                            action = Some(ScrubberAction::SetDebugCameraFov(value));
                                         }
                                     } else if let Some(zoom) = state.camera_zoom_2d {
                                         ui.separator();
@@ -1306,16 +1336,15 @@ impl Scrubber {
                                                 )
                                                 .clicked()
                                             {
-                                                action = Some(
-                                                    ScrubberAction::SetDebugMaterial(material),
-                                                );
+                                                action = Some(ScrubberAction::SetDebugMaterial(
+                                                    material,
+                                                ));
                                             }
                                         }
                                         ui.separator();
                                         let mut physics = state.debug_presentation.physics;
                                         if ui.checkbox(&mut physics, "Physics").changed() {
-                                            action =
-                                                Some(ScrubberAction::SetDebugPhysics(physics));
+                                            action = Some(ScrubberAction::SetDebugPhysics(physics));
                                         }
                                         let mut frustum =
                                             state.debug_presentation.authored_camera_frustum;
@@ -1330,8 +1359,7 @@ impl Scrubber {
                                     ui.separator();
                                     let mut game_ui = state.debug_presentation.show_game_ui;
                                     if ui.checkbox(&mut game_ui, "Game UI").changed() {
-                                        action =
-                                            Some(ScrubberAction::SetGameUiVisible(game_ui));
+                                        action = Some(ScrubberAction::SetGameUiVisible(game_ui));
                                     }
                                 });
                             }
@@ -1503,6 +1531,7 @@ mod tests {
                 seen_sliders: &mut seen_sliders,
                 texts,
                 seen_texts: &mut seen_texts,
+                salt: egui::Id::new("test"),
             };
             render_view(ui, view, &mut state);
         });
@@ -1546,7 +1575,10 @@ mod tests {
             modifiers: egui::Modifiers::default(),
         }];
         assert!(run_widget_frame(&ctx, release, &mut texts, &view("cube")).is_empty());
-        assert!(ctx.egui_wants_keyboard_input(), "click should focus the field");
+        assert!(
+            ctx.egui_wants_keyboard_input(),
+            "click should focus the field"
+        );
 
         // Frame 3: a typed character (the shell's Char event, lowered the
         // same way draw_view lowers it) must emit exactly one TextChanged.
@@ -1557,7 +1589,10 @@ mod tests {
         let UiEventKind::TextChanged(new_text) = &events[0].kind else {
             panic!("expected TextChanged, got {:?}", events[0].kind);
         };
-        assert!(new_text.contains('s'), "typed char should land: {new_text:?}");
+        assert!(
+            new_text.contains('s'),
+            "typed char should land: {new_text:?}"
+        );
         let emitted = new_text.clone();
 
         // Frame 4 — the ECHO: the model comes back equal to what we emitted;
@@ -1614,5 +1649,4 @@ mod tests {
             UiEventKind::TextChanged(s) if s == "a"
         ));
     }
-
 }

--- a/runtime/functor-runtime-common/src/ui.rs
+++ b/runtime/functor-runtime-common/src/ui.rs
@@ -723,20 +723,10 @@ in this frame; only the first declaration is rendered"
         pass: &crate::frame::UiTargetPass,
     ) {
         let gl = &self.gl;
-        // Remember the caller's render target BEFORE ensure_render_target —
-        // (re)allocating buffers leaves the FBO binding on `None` — and
-        // restore it after the pass (the shadow-pass rule, shadow.rs): XR
-        // shells render into per-eye swapchain FBOs, so resetting to the
-        // default would send the forward pass into an invisible pbuffer.
-        // Reconstructing the key from the GL query is native-only; on wasm
-        // the canvas default framebuffer IS the target, so `None` is exact.
-        #[cfg(not(target_arch = "wasm32"))]
-        let previous_fbo = std::num::NonZeroU32::new(unsafe {
-            gl.get_parameter_i32(glow::DRAW_FRAMEBUFFER_BINDING) as u32
-        })
-        .map(glow::NativeFramebuffer);
-        #[cfg(target_arch = "wasm32")]
-        let previous_fbo: Option<glow::Framebuffer> = None;
+        // The caller's render target, restored after the pass — captured
+        // BEFORE ensure_render_target, since (re)allocating buffers leaves
+        // the FBO binding on `None`.
+        let previous_fbo = crate::renderer::ambient_framebuffer(gl);
         // UI targets clear to the engine default backdrop for now — there is
         // no target frame to take a fog/clear color from.
         let clear = crate::fog::clear_color(None);

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -1288,6 +1288,17 @@ impl Game for FunctorLangGame {
             },
             Err(err) => self.reporter.frame_error(self.names.draw, &err),
         }
+        // Handlers registered during the `draw` eval (interactive widgets in
+        // `Frame.withUiTarget` trees) are display-only for now: drop them so
+        // they neither accumulate across frames nor pollute the `ui`/`webview`
+        // tables adopted below.
+        if !take_ui_handlers().is_empty() {
+            self.reporter.report_once(
+                "[functor-lang] interactive Ui widgets in a draw-eval tree (e.g. \
+Frame.withUiTarget) are display-only for now; their handlers are ignored"
+                    .to_string(),
+            );
+        }
         // The optional HUD, evaluated beside `draw` (same settled model) and
         // cached — `Game::ui` is a `&self` accessor, and errors need `&mut`
         // dedupe. A bad `ui` keeps the last good view (the last_frame rule).

--- a/runtime/functor-runtime-desktop/src/functor_lang_game.rs
+++ b/runtime/functor-runtime-desktop/src/functor_lang_game.rs
@@ -654,8 +654,8 @@ impl FunctorLangGame {
         self.recorder
             .finish_reload(&self.model, self.physics_frame, live_model_was_safe);
         let replay_started = Instant::now();
-        let history_replay = match
-            functor_runtime_common::functor_lang_producer::materialize_counterfactual_history(
+        let history_replay =
+            match functor_runtime_common::functor_lang_producer::materialize_counterfactual_history(
                 &self.session,
                 &self.names,
                 &mut self.model,
@@ -663,16 +663,15 @@ impl FunctorLangGame {
                 self.has_physics,
                 self.has_subscriptions,
                 !self.input_buf.is_empty(),
-            )
-        {
-            Ok(frames) => frames.map(|frames| {
-                (frames, replay_started.elapsed().as_secs_f64() * 1000.0)
-            }),
-            Err(error) => {
-                self.reporter.report_once(format!("[functor-lang] {error}"));
-                None
-            }
-        };
+            ) {
+                Ok(frames) => {
+                    frames.map(|frames| (frames, replay_started.elapsed().as_secs_f64() * 1000.0))
+                }
+                Err(error) => {
+                    self.reporter.report_once(format!("[functor-lang] {error}"));
+                    None
+                }
+            };
         (report.rebound, history_replay)
     }
 
@@ -1288,14 +1287,11 @@ impl Game for FunctorLangGame {
             },
             Err(err) => self.reporter.frame_error(self.names.draw, &err),
         }
-        // Handlers registered during the `draw` eval (interactive widgets in
-        // `Frame.withUiTarget` trees) are display-only for now: drop them so
-        // they neither accumulate across frames nor pollute the `ui`/`webview`
-        // tables adopted below.
-        if !take_ui_handlers().is_empty() {
+        // Draw-eval handlers are display-only: drop them so they neither
+        // accumulate across frames nor pollute the ui/webview tables below.
+        if functor_runtime_common::functor_lang_prelude::drop_draw_eval_ui_handlers() {
             self.reporter.report_once(
-                "[functor-lang] interactive Ui widgets in a draw-eval tree (e.g. \
-Frame.withUiTarget) are display-only for now; their handlers are ignored"
+                functor_runtime_common::functor_lang_prelude::DRAW_EVAL_HANDLERS_WARNING
                     .to_string(),
             );
         }
@@ -2680,7 +2676,10 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
             }
         }
 
-        let platformer = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/platformer/game.fun");
+        let platformer = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/platformer/game.fun"
+        );
         let mut game = FunctorLangGame::create(platformer);
         assert!(!game.has_physics, "platformer must have no physics hook");
 
@@ -2821,7 +2820,10 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
             }
         }
 
-        let platformer = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/platformer/game.fun");
+        let platformer = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/platformer/game.fun"
+        );
         let mut game = FunctorLangGame::create(platformer);
 
         const SUB_DT: f32 = 1.0 / 60.0;
@@ -3034,7 +3036,10 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
             }
         }
 
-        let platformer = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/platformer/game.fun");
+        let platformer = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/platformer/game.fun"
+        );
         let source = std::fs::read_to_string(platformer).expect("read platformer source");
         // `jumpVelocity` is the example's tuning knob, so read the CURRENT value
         // out of the source and weaken it, rather than hardcoding the literal:
@@ -3183,7 +3188,10 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
                 .collect()
         }
 
-        let platformer = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/platformer/game.fun");
+        let platformer = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/platformer/game.fun"
+        );
         let source = std::fs::read_to_string(platformer).expect("read platformer source");
         let mut game = FunctorLangGame::create(platformer);
         const SUB_DT: f32 = 1.0 / 60.0;
@@ -3235,7 +3243,10 @@ Vec3.make(0.0, 0.0, 0.0)), Scene.cube())\n\
     fn scrub_drops_input_buffered_on_a_zero_substep_frame() {
         use functor_runtime_common::Key;
 
-        let platformer = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/platformer/game.fun");
+        let platformer = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../examples/platformer/game.fun"
+        );
         let mut game = FunctorLangGame::create(platformer);
 
         // Record a few frames of history at the fixed step (each tick records).

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -3079,7 +3079,7 @@ Escape again to quit"
             // `Frame.withUiTarget` passes go first, so the passes below —
             // including each eye of a stereo pair — sample this frame's image.
             if !drawn_frame.ui_targets.is_empty() {
-                ui_target_renderer.render(&scene_context, &drawn_frame.ui_targets);
+                ui_target_renderer.render(&scene_context, drawn_frame);
             }
 
             // Shadow + forward passes, shared with the web runtime. In stereo

--- a/runtime/functor-runtime-desktop/src/run.rs
+++ b/runtime/functor-runtime-desktop/src/run.rs
@@ -1737,6 +1737,9 @@ Escape releases while captured"
         // rest of the runtime keeps using `&gl`, which derefs through the Arc.
         let gl = std::sync::Arc::new(gl);
         let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+        // `Frame.withUiTarget` passes: Ui views painted into render targets
+        // before the main pass samples them (`Scene.screen`).
+        let mut ui_target_renderer = functor_runtime_common::ui::UiTargetRenderer::new(gl.clone());
         // The game's HTML/CSS webview overlay (`webview model`), blitz-rendered
         // to a texture and composited between the game UI and the scrubber.
         let mut webview_overlay =
@@ -3072,6 +3075,12 @@ Escape again to quit"
                 _ => None,
             };
             let drawn_frame = display_frame.as_ref().unwrap_or(&frame);
+
+            // `Frame.withUiTarget` passes go first, so the passes below —
+            // including each eye of a stereo pair — sample this frame's image.
+            if !drawn_frame.ui_targets.is_empty() {
+                ui_target_renderer.render(&scene_context, &drawn_frame.ui_targets);
+            }
 
             // Shadow + forward passes, shared with the web runtime. In stereo
             // mode, render the same frame twice — once per eye camera into each

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -1099,6 +1099,9 @@ pub fn android_main(app: AndroidApp) {
     let asset_cache = Arc::new(AssetCache::new());
     let scene_context = SceneContext::new();
     let shadow_map = functor_runtime_common::shadow::ShadowMap::new(&gl, 2048);
+    // `Frame.withUiTarget` passes: constructed lazily on the first frame that
+    // declares one, so games without ui targets never build an egui painter.
+    let mut ui_target_renderer: Option<functor_runtime_common::ui::UiTargetRenderer> = None;
 
     // The real Functor Lang producer, booting the embedded scene. A broken embedded
     // scene is a build bug, not a runtime condition — fail loud.
@@ -1365,15 +1368,14 @@ pub fn android_main(app: AndroidApp) {
         }
         let frame = game.render(frame_time.clone());
         if !frame.ui_targets.is_empty() {
-            // Frame.withUiTarget is not wired on this shell yet — the screen
-            // samples the magenta fallback. Warn once so the gap is loud.
-            static UI_TARGETS_WARNED: std::sync::Once = std::sync::Once::new();
-            UI_TARGETS_WARNED.call_once(|| {
-                log::warn!(
-                    "Frame.withUiTarget is not supported on the VR runtime yet; \
-ui-target screens render the fallback texture"
-                );
+            // Paint ui-target passes ONCE per frame, before the per-eye
+            // passes — both eyes sample the same published image. The
+            // renderer saves and restores the ambient FBO binding, so the
+            // eye swapchain bindings below are unaffected.
+            let renderer = ui_target_renderer.get_or_insert_with(|| {
+                functor_runtime_common::ui::UiTargetRenderer::new(gl.clone())
             });
+            renderer.render(&scene_context, &frame);
         }
         // No audio/HTTP hosts on device yet: drain their command queues so
         // they don't grow unbounded. Preloads and physics terrain requests

--- a/runtime/functor-runtime-oculus/src/lib.rs
+++ b/runtime/functor-runtime-oculus/src/lib.rs
@@ -1364,6 +1364,17 @@ pub fn android_main(app: AndroidApp) {
             debug.frame_count += 1;
         }
         let frame = game.render(frame_time.clone());
+        if !frame.ui_targets.is_empty() {
+            // Frame.withUiTarget is not wired on this shell yet — the screen
+            // samples the magenta fallback. Warn once so the gap is loud.
+            static UI_TARGETS_WARNED: std::sync::Once = std::sync::Once::new();
+            UI_TARGETS_WARNED.call_once(|| {
+                log::warn!(
+                    "Frame.withUiTarget is not supported on the VR runtime yet; \
+ui-target screens render the fallback texture"
+                );
+            });
+        }
         // No audio/HTTP hosts on device yet: drain their command queues so
         // they don't grow unbounded. Preloads and physics terrain requests
         // are driven above through the shared asset cache.

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1965,7 +1965,7 @@ async fn run_async() -> Result<(), JsValue> {
             // `Frame.withUiTarget` passes go first, so the main pass below
             // samples this frame's image.
             if !frame.ui_targets.is_empty() {
-                ui_target_renderer.render(&scene_context, &frame.ui_targets);
+                ui_target_renderer.render(&scene_context, &frame);
             }
             // Shadow + forward passes, shared with the desktop runtime.
             functor_runtime_common::render_frame_with_view(

--- a/runtime/functor-runtime-web/src/lib.rs
+++ b/runtime/functor-runtime-web/src/lib.rs
@@ -1428,6 +1428,9 @@ async fn run_async() -> Result<(), JsValue> {
         // The 2D UI overlay (egui), painting the game's `ui model` View on top of
         // the 3D frame — the web sibling of the desktop runner's overlay.
         let mut text_overlay = functor_runtime_common::ui::TextOverlay::new(gl.clone());
+        // `Frame.withUiTarget` passes: Ui views painted into render targets
+        // before the main pass samples them (`Scene.screen`).
+        let mut ui_target_renderer = functor_runtime_common::ui::UiTargetRenderer::new(gl.clone());
 
         // In deterministic mode (?fixed-time, the golden) the canvas is sized
         // once and then left fixed (see below), and the render loop stops after
@@ -1958,6 +1961,11 @@ async fn run_async() -> Result<(), JsValue> {
             // Preview overlays go on the live frame.
             if let Some(p) = &preview {
                 p.apply_all_with_presence(&mut frame, display_presence);
+            }
+            // `Frame.withUiTarget` passes go first, so the main pass below
+            // samples this frame's image.
+            if !frame.ui_targets.is_empty() {
+                ui_target_renderer.render(&scene_context, &frame.ui_targets);
             }
             // Shadow + forward passes, shared with the desktop runtime.
             functor_runtime_common::render_frame_with_view(

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -674,7 +674,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (29, 323));
+        assert_eq!(count(ApiGroup::Engine), (29, 324));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
## What

`Frame.withUiTarget(target, view)` paints a declarative `Ui.*` tree into a named render target each frame, before the main pass — so the existing `Scene.screen` reader can put a live, model-driven UI on world geometry (a monitor mesh, a cockpit panel). Phase 1 of the [ui-render-targets plan]: display-only, native + web.

```fun
let board = RenderTarget.named("scoreboard") |> RenderTarget.sized(512.0, 256.0)

let draw = (m, tts) =>
  Frame.createLit(camera, Scene.group([arena(tts), monitor()]), lights())
  |> Frame.withUiTarget(board, scoreboard(m.score, tts))
// monitor(): Scene.quad() |> Scene.screen(board)
```

## How

- `Frame.ui_targets: Vec<UiTargetPass { target, view }>` (`serde(default, skip_serializing_if = empty)` — wire format pinned; legacy frames decode unchanged).
- `UiTargetRenderer` (ui.rs): its own egui context (the overlay's retains real pointer position across runs — sharing it would replay hover onto target widgets), painting through the same extracted `run_and_paint_with`/`render_root` path as `TextOverlay`. FBO binding captured before `ensure_render_target` and restored after (the shadow-pass rule). Every egui `Area` id is salted per pass, so passes sharing a context never share retained Area state.
- Both shells render ui targets once, before the main pass (before the stereo eye loop), so `Scene.screen` samples this frame's image.
- Duplicate ids: first declaration wins with a one-time warning (matching `withRenderTarget`); an id declared by both `withUiTarget` and `withRenderTarget` skips the ui pass with a warning; nested ui targets inside a target frame warn once.
- **Display-only for now**: handlers registered during the draw eval are dropped right after it with a one-time warning. This also fixes a pre-existing silent leak — draw-eval `Ui.*` handler pushes previously accumulated forever when no `ui`/`webview` hook existed, and ghost/history auxiliary draws never drained. Producer-level test pins that a `withUiTarget` button never reaches the `ui` hook's table.
- `examples/monitor-ui`: a world-space arena scoreboard driven by the model.

## VR (device-verified on a Quest 3)

Closes #707. Closes #708.

- The Oculus shell now paints `Frame.withUiTarget` passes once per frame, before the per-eye loop (lazily constructed egui painter — games without ui targets never build one).
- Fixed the pre-existing #708 bug this work surfaced: 3D target passes (and the composite path) reset the framebuffer to `None` instead of restoring the caller's binding, freezing the headset for any `Frame.withRenderTarget` game (reproduced on device with `examples/monitor` — eyes stopped updating; fixed via the shared `renderer::ambient_framebuffer` capture/restore, re-verified live on device). Desktop/web behavior is unchanged (ambient binding is `None` there; goldens identical).
- **Bench** (release APK, signed locally; `npm run bench:quest -- --label monitor-ui --warmup 10 --seconds 30`, Quest 3 @ 80 Hz): 80.76 FPS mean, p5 = min = 80; App 2.43 ms mean; CPU+GPU 4.16 ms; GPU load 0.29; 1 stale / 0 torn frames; 195.8 MiB PSS.

![quest stereo](https://gist.githubusercontent.com/tommy-xr/d1214e2d42466d6280423da5e4f624a3/raw/monitor-ui-quest-stereo.png)

<sub>Raw per-eye swapchain capture (`POST /capture`, 3360x1760) — the scoreboard live in both eyes at match clock 26s (home 6 = floor(26/4), away 3 = floor(26/8)).</sub>

## Not in this PR (follow-ups)

- **Transparency**: targets clear to the engine default background; a transparent-UI-panel variant (clear alpha 0 + per-texel premultiplied blend reader) is the next stacked PR.
- **Interaction** (pick-to-interact) is Phase 3 of the plan.

## Verification

- `cargo test -p functor_runtime_common` (741) and `-p functor-runtime-desktop` (95) green; drift test pins registry ≡ `.funi`.
- CI-strict (`--features=strict`) build clean; `wasm32` check clean; `npm run test:golden` green.
- `functor -d examples/monitor-ui build/test` green; native `--capture-frame --fixed-time 9` shows home 2 / away 1 / clock 9s (deterministic); web runtime verified via Playwright screenshot, no console errors.
- **frame_bench** (release, back-to-back): `allocs/frame` identical (13877 / 54717 / 106973); `bytes/frame` +24 constant at every scale (the `Frame` struct's new empty Vec in the per-frame `last_frame` clone); wall-clock min within run-to-run spread (branch runs bracket main's).
- `/xreview` (Claude + Codex + de-dup pass) ran; all Critical/High/Medium findings fixed in the second commit (FBO capture order, duplicate-id semantics, Area-id salting, paint-path dedup, producer drain dedup + test, nested-ui warning, VR warning) and verification re-run after the fixes. Remaining Lows dispositioned: clear color is documented as engine-default pending the transparency PR; `pixels_per_point` pinned at 1.0 (text size follows target resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

![monitor-ui demo](https://gist.githubusercontent.com/tommy-xr/d1214e2d42466d6280423da5e4f624a3/raw/monitor-ui.gif)

<sub>examples/monitor-ui — a model-driven Ui view painted into a render target (`Frame.withUiTarget`) and shown on a world-space monitor via `Scene.screen`. Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![monitor-ui at t=9 — home 2 / away 1 / clock 9s](https://gist.githubusercontent.com/tommy-xr/d1214e2d42466d6280423da5e4f624a3/raw/monitor-ui-t9.png)

