### PR TITLE
feat(cli): multiplayer init template — same-file client/server roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ by default; `--format json`, `--output <path>`, and `--check <path>` are availab
 `functor.json` or `game.fun`; `3d` is the default template:
 
 ```sh
-./target/debug/functor -d my-game init [3d|fps]
+./target/debug/functor -d my-game init [3d|fps|multiplayer]
 ```
 
 **Run / build a game.** The CLI operates on a directory with a `functor.json`

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ use `./target/release/functor` instead — see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 | Command | Description |
 | --- | --- |
-| `functor -d <dir> init [3d\|fps]` | Scaffold a new Functor Lang project (`3d` is the default) |
+| `functor -d <dir> init [3d\|fps\|multiplayer]` | Scaffold a new Functor Lang project (`3d` is the default; `multiplayer` scaffolds client + server roles) |
 | `functor -d <dir> build [native\|wasm]` | Typecheck the `.fun` project (diagnostics are errors) |
 | `functor -d <dir> run [native\|wasm]` | Interpret and run the game (native window / browser) |
 | `functor -d <dir> develop [native\|wasm]` | Same as `run` — Functor Lang hot-reload is built into the runtime — plus, on native, the debug runtime on `localhost:8077` (`--no-debug` to skip it) |

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -216,7 +216,7 @@ mod tests {
         name: &str,
         template: Template,
         expected: &[(&str, &'static str)],
-    ) {
+    ) -> TestDir {
         let directory = TestDir::new(name);
         execute(&directory.0, &template).unwrap();
 
@@ -230,11 +230,12 @@ mod tests {
             );
         }
         assert_project_typechecks(&directory.0);
+        directory
     }
 
     #[test]
     fn three_d_template_creates_a_typechecked_project() {
-        assert_template_scaffolds(
+        let _ = assert_template_scaffolds(
             "3d",
             Template::ThreeD,
             &[("functor.json", MANIFEST_3D), ("game.fun", GAME_3D)],
@@ -243,7 +244,7 @@ mod tests {
 
     #[test]
     fn fps_template_creates_a_typechecked_project() {
-        assert_template_scaffolds(
+        let _ = assert_template_scaffolds(
             "fps",
             Template::Fps,
             &[("functor.json", MANIFEST_FPS), ("game.fun", GAME_FPS)],
@@ -256,7 +257,7 @@ mod tests {
     /// resolved and contract-checked against the loaded project.
     #[test]
     fn multiplayer_template_creates_a_typechecked_project() {
-        assert_template_scaffolds(
+        let directory = assert_template_scaffolds(
             "multiplayer",
             Template::Multiplayer,
             &[
@@ -265,8 +266,6 @@ mod tests {
             ],
         );
 
-        let directory = TestDir::new("multiplayer-roles");
-        execute(&directory.0, &Template::Multiplayer).unwrap();
         let config = crate::commands::functor_lang_project::detect(&directory.0.to_string_lossy())
             .expect("the scaffolded functor.json is a Functor Lang project");
         let project = functor_lang::project::load_with_bundled_modules(
@@ -275,8 +274,12 @@ mod tests {
             &functor_prelude::bundled_modules(),
         )
         .unwrap_or_else(|error| panic!("template should load: {}", error.render()));
+        // The role NAMES are part of the contract too: the header tells the
+        // user to run `--entry server`, and a bare `run` must pick the client.
         let roles = config.all().expect("both roles resolve");
-        assert_eq!(roles.len(), 2, "client and server");
+        let names: Vec<&str> = roles.iter().map(|role| role.role.as_str()).collect();
+        assert_eq!(names, ["client", "server"]);
+        assert_eq!(config.select(None).unwrap().role, "client");
         for role in roles {
             role.check_contract(&project)
                 .unwrap_or_else(|error| panic!("role contract should validate: {error}"));

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -9,6 +9,8 @@ const MANIFEST_3D: &str = include_str!("../../templates/functor.json");
 const MANIFEST_FPS: &str = include_str!("../../templates/fps/functor.json");
 const GAME_3D: &str = include_str!("../../templates/3d/game.fun");
 const GAME_FPS: &str = include_str!("../../templates/fps/game.fun");
+const MANIFEST_MULTIPLAYER: &str = include_str!("../../templates/multiplayer/functor.json");
+const GAME_MULTIPLAYER: &str = include_str!("../../templates/multiplayer/game.fun");
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum Template {
@@ -18,6 +20,8 @@ pub enum Template {
     ThreeD,
     /// A first-person WASD + mouse-look scene.
     Fps,
+    /// An authoritative client/server multiplayer starter (both roles in one file).
+    Multiplayer,
 }
 
 impl Template {
@@ -25,6 +29,7 @@ impl Template {
         match self {
             Self::ThreeD => "3d",
             Self::Fps => "fps",
+            Self::Multiplayer => "multiplayer",
         }
     }
 
@@ -40,6 +45,7 @@ impl Template {
         match self {
             Self::ThreeD => FILES_3D,
             Self::Fps => FILES_FPS,
+            Self::Multiplayer => FILES_MULTIPLAYER,
         }
     }
 }
@@ -68,6 +74,17 @@ static FILES_FPS: &[TemplateFile] = &[
     TemplateFile {
         name: "game.fun",
         contents: GAME_FPS,
+    },
+];
+
+static FILES_MULTIPLAYER: &[TemplateFile] = &[
+    TemplateFile {
+        name: "functor.json",
+        contents: MANIFEST_MULTIPLAYER,
+    },
+    TemplateFile {
+        name: "game.fun",
+        contents: GAME_MULTIPLAYER,
     },
 ];
 
@@ -151,7 +168,10 @@ fn rollback(directory: &Path, created_directory: bool, created_files: &[PathBuf]
 
 #[cfg(test)]
 mod tests {
-    use super::{execute, Template, GAME_3D, GAME_FPS, MANIFEST_3D, MANIFEST_FPS};
+    use super::{
+        execute, Template, GAME_3D, GAME_FPS, GAME_MULTIPLAYER, MANIFEST_3D, MANIFEST_FPS,
+        MANIFEST_MULTIPLAYER,
+    };
     use std::collections::HashMap;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -228,6 +248,39 @@ mod tests {
             Template::Fps,
             &[("functor.json", MANIFEST_FPS), ("game.fun", GAME_FPS)],
         );
+    }
+
+    /// The multiplayer template declares TWO roles, so typechecking is not the
+    /// whole gate: `build` also validates each declared role's contract. This
+    /// walks the same path — every role in the scaffolded `functor.json`,
+    /// resolved and contract-checked against the loaded project.
+    #[test]
+    fn multiplayer_template_creates_a_typechecked_project() {
+        assert_template_scaffolds(
+            "multiplayer",
+            Template::Multiplayer,
+            &[
+                ("functor.json", MANIFEST_MULTIPLAYER),
+                ("game.fun", GAME_MULTIPLAYER),
+            ],
+        );
+
+        let directory = TestDir::new("multiplayer-roles");
+        execute(&directory.0, &Template::Multiplayer).unwrap();
+        let config = crate::commands::functor_lang_project::detect(&directory.0.to_string_lossy())
+            .expect("the scaffolded functor.json is a Functor Lang project");
+        let project = functor_lang::project::load_with_bundled_modules(
+            &directory.0.join("game.fun"),
+            &HashMap::new(),
+            &functor_prelude::bundled_modules(),
+        )
+        .unwrap_or_else(|error| panic!("template should load: {}", error.render()));
+        let roles = config.all().expect("both roles resolve");
+        assert_eq!(roles.len(), 2, "client and server");
+        for role in roles {
+            role.check_contract(&project)
+                .unwrap_or_else(|error| panic!("role contract should validate: {error}"));
+        }
     }
 
     #[test]

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -1067,7 +1067,10 @@ pub struct InitGameArgs {
     /// Directory to scaffold, absolute or relative to the MCP server's
     /// working directory. It is created if it does not exist.
     pub dir: String,
-    /// `"3d"` (default — a small lit scene) or `"fps"` (WASD + mouse-look).
+    /// `"3d"` (default — a small lit scene), `"fps"` (WASD + mouse-look), or
+    /// `"multiplayer"` (an authoritative client/server starter whose `client`
+    /// and `server` roles share one file; run the authority with
+    /// `launch_game`'s `entry: "server"`).
     pub template: Option<String>,
 }
 
@@ -2073,7 +2076,9 @@ in the list have already advanced; the group is no longer in lockstep."
 
     /// Scaffold a new project on disk — the same `functor.json` + `game.fun`
     /// starter `functor init` writes. `template` is `"3d"` (default, a small
-    /// lit scene) or `"fps"` (WASD + mouse-look). Existing files are never
+    /// lit scene), `"fps"` (WASD + mouse-look), or `"multiplayer"` (an
+    /// authoritative client/server starter — launch its authority with
+    /// `launch_game`'s `entry: "server"`). Existing files are never
     /// overwritten. The directory it returns is ready to pass straight to
     /// `launch_game`'s `dir`.
     #[tool]

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -2085,10 +2085,12 @@ in the list have already advanced; the group is no longer in lockstep."
         let template = match name {
             "3d" => crate::commands::init::Template::ThreeD,
             "fps" => crate::commands::init::Template::Fps,
+            "multiplayer" => crate::commands::init::Template::Multiplayer,
             other => {
                 return tool_error(format!(
                     "unknown template {other:?}: expected \"3d\" (a small lit 3D scene) \
-or \"fps\" (a first-person WASD + mouse-look scene)"
+or \"fps\" (a first-person WASD + mouse-look scene) or \"multiplayer\" (an \
+authoritative client/server starter)"
                 ))
             }
         };

--- a/cli/templates/multiplayer/functor.json
+++ b/cli/templates/multiplayer/functor.json
@@ -1,0 +1,7 @@
+{
+  "language": "functor-lang",
+  "entries": {
+    "client": { "file": "game.fun", "module": "Client" },
+    "server": { "file": "game.fun", "module": "Server" }
+  }
+}

--- a/cli/templates/multiplayer/game.fun
+++ b/cli/templates/multiplayer/game.fun
@@ -1,0 +1,204 @@
+// An authoritative multiplayer starter: move your square, the SERVER owns the
+// world. Start the authority, then dial it with one client per player:
+//   functor -d . run native --entry server
+//   functor -d . run native                  # a player (repeat for a second)
+// Arrows or WASD move. Saving this file hot-reloads BOTH roles at once.
+//
+// Both roles are inline modules of this ONE file — `module Client` and
+// `module Server` at the bottom; each block's members ARE that role's contract
+// (`Client.init`/`Client.tick`/…), and functor.json maps the roles to them.
+// Everything above the blocks is shared: the protocol is declared exactly once,
+// so the two ends cannot drift apart.
+
+// ============================  PROTOCOL  ==============================
+
+let bind = "127.0.0.1:9300"                  // the server's listen address…
+let serverUrl = "ws://127.0.0.1:9300/game"   // …and the string a client dials
+
+let half = 8.0          // arena half-extent (world units)
+let moveSpeed = 7.0     // units/second
+
+type Player = { pid: float, x: float, y: float }
+type Intent = { dx: float, dy: float }       // held controls, per tick
+
+// The wire. `Effect.sendMsg` carries these values structurally — no string
+// codec, and a typo is a check-time error.
+//   Join            client -> server, once: opens the handshake
+//   Welcome(pid)    server -> client: your identity
+//   Steer(intent)   client -> server, per tick: held controls. Carries NO pid —
+//                   the server keys it by the connection it arrived on.
+//   Snapshot(...)   server -> client, per tick: the authoritative state
+type Wire =
+  | Join
+  | Welcome(pid: float)
+  | Steer(intent: Intent)
+  | Snapshot(players: List<Player>)
+
+// Both ends see the same socket events; only what they DO with them differs.
+type Msg =
+  | Opened(id: float)
+  | Packet(id: float, wire: Wire)
+  | Closed(id: float)
+  | Noise(why: string)          // a bad frame or a hiccup — NOT a disconnect
+
+let toMsg = (ev: Net.NetEvent): Msg =>
+  match ev with
+  | Net.Connected(id) => Opened(id)
+  | Net.Data(id, wire) => Packet(id, wire)
+  | Net.Disconnected(id) => Closed(id)
+  | Net.Error(_, why) => Noise(why)
+  | Net.Message(_, _) => Noise("unexpected text frame")   // this wire is typed
+
+// =========================  THE WORLD (shared)  =======================
+// PURE functions over the protocol types. `module Server` is the role that
+// puts them behind a socket.
+
+type Pilot = { player: Player, intent: Intent }
+type World = { pilots: List<Pilot>, nextPid: float }
+
+let still: Intent = { dx: 0.0, dy: 0.0 }
+let newWorld = (): World => { pilots: [], nextPid: 0.0 }
+
+let join = (w: World): (World, float) =>      // allocate a pid and spawn it
+  let pid = w.nextPid in
+  let spawn = { pid: pid, x: 0.0 - 6.0 + Math.mod(pid, 4.0) * 4.0, y: 0.0 } in
+  ({ pilots: [{ player: spawn, intent: still }, ..w.pilots], nextPid: pid + 1.0 }, pid)
+
+let leave = (pid: float, w: World): World =>
+  { w with pilots: w.pilots |> List.filter((p: Pilot) => not (p.player.pid == pid)) }
+
+// Fold one arriving message in, keyed by the CONNECTION it arrived on —
+// identity is never read from the wire value, so nobody can steer a rival.
+let recv = (senderPid: float, wire: Wire, w: World): World =>
+  match wire with
+  | Steer(intent) =>
+      { w with pilots: w.pilots |> List.map((p: Pilot) =>
+          if p.player.pid == senderPid then { p with intent: intent } else p) }
+  | _ => w              // Join/Welcome/Snapshot: nothing to fold here
+
+let stepPlayer = (i: Intent, dt: float, p: Player): Player =>
+  { p with x: Math.clamp(0.0 - half, half, p.x + i.dx * moveSpeed * dt),
+           y: Math.clamp(0.0 - half, half, p.y + i.dy * moveSpeed * dt) }
+
+let step = (dt: float, w: World): World =>
+  { w with pilots: w.pilots |> List.map((p: Pilot) =>
+      { p with player: stepPlayer(p.intent, dt, p.player) }) }
+
+// ======================  PRESENTATION (shared)  =======================
+// Both roles draw the same board — the client from the last Snapshot it was
+// sent, the authority from the world it owns. Color carries IDENTITY, so a
+// player looks the same in every window.
+
+let ink = (pid: float) =>
+  if Math.mod(pid, 2.0) == 0.0 then Color.rgb(0.25, 0.85, 0.9)
+  else Color.rgb(0.91, 0.35, 0.72)
+
+let board = (me: float, status: string, players: List<Player>) =>
+  Frame.create2D(
+    Camera2D.create(half * 2.0 + 4.0, half * 2.0 + 4.0),
+    Sprite.group(
+      [Sprite.rectangle(Color.rgb(0.12, 0.14, 0.25), half * 2.0, half * 2.0),
+       status |> Sprite.text(Color.rgb(0.75, 0.8, 0.95), 0.8)
+              |> Sprite.move(0.0, half + 1.2)]
+        |> List.append(players |> List.map((p: Player) =>
+             Sprite.rectangle(ink(p.pid), 1.2, 1.2)
+               |> Sprite.fade(if p.pid == me then 1.0 else 0.55)   // yours is bright
+               |> Sprite.move(p.x, p.y)))))
+    |> Frame.withClearColor(Color.rgb(0.03, 0.03, 0.08))
+
+// =============================  CLIENT  ===============================
+// Holds NO authority: it dials the server, says what it is doing, and draws
+// the last Snapshot it was sent. Your pid arrives in the Welcome.
+
+module Client {
+  type Model = { conn: Option.t<float>, myPid: float,
+                 players: List<Player>, intent: Intent }
+
+  let init: Model = { conn: Option.None, myPid: 0.0 - 1.0,
+                      players: [], intent: still }
+
+  // Declaring the connection in `subscriptions` keeps the socket open.
+  let subscriptions = (m: Model) => Sub.connect(serverUrl, toMsg)
+
+  let update = (m: Model, msg: Msg) =>
+    match msg with
+    | Opened(id) => ({ m with conn: Option.Some(id) }, Effect.sendMsg(id, Join))
+    | Packet(_, wire) =>
+        (match wire with
+         | Welcome(pid) => { m with myPid: pid }
+         | Snapshot(players) => { m with players: players }
+         | _ => m)                     // Join/Steer are client -> server only
+    | Closed(_) => { m with conn: Option.None, players: [] }
+    | Noise(_) => m                    // a hiccup is not a disconnect
+
+  // Held LEVELS, read once per tick — exactly what the Steer forwards.
+  let sampledInput = (m: Model, snap: Input.snapshot) =>
+    let held = (k: Key.t) => snap.heldKeys |> List.any((h: Key.t) => h == k) in
+    { m with intent: {
+        dx: (if held(Key.Right) || held(Key.D) then 1.0 else 0.0)
+          - (if held(Key.Left) || held(Key.A) then 1.0 else 0.0),
+        dy: (if held(Key.Up) || held(Key.W) then 1.0 else 0.0)
+          - (if held(Key.Down) || held(Key.S) then 1.0 else 0.0) } }
+
+  // One burst per tick — a PROPOSAL, not a fact: the server decides where you
+  // actually end up, and the next Snapshot says so.
+  let tick = (m: Model, dt: float, tts: float) =>
+    match m.conn with
+    | Option.None => m
+    | Option.Some(id) => (m, Effect.sendMsg(id, Steer(m.intent)))
+
+  let draw = (m: Model, tts: float) =>
+    match m.conn with
+    | Option.None => board(m.myPid, "connecting to the server...", m.players)
+    | Option.Some(_) => board(m.myPid, "arrows / WASD to move", m.players)
+}
+
+// =============================  SERVER  ===============================
+// The same file's other block, run with `--entry server`. It owns the world:
+// every client sends intent, the server steps and broadcasts the truth.
+
+module Server {
+  type Seat = { cid: float, pid: float }   // connection -> the player it steers
+
+  let init = { world: newWorld(), seats: [] }
+
+  // Declaring the listener in `subscriptions` keeps the server bound.
+  let subscriptions = (m) => Sub.listen(bind, toMsg)
+
+  let seatPid = (cid: float, m): Option.t<float> =>
+    m.seats |> List.find((s: Seat) => s.cid == cid) |> Option.map((s: Seat) => s.pid)
+
+  let update = (m, msg: Msg) =>
+    match msg with
+    | Opened(_) => m       // a socket, not yet a player: the Join seats it
+    | Packet(cid, wire) =>
+        (match wire with
+         | Join =>          // the handshake: seat a player, answer its identity
+           (match seatPid(cid, m) with
+            | Option.Some(pid) => (m, Effect.sendMsg(cid, Welcome(pid)))
+            | Option.None =>
+              let (w, pid) = join(m.world) in
+              ({ m with world: w, seats: [{ cid: cid, pid: pid }, ..m.seats] },
+               Effect.sendMsg(cid, Welcome(pid))))
+         | _ =>             // keyed by the connection, never by the wire value
+           (match seatPid(cid, m) with
+            | Option.Some(pid) => { m with world: m.world |> recv(pid, wire) }
+            | Option.None => m))
+    | Closed(cid) =>
+        (match seatPid(cid, m) with
+         | Option.Some(pid) =>
+           { m with world: m.world |> leave(pid),
+                    seats: m.seats |> List.filter((s: Seat) => not (s.cid == cid)) }
+         | Option.None => m)
+    | Noise(_) => m
+
+  let tick = (m, dt: float, tts: float) =>
+    let stepped = m.world |> step(dt) in
+    let snap = Snapshot(stepped.pilots |> List.map((p: Pilot) => p.player)) in
+    ({ m with world: stepped },
+     Effect.batch(m.seats |> List.map((s: Seat) => Effect.sendMsg(s.cid, snap))))
+
+  let draw = (m, tts: float) =>   // the authority holds no seat of its own
+    board(0.0 - 1.0, "server - the authority",
+          m.world.pilots |> List.map((p: Pilot) => p.player))
+}

--- a/cli/templates/multiplayer/game.fun
+++ b/cli/templates/multiplayer/game.fun
@@ -3,6 +3,8 @@
 //   functor -d . run native --entry server
 //   functor -d . run native                  # a player (repeat for a second)
 // Arrows or WASD move. Saving this file hot-reloads BOTH roles at once.
+// Start the authority FIRST: a client that finds nobody home says so in its
+// status line and keeps retrying, backing off up to 8s between attempts.
 //
 // Both roles are inline modules of this ONE file — `module Client` and
 // `module Server` at the bottom; each block's members ARE that role's contract
@@ -16,6 +18,7 @@ let bind = "127.0.0.1:9300"                  // the server's listen address…
 let serverUrl = "ws://127.0.0.1:9300/game"   // …and the string a client dials
 
 let half = 8.0          // arena half-extent (world units)
+let boxHalf = 0.6       // half a player square, so the clamp keeps it inside
 let moveSpeed = 7.0     // units/second
 
 type Player = { pid: float, x: float, y: float }
@@ -61,7 +64,7 @@ let newWorld = (): World => { pilots: [], nextPid: 0.0 }
 
 let join = (w: World): (World, float) =>      // allocate a pid and spawn it
   let pid = w.nextPid in
-  let spawn = { pid: pid, x: 0.0 - 6.0 + Math.mod(pid, 4.0) * 4.0, y: 0.0 } in
+  let spawn = { pid: pid, x: -6.0 + Math.mod(pid, 4.0) * 4.0, y: 0.0 } in
   ({ pilots: [{ player: spawn, intent: still }, ..w.pilots], nextPid: pid + 1.0 }, pid)
 
 let leave = (pid: float, w: World): World =>
@@ -74,11 +77,20 @@ let recv = (senderPid: float, wire: Wire, w: World): World =>
   | Steer(intent) =>
       { w with pilots: w.pilots |> List.map((p: Pilot) =>
           if p.player.pid == senderPid then { p with intent: intent } else p) }
-  | _ => w              // Join/Welcome/Snapshot: nothing to fold here
+  | Join => w             // the handshake, answered where seats are handed out
+  | Welcome(_) => w       // server -> client only; nothing to fold
+  | Snapshot(_) => w      // server -> client only; nothing to fold
 
+// The authority moves a player. NEVER TRUST THE CLIENT: an intent arrives over
+// the wire, so clamp it to one unit per axis here rather than believing a peer
+// that claims dx = 1000. Diagonals are evened out so they aren't 1.41x faster.
 let stepPlayer = (i: Intent, dt: float, p: Player): Player =>
-  { p with x: Math.clamp(0.0 - half, half, p.x + i.dx * moveSpeed * dt),
-           y: Math.clamp(0.0 - half, half, p.y + i.dy * moveSpeed * dt) }
+  let dx = Math.clamp(-1.0, 1.0, i.dx) in
+  let dy = Math.clamp(-1.0, 1.0, i.dy) in
+  let even = if dx != 0.0 && dy != 0.0 then 0.7071 else 1.0 in
+  let reach = half - boxHalf in
+  { p with x: Math.clamp(-reach, reach, p.x + dx * even * moveSpeed * dt),
+           y: Math.clamp(-reach, reach, p.y + dy * even * moveSpeed * dt) }
 
 let step = (dt: float, w: World): World =>
   { w with pilots: w.pilots |> List.map((p: Pilot) =>
@@ -112,24 +124,29 @@ let board = (me: float, status: string, players: List<Player>) =>
 
 module Client {
   type Model = { conn: Option.t<float>, myPid: float,
-                 players: List<Player>, intent: Intent }
+                 players: List<Player>, intent: Intent, note: string }
 
-  let init: Model = { conn: Option.None, myPid: 0.0 - 1.0,
-                      players: [], intent: still }
+  let init: Model = { conn: Option.None, myPid: -1.0, players: [],
+                      intent: still, note: "waiting for the server..." }
 
   // Declaring the connection in `subscriptions` keeps the socket open.
   let subscriptions = (m: Model) => Sub.connect(serverUrl, toMsg)
 
   let update = (m: Model, msg: Msg) =>
     match msg with
-    | Opened(id) => ({ m with conn: Option.Some(id) }, Effect.sendMsg(id, Join))
+    | Opened(id) => ({ m with conn: Option.Some(id), note: "" },
+                      Effect.sendMsg(id, Join))
     | Packet(_, wire) =>
         (match wire with
          | Welcome(pid) => { m with myPid: pid }
          | Snapshot(players) => { m with players: players }
-         | _ => m)                     // Join/Steer are client -> server only
-    | Closed(_) => { m with conn: Option.None, players: [] }
-    | Noise(_) => m                    // a hiccup is not a disconnect
+         | Join => m                   // Join/Steer are client -> server only
+         | Steer(_) => m)
+    | Closed(_) => { m with conn: Option.None, players: [],
+                            note: "the server went away..." }
+    // A hiccup is not a disconnect — but SHOW it: a server that never came up
+    // reports here ("connection refused"), and silence would be baffling.
+    | Noise(why) => { m with note: why }
 
   // Held LEVELS, read once per tick — exactly what the Steer forwards.
   let sampledInput = (m: Model, snap: Input.snapshot) =>
@@ -149,7 +166,7 @@ module Client {
 
   let draw = (m: Model, tts: float) =>
     match m.conn with
-    | Option.None => board(m.myPid, "connecting to the server...", m.players)
+    | Option.None => board(m.myPid, m.note, m.players)
     | Option.Some(_) => board(m.myPid, "arrows / WASD to move", m.players)
 }
 
@@ -160,7 +177,7 @@ module Client {
 module Server {
   type Seat = { cid: float, pid: float }   // connection -> the player it steers
 
-  let init = { world: newWorld(), seats: [] }
+  let init = { world: newWorld(), seats: [], note: "" }
 
   // Declaring the listener in `subscriptions` keeps the server bound.
   let subscriptions = (m) => Sub.listen(bind, toMsg)
@@ -170,7 +187,9 @@ module Server {
 
   let update = (m, msg: Msg) =>
     match msg with
-    | Opened(_) => m       // a socket, not yet a player: the Join seats it
+    // A socket, not yet a player: the Join seats it. An accepted socket also
+    // proves the listener is up, so it clears any earlier complaint.
+    | Opened(_) => { m with note: "" }
     | Packet(cid, wire) =>
         (match wire with
          | Join =>          // the handshake: seat a player, answer its identity
@@ -190,7 +209,9 @@ module Server {
            { m with world: m.world |> leave(pid),
                     seats: m.seats |> List.filter((s: Seat) => not (s.cid == cid)) }
          | Option.None => m)
-    | Noise(_) => m
+    // A failed bind (the port already in use) arrives here — show it rather
+    // than drawing a healthy-looking arena nobody can reach.
+    | Noise(why) => { m with note: why }
 
   let tick = (m, dt: float, tts: float) =>
     let stepped = m.world |> step(dt) in
@@ -199,6 +220,6 @@ module Server {
      Effect.batch(m.seats |> List.map((s: Seat) => Effect.sendMsg(s.cid, snap))))
 
   let draw = (m, tts: float) =>   // the authority holds no seat of its own
-    board(0.0 - 1.0, "server - the authority",
+    board(-1.0, if m.note == "" then "server - the authority" else m.note,
           m.world.pilots |> List.map((p: Pilot) => p.player))
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -126,7 +126,7 @@ New and already-queued mutations on a closing id reject without runtime I/O.
 
 | Tool | What it does |
 | --- | --- |
-| `init_game` | Scaffold a starter project on disk — the same `functor.json` + `game.fun` `functor init` writes. `template` is `"3d"` (default) or `"fps"`. Never overwrites; its `dir` goes straight into `launch_game`. |
+| `init_game` | Scaffold a starter project on disk — the same `functor.json` + `game.fun` `functor init` writes. `template` is `"3d"` (default), `"fps"`, or `"multiplayer"`. Never overwrites; its `dir` goes straight into `launch_game`. |
 | `save_project` | Write a session's **current** source to a directory, with the `functor.json` it booted with — so a multi-entry (multiplayer) project keeps its roles. The sources come from the RUNTIME (`GET /project`), so they include every wire-only edit. Refuses a directory that already holds a project unless `overwrite`. |
 
 **Learning the language and the API.** Two session-free tools, and they are


### PR DESCRIPTION
Track D step 2: a `multiplayer` template for `functor init`, so the shortest path
to an authoritative client/server game is one command.

```sh
functor -d my-game init multiplayer
functor -d my-game run native --entry server   # the authority
functor -d my-game run native                  # a player (repeat for a second)
```

![The scaffolded multiplayer starter, client view: two player squares in a dark arena, this client's own square bright, the other dimmed, with an "arrows / WASD to move" status line](https://gist.githubusercontent.com/tommy-xr/6fc4ae72e9677c381824019e15ec73c1/raw/multiplayer-template-client.png)

*(client pane, pid 1 bright pink; the other player — driven headlessly and clamped
into the corner — is the dim cyan square. The server pane draws the same board with
no seat of its own.)*

## What the template contains

Two files, `functor.json` + `game.fun` (~200 lines with comments, asset-free, primitives only):

- **Protocol** (shared, bare at the top): `Player`/`Intent` records and a `Wire` ADT
  (`Join` / `Welcome(pid)` / `Steer(intent)` / `Snapshot(players)`), plus the
  `Net.NetEvent -> Msg` tagger.
- **World** (shared, pure): `join` / `leave` / `recv` / `stepPlayer` / `step` — no
  sockets, no rendering, unit-testable.
- **Presentation** (shared): one `board` both roles draw, colored by pid so a player
  looks the same in every window.
- **`module Client`**: `Sub.connect` keeps the socket open, `sampledInput` reads held
  levels, `tick` sends one `Steer` per tick, `draw` renders the last `Snapshot`.
- **`module Server`**: `Sub.listen` binds, seats are keyed by CONNECTION (identity is
  never read off the wire), `tick` steps the world and broadcasts a `Snapshot`.

## Why the same-file / orbs shape

`examples/orbs` is the multiplayer reference and the shape CLAUDE.md calls preferred
on native: one `game.fun` whose `client` and `server` roles are inline modules
(`{"file": "game.fun", "module": "Server"}`). For a *starter* that matters more than
for an example — the protocol is declared exactly once so the two ends cannot drift,
one buffer hot-reloads both roles atomically, and a beginner sees the whole system in
one screen. The roles-as-files shape (`examples/netpong`) is the thing to grow *into*
once roles outgrow one buffer; the header comment says so.

## Wiring

- `cli/src/commands/init.rs` — `Template::Multiplayer` + `FILES_MULTIPLAYER`.
- `cli/src/commands/mcp.rs` — `init_game` accepts `"multiplayer"`; both the tool
  rustdoc and the `template` field rustdoc (the schema an MCP client actually reads)
  name it, and point at `launch_game`'s `entry: "server"` for the authority.
- `README.md`, `docs/mcp.md` — the template lists. (`CLAUDE.md`'s own
  `init [3d|fps]` line is being updated separately.)

## Verification

- `cargo test -p functor-cli` — **141 passed, 0 failed**, including the new
  `multiplayer_template_creates_a_typechecked_project`. Beyond byte-verbatim scaffolding
  + typecheck, it walks the path `build` takes for a multi-role project: `detect` →
  `config.all()` → `check_contract` for **both** roles, asserts the role names are
  `client`/`server`, and asserts a bare run selects `client`.
- `functor -d <tmp> init multiplayer` then `functor -d <tmp> build`:
  `✓ checked game.fun as client` / `✓ checked game.fun as server`.
- Live, with a debug-built binary: server headless + clients, checked through
  `/state` —
  - handshake seats by connection: `seats: [{ cid: 1, pid: 0 }]`, client model
    `conn: Option.Some(1), myPid: 0`;
  - injected input moves the right player and clamps inside the arena
    (`x: -7.4, y: 7.4` with `dx: -1, dy: 1`, i.e. `±(half - boxHalf)`);
  - killing a client removes its seat and its pilot;
  - windowed `--capture-frame` of the client role (screenshot above) and of the
    server role both render.

## Review dispositions (`/xreview`: Claude subagent + Codex)

Both engines independently raised the same four issues — **[AGREED]**, all fixed in
`124f61d`:

- **[AGREED]** diagonal movement was 1.41× faster than cardinal → evened out.
- **[AGREED]** the clamp let a square's half-width protrude → clamp to `half - boxHalf`.
- **[AGREED]** `Noise` was swallowed, so a failed bind (port in use) or a refused
  connection looked identical to a healthy game → both roles keep the last socket
  complaint and show it in the status line; the server clears it when a socket is
  accepted.
- **[AGREED]** `recv`'s wildcard would silently ignore a newly added `Wire` variant →
  every variant enumerated, as orbs does (same for the client's inner match).

Also applied: server-side clamp of the received intent to ±1 per axis (Codex —
"never trust the client", which is the whole lesson of an authoritative server); unary
minus instead of `0.0 - x`; MCP rustdoc (Claude — the served schema, not just
`docs/mcp.md`); test asserts role names and no longer scaffolds twice.

Not applied: `CLAUDE.md:216`'s `init [3d|fps]` line (owned by a separate change).
Codex's first run reviewed an out-of-scope already-merged refactor; it was re-run with
a scope guard and the findings above are from that run.

Duplication pass (`dupfinder names --base main`): the only high scores are against
`examples/orbs` (`bind`, `serverUrl`, `toMsg`, `join`, `recv`, `step`, `board`) — by
design, since this is a deliberately simplified restatement of the reference shape in
a *scaffolded* file the user owns and edits; a template cannot import from `examples/`.

No visual before/after: this is a brand-new scene.
