### PR TITLE
feat(scene): Scene.billboard — camera-facing quad primitive

### DIFF
--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1081,7 +1081,7 @@ scale → rotation → translation whatever order you pipe the combinators, and
 each combinator composes within its own channel (rotations multiply with the
 outer pipe applying last; scales and tints multiply componentwise). The
 renderer hardware-instances a recognized template — one
-cube/sphere/cylinder/quad/plane leaf under transforms and at most one solid
+cube/sphere/cylinder/quad/billboard/plane leaf under transforms and at most one solid
 `Scene.color`/`Scene.lit`/`Scene.emissive` material (ONE draw call), or a
 `Scene.model` leaf under transforms (one draw call per mesh primitive,
 textured like the ordinary model draw; a SKINNED model — via `Scene.animate`
@@ -1092,6 +1092,14 @@ once-per-topology `[functor]` perf note.
 `Scene.opacity` inside a template is a teaching error — wrap the whole
 instanced node instead. `Scene.equals` compares instanced nodes structurally
 (template + every instance's channels).
+
+**`Scene.billboard` is a camera-facing quad — a SHAPE, not a flag.** The scene
+value stays camera-free plain data (so stamping, `Scene.equals`, and replay
+are unaffected); only at DRAW time do its local XY axes map onto the active
+pass's camera right/up (spherical billboarding). `Scene.rotateZ` /
+`Instance.rotateZ` spins it in the screen plane, and scale reads as
+screen-plane width/height. It faces each pass's OWN view, so in the shadow
+pass it faces the light and casts a full-quad shadow.
 
 **Zero-argument constructors take their parens** — `Scene.cube()`,
 `Sprite.blank()`, `Anim.rest()`, `Effect.none()`, `Map.empty()`,

--- a/.claude/skills/functor-lang/SKILL.md
+++ b/.claude/skills/functor-lang/SKILL.md
@@ -1098,8 +1098,9 @@ value stays camera-free plain data (so stamping, `Scene.equals`, and replay
 are unaffected); only at DRAW time do its local XY axes map onto the active
 pass's camera right/up (spherical billboarding). `Scene.rotateZ` /
 `Instance.rotateZ` spins it in the screen plane, and scale reads as
-screen-plane width/height. It faces each pass's OWN view, so in the shadow
-pass it faces the light and casts a full-quad shadow.
+screen-plane width/height. Billboards cast NO shadow — a light-facing shadow
+quad would cut the camera-facing quad in half with its own shadow, so both
+draw paths skip billboards in the shadow pass.
 
 **Zero-argument constructors take their parens** — `Scene.cube()`,
 `Sprite.blank()`, `Anim.rest()`, `Effect.none()`, `Map.empty()`,

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -26,9 +26,9 @@ let quad : () => t
 ///
 /// At draw time its local XY axes map to the active view's right/up, so it
 /// always faces the viewer, `Scene.rotateZ` / `Instance.rotateZ` spins it in
-/// the screen plane, and scale reads as screen-plane width/height. It faces
-/// each PASS's own view — so in the shadow pass it faces the light and casts
-/// a full-quad shadow.
+/// the screen plane, and scale reads as screen-plane width/height. Billboards
+/// cast NO shadow: a light-facing shadow quad would cut the camera-facing
+/// quad in half with its own shadow, so they skip the shadow pass entirely.
 let billboard : () => t
 /// Create a unit plane in the XZ ground plane.
 let plane : () => t

--- a/functor-prelude/prelude/scene.funi
+++ b/functor-prelude/prelude/scene.funi
@@ -22,6 +22,14 @@ let sphere : () => t
 let cylinder : () => t
 /// Create a unit quad in the XY plane, facing `+Z`.
 let quad : () => t
+/// Create a camera-facing unit quad (spherical billboarding).
+///
+/// At draw time its local XY axes map to the active view's right/up, so it
+/// always faces the viewer, `Scene.rotateZ` / `Instance.rotateZ` spins it in
+/// the screen plane, and scale reads as screen-plane width/height. It faces
+/// each PASS's own view — so in the shadow pass it faces the light and casts
+/// a full-quad shadow.
+let billboard : () => t
 /// Create a unit plane in the XZ ground plane.
 let plane : () => t
 
@@ -102,7 +110,7 @@ let opacity : (float, t) => t
 /// lit and shadowed exactly like its copies would be.
 ///
 /// The renderer draws recognized templates with hardware instancing — a
-/// single cube/sphere/cylinder/quad/plane leaf under any transforms and at
+/// single cube/sphere/cylinder/quad/billboard/plane leaf under any transforms and at
 /// most one solid `Scene.color` / `Scene.lit` / `Scene.emissive` material
 /// (one draw call), or a `Scene.model` leaf under transforms (one draw call
 /// per mesh primitive, textured exactly like the ordinary model draw). A

--- a/runtime/functor-runtime-common/src/functor_lang_prelude.rs
+++ b/runtime/functor-runtime-common/src/functor_lang_prelude.rs
@@ -2233,6 +2233,9 @@ fn register_scene(reg: &mut crate::host_registry::Registry) {
         FunctorLangScene(Scene3D::cylinder())
     });
     reg.fn0("Scene.quad", "Scene.quad()", || FunctorLangScene(Scene3D::quad()));
+    reg.fn0("Scene.billboard", "Scene.billboard()", || {
+        FunctorLangScene(Scene3D::billboard())
+    });
     reg.fn0("Scene.plane", "Scene.plane()", || FunctorLangScene(Scene3D::plane()));
     // A glTF model by file path (relative to the game dir), the Functor Lang
     // face of F#'s `Model.file |> Graphics.Scene3D.model`. Loading is the
@@ -8154,6 +8157,23 @@ Vec3.make(x, y, z)"
             scene_of(&with).expect("a Scene"),
             scene_of(&without).expect("a Scene")
         );
+    }
+
+    /// `Scene.billboard` builds the plain `Shape::Billboard` leaf — a
+    /// camera-FREE scene value (the view-dependence is the renderer's, at
+    /// draw time), so it stamps, compares, and replays like any other shape.
+    #[test]
+    fn scene_billboard_is_a_plain_camera_free_leaf() {
+        let value = eval("let main = () => Scene.billboard()");
+        let scene = scene_of(&value).expect("a Scene");
+        assert!(matches!(
+            scene.obj,
+            SceneObject::Geometry(Shape::Billboard)
+        ));
+
+        // And `Scene.equals` sees it structurally, like every shape.
+        let equal = eval("let main = () => Scene.equals(Scene.billboard(), Scene.billboard())");
+        assert!(matches!(equal, functor_lang::Value::Bool(true)));
     }
 
     /// The identity test happens AFTER narrowing to 32-bit, so an alpha that

--- a/runtime/functor-runtime-common/src/protocol.rs
+++ b/runtime/functor-runtime-common/src/protocol.rs
@@ -71,6 +71,11 @@
 /// for now — nothing transmits or checks it; [`GameProducer`] impls all speak
 /// the current version.
 ///
+/// v16: camera-facing billboards — the `SceneObject::Geometry(Shape::Billboard)`
+/// variant (a unit quad whose local XY maps to the active pass's camera
+/// right/up at draw time). Emitted only by `Scene.billboard`, so frames
+/// without one keep their v15 shape.
+///
 /// v15: the touch device domain — [`crate::InputSnapshot::touch`], defaulted
 /// (and omitted when absent) when decoding older samples, so retained
 /// recordings remain readable.
@@ -124,7 +129,7 @@
 /// omitted when empty, so v1 frames read back and chainless frames stay v1-
 /// shaped) and the `TextureDescription::FileWhilePending` variant (a v1
 /// reader cannot decode a frame carrying one).
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = 16;
 
 /// The producer side of the protocol: one game logic instance as consumed by a
 /// runtime shell's frame loop. Every method carries a payload enumerated in
@@ -638,7 +643,7 @@ mod tests {
     fn sprite_atlas_material_wire_is_pinned() {
         use crate::{MaterialDescription, SpriteSampling, TextureDescription};
 
-        assert_eq!(PROTOCOL_VERSION, 15);
+        assert_eq!(PROTOCOL_VERSION, 16);
         let material = MaterialDescription::sprite_texture_tinted(
             TextureDescription::FileClamped("hero-atlas.png".to_string()),
             Some([96.0, 0.0, 96.0, 96.0]),
@@ -665,7 +670,7 @@ mod tests {
     fn convex_polygon_geometry_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 15);
+        assert_eq!(PROTOCOL_VERSION, 16);
         let scene = Scene3D {
             obj: SceneObject::Geometry(Shape::ConvexPolygon {
                 points: vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]],
@@ -681,6 +686,21 @@ mod tests {
         assert_eq!(serde_json::to_string(&back).unwrap(), json);
     }
 
+    /// The billboard geometry is a bare unit variant on the wire — pinned so
+    /// `GET /scene` consumers and `Scene.equals` see a stable tag (the
+    /// view-dependence is draw-time only and never serializes).
+    #[test]
+    fn billboard_geometry_wire_is_pinned() {
+        use crate::{SceneObject, Shape};
+
+        assert_eq!(PROTOCOL_VERSION, 16);
+        let obj = SceneObject::Geometry(Shape::Billboard);
+        let json = serde_json::to_string(&obj).expect("serialize billboard geometry");
+        assert_eq!(json, r#"{"Geometry":"Billboard"}"#);
+        let back: SceneObject = serde_json::from_str(&json).expect("deserialize billboard geometry");
+        assert_eq!(serde_json::to_string(&back).unwrap(), json);
+    }
+
     /// The translucent-subtree node carries its alpha inline, so its wire shape
     /// is pinned like the variants above — `GET /scene`, `Scene.equals` and the
     /// extrapolation copies all read it.
@@ -688,7 +708,7 @@ mod tests {
     fn opacity_subtree_wire_is_pinned() {
         use crate::{Scene3D, SceneObject, Shape};
 
-        assert_eq!(PROTOCOL_VERSION, 15);
+        assert_eq!(PROTOCOL_VERSION, 16);
         let scene = SceneObject::Opacity(
             0.35,
             vec![Scene3D {
@@ -712,7 +732,7 @@ mod tests {
     fn instanced_wire_is_pinned() {
         use crate::{InstanceData, MaterialDescription, Scene3D, SceneObject};
 
-        assert_eq!(PROTOCOL_VERSION, 15);
+        assert_eq!(PROTOCOL_VERSION, 16);
         let template = Scene3D {
             obj: SceneObject::Material(
                 MaterialDescription::lit(1.0, 0.5, 0.25, 1.0),
@@ -742,7 +762,7 @@ mod tests {
     fn two_bone_reach_animation_wire_is_pinned() {
         use crate::anim::AnimExpr;
 
-        assert_eq!(PROTOCOL_VERSION, 15);
+        assert_eq!(PROTOCOL_VERSION, 16);
         let reach = AnimExpr::Reach {
             root: "upper".to_string(),
             middle: "lower".to_string(),

--- a/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
@@ -40,6 +40,15 @@ use super::MaterialDescription;
 // placement is provably identical. `base` is the first instance-attribute
 // location: 4 for the primitive/rigid-model shaders, 6 for the skinned ones
 // (whose 4/5 carry the mesh's joint indices/weights).
+//
+// `billboardMode` (0/1) is the billboard template's draw-time seam: when 1,
+// the copy's world-space center is kept and the vertex OFFSET around it is
+// re-expressed on the ACTIVE PASS's camera axes (the transpose of the bound
+// `view`'s upper 3×3 — its rows are camera right/up/back), so every copy
+// faces the viewer while the instance rotation still spins it in the screen
+// plane and the instance scale reads as screen-plane width/height. Because
+// it uses the pass's own view, the depth pass billboards toward the LIGHT —
+// a full-quad shadow — keeping the two passes' placement rule identical.
 fn instance_transform_glsl(base: u32) -> String {
     format!(
         r#"
@@ -49,6 +58,8 @@ fn instance_transform_glsl(base: u32) -> String {
 
         uniform mat4 world;
         uniform mat4 local;
+        uniform mat4 view;
+        uniform int billboardMode;
 
         vec3 rotate(vec4 q, vec3 v) {{
             return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
@@ -57,6 +68,18 @@ fn instance_transform_glsl(base: u32) -> String {
         vec3 instanceLocal(vec3 pos) {{
             vec4 lp = local * vec4(pos, 1.0);
             return rotate(instanceRotation, lp.xyz * instanceScale) + instancePosition;
+        }}
+
+        vec4 instanceWorld(vec3 pos) {{
+            vec3 p = instanceLocal(pos);
+            if (billboardMode == 1) {{
+                vec3 center = rotate(instanceRotation,
+                    (local * vec4(0.0, 0.0, 0.0, 1.0)).xyz * instanceScale) + instancePosition;
+                vec4 wc = world * vec4(center, 1.0);
+                vec3 offset = mat3(world) * (p - center);
+                return vec4(wc.xyz + transpose(mat3(view)) * offset, 1.0);
+            }}
+            return world * vec4(p, 1.0);
         }}
 "#,
         p = base,
@@ -100,7 +123,6 @@ const VERTEX_SHADER_SOURCE: &str = r#"
 
         uniform mat3 normalMatrix;
         uniform mat3 localNormalMatrix;
-        uniform mat4 view;
         uniform mat4 projection;
 
         out vec2 texCoord;
@@ -110,16 +132,24 @@ const VERTEX_SHADER_SOURCE: &str = r#"
         out vec3 tintColor;
 
         void main() {
-            vec4 wp = world * vec4(instanceLocal(inPos), 1.0);
+            vec4 wp = instanceWorld(inPos);
             texCoord = inTex;
             worldPos = wp.xyz;
             tintColor = instanceTint;
-            vec3 ln = localNormalMatrix * inNormal;
-            vec3 safeScale = mix(instanceScale, vec3(1.0),
-                vec3(lessThan(abs(instanceScale), vec3(1e-8))));
-            worldNormal = normalMatrix * rotate(instanceRotation, ln / safeScale);
-            vec3 lt = mat3(local) * inTangent.xyz;
-            worldTangent = mat3(world) * rotate(instanceRotation, lt * instanceScale);
+            if (billboardMode == 1) {
+                // A billboarded copy faces the viewer by construction: its
+                // normal is the view's back axis (row 2) and its tangent the
+                // view's right axis (row 0).
+                worldNormal = vec3(view[0][2], view[1][2], view[2][2]);
+                worldTangent = vec3(view[0][0], view[1][0], view[2][0]);
+            } else {
+                vec3 ln = localNormalMatrix * inNormal;
+                vec3 safeScale = mix(instanceScale, vec3(1.0),
+                    vec3(lessThan(abs(instanceScale), vec3(1e-8))));
+                worldNormal = normalMatrix * rotate(instanceRotation, ln / safeScale);
+                vec3 lt = mat3(local) * inTangent.xyz;
+                worldTangent = mat3(world) * rotate(instanceRotation, lt * instanceScale);
+            }
             gl_Position = projection * view * wp;
         }
 "#;
@@ -171,11 +201,10 @@ const FRAGMENT_SHADER_SOURCE: &str = r#"
 const DEPTH_VERTEX_SHADER_SOURCE: &str = r#"
         layout (location = 0) in vec3 inPos;
 
-        uniform mat4 view;
         uniform mat4 projection;
 
         void main() {
-            gl_Position = projection * view * world * vec4(instanceLocal(inPos), 1.0);
+            gl_Position = projection * view * instanceWorld(inPos);
         }
 "#;
 
@@ -205,7 +234,6 @@ const SKINNED_VERTEX_SHADER_SOURCE: &str = r#"
 
         uniform mat3 normalMatrix;
         uniform mat3 localNormalMatrix;
-        uniform mat4 view;
         uniform mat4 projection;
 
         out vec2 texCoord;
@@ -217,7 +245,7 @@ const SKINNED_VERTEX_SHADER_SOURCE: &str = r#"
         void main() {
             mat4 skin = skinMatrix();
             vec3 sp = (skin * vec4(inPos, 1.0)).xyz;
-            vec4 wp = world * vec4(instanceLocal(sp), 1.0);
+            vec4 wp = instanceWorld(sp);
             texCoord = inTex;
             worldPos = wp.xyz;
             tintColor = instanceTint;
@@ -237,12 +265,11 @@ const SKINNED_VERTEX_SHADER_SOURCE: &str = r#"
 const SKINNED_DEPTH_VERTEX_SHADER_SOURCE: &str = r#"
         layout (location = 0) in vec3 inPos;
 
-        uniform mat4 view;
         uniform mat4 projection;
 
         void main() {
             vec3 sp = (skinMatrix() * vec4(inPos, 1.0)).xyz;
-            gl_Position = projection * view * world * vec4(instanceLocal(sp), 1.0);
+            gl_Position = projection * view * instanceWorld(sp);
         }
 "#;
 
@@ -258,6 +285,7 @@ struct ForwardUniforms {
     use_texture: UniformLocation,
     material_mode: UniformLocation,
     debug_mode: UniformLocation,
+    billboard_mode: UniformLocation,
     lighting: LightingUniforms,
     fog: FogUniforms,
 }
@@ -267,6 +295,7 @@ struct DepthUniforms {
     local: UniformLocation,
     view: UniformLocation,
     projection: UniformLocation,
+    billboard_mode: UniformLocation,
 }
 
 /// One primitive's persistent buffers: the static mesh plus that mesh's
@@ -414,7 +443,9 @@ impl InstancedRenderer {
                 InstancedPrimitive::Cube => cube_mesh_data(),
                 InstancedPrimitive::Sphere => sphere_mesh_data(),
                 InstancedPrimitive::Cylinder => cylinder_mesh_data(),
-                InstancedPrimitive::Quad => quad_mesh_data(),
+                // The billboard IS the quad mesh — only its draw-time
+                // placement differs (`billboardMode`).
+                InstancedPrimitive::Quad | InstancedPrimitive::Billboard => quad_mesh_data(),
                 InstancedPrimitive::Plane => plane_mesh_data(),
             };
             let vertex_bytes = crate::terrain_renderer::slice_bytes(&vertices);
@@ -488,6 +519,7 @@ impl InstancedRenderer {
         view: &Matrix4<f32>,
     ) {
         let depth_pass = ctx.render_pass == RenderPass::DepthOnly;
+        let billboard = template.primitive == InstancedPrimitive::Billboard;
         let bytes = crate::terrain_renderer::slice_bytes(instances);
         // Scope the mutable mesh borrow: upload the instance records, then
         // carry only the Copy GL handles into the uniform/draw phase.
@@ -510,6 +542,7 @@ impl InstancedRenderer {
                 &template.local,
                 projection,
                 view,
+                billboard,
             );
         } else {
             let (color, lit) = match template.material {
@@ -533,6 +566,7 @@ impl InstancedRenderer {
                 &color,
                 false,
                 lit,
+                billboard,
             );
         }
         unsafe {
@@ -607,6 +641,7 @@ impl InstancedRenderer {
                     &mesh_local,
                     projection,
                     view,
+                    false,
                 );
             } else {
                 mesh.base_color_texture.bind(0, ctx);
@@ -620,6 +655,7 @@ impl InstancedRenderer {
                     view,
                     &cgmath::vec4(1.0, 1.0, 1.0, 1.0),
                     true,
+                    false,
                     false,
                 );
             }
@@ -714,6 +750,7 @@ impl InstancedRenderer {
                     local,
                     projection,
                     view,
+                    false,
                 );
             } else {
                 mesh.base_color_texture.bind(0, ctx);
@@ -728,6 +765,7 @@ impl InstancedRenderer {
                     &cgmath::vec4(1.0, 1.0, 1.0, 1.0),
                     true,
                     true,
+                    false,
                 );
             }
             unsafe {
@@ -919,6 +957,7 @@ fn forward_uniforms_of(program: &ShaderProgram, gl: &glow::Context) -> ForwardUn
         use_texture: program.get_uniform_location(gl, "useTexture"),
         material_mode: program.get_uniform_location(gl, "materialMode"),
         debug_mode: program.get_uniform_location(gl, "debugMode"),
+        billboard_mode: program.get_uniform_location(gl, "billboardMode"),
         lighting: LightingUniforms::get(program, gl),
         fog: FogUniforms::get(program, gl),
     }
@@ -931,10 +970,12 @@ fn depth_uniforms_of(program: &ShaderProgram, gl: &glow::Context) -> DepthUnifor
         local: program.get_uniform_location(gl, "local"),
         view: program.get_uniform_location(gl, "view"),
         projection: program.get_uniform_location(gl, "projection"),
+        billboard_mode: program.get_uniform_location(gl, "billboardMode"),
     }
 }
 
 /// Set a depth program's uniforms for one instanced draw.
+#[allow(clippy::too_many_arguments)]
 fn set_depth_uniforms(
     program: &ShaderProgram,
     u: &DepthUniforms,
@@ -943,12 +984,14 @@ fn set_depth_uniforms(
     local: &Matrix4<f32>,
     projection: &Matrix4<f32>,
     view: &Matrix4<f32>,
+    billboard: bool,
 ) {
     program.use_program(ctx.gl);
     program.set_uniform_matrix4(ctx.gl, &u.world, world);
     program.set_uniform_matrix4(ctx.gl, &u.local, local);
     program.set_uniform_matrix4(ctx.gl, &u.view, view);
     program.set_uniform_matrix4(ctx.gl, &u.projection, projection);
+    program.set_uniform_1i(ctx.gl, &u.billboard_mode, billboard as i32);
 }
 
 /// Set a forward program's uniforms for one instanced draw.
@@ -964,6 +1007,7 @@ fn set_forward_uniforms(
     color: &cgmath::Vector4<f32>,
     use_texture: bool,
     lit: bool,
+    billboard: bool,
 ) {
     let p = program;
     p.use_program(ctx.gl);
@@ -983,6 +1027,7 @@ fn set_forward_uniforms(
         DebugRenderMode::Default | DebugRenderMode::Transparent | DebugRenderMode::Physics => 0,
     };
     p.set_uniform_1i(ctx.gl, &u.debug_mode, debug_mode);
+    p.set_uniform_1i(ctx.gl, &u.billboard_mode, billboard as i32);
     u.lighting.set(p, ctx, view);
     u.fog.set(p, ctx.gl, ctx.fog, &ctx.camera_pos);
 }

--- a/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instanced_renderer.rs
@@ -43,12 +43,13 @@ use super::MaterialDescription;
 //
 // `billboardMode` (0/1) is the billboard template's draw-time seam: when 1,
 // the copy's world-space center is kept and the vertex OFFSET around it is
-// re-expressed on the ACTIVE PASS's camera axes (the transpose of the bound
-// `view`'s upper 3×3 — its rows are camera right/up/back), so every copy
-// faces the viewer while the instance rotation still spins it in the screen
-// plane and the instance scale reads as screen-plane width/height. Because
-// it uses the pass's own view, the depth pass billboards toward the LIGHT —
-// a full-quad shadow — keeping the two passes' placement rule identical.
+// re-expressed on the camera axes (the transpose of the bound `view`'s upper
+// 3×3 — its rows are camera right/up/back), so every copy faces the viewer
+// while the instance rotation still spins it in the screen plane and the
+// instance scale reads as screen-plane width/height. Only the forward pass
+// billboards: billboarded copies are excluded from the depth pass entirely
+// (billboards cast no shadow — a light-facing depth quad would make the
+// camera-facing forward quad straddle its own shadow plane and self-shadow).
 fn instance_transform_glsl(base: u32) -> String {
     format!(
         r#"
@@ -71,15 +72,18 @@ fn instance_transform_glsl(base: u32) -> String {
         }}
 
         vec4 instanceWorld(vec3 pos) {{
-            vec3 p = instanceLocal(pos);
             if (billboardMode == 1) {{
+                // The offset is formed DIRECTLY (never as a difference of two
+                // world-magnitude points, which would cancel catastrophically
+                // for instances far from the origin).
+                vec3 offset = mat3(world) * rotate(instanceRotation,
+                    (mat3(local) * pos) * instanceScale);
                 vec3 center = rotate(instanceRotation,
-                    (local * vec4(0.0, 0.0, 0.0, 1.0)).xyz * instanceScale) + instancePosition;
+                    local[3].xyz * instanceScale) + instancePosition;
                 vec4 wc = world * vec4(center, 1.0);
-                vec3 offset = mat3(world) * (p - center);
                 return vec4(wc.xyz + transpose(mat3(view)) * offset, 1.0);
             }}
-            return world * vec4(p, 1.0);
+            return world * vec4(instanceLocal(pos), 1.0);
         }}
 "#,
         p = base,
@@ -136,20 +140,19 @@ const VERTEX_SHADER_SOURCE: &str = r#"
             texCoord = inTex;
             worldPos = wp.xyz;
             tintColor = instanceTint;
-            if (billboardMode == 1) {
-                // A billboarded copy faces the viewer by construction: its
-                // normal is the view's back axis (row 2) and its tangent the
-                // view's right axis (row 0).
-                worldNormal = vec3(view[0][2], view[1][2], view[2][2]);
-                worldTangent = vec3(view[0][0], view[1][0], view[2][0]);
-            } else {
-                vec3 ln = localNormalMatrix * inNormal;
-                vec3 safeScale = mix(instanceScale, vec3(1.0),
-                    vec3(lessThan(abs(instanceScale), vec3(1e-8))));
-                worldNormal = normalMatrix * rotate(instanceRotation, ln / safeScale);
-                vec3 lt = mat3(local) * inTangent.xyz;
-                worldTangent = mat3(world) * rotate(instanceRotation, lt * instanceScale);
-            }
+            vec3 ln = localNormalMatrix * inNormal;
+            vec3 safeScale = mix(instanceScale, vec3(1.0),
+                vec3(lessThan(abs(instanceScale), vec3(1e-8))));
+            vec3 wn = normalMatrix * rotate(instanceRotation, ln / safeScale);
+            vec3 lt = mat3(local) * inTangent.xyz;
+            vec3 wt = mat3(world) * rotate(instanceRotation, lt * instanceScale);
+            // A billboarded copy's frame rotates with its offset: the same
+            // inverse view rotation applies to normal and tangent, matching
+            // the CPU-expanded reference (`billboard_xform`'s T * R_view⁻¹ * L
+            // — R_view⁻¹ is orthonormal, so it is its own inverse-transpose).
+            mat3 bb = billboardMode == 1 ? transpose(mat3(view)) : mat3(1.0);
+            worldNormal = bb * wn;
+            worldTangent = bb * wt;
             gl_Position = projection * view * wp;
         }
 "#;
@@ -204,7 +207,7 @@ const DEPTH_VERTEX_SHADER_SOURCE: &str = r#"
         uniform mat4 projection;
 
         void main() {
-            gl_Position = projection * view * instanceWorld(inPos);
+            gl_Position = projection * view * world * vec4(instanceLocal(inPos), 1.0);
         }
 "#;
 
@@ -245,7 +248,7 @@ const SKINNED_VERTEX_SHADER_SOURCE: &str = r#"
         void main() {
             mat4 skin = skinMatrix();
             vec3 sp = (skin * vec4(inPos, 1.0)).xyz;
-            vec4 wp = instanceWorld(sp);
+            vec4 wp = world * vec4(instanceLocal(sp), 1.0);
             texCoord = inTex;
             worldPos = wp.xyz;
             tintColor = instanceTint;
@@ -269,7 +272,7 @@ const SKINNED_DEPTH_VERTEX_SHADER_SOURCE: &str = r#"
 
         void main() {
             vec3 sp = (skinMatrix() * vec4(inPos, 1.0)).xyz;
-            gl_Position = projection * view * instanceWorld(sp);
+            gl_Position = projection * view * world * vec4(instanceLocal(sp), 1.0);
         }
 "#;
 
@@ -295,7 +298,6 @@ struct DepthUniforms {
     local: UniformLocation,
     view: UniformLocation,
     projection: UniformLocation,
-    billboard_mode: UniformLocation,
 }
 
 /// One primitive's persistent buffers: the static mesh plus that mesh's
@@ -438,13 +440,18 @@ impl InstancedRenderer {
     }
 
     fn mesh(&mut self, gl: &glow::Context, primitive: InstancedPrimitive) -> &mut MeshBuffers {
+        // The billboard IS the quad mesh — only its draw-time placement
+        // differs (`billboardMode`) — so both share ONE cache entry rather
+        // than allocating duplicate VAO/VBO/EBO sets.
+        let primitive = match primitive {
+            InstancedPrimitive::Billboard => InstancedPrimitive::Quad,
+            other => other,
+        };
         self.meshes.entry(primitive).or_insert_with(|| {
             let (vertices, indices) = match primitive {
                 InstancedPrimitive::Cube => cube_mesh_data(),
                 InstancedPrimitive::Sphere => sphere_mesh_data(),
                 InstancedPrimitive::Cylinder => cylinder_mesh_data(),
-                // The billboard IS the quad mesh — only its draw-time
-                // placement differs (`billboardMode`).
                 InstancedPrimitive::Quad | InstancedPrimitive::Billboard => quad_mesh_data(),
                 InstancedPrimitive::Plane => plane_mesh_data(),
             };
@@ -520,6 +527,13 @@ impl InstancedRenderer {
     ) {
         let depth_pass = ctx.render_pass == RenderPass::DepthOnly;
         let billboard = template.primitive == InstancedPrimitive::Billboard;
+        // Billboards cast no shadow: a light-facing depth quad would make the
+        // camera-facing forward quad straddle its own shadow plane and
+        // self-shadow, so billboarded copies skip the depth pass outright
+        // (matching the CPU-expand arm in `Scene3D::render`).
+        if depth_pass && billboard {
+            return;
+        }
         let bytes = crate::terrain_renderer::slice_bytes(instances);
         // Scope the mutable mesh borrow: upload the instance records, then
         // carry only the Copy GL handles into the uniform/draw phase.
@@ -542,7 +556,6 @@ impl InstancedRenderer {
                 &template.local,
                 projection,
                 view,
-                billboard,
             );
         } else {
             let (color, lit) = match template.material {
@@ -641,7 +654,6 @@ impl InstancedRenderer {
                     &mesh_local,
                     projection,
                     view,
-                    false,
                 );
             } else {
                 mesh.base_color_texture.bind(0, ctx);
@@ -750,7 +762,6 @@ impl InstancedRenderer {
                     local,
                     projection,
                     view,
-                    false,
                 );
             } else {
                 mesh.base_color_texture.bind(0, ctx);
@@ -970,12 +981,10 @@ fn depth_uniforms_of(program: &ShaderProgram, gl: &glow::Context) -> DepthUnifor
         local: program.get_uniform_location(gl, "local"),
         view: program.get_uniform_location(gl, "view"),
         projection: program.get_uniform_location(gl, "projection"),
-        billboard_mode: program.get_uniform_location(gl, "billboardMode"),
     }
 }
 
 /// Set a depth program's uniforms for one instanced draw.
-#[allow(clippy::too_many_arguments)]
 fn set_depth_uniforms(
     program: &ShaderProgram,
     u: &DepthUniforms,
@@ -984,14 +993,12 @@ fn set_depth_uniforms(
     local: &Matrix4<f32>,
     projection: &Matrix4<f32>,
     view: &Matrix4<f32>,
-    billboard: bool,
 ) {
     program.use_program(ctx.gl);
     program.set_uniform_matrix4(ctx.gl, &u.world, world);
     program.set_uniform_matrix4(ctx.gl, &u.local, local);
     program.set_uniform_matrix4(ctx.gl, &u.view, view);
     program.set_uniform_matrix4(ctx.gl, &u.projection, projection);
-    program.set_uniform_1i(ctx.gl, &u.billboard_mode, billboard as i32);
 }
 
 /// Set a forward program's uniforms for one instanced draw.

--- a/runtime/functor-runtime-common/src/scene3d/instancing.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instancing.rs
@@ -279,7 +279,7 @@ pub(crate) struct RecognizedModel<'a> {
 ///
 /// Recognized: `Group` chains with exactly one child (their transforms
 /// compose into `local`) ending in either a
-/// `Cube`/`Sphere`/`Cylinder`/`Quad`/`Plane` leaf under at most ONE material
+/// `Cube`/`Sphere`/`Cylinder`/`Quad`/`Billboard`/`Plane` leaf under at most ONE material
 /// node — a solid `Color`, `Emissive` (no texture), or `Lit` (no texture, no
 /// normal map) — or a `Scene.model` leaf with no overrides, with or without
 /// an attached `Scene.animate` pose (every copy shows the same sampled pose;

--- a/runtime/functor-runtime-common/src/scene3d/instancing.rs
+++ b/runtime/functor-runtime-common/src/scene3d/instancing.rs
@@ -237,6 +237,9 @@ pub(crate) enum InstancedPrimitive {
     Sphere,
     Cylinder,
     Quad,
+    /// The quad mesh, billboarded per instance at draw time (see
+    /// [`Shape::Billboard`]).
+    Billboard,
     Plane,
 }
 
@@ -298,6 +301,7 @@ pub(crate) fn recognize(template: &Scene3D) -> Option<RecognizedTemplate<'_>> {
                     Shape::Sphere => InstancedPrimitive::Sphere,
                     Shape::Cylinder => InstancedPrimitive::Cylinder,
                     Shape::Quad => InstancedPrimitive::Quad,
+                    Shape::Billboard => InstancedPrimitive::Billboard,
                     Shape::Plane => InstancedPrimitive::Plane,
                     Shape::Heightmap { .. } | Shape::ConvexPolygon { .. } => return None,
                 };
@@ -376,6 +380,7 @@ pub(crate) fn template_summary(template: &Scene3D) -> String {
                 Shape::Sphere => "sphere",
                 Shape::Cylinder => "cylinder",
                 Shape::Quad => "quad",
+                Shape::Billboard => "billboard",
                 Shape::Plane => "plane",
                 Shape::Heightmap { .. } => "heightmap",
                 Shape::ConvexPolygon { .. } => "polygon",
@@ -532,6 +537,7 @@ mod tests {
             (Scene3D::sphere(), InstancedPrimitive::Sphere),
             (Scene3D::cylinder(), InstancedPrimitive::Cylinder),
             (Scene3D::quad(), InstancedPrimitive::Quad),
+            (Scene3D::billboard(), InstancedPrimitive::Billboard),
             (Scene3D::plane(), InstancedPrimitive::Plane),
         ] {
             let template = Scene3D {
@@ -608,6 +614,8 @@ mod tests {
 
         // A bare primitive: correct only through the stamp (pass material).
         assert!(recognize(&Scene3D::cube()).is_none());
+        // A bare billboard behaves exactly like a bare quad — fall back.
+        assert!(recognize(&Scene3D::billboard()).is_none());
         // A textured material.
         let textured = Scene3D {
             obj: SceneObject::Material(

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -6,7 +6,7 @@ use std::{
 
 use glow::HasContext;
 
-use cgmath::{vec3, Matrix4, SquareMatrix};
+use cgmath::{vec3, Matrix, Matrix4, SquareMatrix};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -1046,6 +1046,18 @@ pub enum Shape {
     Sphere,
     Cylinder,
     Quad,
+    /// A camera-facing unit quad (spherical billboarding) — the same mesh as
+    /// [`Shape::Quad`], but at draw time its local XY axes are mapped to the
+    /// ACTIVE PASS's camera right/up, so it always faces the viewer. A local
+    /// Z rotation (`Scene.rotateZ` / `Instance.rotateZ`) therefore spins it
+    /// in the screen plane, and scale applies as screen-plane width/height.
+    ///
+    /// The shape itself is camera-free plain data — the view-dependence
+    /// exists only at draw time (in both the CPU and hardware-instanced
+    /// paths), so stamping semantics, `Scene.equals`, and replay stay honest.
+    /// One consequence of "the active pass's view": in the depth/shadow pass
+    /// the billboard faces the LIGHT, casting a full-quad shadow.
+    Billboard,
     Plane,
     /// A subdivided XZ grid displaced by per-vertex heights (row-major,
     /// length `rows * cols`).
@@ -1192,6 +1204,14 @@ impl Scene3D {
     pub fn plane() -> Self {
         Scene3D {
             obj: SceneObject::Geometry(Shape::Plane),
+            xform: Matrix4::identity(),
+        }
+    }
+
+    /// `Scene.billboard`: a camera-facing unit quad — see [`Shape::Billboard`].
+    pub fn billboard() -> Self {
+        Scene3D {
+            obj: SceneObject::Geometry(Shape::Billboard),
             xform: Matrix4::identity(),
         }
     }
@@ -1885,7 +1905,7 @@ impl Scene3D {
                                     format!(
                                         "[functor] Scene.instanced template `{summary}` is not hardware-instanced \
 — rendering {copies} copies as a stamped group, comparable to writing \
-the group by hand (hardware templates are one cube/sphere/cylinder/quad/plane \
+the group by hand (hardware templates are one cube/sphere/cylinder/quad/billboard/plane \
 leaf under transforms and at most one solid Scene.color / Scene.lit / \
 Scene.emissive material, or a bare Scene.model leaf under transforms)"
                                     )
@@ -1941,6 +1961,45 @@ Scene.emissive material, or a bare Scene.model leaf under transforms)"
             }
             SceneObject::Geometry(Shape::Quad) => {
                 let xform = world_matrix * self.xform;
+                geometry_material.draw_opaque(
+                    &render_context,
+                    &projection_matrix,
+                    &view_matrix,
+                    &xform,
+                    &skinning_data,
+                );
+                scene_context.quad.borrow_mut().draw(&render_context.gl);
+            }
+            SceneObject::Geometry(Shape::Billboard) => {
+                // Billboarding happens HERE, at draw time: the accumulated
+                // matrix splits into its translation `T` and linear part `L`
+                // (scale and any authored rotation), and the model matrix is
+                // rebuilt as `T * R_view⁻¹ * L` — the inverse view rotation
+                // (the transpose of the view's upper 3×3; the view has no
+                // scale) maps local X/Y onto the ACTIVE PASS's camera
+                // right/up. Keeping the full linear part (not just its
+                // per-column scale) is what makes `Scene.rotateZ` spin the
+                // quad in the screen plane, exactly like the hardware
+                // instanced path, which rotates the vertex before mapping it
+                // onto the camera axes. In the depth pass the "camera" is the
+                // light, so a billboard casts a full-quad shadow.
+                let acc = world_matrix * self.xform;
+                let view_rotation_inverse = Matrix4::from(
+                    cgmath::Matrix3::from_cols(
+                        view_matrix.x.truncate(),
+                        view_matrix.y.truncate(),
+                        view_matrix.z.truncate(),
+                    )
+                    .transpose(),
+                );
+                let linear = Matrix4::from(cgmath::Matrix3::from_cols(
+                    acc.x.truncate(),
+                    acc.y.truncate(),
+                    acc.z.truncate(),
+                ));
+                let xform = Matrix4::from_translation(acc.w.truncate())
+                    * view_rotation_inverse
+                    * linear;
                 geometry_material.draw_opaque(
                     &render_context,
                     &projection_matrix,

--- a/runtime/functor-runtime-common/src/scene3d/mod.rs
+++ b/runtime/functor-runtime-common/src/scene3d/mod.rs
@@ -1055,8 +1055,9 @@ pub enum Shape {
     /// The shape itself is camera-free plain data — the view-dependence
     /// exists only at draw time (in both the CPU and hardware-instanced
     /// paths), so stamping semantics, `Scene.equals`, and replay stay honest.
-    /// One consequence of "the active pass's view": in the depth/shadow pass
-    /// the billboard faces the LIGHT, casting a full-quad shadow.
+    /// Billboards cast NO shadow: a light-facing depth quad would make the
+    /// camera-facing forward quad straddle its own shadow plane and
+    /// self-shadow, so both draw paths skip billboards in the depth pass.
     Billboard,
     Plane,
     /// A subdivided XZ grid displaced by per-vertex heights (row-major,
@@ -1171,6 +1172,117 @@ pub struct TransparentDraw<'a> {
 /// which `sort_by` is allowed to panic on.
 ///
 /// Free of GL, so the ordering is testable headlessly.
+/// The billboard model matrix: split the accumulated transform `acc` into its
+/// translation `T` and linear part `L` (scale and any authored rotation) and
+/// rebuild it as `T * R_view⁻¹ * L`. The inverse view rotation (the transpose
+/// of the view's upper 3×3 — every view in the tree comes from `look_at_rh`,
+/// so it is orthonormal) maps local X/Y onto the camera's right/up. Keeping
+/// the FULL linear part (not just its per-column scale) is what makes
+/// `Scene.rotateZ` spin the quad in the screen plane, exactly like the
+/// hardware instanced path, which rotates the vertex before mapping it onto
+/// the camera axes. Pure — the testable core of billboard placement.
+pub(crate) fn billboard_xform(
+    acc: &Matrix4<f32>,
+    view_matrix: &Matrix4<f32>,
+) -> Matrix4<f32> {
+    let view_rotation_inverse = Matrix4::from(
+        cgmath::Matrix3::from_cols(
+            view_matrix.x.truncate(),
+            view_matrix.y.truncate(),
+            view_matrix.z.truncate(),
+        )
+        .transpose(),
+    );
+    let linear = Matrix4::from(cgmath::Matrix3::from_cols(
+        acc.x.truncate(),
+        acc.y.truncate(),
+        acc.z.truncate(),
+    ));
+    Matrix4::from_translation(acc.w.truncate()) * view_rotation_inverse * linear
+}
+
+#[cfg(test)]
+mod billboard_xform_tests {
+    use super::billboard_xform;
+    use cgmath::{vec3, Deg, Matrix4, Point3, SquareMatrix, Vector4};
+
+    fn assert_vec4_near(a: Vector4<f32>, b: Vector4<f32>) {
+        for (x, y) in [(a.x, b.x), (a.y, b.y), (a.z, b.z), (a.w, b.w)] {
+            assert!((x - y).abs() < 1e-5, "{a:?} != {b:?}");
+        }
+    }
+
+    #[test]
+    fn identity_view_is_identity() {
+        let acc = Matrix4::from_translation(vec3(3.0, -2.0, 7.0))
+            * Matrix4::from_angle_z(Deg(30.0))
+            * Matrix4::from_nonuniform_scale(2.0, 0.5, 1.0);
+        let out = billboard_xform(&acc, &Matrix4::identity());
+        assert_vec4_near(out.x, acc.x);
+        assert_vec4_near(out.y, acc.y);
+        assert_vec4_near(out.z, acc.z);
+        assert_vec4_near(out.w, acc.w);
+    }
+
+    #[test]
+    fn camera_on_x_turns_the_quad_normal_to_x() {
+        // Camera at +X looking at the origin: the quad's local +Z normal must
+        // come out along world +X (toward the camera).
+        let view = Matrix4::look_at_rh(
+            Point3::new(10.0, 0.0, 0.0),
+            Point3::new(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        );
+        let out = billboard_xform(&Matrix4::identity(), &view);
+        let n = out * Vector4::new(0.0, 0.0, 1.0, 0.0);
+        assert_vec4_near(n, Vector4::new(1.0, 0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn translation_is_preserved_exactly() {
+        let acc = Matrix4::from_translation(vec3(123.0, -4.5, 0.25));
+        let view = Matrix4::look_at_rh(
+            Point3::new(5.0, 8.0, -3.0),
+            Point3::new(0.0, 1.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        );
+        let out = billboard_xform(&acc, &view);
+        assert_vec4_near(out.w, acc.w);
+    }
+
+    #[test]
+    fn rotate_z_survives_as_screen_plane_spin() {
+        // Under ANY view, a local Z-rotation must keep the quad's corners in
+        // the plane spanned by the (billboarded) local X/Y axes — i.e. the Z
+        // rotation composes INSIDE the view alignment instead of tilting it.
+        let view = Matrix4::look_at_rh(
+            Point3::new(4.0, 2.0, 9.0),
+            Point3::new(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        );
+        let plain = billboard_xform(&Matrix4::identity(), &view);
+        let spun = billboard_xform(&Matrix4::from_angle_z(Deg(90.0)), &view);
+        // 90° spin: spun X axis == plain Y axis, spun Y axis == -plain X.
+        assert_vec4_near(spun * Vector4::unit_x(), plain * Vector4::unit_y());
+        assert_vec4_near(spun * Vector4::unit_y(), -(plain * Vector4::unit_x()));
+        // The normal is untouched by an in-plane spin.
+        assert_vec4_near(spun * Vector4::unit_z(), plain * Vector4::unit_z());
+    }
+
+    #[test]
+    fn nonuniform_scale_reads_as_screen_plane_size() {
+        let view = Matrix4::look_at_rh(
+            Point3::new(0.0, 0.0, 5.0),
+            Point3::new(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        );
+        let out = billboard_xform(&Matrix4::from_nonuniform_scale(3.0, 0.5, 1.0), &view);
+        let plain = billboard_xform(&Matrix4::identity(), &view);
+        assert_vec4_near(out * Vector4::unit_x(), plain * Vector4::unit_x() * 3.0);
+        assert_vec4_near(out * Vector4::unit_y(), plain * Vector4::unit_y() * 0.5);
+    }
+}
+
 pub fn sort_back_to_front(draws: &mut [TransparentDraw<'_>], view_matrix: &Matrix4<f32>) {
     let view_depth = |draw: &TransparentDraw<'_>| {
         let c = draw.centroid;
@@ -1959,55 +2071,27 @@ Scene.emissive material, or a bare Scene.model leaf under transforms)"
 
                 scene_context.sphere.borrow_mut().draw(&render_context.gl);
             }
-            SceneObject::Geometry(Shape::Quad) => {
-                let xform = world_matrix * self.xform;
-                geometry_material.draw_opaque(
-                    &render_context,
-                    &projection_matrix,
-                    &view_matrix,
-                    &xform,
-                    &skinning_data,
-                );
-                scene_context.quad.borrow_mut().draw(&render_context.gl);
-            }
-            SceneObject::Geometry(Shape::Billboard) => {
-                // Billboarding happens HERE, at draw time: the accumulated
-                // matrix splits into its translation `T` and linear part `L`
-                // (scale and any authored rotation), and the model matrix is
-                // rebuilt as `T * R_view⁻¹ * L` — the inverse view rotation
-                // (the transpose of the view's upper 3×3; the view has no
-                // scale) maps local X/Y onto the ACTIVE PASS's camera
-                // right/up. Keeping the full linear part (not just its
-                // per-column scale) is what makes `Scene.rotateZ` spin the
-                // quad in the screen plane, exactly like the hardware
-                // instanced path, which rotates the vertex before mapping it
-                // onto the camera axes. In the depth pass the "camera" is the
-                // light, so a billboard casts a full-quad shadow.
-                let acc = world_matrix * self.xform;
-                let view_rotation_inverse = Matrix4::from(
-                    cgmath::Matrix3::from_cols(
-                        view_matrix.x.truncate(),
-                        view_matrix.y.truncate(),
-                        view_matrix.z.truncate(),
-                    )
-                    .transpose(),
-                );
-                let linear = Matrix4::from(cgmath::Matrix3::from_cols(
-                    acc.x.truncate(),
-                    acc.y.truncate(),
-                    acc.z.truncate(),
-                ));
-                let xform = Matrix4::from_translation(acc.w.truncate())
-                    * view_rotation_inverse
-                    * linear;
-                geometry_material.draw_opaque(
-                    &render_context,
-                    &projection_matrix,
-                    &view_matrix,
-                    &xform,
-                    &skinning_data,
-                );
-                scene_context.quad.borrow_mut().draw(&render_context.gl);
+            SceneObject::Geometry(shape @ (Shape::Quad | Shape::Billboard)) => {
+                let is_billboard = matches!(shape, Shape::Billboard);
+                // Billboards cast no shadow (see `Shape::Billboard`): skip
+                // them in the depth pass, matching the instanced hardware
+                // path's skip.
+                if !(is_billboard && depth_pass) {
+                    let acc = world_matrix * self.xform;
+                    let xform = if is_billboard {
+                        billboard_xform(&acc, view_matrix)
+                    } else {
+                        acc
+                    };
+                    geometry_material.draw_opaque(
+                        &render_context,
+                        &projection_matrix,
+                        &view_matrix,
+                        &xform,
+                        &skinning_data,
+                    );
+                    scene_context.quad.borrow_mut().draw(&render_context.gl);
+                }
             }
             SceneObject::Geometry(Shape::Plane) => {
                 let xform = world_matrix * self.xform;

--- a/tools/functor-docgen/src/lib.rs
+++ b/tools/functor-docgen/src/lib.rs
@@ -674,7 +674,7 @@ mod tests {
             let items: usize = modules.iter().map(|module| module.items.len()).sum();
             (modules.len(), items)
         };
-        assert_eq!(count(ApiGroup::Engine), (29, 324));
+        assert_eq!(count(ApiGroup::Engine), (29, 325));
         assert_eq!(count(ApiGroup::Stdlib), (10, 97));
         assert!(reference
             .modules


### PR DESCRIPTION
A new `Shape::Billboard` leaf primitive — `Scene.billboard()`, a unit quad (the same mesh as `Scene.quad`) whose local XY axes map to the **active pass's** camera right/up at draw time (spherical billboarding). `Scene.rotateZ` / `Instance.rotateZ` spin it in the screen plane; scale reads as screen-plane width/height.

## Demo

![Scene.billboard demo](https://gist.githubusercontent.com/tommy-xr/057b94df15ecf11d7fd626e639f6a08a/raw/billboard-demo.gif)

<sub>Camera orbits the ring over one 4s period. The emissive **billboards stay camera-facing squares** the whole way round — including the ~100-instance hardware-instanced field — while the two plain `Scene.quad`s in the ring skew and go edge-on with perspective (that contrast is the feature). The large pink billboard spins via `Scene.rotateZ` (one full screen-plane turn per orbit). Rendered headlessly via `--capture-frame` / `--fixed-time`.</sub>

![still t=0.5 — rotateZ spinner mid-turn, plain quads skewing](https://gist.githubusercontent.com/tommy-xr/057b94df15ecf11d7fd626e639f6a08a/raw/billboard-still-t05.png)

![still t=2.6 — opposite side of the orbit: billboards still square, plain quads near edge-on](https://gist.githubusercontent.com/tommy-xr/057b94df15ecf11d7fd626e639f6a08a/raw/billboard-still-t26.png)

## Design rationale

- **A shape, not a flag.** The scene value stays camera-free plain data, so `expand_instanced` stamping semantics, `Scene.equals`, and replay stay honest — the view-dependence exists only at draw time, in both the CPU leaf draw and the hardware-instanced path.
- **One placement rule, forward-pass only.** Both the CPU path and the shared instance-placement GLSL (`billboardMode` uniform, set per draw in the forward uniforms) rebuild the transform against the bound `view`. Billboards cast **no shadow** — both draw paths skip the depth pass (see the review section below: the originally documented faces-the-light shadow behavior was neither implemented nor desirable), documented in the shape's rustdoc and the `.funi` doc.
- **Hardware instancing:** `recognize()` maps `Shape::Billboard` like `Quad`; a billboard template under a solid material is one instanced draw call, and the bare-billboard template falls back to CPU expansion exactly like a bare quad.

### One deviation from the task spec, with reason

The spec's CPU formula said "decompose into translation + **per-column-length scale**, rebuild as `T * R_view⁻¹ * S_local`". Taking only column lengths discards the accumulated rotation — which would kill the *stated* semantics that `Scene.rotateZ` spins the quad in the screen plane, and would diverge from the spec's own hardware path (whose vertex is transformed by local transform + instance **rotation** before mapping onto camRight/camUp). The implementation keeps the full linear part: `T * R_view⁻¹ * L` with `L` the accumulated upper 3×3. For the common translate+scale case this is identical to the spec's formula; with rotations it is the version consistent with the GLSL path and the rotateZ contract.

## frame_bench (release, min of 3, same machine)

`allocs/frame` and `bytes/frame` are **byte-exact** on every grid (nothing existing takes new branches). Wall clock: an initial sequential BEFORE/AFTER comparison was skewed ~40% by machine load (even the trivial identity-`tick` number moved 0.44→0.77us), so the honest numbers below are from **interleaved A/B runs of the two prebuilt binaries** in one quiet window:

| grid | base min us/frame | PR min us/frame | allocs/frame | bytes/frame |
| --- | --- | --- | --- | --- |
| 20×20 (400) | 717.3 | 696.6 | 13877 = 13877 | 844497 = 844497 |
| 40×40 (1600) | 2854.0 | 2699.4 | 54717 = 54717 | 3308337 = 3308337 |
| 56×56 (3136) | 5418.1 | 5497.6 | 106973 = 106973 | 6461361 = 6461361 |

Deltas are inside run-to-run spread (two of three sizes read faster on the PR) — parity.

## Verification

- [x] `cargo test -p functor_runtime_common` — 744 passed (includes the `.funi`≡registry drift test, new instancing recognizer tests, the new prelude test, and a pinned v16 wire test)
- [x] `cargo test -p functor-lang` — all suites pass (unaffected)
- [x] `npm run check:docs` — markdown + json generation ✓
- [x] frame_bench before/after — exact allocs/bytes parity (table above)
- [x] `npm run test:golden` — all scenarios match (only pre-existing sub-tolerance diffs, e.g. terrain-tangents 0.032%)
- [x] `npm run build:cli` — wasm bundle (wasm32-unknown-unknown) + release CLI build clean
- [x] Quest cross-compile check — `npm run build:oculus` (cargo ndk, arm64-v8a) builds clean; no device work in this PR
- [x] Headless sanity capture — a ring of `Scene.billboard`s next to a ring of plain `Scene.quad`s from an off-axis camera: every billboard reads as a full screen-facing square, the plain quads show perspective skew/edge-on, and a `rotateZ(45deg)` billboard spins in the screen plane (verified by viewing the PNG)

**Note:** GPU cost is untouched for existing content (the billboard branch is uniform-selected per draw and only taken by billboard templates); no Quest device was attached, so no on-device numbers — stated per the perf policy. pr-visuals media (GIF + PNG) and `/xreview` follow before this is marked ready.


## Cross-engine review (/xreview) — findings & dispositions

Two independent engines (Claude subagent + Codex CLI) reviewed `main...feat/scene-billboard`; a dedicated de-dup pass ran over dupfinder reports. Fixes landed in the follow-up commit; all verification re-run after (tests 749+32 pass, goldens unchanged, frame_bench allocs/bytes byte-exact, wasm cross-compile clean).

**Fixed:**
- **[AGREED · High] Hardware billboard normals/tangents were hardcoded to the view axes**, breaking CPU-expand parity under instance/ancestor rotations. Now both rotate through the same inverse view rotation as the offset (`R_view⁻¹` is orthonormal, so it's its own inverse-transpose) — hardware and stamped fallback shade identically.
- **[High] The documented "faces the light, casts a full-quad shadow" behavior was not what shipped** (the shadow pass binds an identity view — Codex), and implementing it literally would make lit billboards self-shadow (forward fragments straddle their own depth-pass plane — Claude reviewer). Resolution: **billboards cast no shadow**; both draw paths skip the depth pass, docs/`.funi`/skill updated. Smaller diff than either "fix".
- **[Medium] fp32 cancellation**: the instanced offset was formed as a difference of two world-magnitude points; at large coordinates billboards would shimmer/collapse. Now formed directly (also cheaper — subsumes the `local[3]` recompute nit).
- **[Medium] Untestable placement math**: extracted as pure `billboard_xform` with 5 unit tests (identity view, camera-on-+X facing, exact translation preservation, rotateZ-as-screen-spin, non-uniform scale as screen-plane size); the duplicated Quad/Billboard draw arms merged.
- **[Low] Duplicate GPU mesh**: Quad and Billboard now share one mesh-cache entry.
- **[Low] Skinned shaders** reverted to the branch-free placement expression (a skinned template can never be a billboard); `billboardMode` no longer exists in any depth program, and `set_depth_uniforms` lost its lint suppression.
- **[Low] Stale doc enumeration** in `recognize()` fixed.

**Declined with rationale:**
- *"Land the CPU arm only; drop the hardware-instanced path"* (reviewer minimality suggestion): declined — solid-color **emissive billboards are exactly the instanced-particles hot case** this PR exists to enable (fire/sparks at 1k–10k instances); the follow-up stack (Scene.additive, Instance.alpha, examples/particles) consumes the hardware path immediately.
- *Golden scenario for billboards*: deferred to the `examples/particles` PR in this stack, which adds a billboard-heavy golden scene; this PR's evidence is the headless capture + the pure-function tests.

De-dup coverage: S1-names (16 queries, 7,989 candidates), S2-clones (0 pairs), S3-index (3,353 items), S4-read — one actionable finding (the shared mesh entry), fixed above.


