### PR TITLE
feat(site): file sidebar + multi-file editing in the sandbox

### DIFF
--- a/e2e/sandbox-files.mjs
+++ b/e2e/sandbox-files.mjs
@@ -14,7 +14,9 @@
 //   4. analysis is project-wide: client.fun's calls into its sibling modules
 //      (Protocol.*, Game.*) resolve, and the Problems rows name the file the
 //      editor is actually showing;
-//   5. a single-file example shows no sidebar at all — unchanged from before
+//   5. an ordinary single-role multi-file example (asteroids) lists and edits
+//      its siblings too — the switcher isn't coupled to a server role;
+//   6. a single-file example shows no sidebar at all — unchanged from before
 //      the switcher existed.
 //
 // Run manually (needs the web-runtime wasm bundle):
@@ -228,7 +230,46 @@ const browser = await chromium.launch();
   await page.close();
 }
 
-// --- 5. A single-file example has no sidebar. ---------------------------------
+// --- 5. A multi-file SINGLE-ROLE example edits its siblings too. --------------
+// netpong proves the multiplayer path; asteroids is the ordinary case — one
+// pane, four files — so the switcher can't be quietly coupled to a server role.
+{
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.goto(`${BASE}/sandbox.html?example=asteroids`);
+  await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+    timeout: 40000,
+  });
+  const listed = await sidebar(page);
+  check(
+    listed.shown &&
+      listed.rows.join(", ") === "asteroids.fun, assets.fun, lib.fun, font.fun",
+    "a single-role multi-file example lists its siblings",
+    listed.rows.join(", ")
+  );
+  await page.click(".file-row:has(.file-label:text-is('lib.fun')) .file-name");
+  await page.evaluate(() =>
+    window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// sibling edit\n`)
+  );
+  const swapped = await page
+    .waitForFunction(
+      () =>
+        [...document.querySelectorAll(".output-line")].some((n) =>
+          n.textContent.includes("model preserved")
+        ),
+      null,
+      { timeout: 30000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  check(
+    swapped && (await page.evaluate(() => window.__sandbox.status().state)) === "live",
+    "editing a sibling module hot-reloads the preview",
+    (await page.locator(".output-line").allTextContents()).slice(-1).join("")
+  );
+  await page.close();
+}
+
+// --- 6. A single-file example has no sidebar. ---------------------------------
 {
   const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
   await page.goto(`${BASE}/sandbox.html?example=hero`);

--- a/e2e/sandbox-files.mjs
+++ b/e2e/sandbox-files.mjs
@@ -1,0 +1,263 @@
+// Sandbox multi-file e2e: the FILE SIDEBAR and editing a file that is not the
+// entry.
+//
+// The sandbox pushes the loaded example's whole file set over
+// `functor-lang-set-project` (e2e/sandbox-mp.mjs proves the push reaches every
+// role). This one proves the AUTHORING half of that seam:
+//
+//   1. a multi-file example (netpong: client/server/protocol/game) shows the
+//      sidebar, listing every .fun with the entry open;
+//   2. clicking a row switches the buffer — and only the buffer: nothing is
+//      pushed, so the running panes keep their models;
+//   3. an edit to server.fun — a file the editor could not previously open —
+//      hot-reloads the SERVER pane at its own entry, model preserved;
+//   4. analysis is project-wide: client.fun's calls into its sibling modules
+//      (Protocol.*, Game.*) resolve, and the Problems rows name the file the
+//      editor is actually showing;
+//   5. a single-file example shows no sidebar at all — unchanged from before
+//      the switcher existed.
+//
+// Run manually (needs the web-runtime wasm bundle):
+//
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/sandbox-files.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const PORT = Number(process.env.FUNCTOR_FILES_PORT ?? 8127);
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+const check = (ok, what, detail = "") => {
+  console.log(`${ok ? "  ok" : "FAIL"}  ${what}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+const build = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+try {
+  await fetch(BASE);
+  console.error(`port ${PORT} is already in use — kill the process on it first`);
+  process.exit(1);
+} catch {
+  // Nothing listening: good.
+}
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+process.on("exit", () => server.kill());
+for (let i = 0; ; i++) {
+  try {
+    await fetch(BASE);
+    break;
+  } catch {
+    if (i > 50) throw new Error("site server never came up");
+    await sleep(200);
+  }
+}
+
+/** The sidebar as rendered: the visible rows and which one is marked open. */
+const sidebar = (page) =>
+  page.evaluate(() => {
+    const pane = document.querySelector(".file-pane");
+    return {
+      shown: Boolean(pane) && !pane.hidden,
+      rows: [...document.querySelectorAll(".file-row .file-label")].map((n) => n.textContent),
+      active: document.querySelector(".file-row.active .file-label")?.textContent ?? null,
+      // The rows are a switcher here, not a file manager.
+      manage: document.querySelectorAll(".file-pane #new-file, .file-pane .file-delete").length,
+    };
+  });
+
+const browser = await chromium.launch();
+
+// --- 1–4. netpong: four files, switch, edit the server, per-file problems. ----
+{
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  const consoleLog = [];
+  page.on("console", (m) => consoleLog.push(m.text()));
+  page.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+  await page.goto(`${BASE}/sandbox.html?example=netpong`);
+  await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+    timeout: 40000,
+  });
+
+  // The rows are the paths the BUILT SITE serves — the entry is copied to
+  // `examples/<id>.fun` (examples.ts `exampleEntryPath`), which is also the
+  // module the running panes derive, so netpong's client entry reads
+  // `netpong.fun` here.
+  const listed = await sidebar(page);
+  check(
+    listed.shown && listed.rows.join(", ") === "netpong.fun, server.fun, protocol.fun, game.fun",
+    "a multi-file example lists every .fun in the sidebar",
+    listed.rows.join(", ")
+  );
+  check(
+    listed.active === "netpong.fun",
+    "the entry is the file that starts open",
+    String(listed.active)
+  );
+  check(listed.manage === 0, "the sandbox sidebar offers no new/delete", `${listed.manage} controls`);
+
+  // Language analysis is project-wide, so the entry's calls into its siblings
+  // resolve. Before setLangContext reached the sandbox these were "unknown"
+  // errors on a perfectly good sample.
+  await page.evaluate(() => window.__lang.ready);
+  await page.waitForFunction(
+    () => document.querySelector(".statusbar-tab.problems, .statusbar-tab") !== null,
+    null,
+    { timeout: 10000 }
+  );
+  await sleep(1500);
+  const clientProblems = await page.evaluate(() =>
+    [...document.querySelectorAll(".problem-row")].map((n) => n.innerText.replace(/\s+/g, " "))
+  );
+  // Nothing at all: the sibling modules resolve (single-file analysis reported
+  // `unknown module Protocol` on this very sample), and netpong's expects —
+  // which the browser's hostless runner cannot execute, since game.fun's
+  // palette calls `Color.rgb` — read as unrunnable rather than failing.
+  check(
+    clientProblems.length === 0,
+    "a multi-file example analyzes clean — siblings resolve, no false problems",
+    clientProblems.slice(0, 3).join(" | ")
+  );
+
+  // --- Switch to server.fun by CLICKING its row. -----------------------------
+  const framesBefore = await page.evaluate(() =>
+    [...document.querySelectorAll(".mp-pane iframe")].map((f) => f.getAttribute("src"))
+  );
+  await page.click(".file-row:has(.file-label:text-is('server.fun')) .file-name");
+  const opened = await page.evaluate(() => ({
+    files: window.__sandbox.files(),
+    source: window.__sandbox.getSource(),
+  }));
+  check(
+    opened.files.active === "examples/netpong/server.fun",
+    "clicking a row opens that file",
+    opened.files.active
+  );
+  check(
+    opened.source.includes("let init") && !opened.source.includes("Client"),
+    "the buffer really holds server.fun",
+    opened.source.slice(0, 60).replace(/\n/g, " ")
+  );
+  check(
+    opened.files.paths[0] === "examples/netpong.fun",
+    "switching files does NOT reorder the project (files[0] is still the entry)",
+    opened.files.paths.join(", ")
+  );
+  const framesAfter = await page.evaluate(() =>
+    [...document.querySelectorAll(".mp-pane iframe")].map((f) => f.getAttribute("src"))
+  );
+  check(
+    framesAfter.join("|") === framesBefore.join("|"),
+    "a file switch reloads no pane",
+    framesAfter.join(" | ")
+  );
+
+  // --- Edit server.fun → the SERVER pane hot-reloads. ------------------------
+  await page.evaluate(() =>
+    window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// sandbox server edit\n`)
+  );
+  const reloaded = await page
+    .waitForFunction(
+      () => {
+        const lines = [...document.querySelectorAll(".output-line")].map((n) => n.textContent);
+        return lines.some((line) => line.includes("[server]") && line.includes("model preserved"));
+      },
+      null,
+      { timeout: 30000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  const lines = await page.locator(".output-line").allTextContents();
+  check(
+    reloaded,
+    "editing server.fun hot-reloads the server pane, model preserved",
+    lines.filter((line) => line.includes("[server]")).slice(-2).join(" / ")
+  );
+  const pushed = await page.evaluate(() =>
+    window.__sandbox
+      .files()
+      .paths.map((path, index) => ({ path, index }))
+      .find(({ path }) => path.endsWith("server.fun"))
+  );
+  check(pushed !== undefined, "server.fun stays in the pushed file set", JSON.stringify(pushed));
+  check(
+    (await page.evaluate(() => window.__sandbox.status().state)) === "live",
+    "the session stays live after an off-entry edit"
+  );
+
+  // Problems are per-file: a type error typed into server.fun is reported
+  // against server.fun, not against the entry the panel used to hardcode.
+  const good = await page.evaluate(() => window.__sandbox.getSource());
+  await page.evaluate(
+    (src) => window.__sandbox.setSource(`${src}\nlet wrongType: float = "not a float"\n`),
+    good
+  );
+  const located = await page
+    .waitForFunction(
+      () =>
+        [...document.querySelectorAll(".problem-loc")].some((n) =>
+          n.textContent.includes("netpong/server.fun")
+        ),
+      null,
+      { timeout: 15000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  const locs = await page.evaluate(() =>
+    [...document.querySelectorAll(".problem-loc")].map((n) => n.textContent)
+  );
+  check(located, "a problem in an off-entry file is reported against THAT file", locs.join(" | "));
+  await page.evaluate((src) => window.__sandbox.setSource(src), good);
+  await page.waitForFunction(
+    () => document.querySelectorAll(".problem-row").length === 0,
+    null,
+    { timeout: 15000 }
+  );
+
+  const errors = consoleLog.filter((line) => /unknown external|panic|pageerror/i.test(line));
+  check(errors.length === 0, "no pane reported a load error", errors.slice(0, 2).join(" | "));
+  await page.close();
+}
+
+// --- 5. A single-file example has no sidebar. ---------------------------------
+{
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.goto(`${BASE}/sandbox.html?example=hero`);
+  await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+    timeout: 40000,
+  });
+  const solo = await sidebar(page);
+  check(
+    !solo.shown && solo.rows.length === 1,
+    "a single-file example shows no file sidebar",
+    JSON.stringify(solo)
+  );
+
+  // …and switching TO a multi-file example brings it back live, without a
+  // reload: the sidebar is a function of the loaded project, not of boot.
+  await page.selectOption("#example-picker", "netpong");
+  await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
+    timeout: 40000,
+  });
+  const grown = await sidebar(page);
+  check(
+    grown.shown && grown.rows.length === 4 && grown.active === "netpong.fun",
+    "switching to a multi-file example reveals the sidebar at its entry",
+    JSON.stringify(grown)
+  );
+  await page.close();
+}
+
+await browser.close();
+server.kill();
+console.log(failures === 0 ? "\nsandbox files e2e passed" : `\n${failures} check(s) failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/e2e/sandbox-files.mjs
+++ b/e2e/sandbox-files.mjs
@@ -245,6 +245,11 @@ const browser = await chromium.launch();
   // …and switching TO a multi-file example brings it back live, without a
   // reload: the sidebar is a function of the loaded project, not of boot.
   await page.selectOption("#example-picker", "netpong");
+  // The pill is still "live" from the outgoing example for a moment, so wait
+  // on the PROJECT arriving, then on the new panes reporting in.
+  await page.waitForFunction(() => window.__sandbox?.files().paths.length === 4, null, {
+    timeout: 40000,
+  });
   await page.waitForFunction(() => window.__sandbox?.status().state === "live", {
     timeout: 40000,
   });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:site": "node e2e/site-sandbox.mjs",
     "test:net-coordinator": "node e2e/net-coordinator.mjs",
     "test:sandbox-mp": "node e2e/sandbox-mp.mjs",
+    "test:sandbox-files": "node e2e/sandbox-files.mjs",
     "test:editor-keybindings": "node e2e/editor-keybindings.mjs",
     "test:detached-camera": "node e2e/detached-camera.mjs",
     "test:ide": "node e2e/ide-project.mjs",

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -40,6 +40,17 @@
     <!--/@header-->
 
     <main class="sandbox-split">
+      <!--
+        The file sidebar, hidden until the loaded example proves it has more
+        than one .fun (src/sandbox.tsx unhides it, and the FilePane island
+        replaces these children on mount). A single-file example never sees it.
+      -->
+      <aside class="file-pane" hidden>
+        <div class="file-pane-head">
+          <span class="file-pane-title">Files</span>
+        </div>
+        <div id="file-list" class="file-list"></div>
+      </aside>
       <section class="editor-pane">
         <div id="editor"></div>
       </section>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -41,16 +41,12 @@
 
     <main class="sandbox-split">
       <!--
-        The file sidebar, hidden until the loaded example proves it has more
-        than one .fun (src/sandbox.tsx unhides it, and the FilePane island
-        replaces these children on mount). A single-file example never sees it.
+        The FilePane island's host. Empty and hidden on purpose — unlike the
+        IDE's, this sidebar only appears once the loaded example proves it has
+        more than one .fun (src/sandbox.tsx unhides it), so a pre-JS skeleton
+        would never be seen.
       -->
-      <aside class="file-pane" hidden>
-        <div class="file-pane-head">
-          <span class="file-pane-title">Files</span>
-        </div>
-        <div id="file-list" class="file-list"></div>
-      </aside>
+      <aside class="file-pane" hidden></aside>
       <section class="editor-pane">
         <div id="editor"></div>
       </section>

--- a/site/src/components/FilePane.tsx
+++ b/site/src/components/FilePane.tsx
@@ -1,10 +1,15 @@
-// The IDE's file sidebar, and the editor tab that names the open file. Both
+// The file sidebar, and the editor tab that names the open file. Both
 // render one store — the project's file paths plus the active one — so opening,
 // adding, or deleting a file is a single `set` on the page's side instead of a
 // hand-built teardown-and-rebuild of the list.
 //
 // The page still owns the project itself (the buffers, localStorage, the push
 // to the preview); this island only shows the paths and reports clicks.
+//
+// Two pages render it. The IDE owns its project outright, so it passes `onNew`
+// and `onDelete` and gets the + / × affordances. The sandbox shows a LOADED
+// example — the file set is the sample's, not the reader's — so it passes
+// neither, and the same list is purely a switcher.
 
 import { useSyncExternalStore } from "react";
 import type { Store } from "../store.js";
@@ -20,9 +25,16 @@ export interface FilePaneProps {
   /** The program root — it names itself in the tooltip and cannot be deleted. */
   entry: string;
   onOpen: (path: string) => void;
-  onDelete: (path: string) => void;
-  onNew: () => void;
+  /** Omitted where the file set is not the reader's to change (the sandbox). */
+  onDelete?: (path: string) => void;
+  /** Omitted where the file set is not the reader's to change (the sandbox). */
+  onNew?: () => void;
 }
+
+// A sandbox example lives in a directory (`examples/netpong/server.fun`), and
+// the module is the STEM either way — so the row shows the file and the
+// tooltip keeps the full path. The IDE's flat names are their own basename.
+const basename = (path: string) => path.slice(path.lastIndexOf("/") + 1);
 
 // The Functor mark, shown on every .fun file row — the same art as the site
 // favicon and the VS Code file icon (docs/media/functor-icon.svg).
@@ -41,9 +53,11 @@ export const FilePane = ({ store, entry, onOpen, onDelete, onNew }: FilePaneProp
     <>
       <div className="file-pane-head">
         <span className="file-pane-title">Files</span>
-        <button id="new-file" type="button" title="New .fun file" onClick={onNew}>
-          +
-        </button>
+        {onNew && (
+          <button id="new-file" type="button" title="New .fun file" onClick={onNew}>
+            +
+          </button>
+        )}
       </div>
       <div id="file-list" className="file-list">
         {files.map((path) => (
@@ -54,10 +68,10 @@ export const FilePane = ({ store, entry, onOpen, onDelete, onNew }: FilePaneProp
               onClick={() => onOpen(path)}
             >
               <FileIcon />
-              <span className="file-label">{path}</span>
+              <span className="file-label">{basename(path)}</span>
             </button>
             {/* Every file but the entry can be deleted (the entry is the root). */}
-            {path !== entry && (
+            {onDelete && path !== entry && (
               <button
                 className="file-delete"
                 title={`Delete ${path}`}

--- a/site/src/components/FilePane.tsx
+++ b/site/src/components/FilePane.tsx
@@ -13,6 +13,7 @@
 
 import { useSyncExternalStore } from "react";
 import type { Store } from "../store.js";
+import { fileName } from "../protocol.js";
 
 /** What the sidebar and the editor tab render: the paths, and which is open. */
 export interface FileListState {
@@ -22,8 +23,13 @@ export interface FileListState {
 
 export interface FilePaneProps {
   store: Store<FileListState>;
-  /** The program root — it names itself in the tooltip and cannot be deleted. */
-  entry: string;
+  /**
+   * The program root — it names itself in the tooltip and cannot be deleted.
+   * Optional: a host that doesn't hold one separately (the sandbox, whose root
+   * is whatever the loaded example leads with) falls back to `files[0]`, the
+   * entry-first order both pages already guarantee.
+   */
+  entry?: string;
   onOpen: (path: string) => void;
   /** Omitted where the file set is not the reader's to change (the sandbox). */
   onDelete?: (path: string) => void;
@@ -32,9 +38,8 @@ export interface FilePaneProps {
 }
 
 // A sandbox example lives in a directory (`examples/netpong/server.fun`), and
-// the module is the STEM either way — so the row shows the file and the
-// tooltip keeps the full path. The IDE's flat names are their own basename.
-const basename = (path: string) => path.slice(path.lastIndexOf("/") + 1);
+// the module is the STEM either way — so the row shows the file name and the
+// tooltip keeps the full path. The IDE's flat names are already their own.
 
 // The Functor mark, shown on every .fun file row — the same art as the site
 // favicon and the VS Code file icon (docs/media/functor-icon.svg).
@@ -48,6 +53,7 @@ const FileIcon = () => (
 
 export const FilePane = ({ store, entry, onOpen, onDelete, onNew }: FilePaneProps) => {
   const { files, active } = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const root = entry ?? files[0];
 
   return (
     <>
@@ -64,14 +70,14 @@ export const FilePane = ({ store, entry, onOpen, onDelete, onNew }: FilePaneProp
           <div className={`file-row${path === active ? " active" : ""}`} key={path}>
             <button
               className="file-name"
-              title={path === entry ? `${entry} — the program entry` : path}
+              title={path === root ? `${path} — the program entry` : path}
               onClick={() => onOpen(path)}
             >
               <FileIcon />
-              <span className="file-label">{basename(path)}</span>
+              <span className="file-label">{fileName(path)}</span>
             </button>
             {/* Every file but the entry can be deleted (the entry is the root). */}
-            {onDelete && path !== entry && (
+            {onDelete && path !== root && (
               <button
                 className="file-delete"
                 title={`Delete ${path}`}

--- a/site/src/examples.ts
+++ b/site/src/examples.ts
@@ -9,8 +9,8 @@
 // `source` is a path relative to the repo root. Most entries are a single,
 // asset-free .fun (or use absolute CDN assets). A project that needs sibling
 // modules or local assets declares explicit sibling/asset
-// `{ source, output }` copies; the sandbox still edits only the canonical
-// `source` entry while the player fetches the complete project file list.
+// `{ source, output }` copies; the sandbox loads the complete file list and its
+// sidebar can open any of them, with `source` the entry every pane boots at.
 // Asset outputs are relative to the site root because browser fetches resolve
 // `Asset.*` locators against player.html.
 /** A file copied verbatim into the built site at `output` (relative to dist). */

--- a/site/src/lang-intel.ts
+++ b/site/src/lang-intel.ts
@@ -829,17 +829,24 @@ const hintOffset = (source: string, b: { name: string; start: number; end: numbe
   return found >= 0 ? b.start + found + b.name.length : b.end;
 };
 
-// The wire's file name for the buffer being edited: the active path in
-// project mode (the IDE), else the trace's single user file (the sandbox
-// serves examples under their own names — `hero.fun`, not `game.fun`).
-// SINGLE-FILE ASSUMPTION: a sandbox program that ever loads sibling modules
-// would yield multiple sources here and the overlay stays hidden — the
-// sandbox is a one-buffer editor by design, so there is nothing to overlay
-// the siblings on anyway.
+// The wire's file name for the buffer being edited — the name the TRACE uses,
+// which is what every recorded site is keyed by. In project mode it is the
+// active path resolved against the trace's own naming: the IDE's flat modules
+// come back identical, while the sandbox pushes site paths
+// (`examples/netpong/server.fun`) that the runtime reports by their file name
+// (`server.fun`, the module stem). Matching exactly first keeps the IDE
+// unambiguous. Without a context provider there is one user file and it is it.
+const fileName = (path: string) => path.slice(path.lastIndexOf("/") + 1);
+
 const liveFileName = (docString: string): string | null => {
-  const args = projectArgs(docString);
-  if (args) return args.active;
   const sources = liveTrace?.sources || [];
+  const args = projectArgs(docString);
+  if (args) {
+    const hit =
+      sources.find((source) => source.file === args.active) ??
+      sources.find((source) => fileName(source.file) === fileName(args.active));
+    return hit ? hit.file : null;
+  }
   return sources.length === 1 ? sources[0].file : null;
 };
 
@@ -1107,6 +1114,24 @@ const expectGutter = gutter({
   markers: (view) => view.state.field(expectField, false) || RangeSet.empty,
 });
 
+// The browser evaluates expects HOSTLESS (the analysis wasm has no engine
+// prelude — `NoHost`), so a project whose module-level defs call an engine
+// external (netpong's `let cyan = Color.rgb(…)`) can't load its defs at all
+// and the wasm reports every expect as `error`. That is a limitation of where
+// the tests are being run, not a failing test — `functor -d <dir> test` runs
+// the same expects green under the real prelude. Report those rows as what
+// they are: UNRUNNABLE (a gray gutter dot, keeping the detail on hover), which
+// also keeps them out of the Problems panel.
+const HOSTLESS_DEFS = /^defs failed to load: unknown external/;
+
+const hostless = (rows: ExpectRow[] | null): ExpectRow[] | null =>
+  rows &&
+  rows.map((row) =>
+    row.state === "error" && HOSTLESS_DEFS.test(row.detail ?? "")
+      ? { ...row, state: "unrunnable" }
+      : row
+  );
+
 // Evaluate the active file's expects, memoized per (doc, context) key like
 // analyzeCached. Returns rows ([{from, state, detail}]), null when the
 // project didn't load (keep the current gutter), or null when unavailable.
@@ -1121,7 +1146,7 @@ const expectRowsCached = (docString: string): ExpectRow[] | null => {
       ? args.filesJson
       : JSON.stringify([{ path: "game.fun", source: docString }]);
     const active = args ? args.active : "game.fun";
-    rows = JSON.parse(expectsProjectFn(filesJson, active, EXPECT_BUDGET)).rows;
+    rows = hostless(JSON.parse(expectsProjectFn(filesJson, active, EXPECT_BUDGET)).rows);
   } catch (e) {
     // A wasm trap (e.g. a pathologically deep value exhausting the engine
     // stack on teardown — the browser has no big-stack worker seam) can

--- a/site/src/lang-intel.ts
+++ b/site/src/lang-intel.ts
@@ -1,10 +1,10 @@
 // Live language intelligence for the sandbox and IDE editors: loads the small
 // functor-lang analysis wasm (built by `npm run build:lang-wasm`, copied to
 // dist/pkg/ by build.mjs) and turns its type diagnostics into CodeMirror lint
-// underlines, plus hover types, inlay hints, and signature codelenses. The
-// sandbox analyzes its single buffer; the IDE registers a context provider
-// (setLangContext) so every pass runs over the whole file set with sibling
-// modules resolved.
+// underlines, plus hover types, inlay hints, and signature codelenses.
+// Both editor pages register a context provider (setLangContext) so every pass runs
+// over the whole file set with sibling modules resolved; without one (the hero
+// and demo editors) a pass analyzes the single buffer.
 // Optional by design — if the pkg is absent or fails to init, the setup
 // resolves to [] and the editor works exactly as before (no analysis, no
 // console spam beyond one info line).
@@ -33,6 +33,7 @@ import { RangeSet, StateEffect, StateField } from "@codemirror/state";
 import type { EditorState, Extension, Range, Text } from "@codemirror/state";
 import type { CompletionContext } from "@codemirror/autocomplete";
 import { functorLangLanguage } from "./functor-lang.js";
+import { fileName as pathFileName } from "./protocol.js";
 import type { ProjectFile } from "./protocol.js";
 import type { StatusBar } from "./status-bar-store.js";
 import { fromValueJson } from "./wire-value.js";
@@ -279,7 +280,7 @@ const toDiagnostics = (view: EditorView): Diagnostic[] => {
   // Inline expect tests ride the same heartbeat: refresh the gutter, and
   // surface failing/erroring expects as diagnostics too (squiggle + the
   // Problems panel carry the decomposed actual-vs-expected detail).
-  const rows = expectRowsCached(doc.toString());
+  const rows = expectRowsCached(doc.toString(), diagnostics.length === 0);
   if (rows !== null) {
     const marks = expectSetFor(rows, doc);
     queueMicrotask(() => {
@@ -835,17 +836,20 @@ const hintOffset = (source: string, b: { name: string; start: number; end: numbe
 // come back identical, while the sandbox pushes site paths
 // (`examples/netpong/server.fun`) that the runtime reports by their file name
 // (`server.fun`, the module stem). Matching exactly first keeps the IDE
-// unambiguous. Without a context provider there is one user file and it is it.
-const fileName = (path: string) => path.slice(path.lastIndexOf("/") + 1);
-
+// unambiguous, and a name match is trusted only when exactly one source
+// carries it — two pushed paths sharing a stem hide the overlay rather than
+// bind it to the wrong file. Without a context provider there is one user file
+// and it is it.
 const liveFileName = (docString: string): string | null => {
   const sources = liveTrace?.sources || [];
   const args = projectArgs(docString);
   if (args) {
-    const hit =
-      sources.find((source) => source.file === args.active) ??
-      sources.find((source) => fileName(source.file) === fileName(args.active));
-    return hit ? hit.file : null;
+    const exact = sources.find((source) => source.file === args.active);
+    if (exact) return exact.file;
+    const named = sources.filter(
+      (source) => pathFileName(source.file) === pathFileName(args.active)
+    );
+    return named.length === 1 ? named[0].file : null;
   }
   return sources.length === 1 ? sources[0].file : null;
 };
@@ -1122,12 +1126,17 @@ const expectGutter = gutter({
 // the same expects green under the real prelude. Report those rows as what
 // they are: UNRUNNABLE (a gray gutter dot, keeping the detail on hover), which
 // also keeps them out of the Problems panel.
+//
+// `clean` is the guard that keeps this from swallowing a real mistake: the
+// typechecker links the engine prelude's `.funi` declarations, so a MISSPELLED
+// external (`Color.rgbb`) is already a diagnostic on the same pass. Only a
+// project that typechecks clean can be failing purely for want of a host.
 const HOSTLESS_DEFS = /^defs failed to load: unknown external/;
 
-const hostless = (rows: ExpectRow[] | null): ExpectRow[] | null =>
+const hostless = (rows: ExpectRow[] | null, clean: boolean): ExpectRow[] | null =>
   rows &&
   rows.map((row) =>
-    row.state === "error" && HOSTLESS_DEFS.test(row.detail ?? "")
+    clean && row.state === "error" && HOSTLESS_DEFS.test(row.detail ?? "")
       ? { ...row, state: "unrunnable" }
       : row
   );
@@ -1135,7 +1144,7 @@ const hostless = (rows: ExpectRow[] | null): ExpectRow[] | null =>
 // Evaluate the active file's expects, memoized per (doc, context) key like
 // analyzeCached. Returns rows ([{from, state, detail}]), null when the
 // project didn't load (keep the current gutter), or null when unavailable.
-const expectRowsCached = (docString: string): ExpectRow[] | null => {
+const expectRowsCached = (docString: string, clean: boolean): ExpectRow[] | null => {
   if (!expectsProjectFn) return null;
   const args = projectArgs(docString);
   const key = cacheKey(docString, args);
@@ -1146,7 +1155,7 @@ const expectRowsCached = (docString: string): ExpectRow[] | null => {
       ? args.filesJson
       : JSON.stringify([{ path: "game.fun", source: docString }]);
     const active = args ? args.active : "game.fun";
-    rows = hostless(JSON.parse(expectsProjectFn(filesJson, active, EXPECT_BUDGET)).rows);
+    rows = hostless(JSON.parse(expectsProjectFn(filesJson, active, EXPECT_BUDGET)).rows, clean);
   } catch (e) {
     // A wasm trap (e.g. a pathologically deep value exhausting the engine
     // stack on teardown — the browser has no big-stack worker seam) can

--- a/site/src/mp-panes.ts
+++ b/site/src/mp-panes.ts
@@ -667,9 +667,10 @@ export function initMultiplayerPanes({
   // every pane receives the whole project, and a role is the file it enters at
   // (plus its `?module=`), so pushing the client's edit no longer overwrites
   // the server's program — an edit hot-reloads the authority and its clients
-  // together, each with its own model preserved. The editor still shows one
-  // buffer (the client entry); editing server.fun itself waits on a file
-  // switcher, and `↺ reset` still reboots every role from the served sources.
+  // together, each with its own model preserved. The editor's file sidebar can
+  // open the server's own file, so an edit to server.fun hot-reloads the
+  // authority directly; `↺ reset` still reboots every role from the served
+  // sources.
   // The authority's view of the project: the SAME files, re-entered at its own
   // role's file (the runtime takes `files[0]` as the entry module). A sample
   // whose roles share one file (orbs) hoists nothing — the entry is already

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -22,6 +22,15 @@ export interface ProjectFile {
   source: string;
 }
 
+/**
+ * A project path's file name — its last segment. The IDE's paths are already
+ * bare, but the sandbox pushes the site's paths (`examples/netpong/server.fun`)
+ * and both the runtime (which names a file by its module stem) and the sidebar
+ * speak the last segment. Lives here because a `ProjectFile.path` is what it
+ * takes.
+ */
+export const fileName = (path: string): string => path.slice(path.lastIndexOf("/") + 1);
+
 // --- editor → player ---------------------------------------------------------
 
 /**

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -3,8 +3,11 @@
 // (project-bridge.ts): the page owns every source of the loaded example, boots
 // the player as `player.html?project=inline`, and pushes the whole file set as
 // `functor-lang-set-project` — the runtime hot-swaps the program with the model
-// preserved and replies `functor-lang-set-source-result`. The editor still
-// edits ONE buffer (the entry); a file switcher is a separate concern.
+// preserved and replies `functor-lang-set-source-result`. ANY file of the
+// example is editable: the sidebar (the IDE's FilePane, rows only — an example
+// is read, not authored, so there is no new/delete/rename) switches which one
+// the editor holds, and every edit pushes the whole set. So editing netpong's
+// server.fun hot-reloads the server pane, at its own entry, model preserved.
 //
 // Binary assets are NOT part of that push: the runtime resolves an `Asset.*`
 // locator as a URL against player.html, so an example's png/glb/ogg is served
@@ -30,10 +33,12 @@ import type { EditorKeybindings, EditorKeybindingsState } from "./editor-keybind
 import { functorLangLanguage, synthwaveEditorTheme } from "./functor-lang.js";
 import {
   setupLangIntel,
+  setLangContext,
   analyzeCached,
   completeAt,
   resetIntel,
   refreshIntel,
+  refreshLiveValues,
   onDiagnostics,
   wireLiveTrace,
   currentLiveHints,
@@ -47,6 +52,8 @@ import type { RuntimeTargetState } from "./runtime-target-core.js";
 import { createStore } from "./store.js";
 import { SandboxControls } from "./components/SandboxControls.js";
 import type { PickerState, ClientsState } from "./components/SandboxControls.js";
+import { FilePane } from "./components/FilePane.js";
+import type { FileListState } from "./components/FilePane.js";
 import { initMultiplayerPanes, MAX_CLIENTS } from "./mp-panes.js";
 import type { MultiplayerPanes, PaneProgram } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
@@ -62,6 +69,9 @@ interface SandboxSeam {
   status: () => { state: string; text: string; message: string };
   runtimeTarget: () => RuntimeTargetState;
   getSource: () => string;
+  /** The loaded example's file set (entry first) and which file is open. */
+  files: () => { paths: string[]; active: string };
+  openFile: (path: string) => void;
   triggerComplete(source: string, cursor: number): void;
   acceptCompletion: () => boolean;
   keybindings: () => EditorKeybindingsState;
@@ -200,22 +210,38 @@ window.addEventListener("hashchange", () => {
 });
 // The loaded example's whole file set, ENTRY FIRST — the paths are the ones the
 // built site serves, so `file = module` derives the same module names the
-// player used to get by fetching them. The editor's buffer is the entry's
-// source (the only file it edits for now); every push carries the rest
-// unchanged, so a multi-entry example's other roles keep resolving.
+// player used to get by fetching them. The order is load-bearing beyond
+// modules: every pane boots at `files[0]` (a role re-enters the same set at its
+// own file — see mp-panes), so switching the OPEN file must never reorder it.
+// `active` is a pointer, not a position.
 let project: ProjectFile[] = [];
+let active = "";
 // Binary assets stay a fetched, page-relative concern (see the header note);
 // they are only forwarded to an external runtime target, which has no site to
 // fetch them from.
 let assetSources: [string, Uint8Array][] = [];
 
-/** The file the editor is showing — the entry, until a file switcher lands. */
-const activePath = () => project[0]?.path ?? "";
+/** The file the editor is showing. */
+const activePath = () => active;
 
-// Mirror the live buffer into the entry and hand back the file set to push.
+const activeFile = () => project.find((file) => file.path === active);
+
+// Mirror the live buffer into the open file and hand back the file set to push.
 const projectFiles = (): ProjectFile[] => {
-  if (project[0]) project[0].source = view.state.doc.toString();
+  const file = activeFile();
+  if (file) file.source = view.state.doc.toString();
   return project;
+};
+
+// The sidebar's view of the project: the paths, and which one is open. The
+// list only appears for a multi-file example — a single-file sample looks
+// exactly as it did before the switcher existed.
+const fileList = createStore<FileListState>({ files: [], active: "" });
+const fileListHost = document.querySelector(".file-pane") as HTMLElement;
+
+const publishFiles = () => {
+  fileList.set({ files: project.map((file) => file.path), active });
+  fileListHost.hidden = project.length < 2;
 };
 
 const bridge = new ProjectBridge(frame, {
@@ -296,6 +322,13 @@ const view = new EditorView({
 });
 editorKeybindings.attach(view);
 
+// Project-aware language intelligence: the provider hands the whole loaded
+// file set plus the open path, so diagnostics and completion see the sibling
+// modules (netpong's client.fun calls `Protocol.*`, which single-file analysis
+// could only report as unknown). A single-file example is the same call with
+// one file.
+setLangContext(() => ({ active, files: project }));
+
 // Live type diagnostics: load the analysis wasm lazily and, once ready, append
 // the CodeMirror linter to the already-constructed editor. Degrades silently —
 // if the pkg is absent the promise resolves to no extensions and the sandbox is
@@ -314,8 +347,7 @@ wireLiveTrace(view, statusBar, frame, langReady);
 // editor to it. Positions re-clamp at click time (the doc may have moved on).
 onDiagnostics((diags) => {
   // The lint pass is of the file the editor is showing — name it, rather than
-  // asserting a `game.fun` no example is actually called (the IDE's rule, with
-  // the entry standing in for its `project.active`).
+  // asserting a `game.fun` no example is actually called (the IDE's rule).
   const file = activePath();
   statusBar.setProblems(
     diags.map((d) => {
@@ -325,6 +357,11 @@ onDiagnostics((diags) => {
         message: d.message,
         loc: `${file} ${line.number}:${d.from - line.from + 1}`,
         jump: () => {
+          // A row can outlive the buffer it was measured in (a file switch, or
+          // a whole example switch, during the lint debounce): reopen its file
+          // before seeking, and drop the row entirely if it's gone.
+          if (!project.some((candidate) => candidate.path === file)) return;
+          if (activePath() !== file) openFile(file);
           const len = view.state.doc.length;
           const from = Math.min(d.from, len);
           view.dispatch({
@@ -356,7 +393,9 @@ const setDoc = (files: ProjectFile[], assets: [string, Uint8Array][] = []) => {
   // the wasm completion cache so the previous program's candidates can't leak.
   resetIntel();
   project = files;
+  active = files[0].path; // a fresh load always opens the entry
   assetSources = assets;
+  publishFiles();
   programmaticEdit = true;
   view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: files[0].source } });
   programmaticEdit = false;
@@ -365,6 +404,28 @@ const setDoc = (files: ProjectFile[], assets: [string, Uint8Array][] = []) => {
   // lens rule would otherwise pin the old program's lenses to the new buffer.
   refreshIntel(view);
   runtimeTarget.projectChanged({ fresh: true });
+};
+
+// Switch which file the editor holds. Nothing is pushed: the file set is
+// unchanged, so the running panes stay exactly as they are — only the buffer
+// (and, through the language context, what analysis calls the active module)
+// moves.
+const openFile = (path: string) => {
+  if (path === active) return;
+  const next = project.find((file) => file.path === path);
+  if (!next) return;
+  const current = activeFile();
+  if (current) current.source = view.state.doc.toString();
+  active = path;
+  programmaticEdit = true;
+  view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: next.source } });
+  programmaticEdit = false;
+  publishFiles();
+  // A wholesale document replacement: drop the outgoing file's decorations and
+  // force a fresh pass rather than waiting out the lint debounce, then re-gate
+  // the paused trace's live values against the newly opened buffer.
+  refreshIntel(view);
+  refreshLiveValues(view);
 };
 
 const fromBase64Url = (b64u: string) =>
@@ -544,6 +605,13 @@ createRoot(document.querySelector(".sandbox-controls")!).render(
     onClients={selectClients}
   />
 );
+// Rows only: `onNew`/`onDelete` are the IDE's, and an example's file set is
+// the sample's rather than the reader's. The host element carries the
+// sidebar's visibility (publishFiles), so a single-file example renders none.
+// `entry` is the delete guard and the entry tooltip — neither applies here, so
+// every row keeps its full path as the tooltip (the useful thing to show when
+// the rows are basenames of a directory).
+createRoot(fileListHost).render(<FilePane store={fileList} entry="" onOpen={openFile} />);
 const statusBarHost = document.getElementById("statusbar")!;
 statusBarHost.className = "statusbar";
 createRoot(statusBarHost).render(
@@ -567,6 +635,8 @@ if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initialExample);
     return { state, text, message: detail };
   },
   runtimeTarget: () => runtimeTarget.state(),
+  files: () => ({ paths: project.map((file) => file.path), active }),
+  openFile,
   keybindings: () => editorKeybindings.state.getSnapshot(),
   setKeybindings: (mode) => editorKeybindings.setMode(mode),
   getSource: () => view.state.doc.toString(),

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -58,7 +58,7 @@ import { initMultiplayerPanes, MAX_CLIENTS } from "./mp-panes.js";
 import type { MultiplayerPanes, PaneProgram } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
 import { StatusBar } from "./components/StatusBar.js";
-import { asPlayerMessage } from "./protocol.js";
+import { asPlayerMessage, fileName } from "./protocol.js";
 import type { ProjectFile } from "./protocol.js";
 import { EXAMPLES, exampleEntryPath } from "./examples.js";
 
@@ -71,7 +71,6 @@ interface SandboxSeam {
   getSource: () => string;
   /** The loaded example's file set (entry first) and which file is open. */
   files: () => { paths: string[]; active: string };
-  openFile: (path: string) => void;
   triggerComplete(source: string, cursor: number): void;
   acceptCompletion: () => boolean;
   keybindings: () => EditorKeybindingsState;
@@ -222,8 +221,6 @@ let active = "";
 let assetSources: [string, Uint8Array][] = [];
 
 /** The file the editor is showing. */
-const activePath = () => active;
-
 const activeFile = () => project.find((file) => file.path === active);
 
 // Mirror the live buffer into the open file and hand back the file set to push.
@@ -283,13 +280,15 @@ window.addEventListener("message", (event) => {
 // Created once, outside React: this controller carries the live link's queued
 // pushes and its `/state` poll chain, so a re-render must never restart it.
 // The external runtime target keeps its own FLAT naming: the entry is pushed as
-// `game.fun` and siblings by basename, as it was before the preview moved to the
-// multi-file seam (the device push has no site paths to mirror).
+// `game.fun` and siblings by file name, as it was before the preview moved to
+// the multi-file seam (the device push has no site paths to mirror). KNOWN GAP,
+// inherited: a sample whose sibling is itself named `game.fun` (netpong's
+// shared renderer) collides with that convention on the device — the site
+// preview, which pushes real paths, is unaffected.
 const runtimeTarget = createRuntimeTargetCore({
   getProject: () =>
     projectFiles().map((file, index): [string, string] => [
-      // Every path has at least one segment, so `pop` always yields one.
-      index === 0 ? "game.fun" : file.path.split("/").pop()!,
+      index === 0 ? "game.fun" : fileName(file.path),
       file.source,
     ]),
   getAssets: () => assetSources,
@@ -348,7 +347,7 @@ wireLiveTrace(view, statusBar, frame, langReady);
 onDiagnostics((diags) => {
   // The lint pass is of the file the editor is showing — name it, rather than
   // asserting a `game.fun` no example is actually called (the IDE's rule).
-  const file = activePath();
+  const file = active;
   statusBar.setProblems(
     diags.map((d) => {
       const line = view.state.doc.lineAt(Math.min(d.from, view.state.doc.length));
@@ -361,7 +360,7 @@ onDiagnostics((diags) => {
           // a whole example switch, during the lint debounce): reopen its file
           // before seeking, and drop the row entirely if it's gone.
           if (!project.some((candidate) => candidate.path === file)) return;
-          if (activePath() !== file) openFile(file);
+          if (active !== file) openFile(file);
           const len = view.state.doc.length;
           const from = Math.min(d.from, len);
           view.dispatch({
@@ -608,10 +607,9 @@ createRoot(document.querySelector(".sandbox-controls")!).render(
 // Rows only: `onNew`/`onDelete` are the IDE's, and an example's file set is
 // the sample's rather than the reader's. The host element carries the
 // sidebar's visibility (publishFiles), so a single-file example renders none.
-// `entry` is the delete guard and the entry tooltip — neither applies here, so
-// every row keeps its full path as the tooltip (the useful thing to show when
-// the rows are basenames of a directory).
-createRoot(fileListHost).render(<FilePane store={fileList} entry="" onOpen={openFile} />);
+// No `entry` either — the loaded example's root is `files[0]`, which the pane
+// falls back to for the tooltip.
+createRoot(fileListHost).render(<FilePane store={fileList} onOpen={openFile} />);
 const statusBarHost = document.getElementById("statusbar")!;
 statusBarHost.className = "statusbar";
 createRoot(statusBarHost).render(
@@ -636,7 +634,6 @@ if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initialExample);
   },
   runtimeTarget: () => runtimeTarget.state(),
   files: () => ({ paths: project.map((file) => file.path), active }),
-  openFile,
   keybindings: () => editorKeybindings.state.getSnapshot(),
   setKeybindings: (mode) => editorKeybindings.setMode(mode),
   getSource: () => view.state.doc.toString(),

--- a/site/styles.css
+++ b/site/styles.css
@@ -1356,6 +1356,13 @@ a:hover {
   min-height: 0;
 }
 
+/* A multi-file example adds the file sidebar as a first column. It is narrower
+   than the IDE's (these rows are switched, not managed) and it comes out of the
+   editor's share, never the preview's — the scene keeps its width. */
+.sandbox-split:has(> .file-pane:not([hidden])) {
+  grid-template-columns: 164px minmax(320px, 38%) 1fr;
+}
+
 .editor-pane {
   display: flex;
   flex-direction: column;
@@ -1415,6 +1422,16 @@ a:hover {
     grid-template-rows: 1fr 1fr;
   }
 
+  /* Stacked, the sidebar keeps its column and spans both rows — the same shape
+     the IDE takes at its own breakpoint. */
+  .sandbox-split:has(> .file-pane:not([hidden])) {
+    grid-template-columns: 128px 1fr;
+  }
+
+  .sandbox-split > .file-pane {
+    grid-row: span 2;
+  }
+
   .editor-pane {
     border-right: none;
     border-bottom: 1px solid var(--line);
@@ -1439,6 +1456,12 @@ a:hover {
   border-right: 1px solid var(--line);
   background: var(--bg-panel);
   min-height: 0;
+}
+
+/* The sandbox hides the sidebar for a single-file example; `display: flex`
+   above would otherwise beat the attribute. */
+.file-pane[hidden] {
+  display: none;
 }
 
 .file-pane-head {

--- a/site/styles.css
+++ b/site/styles.css
@@ -1422,14 +1422,35 @@ a:hover {
     grid-template-rows: 1fr 1fr;
   }
 
-  /* Stacked, the sidebar keeps its column and spans both rows — the same shape
-     the IDE takes at its own breakpoint. */
+  /* Stacked, a 130px column would be a third of the screen. The same rows
+     become a horizontal tab strip above the editor instead — it costs one line
+     of height and the editor keeps the full width. */
   .sandbox-split:has(> .file-pane:not([hidden])) {
-    grid-template-columns: 128px 1fr;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr 1fr;
   }
 
   .sandbox-split > .file-pane {
-    grid-row: span 2;
+    flex-direction: row;
+    border-right: none;
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+  }
+
+  .sandbox-split > .file-pane .file-pane-head {
+    border-bottom: none;
+    border-right: 1px solid var(--line);
+  }
+
+  .sandbox-split > .file-pane .file-list {
+    display: flex;
+    overflow: visible;
+  }
+
+  /* The open file is underlined rather than left-barred: the rows now run
+     along the strip, so the marker belongs on the edge they share. */
+  .sandbox-split > .file-pane .file-row.active {
+    box-shadow: inset 0 -2px 0 var(--pink);
   }
 
   .editor-pane {
@@ -1579,7 +1600,10 @@ a:hover {
     grid-template-columns: 150px 1fr;
     grid-template-rows: 1fr 300px;
   }
-  .file-pane {
+  /* Scoped to the IDE's grid: the sandbox mounts the same sidebar in
+     `.sandbox-split`, where spanning two rows would strand it across the
+     editor and the preview. */
+  .ide-split > .file-pane {
     grid-row: span 2;
   }
   .preview-pane {


### PR DESCRIPTION
Track A step 2 of the sandbox/IDE reconciliation, on top of #704. Rebased onto
`main` after #709/#710.

#704 gave the sandbox the whole loaded example as a `ProjectFile[]` pushed over
`functor-lang-set-project`; the editor could still only edit the **entry**, and
analysis still ran single-file. This makes the sandbox a multi-file editor.

## What changed

- **File sidebar.** The IDE's `FilePane` island now mounts in the sandbox too,
  listing every `.fun` of the loaded example. `onNew`/`onDelete` became optional
  props — an example is *read*, not authored, so the sandbox gets rows only, no
  + / ×. Rows show the file name with the full path as the tooltip (the sandbox's
  paths are site paths like `examples/netpong/server.fun`). The sidebar appears
  only when the project has more than one file, so a single-file example (and
  every `#src=` docs snippet) looks exactly as before.
- **Any file is editable.** `project` gained an `active` pointer (never a
  reorder — `files[0]` stays the entry every pane boots at). Opening a file saves
  the outgoing buffer, swaps the doc, and refreshes the decorations/paused trace;
  it pushes nothing, so the running panes keep their models. Every edit still
  pushes the whole set, so **editing netpong's `server.fun` hot-reloads the
  server pane at its own entry, model preserved** — and asteroids' `lib.fun`
  hot-reloads the ordinary single-pane preview.
- **Project-wide language intelligence.** `setLangContext` is wired as the IDE
  does. Netpong previously linted with a *false* `unknown module Protocol`;
  it now analyzes clean, and Problems rows name (and jump back to) the file the
  editor is showing.

Three follow-ons fell out of turning project analysis on for the sandbox:

- The browser evaluates `expect`s hostless (`NoHost` — no engine prelude), so a
  project whose module-level defs call an engine external (netpong's
  `let cyan = Color.rgb(…)` in `game.fun`) can't load its defs and the wasm
  reports every expect as `error`. Those rows now read **`unrunnable`** — a
  limitation of *where* they run, not a failing test (`functor -d examples/netpong test`
  is green). The downgrade only applies when the analysis pass is otherwise
  **clean**, so a misspelled external is still a real failure (review finding).
- `liveFileName` resolves the active path against the trace's own naming: the
  runtime reports a pushed `examples/hero.fun` as `hero.fun`, so under a context
  provider the sandbox's paused-inspector inlays went silent. Caught by
  `test:site`, fixed, re-verified (45 inlays); a name match is only trusted when
  exactly one trace source carries it.
- Below 820px the sidebar becomes a horizontal tab strip instead of eating a
  third of the screen, and the IDE's `grid-row: span 2` is scoped to
  `.ide-split` (it was stranding the sandbox's aside across editor + preview).
  IDE checked by screenshot at 1440/880/420 — unchanged.

## Visuals

![sandbox multi-file editing](https://gist.githubusercontent.com/tommy-xr/bd9e00410426713e88244249d23f1fc4/raw/sandbox-files.gif)

<sub>netpong in the sandbox: click `server.fun`, click `game.fun`, recolor the shared
palette — both the client and the authority hot-reload, models preserved. Captured
headlessly with Playwright against the built site.</sub>

**Before / after — sandbox on netpong, desktop (1440×900):**

| before (main) | after |
| --- | --- |
| ![before desktop](https://gist.githubusercontent.com/tommy-xr/bd9e00410426713e88244249d23f1fc4/raw/before-desktop.png) | ![after desktop](https://gist.githubusercontent.com/tommy-xr/bd9e00410426713e88244249d23f1fc4/raw/after-desktop.png) |

<sub>Note the status bar: `✖ 1 problem` (the false `unknown module Protocol`) becomes `✓ 0 problems`.</sub>

**Before / after — mobile (420×860):**

| before (main) | after |
| --- | --- |
| ![before mobile](https://gist.githubusercontent.com/tommy-xr/bd9e00410426713e88244249d23f1fc4/raw/before-mobile.png) | ![after mobile](https://gist.githubusercontent.com/tommy-xr/bd9e00410426713e88244249d23f1fc4/raw/after-mobile.png) |

## Verification

Re-run in full **after** the review fixes and the rebase onto `main` (`5a4c951`):
`npm run check:site`, `npm run site:build`, then

| suite | result |
| --- | --- |
| `test:sandbox-files` (**new**, `e2e/sandbox-files.mjs`) | 17/17 ok |
| `test:site` | ALL CHECKS PASSED |
| `test:sandbox-mp` | ALL CHECKS PASSED |
| `test:ide` | PASS |
| `test:ide-page` | PASS |
| `test:runtime-target` | ALL CHECKS PASSED |
| `test:editor-keybindings` | PASS |

The new e2e asserts: netpong lists its four files with the entry open and no
new/delete controls; the example analyzes clean (siblings resolve, no false
problems); clicking `server.fun` opens it without reordering the project or
reloading any pane; editing it hot-reloads the **server** pane (`[server] …
model preserved` at `examples/netpong/server.fun`); a type error typed into an
off-entry file is reported against *that* file; asteroids (a single-role
multi-file example, so the switcher isn't coupled to a server role) lists its
siblings and hot-reloads on a `lib.fun` edit; a single-file example shows no
sidebar, and switching to a multi-file one reveals it at its entry.

## Review (`/xreview`)

Codex (correct-scope run): *"No correctness or simplicity findings"* — it
specifically checked buffer mirroring across edits/file switches/example
switches and `loadToken`, every caller of `liveFileName`/`expectRowsCached`,
`hidden` vs `.file-pane { display: flex }`, the `:has()` grid switch, and
entry-first ordering for the panes.

Claude reviewer + de-dup pass — dispositions:

| finding | disposition |
| --- | --- |
| Hostless-expect downgrade could hide a misspelled external (Medium) | **Fixed** — the downgrade now requires a clean analysis pass; a typo is still a diagnostic, so its expects stay `error` (proved by the e2e: with a type error present, the expect rows come back as errors again) |
| `liveFileName` basename fallback could bind to the wrong file if two paths share a stem (Low) | **Fixed** — a name match is used only when exactly one trace source has it |
| Three copies of "last path segment" (S1-names, S4-read) | **Fixed** — one `fileName(path)` in `protocol.ts`, used by `FilePane`, `lang-intel`, and the device-push flattening |
| `entry=""` discarded the entry tooltip (Low) | **Fixed** — `FilePane.entry` is optional and falls back to `files[0]` |
| Unused `__sandbox.openFile` seam, `activePath()` alias, unused pre-JS sidebar skeleton (Low) | **Fixed** — all removed |
| Stale "the sandbox edits one buffer" comments in `mp-panes.ts` / `examples.ts` / `lang-intel.ts` (Low) | **Fixed** |
| `analyzeProjectFn!` non-null assertion (Low) | **No change** — the six wasm entry points install as a unit (`setupLangIntel` throws if any is missing), which the module documents at its declaration |
| Device-push name collision: the entry flattens to `game.fun`, and netpong's shared renderer *is* `game.fun` (Medium) | **Out of scope, documented in code** — pre-existing from #704 and specific to the external runtime-target push (the site preview pushes real paths and is unaffected). Fixing it means choosing the device's entry-naming convention, which wants a Quest to verify. Filed as a follow-up |
| Extract the sandbox/IDE file-switcher (and the Problems-row mapper) into one shared module | **Deferred** — the two pages differ in persistence and reset semantics; a shared switcher is its own PR rather than a rider on this one |
