### PR TITLE
feat(site): Share button — #code= links for the sandbox and the IDE

### DIFF
--- a/e2e/share-page.mjs
+++ b/e2e/share-page.mjs
@@ -82,12 +82,25 @@ const live = (page, timeout = 40000) =>
     { timeout }
   );
 
-/** Click Share and hand back the URL it minted (the page's own address). */
+/**
+ * Click Share and hand back the URL it minted (the page's own address).
+ *
+ * The wait is on the BUTTON's confirmation, not on the hash: a page that has
+ * already shared once carries a `#code=` from that first click, so waiting for
+ * the fragment to exist would hand back the previous link.
+ */
 const clickShare = async (page) => {
+  const idle = () =>
+    page.waitForFunction(() => !document.querySelector("#share").textContent.includes("copied"), null, {
+      timeout: 15000,
+    });
+  await idle();
   await page.click("#share");
-  await page.waitForFunction(() => window.location.hash.includes("code="), null, {
-    timeout: 15000,
-  });
+  await page.waitForFunction(
+    () => document.querySelector("#share").textContent.includes("copied"),
+    null,
+    { timeout: 15000 }
+  );
   return page.url();
 };
 
@@ -157,6 +170,29 @@ const bannerText = (page) =>
   );
   check(state.picker === "shared link", "the picker names the loaded link", String(state.picker));
   check(state.status.state === "live", "the shared program is live", JSON.stringify(state.status));
+  // Reset restores the LINK's project, not the edits made after opening it —
+  // the shared snapshot is the only copy there is, so it must not be the live
+  // buffer in disguise.
+  await opened.evaluate(() =>
+    window.__sandbox.setSource(`// edited after opening the link\n${window.__sandbox.getSource()}`)
+  );
+  await opened.waitForFunction(() => window.__sandbox.status().state === "live", null, {
+    timeout: 30000,
+  });
+  await opened.click("#reset");
+  await opened.waitForFunction(
+    () => !window.__sandbox.getSource().includes("edited after opening the link"),
+    null,
+    { timeout: 30000 }
+  ).catch(() => {});
+  const reset = await opened.evaluate(() => window.__sandbox.getSource());
+  check(
+    reset.startsWith("// shared-edit marker 4711") &&
+      !reset.includes("edited after opening the link"),
+    "Reset restores the shared project as linked",
+    reset.split("\n")[0]
+  );
+
   const errors = consoleLog.filter((line) => /unknown external|panic|pageerror/i.test(line));
   check(errors.length === 0, "no load error on either page", errors.slice(0, 2).join(" | "));
   await opened.close();
@@ -164,6 +200,8 @@ const bannerText = (page) =>
 }
 
 // --- 2. Sandbox: netpong, with an edit to the SERVER file. --------------------
+// Kept for section 4: a link with client/server ROLES is one the IDE must refuse.
+let rolesUrl = null;
 {
   const page = await context.newPage();
   await page.goto(`${BASE}/sandbox.html?example=netpong`);
@@ -174,6 +212,12 @@ const bannerText = (page) =>
   );
   await sleep(500);
   const url = await clickShare(page);
+  rolesUrl = url;
+  check(
+    !new URL(url).searchParams.has("example"),
+    "a share URL drops ?example= — the fragment IS the project",
+    new URL(url).search || "(no query)"
+  );
   await page.close();
 
   const opened = await context.newPage();
@@ -229,8 +273,9 @@ const bannerText = (page) =>
 
   const opened = await context.newPage();
   // The query asks for `tetris`; the fragment carries `counter`. The fragment is
-  // the only copy of its project, so it wins.
-  await opened.goto(url.replace("example=counter", "example=tetris"));
+  // the only copy of its project, so it wins. (Share strips `?example=` itself,
+  // so this puts one back to make the precedence explicit.)
+  await opened.goto(`${url.split("#")[0]}?example=tetris#${url.split("#")[1]}`);
   await live(opened);
   const loaded = await opened.evaluate(() => window.__sandbox.files().paths[0]);
   check(loaded === "counter.fun", "#code= outranks ?example=", loaded);
@@ -319,6 +364,41 @@ const bannerText = (page) =>
     afterEdit.slice(0, 50)
   );
   await accepted.close();
+
+  // A link the IDE cannot represent (a sandbox multiplayer project: roles, and
+  // an entry that isn't game.fun) is refused BEFORE anything is asked or lost.
+  const refused = await context.newPage();
+  const asked = [];
+  refused.on("dialog", (dialog) => {
+    asked.push(dialog.message());
+    dialog.accept();
+  });
+  await refused.goto(`${BASE}/ide.html#${rolesUrl.split("#")[1]}`);
+  // Watch for the refusal as it is published: the preview reporting in
+  // afterwards overwrites the pill, so a second read can miss it.
+  const told = await refused
+    .waitForFunction(
+      () => window.__ide?.status().message.includes("open it in the sandbox instead"),
+      null,
+      { timeout: 30000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  const refusal = await refused.evaluate(() => ({
+    entry: window.__ide.files()[0].path,
+    source: window.__ide.files()[0].source,
+  }));
+  check(
+    told && asked.length === 0,
+    "a project the IDE can't run is refused, not prompted for",
+    `told=${told} prompts=${asked.length}`
+  );
+  check(
+    refusal.entry === "game.fun" && refusal.source.includes("// SHARED then mine"),
+    "…and the reader's own project is still the one open",
+    refusal.source.split("\n")[0]
+  );
+  await refused.close();
 }
 
 // --- 5. The assets advisory. --------------------------------------------------

--- a/e2e/share-page.mjs
+++ b/e2e/share-page.mjs
@@ -1,0 +1,387 @@
+// Share-link e2e: the round trip a reader actually performs — edit, Share, open
+// the link somewhere else, and find the same program running.
+//
+// The codec has its own unit test (site/src/share-link.test.ts). This one proves
+// the PAGES:
+//
+//   1. sandbox, single file: an edit + Share writes `#code=` and copies the URL,
+//      and a FRESH page on that URL boots the edited program live (not the
+//      pristine example);
+//   2. sandbox, multiplayer + off-entry edit: netpong shared with an edited
+//      server.fun reopens with all four files, the edit intact, and the SERVER
+//      PANE mounted — the role config travels, so the link is still a
+//      client+server session;
+//   3. sandbox: `#code=` outranks `?example=`, and picking an example again
+//      clears the fragment;
+//   4. IDE: Share, then open the link in a page whose localStorage already
+//      holds a project — the prompt appears, Cancel keeps the stored project
+//      (and drops the fragment), Accept opens the shared one WITHOUT persisting
+//      it, and the first edit adopts it;
+//   5. the assets advisory: a project naming a relative asset the site does not
+//      serve shows the banner; an example whose assets the site DOES serve does
+//      not.
+//
+// Run manually (needs the web-runtime wasm bundle):
+//
+//   wasm-pack build runtime/functor-runtime-web --target=web   # once
+//   node e2e/share-page.mjs
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+
+const PORT = Number(process.env.FUNCTOR_SHARE_PORT ?? 8129);
+const BASE = `http://127.0.0.1:${PORT}`;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+const check = (ok, what, detail = "") => {
+  console.log(`${ok ? "  ok" : "FAIL"}  ${what}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures += 1;
+};
+
+const build = spawnSync("node", ["site/build.mjs"], { cwd: ROOT, stdio: "inherit" });
+if (build.status !== 0) process.exit(build.status ?? 1);
+
+try {
+  await fetch(BASE);
+  console.error(`port ${PORT} is already in use — kill the process on it first`);
+  process.exit(1);
+} catch {
+  // Nothing listening: good.
+}
+const server = spawn("node", ["site/serve.mjs", "--port", String(PORT)], {
+  cwd: ROOT,
+  stdio: "ignore",
+});
+process.on("exit", () => server.kill());
+for (let i = 0; ; i++) {
+  try {
+    await fetch(BASE);
+    break;
+  } catch {
+    if (i > 50) throw new Error("site server never came up");
+    await sleep(200);
+  }
+}
+
+const browser = await chromium.launch();
+// One context throughout: the IDE section needs two pages to see the SAME
+// localStorage, and clipboard permission makes the copy path real rather than
+// silently falling back to "copy the URL".
+const context = await browser.newContext({
+  viewport: { width: 1440, height: 900 },
+  permissions: ["clipboard-read", "clipboard-write"],
+});
+
+const live = (page, timeout = 40000) =>
+  page.waitForFunction(
+    () => (window.__sandbox ?? window.__ide)?.status().state === "live",
+    null,
+    { timeout }
+  );
+
+/** Click Share and hand back the URL it minted (the page's own address). */
+const clickShare = async (page) => {
+  await page.click("#share");
+  await page.waitForFunction(() => window.location.hash.includes("code="), null, {
+    timeout: 15000,
+  });
+  return page.url();
+};
+
+const shareLabel = (page) => page.textContent("#share");
+
+/**
+ * A complete little program, marked so a page can be asked WHICH one it holds.
+ * Complete on purpose: the IDE section asserts "live", which a program missing
+ * `draw` never reaches.
+ */
+const program = (marker) => `// ${marker}
+let init = { t: 0.0 }
+
+let tick = (model, dt: float, tts: float) => { model with t: model.t + dt }
+
+let draw = (model, tts: float) =>
+  Frame.create(
+    Camera3D.lookAt(Vec3.make(0.0, 2.0, -6.0), Vec3.make(0.0, 0.5, 0.0)),
+    Scene.sphere() |> Scene.emissive(Color.rgb(0.15, 1.0, 0.85)) |> Scene.scale(1.4))
+`;
+
+const bannerText = (page) =>
+  page.evaluate(() => document.querySelector(".share-banner-text")?.textContent ?? "");
+
+// --- 1. Sandbox: an edited single-file example round-trips. -------------------
+{
+  const page = await context.newPage();
+  const consoleLog = [];
+  page.on("console", (m) => consoleLog.push(m.text()));
+  page.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+  await page.goto(`${BASE}/sandbox.html?example=hero`);
+  await live(page);
+
+  const MARK = "// shared-edit marker 4711\n";
+  await page.evaluate((mark) => window.__sandbox.setSource(mark + window.__sandbox.getSource()), MARK);
+  await page.waitForFunction(() => window.__sandbox.status().state === "live", null, {
+    timeout: 30000,
+  });
+
+  const url = await clickShare(page);
+  check(url.includes("#code="), "Share writes a #code= fragment into the page URL", url.slice(-40));
+  check(
+    (await shareLabel(page)).includes("copied"),
+    "the button confirms itself",
+    await shareLabel(page)
+  );
+  const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+  check(clipboard === url, "the full URL is on the clipboard", clipboard.slice(0, 60));
+  check((await bannerText(page)) === "", "an asset-free example warns about nothing");
+
+  // A FRESH page on that URL: nothing of the first page's state is available to
+  // it, so whatever it shows came out of the fragment.
+  const opened = await context.newPage();
+  await opened.goto(url);
+  await live(opened);
+  const state = await opened.evaluate(() => ({
+    source: window.__sandbox.getSource(),
+    files: window.__sandbox.files(),
+    picker: document.querySelector("#example-picker").selectedOptions[0].textContent,
+    status: window.__sandbox.status(),
+  }));
+  check(state.source.startsWith("// shared-edit marker 4711"), "the shared page holds the EDIT");
+  check(
+    state.files.paths.join(", ") === "hero.fun" && state.files.active === "hero.fun",
+    "the project's flat module file is what loads",
+    state.files.paths.join(", ")
+  );
+  check(state.picker === "shared link", "the picker names the loaded link", String(state.picker));
+  check(state.status.state === "live", "the shared program is live", JSON.stringify(state.status));
+  const errors = consoleLog.filter((line) => /unknown external|panic|pageerror/i.test(line));
+  check(errors.length === 0, "no load error on either page", errors.slice(0, 2).join(" | "));
+  await opened.close();
+  await page.close();
+}
+
+// --- 2. Sandbox: netpong, with an edit to the SERVER file. --------------------
+{
+  const page = await context.newPage();
+  await page.goto(`${BASE}/sandbox.html?example=netpong`);
+  await live(page);
+  await page.click(".file-row:has(.file-label:text-is('server.fun')) .file-name");
+  await page.evaluate(() =>
+    window.__sandbox.setSource(`${window.__sandbox.getSource()}\n// shared server edit\n`)
+  );
+  await sleep(500);
+  const url = await clickShare(page);
+  await page.close();
+
+  const opened = await context.newPage();
+  const consoleLog = [];
+  opened.on("console", (m) => consoleLog.push(m.text()));
+  opened.on("pageerror", (e) => consoleLog.push(`pageerror: ${e}`));
+  await opened.goto(url);
+  await live(opened);
+  const state = await opened.evaluate(() => ({
+    files: window.__sandbox.files(),
+    status: window.__sandbox.status(),
+    serverPanes: document.querySelectorAll(".mp-pane.server").length,
+    sidebar: !document.querySelector(".file-pane").hidden,
+  }));
+  check(
+    state.files.paths.join(", ") === "netpong.fun, server.fun, protocol.fun, game.fun",
+    "every file travels, entry first",
+    state.files.paths.join(", ")
+  );
+  check(state.sidebar, "the multi-file sidebar is back");
+  check(state.serverPanes === 1, "the SERVER pane mounts from the link", String(state.serverPanes));
+  // "1+1 running": the clients and the server are counted separately, so the
+  // pill itself proves the server pane is live rather than merely mounted.
+  await opened
+    .waitForFunction(() => window.__sandbox.status().text.includes("+1"), null, { timeout: 40000 })
+    .catch(() => {});
+  const pill = await opened.evaluate(() => window.__sandbox.status());
+  check(
+    pill.state === "live" && pill.text.includes("+1"),
+    "client and server panes are both live",
+    JSON.stringify(pill)
+  );
+  // The off-entry edit is in the file it was made in, not smeared onto the entry.
+  await opened.click(".file-row:has(.file-label:text-is('server.fun')) .file-name");
+  const serverSource = await opened.evaluate(() => window.__sandbox.getSource());
+  check(
+    serverSource.includes("// shared server edit"),
+    "the edit to server.fun travelled in server.fun",
+    serverSource.slice(-40).replace(/\n/g, " ")
+  );
+  const errors = consoleLog.filter((line) => /unknown external|panic|pageerror/i.test(line));
+  check(errors.length === 0, "no pane reported a load error", errors.slice(0, 2).join(" | "));
+  await opened.close();
+}
+
+// --- 3. Sandbox: the fragment outranks ?example=, and picking clears it. ------
+{
+  const page = await context.newPage();
+  await page.goto(`${BASE}/sandbox.html?example=counter`);
+  await live(page);
+  const url = await clickShare(page);
+  await page.close();
+
+  const opened = await context.newPage();
+  // The query asks for `tetris`; the fragment carries `counter`. The fragment is
+  // the only copy of its project, so it wins.
+  await opened.goto(url.replace("example=counter", "example=tetris"));
+  await live(opened);
+  const loaded = await opened.evaluate(() => window.__sandbox.files().paths[0]);
+  check(loaded === "counter.fun", "#code= outranks ?example=", loaded);
+
+  await opened.selectOption("#example-picker", "tetris");
+  await opened.waitForFunction(() => window.__sandbox.files().paths[0].includes("tetris"), null, {
+    timeout: 40000,
+  });
+  const after = await opened.evaluate(() => window.location.hash);
+  check(!after.includes("code="), "picking an example drops the fragment", after || "(empty)");
+  await opened.close();
+}
+
+// --- 4. IDE: share, prompt, and the localStorage semantics. ------------------
+{
+  const page = await context.newPage();
+  await page.goto(`${BASE}/ide.html`);
+  await live(page);
+
+  // The project that gets shared…
+  await page.evaluate((source) => window.__ide.setActiveSource(source), program("SHARED"));
+  await live(page);
+  const url = await clickShare(page);
+  check(url.includes("#code="), "the IDE mints a link too", url.slice(-30));
+  // …and then the reader's OWN work moves on, which is what a link must not eat.
+  await page.evaluate((source) => window.__ide.setActiveSource(source), program("LOCAL"));
+  await live(page);
+  const stored = await page.evaluate(() => localStorage.getItem("functor-ide-project-v1"));
+  check(stored.includes("// LOCAL"), "the reader's edit is what is stored");
+  await page.close();
+
+  // Cancel: the stored project stays open and the fragment is dropped.
+  const declined = await context.newPage();
+  declined.on("dialog", (dialog) => dialog.dismiss());
+  await declined.goto(url);
+  await live(declined);
+  await sleep(500);
+  const declinedState = await declined.evaluate(() => ({
+    source: window.__ide.files().find((f) => f.path === "game.fun").source,
+    hash: window.location.hash,
+    stored: localStorage.getItem("functor-ide-project-v1"),
+  }));
+  check(
+    declinedState.source.includes("// LOCAL"),
+    "Cancel keeps the stored project open",
+    declinedState.source.split("\n")[0]
+  );
+  check(
+    !declinedState.hash.includes("code="),
+    "Cancel drops the fragment so a reload doesn't re-ask",
+    declinedState.hash || "(empty)"
+  );
+  check(declinedState.stored.includes("// LOCAL"), "…and localStorage is untouched");
+  await declined.close();
+
+  // Accept: the shared project opens, but is NOT written until an edit.
+  const accepted = await context.newPage();
+  const prompts = [];
+  accepted.on("dialog", (dialog) => {
+    prompts.push(dialog.message());
+    dialog.accept();
+  });
+  await accepted.goto(url);
+  await live(accepted);
+  await accepted.waitForFunction(
+    () => window.__ide.files().find((f) => f.path === "game.fun").source.includes("// SHARED"),
+    null,
+    { timeout: 20000 }
+  );
+  check(prompts.length === 1, "a stored project is never replaced silently", prompts[0] ?? "");
+  const beforeEdit = await accepted.evaluate(() =>
+    localStorage.getItem("functor-ide-project-v1")
+  );
+  check(
+    beforeEdit.includes("// LOCAL") && !beforeEdit.includes("// SHARED"),
+    "looking at a shared project does not persist it",
+    beforeEdit.slice(0, 40)
+  );
+  // …and the first edit adopts it.
+  await accepted.evaluate((source) => window.__ide.setActiveSource(source), program("SHARED then mine"));
+  await sleep(600);
+  const afterEdit = await accepted.evaluate(() => localStorage.getItem("functor-ide-project-v1"));
+  check(
+    afterEdit.includes("// SHARED then mine"),
+    "the first edit adopts the shared project",
+    afterEdit.slice(0, 50)
+  );
+  await accepted.close();
+}
+
+// --- 5. The assets advisory. --------------------------------------------------
+{
+  // An example whose local assets the site DOES serve (synthwave's two
+  // textures) must not warn: the link drops nothing.
+  const served = await context.newPage();
+  await served.goto(`${BASE}/sandbox.html?example=synthwave`);
+  await live(served);
+  await clickShare(served);
+  await sleep(1200);
+  check(
+    (await bannerText(served)) === "",
+    "site-served assets travel — no advisory",
+    await bannerText(served)
+  );
+
+  // A locator the site cannot serve does warn, on the encode side…
+  await served.evaluate(() =>
+    window.__sandbox.setSource(
+      `let missing = Asset.texture("not-on-this-site.png")\n${window.__sandbox.getSource()}`
+    )
+  );
+  await sleep(600);
+  const url = await clickShare(served);
+  const warned = await served
+    .waitForFunction(
+      () =>
+        (document.querySelector(".share-banner-text")?.textContent ?? "").includes(
+          "not-on-this-site.png"
+        ),
+      null,
+      { timeout: 15000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  check(warned, "an unservable relative locator warns when sharing", await bannerText(served));
+  await served.close();
+
+  // …and on the decode side, for whoever opens the link.
+  const opened = await context.newPage();
+  await opened.goto(url);
+  const told = await opened
+    .waitForFunction(
+      () =>
+        (document.querySelector(".share-banner-text")?.textContent ?? "").includes(
+          "not-on-this-site.png"
+        ),
+      null,
+      { timeout: 30000 }
+    )
+    .then(() => true)
+    .catch(() => false);
+  check(told, "the reader of the link is told too", await bannerText(opened));
+  // Non-blocking: the program still runs, and the strip dismisses.
+  await live(opened);
+  await opened.click(".share-banner-close");
+  check((await bannerText(opened)) === "", "the advisory dismisses");
+  await opened.close();
+}
+
+await context.close();
+await browser.close();
+server.kill();
+console.log(failures === 0 ? "\nshare page e2e passed" : `\n${failures} check(s) failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:wire-value": "node --test site/src/wire-value.test.ts",
     "test:pr-preview": "node --test scripts/pr-preview.test.mjs",
     "test:share-link": "node --test site/src/share-link.test.ts",
+    "test:share": "node e2e/share-page.mjs",
     "test:vscode-e2e": "playwright test -c tools/functor-lang-vscode/tests-integration/playwright.config.mjs",
     "check:site": "tsc -p site --noEmit",
     "site:build": "npm run generate:icons && node site/build.mjs",

--- a/site/ide.html
+++ b/site/ide.html
@@ -32,6 +32,14 @@
         <button id="download" type="button" title="Download the project as a .zip">
           ↓ project.zip
         </button>
+        <button
+          id="share"
+          type="button"
+          data-tone="idle"
+          title="Copy a link that carries this project — files, entry, roles"
+        >
+          ⧉ share
+        </button>
         <button id="restart" type="button" title="Reload the preview with a fresh model">
           ↻ restart
         </button>
@@ -56,6 +64,9 @@
       </aside>
       <section class="editor-pane">
         <div class="editor-tab"><span id="active-file">game.fun</span></div>
+        <!-- The share advisory's island host (src/components/ShareBanner.tsx).
+             Empty until a link's assets can't follow it. -->
+        <div class="share-banner-host"></div>
         <!-- NOT an island: CodeMirror owns this subtree. -->
         <div id="editor"></div>
       </section>

--- a/site/sandbox.html
+++ b/site/sandbox.html
@@ -34,6 +34,14 @@
         <button id="reset" type="button" title="Reload the example (resets the model)">
           ↺ reset
         </button>
+        <button
+          id="share"
+          type="button"
+          data-tone="idle"
+          title="Copy a link that carries this project — files, entry, roles"
+        >
+          ⧉ share
+        </button>
         <div id="runtime-target"></div>
         <span id="status" class="status-pill" data-state="busy">◌ loading…</span>
       </div>
@@ -48,6 +56,10 @@
       -->
       <aside class="file-pane" hidden></aside>
       <section class="editor-pane">
+        <!-- The share advisory's island host (src/components/ShareBanner.tsx).
+             Empty until a link's assets can't follow it — the strip renders
+             nothing otherwise, so there is no skeleton to keep in step. -->
+        <div class="share-banner-host"></div>
         <div id="editor"></div>
       </section>
       <section class="preview-pane">

--- a/site/src/components/IdeControls.tsx
+++ b/site/src/components/IdeControls.tsx
@@ -1,9 +1,11 @@
-// The IDE's header controls: the zip download, the preview restart, the
-// external-runtime panel, and the live status pill. The page keeps owning the
+// The IDE's header controls: the zip download, the share link, the preview
+// restart, the external-runtime panel, and the live status pill. The page keeps owning the
 // project and preview logic — this island renders the pill's store and calls
 // back on intent, exactly as the sandbox's controls do.
 
 import { RuntimeTargetPanel } from "./RuntimeTargetPanel.js";
+import { ShareButton } from "./ShareButton.js";
+import type { ShareState } from "./ShareButton.js";
 import { StatusPill } from "./StatusPill.js";
 import type { PillState } from "./StatusPill.js";
 import type { RuntimeTargetCore } from "../runtime-target-core.js";
@@ -11,21 +13,26 @@ import type { Store } from "../store.js";
 
 export interface IdeControlsProps {
   pill: Store<PillState>;
+  share: Store<ShareState>;
   runtimeTarget: RuntimeTargetCore;
   onDownload: () => void;
   onRestart: () => void;
+  onShare: () => void;
 }
 
 export const IdeControls = ({
   pill,
+  share,
   runtimeTarget,
   onDownload,
   onRestart,
+  onShare,
 }: IdeControlsProps) => (
   <>
     <button id="download" type="button" title="Download the project as a .zip" onClick={onDownload}>
       ↓ project.zip
     </button>
+    <ShareButton store={share} onShare={onShare} />
     <button
       id="restart"
       type="button"

--- a/site/src/components/SandboxControls.tsx
+++ b/site/src/components/SandboxControls.tsx
@@ -4,6 +4,8 @@
 
 import { useSyncExternalStore } from "react";
 import { RuntimeTargetPanel } from "./RuntimeTargetPanel.js";
+import { ShareButton } from "./ShareButton.js";
+import type { ShareState } from "./ShareButton.js";
 import { StatusPill } from "./StatusPill.js";
 import type { PillState } from "./StatusPill.js";
 import type { RuntimeTargetCore } from "../runtime-target-core.js";
@@ -31,20 +33,24 @@ export interface SandboxControlsProps {
   picker: Store<PickerState>;
   pill: Store<PillState>;
   clients: Store<ClientsState>;
+  share: Store<ShareState>;
   runtimeTarget: RuntimeTargetCore;
   onSelect: (value: string) => void;
   onReset: () => void;
   onClients: (count: number) => void;
+  onShare: () => void;
 }
 
 export const SandboxControls = ({
   picker,
   pill,
   clients,
+  share,
   runtimeTarget,
   onSelect,
   onReset,
   onClients,
+  onShare,
 }: SandboxControlsProps) => {
   const { options, selected } = useSyncExternalStore(picker.subscribe, picker.getSnapshot);
   const clientsState = useSyncExternalStore(clients.subscribe, clients.getSnapshot);
@@ -85,6 +91,7 @@ export const SandboxControls = ({
       <button id="reset" type="button" title="Reload the example (resets the model)" onClick={onReset}>
         ↺ reset
       </button>
+      <ShareButton store={share} onShare={onShare} />
       <div id="runtime-target" className="runtime-target-host">
         <RuntimeTargetPanel core={runtimeTarget} />
       </div>

--- a/site/src/components/ShareBanner.tsx
+++ b/site/src/components/ShareBanner.tsx
@@ -1,0 +1,40 @@
+// A one-line advisory above the editor, used by both editor pages for the one
+// thing a share link cannot promise: assets it does not carry (see share.ts).
+//
+// Non-blocking on purpose — the project is already loaded and running behind
+// it. It is a strip, not a dialog: it never covers the editor, and it dismisses.
+
+import { useSyncExternalStore } from "react";
+import type { Store } from "../store.js";
+
+/** The advisory's text; empty means there is nothing to say. */
+export interface BannerState {
+  text: string;
+}
+
+export const ShareBanner = ({
+  store,
+  onDismiss,
+}: {
+  store: Store<BannerState>;
+  onDismiss: () => void;
+}) => {
+  const { text } = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  if (!text) return null;
+  return (
+    <div className="share-banner" role="status">
+      <span className="share-banner-icon" aria-hidden="true">
+        ⚠
+      </span>
+      <span className="share-banner-text">{text}</span>
+      <button
+        type="button"
+        className="share-banner-close"
+        aria-label="Dismiss this notice"
+        onClick={onDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+};

--- a/site/src/components/ShareButton.tsx
+++ b/site/src/components/ShareButton.tsx
@@ -1,0 +1,37 @@
+// The Share control, shared by the sandbox and the IDE headers: one header
+// button that copies a link carrying the project in its fragment.
+//
+// The button is also its own confirmation — it flips to "✓ copied" for a beat
+// and back. No toast, no new chrome: the control that was clicked is where the
+// reader is already looking, and a share is over the moment it is copied.
+
+import { useSyncExternalStore } from "react";
+import type { Store } from "../store.js";
+
+/** The button's label, its tone (colour), and its tooltip. */
+export interface ShareState {
+  label: string;
+  tone: "idle" | "ok" | "error";
+  detail: string;
+}
+
+export const SHARE_IDLE: ShareState = {
+  label: "⧉ share",
+  tone: "idle",
+  detail: "Copy a link that carries this project — files, entry, roles",
+};
+
+export const ShareButton = ({
+  store,
+  onShare,
+}: {
+  store: Store<ShareState>;
+  onShare: () => void;
+}) => {
+  const { label, tone, detail } = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  return (
+    <button id="share" type="button" data-tone={tone} title={detail} onClick={onShare}>
+      {label}
+    </button>
+  );
+};

--- a/site/src/docs.ts
+++ b/site/src/docs.ts
@@ -5,6 +5,10 @@
 // The tokenizer mirrors src/functor-lang.ts's CodeMirror StreamLanguage; it's a few
 // regexes, so a static-HTML variant beats dragging CodeMirror onto the docs
 // page. Keep the two classifications in sync.
+//
+// The fragment itself is encoded with the share-link codec's base64url (one
+// definition of the alphabet for both ends of a link).
+import { toBase64Url } from "./share-link.js";
 
 const KEYWORDS = new Set([
   "let",
@@ -126,12 +130,6 @@ const highlight = (source: string): string => {
   return html;
 };
 
-const toBase64Url = (s: string): string =>
-  btoa(String.fromCharCode(...new TextEncoder().encode(s)))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-
 for (const pre of document.querySelectorAll("pre.functor-lang")) {
   const source = pre.textContent!;
   pre.innerHTML = highlight(source);
@@ -141,7 +139,7 @@ for (const pre of document.querySelectorAll("pre.functor-lang")) {
     link.textContent = "▶ try it";
     link.title = "Open this program live in the sandbox";
     const sandboxHref = document.body.dataset.sandboxHref || "sandbox.html";
-    link.href = `${sandboxHref}#src=${toBase64Url(source)}`;
+    link.href = `${sandboxHref}#src=${toBase64Url(new TextEncoder().encode(source))}`;
     link.target = "_blank";
     pre.appendChild(link);
   }

--- a/site/src/ide.tsx
+++ b/site/src/ide.tsx
@@ -47,7 +47,7 @@ import { StatusBar } from "./components/StatusBar.js";
 import { FilePane, ActiveFileTab } from "./components/FilePane.js";
 import type { FileListState } from "./components/FilePane.js";
 import type { PillState } from "./components/StatusPill.js";
-import { asPlayerMessage } from "./protocol.js";
+import { asPlayerMessage, entryFirst } from "./protocol.js";
 import type { ProjectFile } from "./protocol.js";
 import { zipFiles } from "./zip.js";
 // The project-file rule lives with the share-link codec, which enforces the
@@ -55,7 +55,7 @@ import { zipFiles } from "./zip.js";
 // the IDE's flat module space.
 import { MODULE_FILE, decodeShare } from "./share-link.js";
 import type { ShareProject } from "./share-link.js";
-import { shareHref, copyLink, unservedAssets, assetWarning } from "./share.js";
+import { createShareController } from "./share.js";
 
 /** The in-memory project: a flat module space plus the open file's path. */
 interface Project {
@@ -208,10 +208,7 @@ function loadProject(): Project {
       // The loader's contract (preview AND language analysis): the ENTRY is
       // files[0] — its module is the program root. Every mutation here keeps
       // that order, but a hand-edited localStorage could reorder.
-      const files = [
-        ...stored.files!.filter((f) => f.path === ENTRY),
-        ...stored.files!.filter((f) => f.path !== ENTRY),
-      ];
+      const files = entryFirst(stored.files!, ENTRY);
       storedProject = true;
       return { files, active };
     }
@@ -494,76 +491,34 @@ const restart = () => {
 
 // ---------------------------------------------------------------- sharing
 
-// The assets advisory: the project's relative `Asset.*` locators this site does
-// not serve — the only thing a link genuinely drops (share.ts explains why the
-// site-served ones are fine). The IDE serves nothing of its own, so an authored
-// locator that isn't already on the site shows up here.
-const warnAboutAssets = () => {
-  void unservedAssets(project.files).then((missing) => {
-    if (missing.length === 0) return;
-    const text = assetWarning(missing);
-    banner.set({ text });
-    statusBar.appendOutput("warn", text);
-  });
-};
-
-let shareFlash = 0;
-const flashShare = (state: ShareState) => {
-  share.set(state);
-  window.clearTimeout(shareFlash);
-  shareFlash = window.setTimeout(() => share.set(SHARE_IDLE), 2600);
-};
-
-// Share: the whole in-memory project in the page's own URL. The IDE's paths are
-// already bare module files and its entry is always `game.fun`, so there is
-// nothing to flatten — only the pointer options ride along, matching the
-// manifest the zip download writes.
-const shareLink = async () => {
-  const carried: ShareProject = { files: project.files, entry: ENTRY };
-  if (cursorPolicy) carried.options = { cursor: cursorPolicy };
-  else if (mouseCapture === false) carried.options = { mouseCapture: false };
-  let url: string;
-  try {
-    url = await shareHref(carried, window.location.href);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    statusBar.appendOutput("error", message);
-    flashShare({ label: "✖ can't share", tone: "error", detail: message });
-    return;
-  }
-  window.history.replaceState(null, "", url);
-  const copied = await copyLink(url);
-  flashShare(
-    copied
-      ? { label: "✓ copied", tone: "ok", detail: url }
-      : {
-          label: "⧉ copy the URL",
-          tone: "error",
-          detail: "the clipboard refused — the link is in the address bar",
-        }
-  );
-  warnAboutAssets();
-};
+// The Share workflow lives in share.ts, so both editor pages behave identically;
+// the IDE supplies only what its project IS. Its paths are already bare module
+// files and its entry is always `game.fun`, so there is nothing to flatten — and
+// nothing to put in `options` either: the IDE takes its pointer policy from the
+// QUERY (`?cursor=` / `?mouseCapture=`), which a share URL preserves, so
+// declaring it in the fragment too would only let the two disagree.
+const sharing = createShareController({
+  share,
+  banner,
+  project: () => ({ files: project.files, entry: ENTRY }),
+  files: () => project.files,
+  onOutput: (level, message) => statusBar.appendOutput(level, message),
+  href: () => window.location.href,
+});
 
 // Open a project that arrived in a `#code=` link. It is NOT saved: `persist`
 // stays false until the reader changes something, so the project already in
 // this browser is still there if they reload without the link.
 const openShared = (carried: ShareProject) => {
   persist = false;
-  project = {
-    active: ENTRY,
-    files: [
-      ...carried.files.filter((file) => file.path === ENTRY),
-      ...carried.files.filter((file) => file.path !== ENTRY),
-    ],
-  };
+  project = { active: ENTRY, files: entryFirst(carried.files, ENTRY) };
   // The incoming module space is a different program: the last-good completion
   // cache would otherwise keep offering the outgoing one's members.
   resetIntel();
   publishFiles();
   setDoc(activeFile()!.source);
   restart(); // a fresh iframe, so the shared program runs its OWN init
-  warnAboutAssets();
+  sharing.checkAssets();
 };
 
 // ---------------------------------------------------------------- boot
@@ -578,7 +533,7 @@ createRoot(document.querySelector(".sandbox-controls")!).render(
     runtimeTarget={runtimeTarget}
     onDownload={download}
     onRestart={restart}
-    onShare={shareLink}
+    onShare={sharing.shareLink}
   />
 );
 // The one thing a link can't promise (share.ts): a strip above the editor.
@@ -608,6 +563,9 @@ setStatus("busy", "◌ loading…");
 // moment the player announces it's ready (no lost first push).
 bridge.setProject(project.files);
 els.player.src = playerUrl();
+// The advisory describes whatever is open, not only what arrived in a link — a
+// stored project naming an asset this site can't serve says so on load.
+sharing.checkAssets();
 
 // A `#code=` link outranks the stored project — but never silently, and never
 // destructively:
@@ -617,21 +575,34 @@ els.player.src = playerUrl();
 //     the URL, so a reload doesn't ask again;
 //   • either way the shared project is not written to localStorage until the
 //     reader changes something (`persist`), so their work survives a look.
-// A shared project whose entry isn't `game.fun` (a sandbox example's link, say)
-// is refused rather than renamed: renaming the entry would silently rename its
-// MODULE and break every sibling that calls into it.
+// A shared project the IDE cannot represent is REFUSED rather than mangled — and
+// refused before the reader is asked anything, so a link it can't open never
+// costs them their project. Two cases: an entry that isn't `game.fun` (renaming
+// it would silently rename its MODULE and break every sibling that calls into
+// it), and a project with declared ROLES, which the IDE has no seam for (it
+// always boots the one entry, with no `module=`/`prefix=`).
 if (new URLSearchParams(window.location.hash.slice(1)).has("code")) {
   void decodeShare(window.location.hash).then((carried) => {
     if (!carried) {
       setStatus("error", "✖ error", "this share link doesn't carry a valid project");
       return;
     }
-    if (!carried.files.some((file) => file.path === ENTRY)) {
+    const entry = carried.entry ?? ENTRY;
+    if (entry !== ENTRY || !carried.files.some((file) => file.path === ENTRY)) {
       setStatus(
         "error",
         "✖ error",
-        `this link's project starts at ${carried.entry ?? carried.files[0].path}; ` +
-          `the IDE's entry is ${ENTRY}`
+        `this link's project starts at ${entry}; the IDE's entry is ${ENTRY} — ` +
+          "open it in the sandbox instead"
+      );
+      return;
+    }
+    if (carried.config?.entries) {
+      setStatus(
+        "error",
+        "✖ error",
+        "this link's project declares client/server roles, which the IDE cannot " +
+          "run — open it in the sandbox instead"
       );
       return;
     }

--- a/site/src/ide.tsx
+++ b/site/src/ide.tsx
@@ -39,6 +39,10 @@ import { createRuntimeTargetCore } from "./runtime-target-core.js";
 import type { RuntimeTargetState } from "./runtime-target-core.js";
 import { createStore } from "./store.js";
 import { IdeControls } from "./components/IdeControls.js";
+import { SHARE_IDLE } from "./components/ShareButton.js";
+import type { ShareState } from "./components/ShareButton.js";
+import { ShareBanner } from "./components/ShareBanner.js";
+import type { BannerState } from "./components/ShareBanner.js";
 import { StatusBar } from "./components/StatusBar.js";
 import { FilePane, ActiveFileTab } from "./components/FilePane.js";
 import type { FileListState } from "./components/FilePane.js";
@@ -49,7 +53,9 @@ import { zipFiles } from "./zip.js";
 // The project-file rule lives with the share-link codec, which enforces the
 // same thing on a decoded fragment — one definition for both entrances into
 // the IDE's flat module space.
-import { MODULE_FILE } from "./share-link.js";
+import { MODULE_FILE, decodeShare } from "./share-link.js";
+import type { ShareProject } from "./share-link.js";
+import { shareHref, copyLink, unservedAssets, assetWarning } from "./share.js";
 
 /** The in-memory project: a flat module space plus the open file's path. */
 interface Project {
@@ -158,8 +164,20 @@ const els = {
 // rebuild the DOM.
 const pill = createStore<PillState>({ state: "busy", text: "◌ loading…", detail: "" });
 const fileList = createStore<FileListState>({ files: [], active: ENTRY });
+// The Share button's own label (it confirms itself) and the assets advisory.
+const share = createStore<ShareState>(SHARE_IDLE);
+const banner = createStore<BannerState>({ text: "" });
 
 // ---------------------------------------------------------------- project
+
+// Whether localStorage held a project of the reader's OWN when the page loaded.
+// A share link asks before displacing one of those, and never asks when the
+// only thing it would displace is the starter.
+let storedProject = false;
+// Whether the in-memory project may be written back to localStorage. False for
+// exactly one state: a project that arrived in a LINK and has not been touched.
+// The reader's own saved project survives merely LOOKING at a shared one.
+let persist = true;
 
 let project = loadProject();
 
@@ -194,6 +212,7 @@ function loadProject(): Project {
         ...stored.files!.filter((f) => f.path === ENTRY),
         ...stored.files!.filter((f) => f.path !== ENTRY),
       ];
+      storedProject = true;
       return { files, active };
     }
   } catch {
@@ -203,6 +222,8 @@ function loadProject(): Project {
 }
 
 const saveProject = () => {
+  // An untouched shared project is not the reader's work yet — see `persist`.
+  if (!persist) return;
   // Best-effort: a disabled/full localStorage (private mode, quota) must not
   // break editing or the live preview — persistence is a convenience.
   try {
@@ -353,6 +374,11 @@ const bridge = new ProjectBridge(els.player, {
 
 // Persist + push the current file set (the bridge debounces the actual send).
 const schedulePush = () => {
+  // Every caller is a MUTATION (an edit, a new file, a delete), so this is also
+  // where a shared project becomes the reader's: from the first change on, it
+  // persists like any other. Merely opening files (openFile → saveProject) is
+  // not a change and does not adopt it.
+  persist = true;
   saveProject();
   bridge.setProject(project.files);
   runtimeTarget.projectChanged();
@@ -466,6 +492,80 @@ const restart = () => {
   runtimeTarget.restart();
 };
 
+// ---------------------------------------------------------------- sharing
+
+// The assets advisory: the project's relative `Asset.*` locators this site does
+// not serve — the only thing a link genuinely drops (share.ts explains why the
+// site-served ones are fine). The IDE serves nothing of its own, so an authored
+// locator that isn't already on the site shows up here.
+const warnAboutAssets = () => {
+  void unservedAssets(project.files).then((missing) => {
+    if (missing.length === 0) return;
+    const text = assetWarning(missing);
+    banner.set({ text });
+    statusBar.appendOutput("warn", text);
+  });
+};
+
+let shareFlash = 0;
+const flashShare = (state: ShareState) => {
+  share.set(state);
+  window.clearTimeout(shareFlash);
+  shareFlash = window.setTimeout(() => share.set(SHARE_IDLE), 2600);
+};
+
+// Share: the whole in-memory project in the page's own URL. The IDE's paths are
+// already bare module files and its entry is always `game.fun`, so there is
+// nothing to flatten — only the pointer options ride along, matching the
+// manifest the zip download writes.
+const shareLink = async () => {
+  const carried: ShareProject = { files: project.files, entry: ENTRY };
+  if (cursorPolicy) carried.options = { cursor: cursorPolicy };
+  else if (mouseCapture === false) carried.options = { mouseCapture: false };
+  let url: string;
+  try {
+    url = await shareHref(carried, window.location.href);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    statusBar.appendOutput("error", message);
+    flashShare({ label: "✖ can't share", tone: "error", detail: message });
+    return;
+  }
+  window.history.replaceState(null, "", url);
+  const copied = await copyLink(url);
+  flashShare(
+    copied
+      ? { label: "✓ copied", tone: "ok", detail: url }
+      : {
+          label: "⧉ copy the URL",
+          tone: "error",
+          detail: "the clipboard refused — the link is in the address bar",
+        }
+  );
+  warnAboutAssets();
+};
+
+// Open a project that arrived in a `#code=` link. It is NOT saved: `persist`
+// stays false until the reader changes something, so the project already in
+// this browser is still there if they reload without the link.
+const openShared = (carried: ShareProject) => {
+  persist = false;
+  project = {
+    active: ENTRY,
+    files: [
+      ...carried.files.filter((file) => file.path === ENTRY),
+      ...carried.files.filter((file) => file.path !== ENTRY),
+    ],
+  };
+  // The incoming module space is a different program: the last-good completion
+  // cache would otherwise keep offering the outgoing one's members.
+  resetIntel();
+  publishFiles();
+  setDoc(activeFile()!.source);
+  restart(); // a fresh iframe, so the shared program runs its OWN init
+  warnAboutAssets();
+};
+
 // ---------------------------------------------------------------- boot
 
 // Mount the islands into the static shell's containers. Each keeps its element
@@ -474,10 +574,16 @@ const restart = () => {
 createRoot(document.querySelector(".sandbox-controls")!).render(
   <IdeControls
     pill={pill}
+    share={share}
     runtimeTarget={runtimeTarget}
     onDownload={download}
     onRestart={restart}
+    onShare={shareLink}
   />
+);
+// The one thing a link can't promise (share.ts): a strip above the editor.
+createRoot(document.querySelector(".share-banner-host")!).render(
+  <ShareBanner store={banner} onDismiss={() => banner.set({ text: "" })} />
 );
 createRoot(document.querySelector(".file-pane")!).render(
   <FilePane
@@ -502,6 +608,51 @@ setStatus("busy", "◌ loading…");
 // moment the player announces it's ready (no lost first push).
 bridge.setProject(project.files);
 els.player.src = playerUrl();
+
+// A `#code=` link outranks the stored project — but never silently, and never
+// destructively:
+//   • no stored project of the reader's own (first visit, or the starter) → the
+//     shared project just opens;
+//   • a stored project → ASK. Cancel keeps their project and drops `code` from
+//     the URL, so a reload doesn't ask again;
+//   • either way the shared project is not written to localStorage until the
+//     reader changes something (`persist`), so their work survives a look.
+// A shared project whose entry isn't `game.fun` (a sandbox example's link, say)
+// is refused rather than renamed: renaming the entry would silently rename its
+// MODULE and break every sibling that calls into it.
+if (new URLSearchParams(window.location.hash.slice(1)).has("code")) {
+  void decodeShare(window.location.hash).then((carried) => {
+    if (!carried) {
+      setStatus("error", "✖ error", "this share link doesn't carry a valid project");
+      return;
+    }
+    if (!carried.files.some((file) => file.path === ENTRY)) {
+      setStatus(
+        "error",
+        "✖ error",
+        `this link's project starts at ${carried.entry ?? carried.files[0].path}; ` +
+          `the IDE's entry is ${ENTRY}`
+      );
+      return;
+    }
+    if (
+      storedProject &&
+      !window.confirm(
+        "Open the shared project from this link?\n\n" +
+          "Your saved project stays in this browser — it is only replaced once you " +
+          "edit the shared one."
+      )
+    ) {
+      const url = new URL(window.location.href);
+      const hash = new URLSearchParams(url.hash.slice(1));
+      hash.delete("code");
+      url.hash = hash.toString();
+      window.history.replaceState(null, "", url);
+      return;
+    }
+    openShared(carried);
+  });
+}
 
 // Test seam for the headless e2e (e2e/ide-page.mjs): drive files without
 // synthesizing DOM events, and read status.

--- a/site/src/protocol.ts
+++ b/site/src/protocol.ts
@@ -31,6 +31,20 @@ export interface ProjectFile {
  */
 export const fileName = (path: string): string => path.slice(path.lastIndexOf("/") + 1);
 
+/**
+ * `files` with `entry` first, order otherwise preserved.
+ *
+ * The loaders' contract — for the preview, for language analysis, and for the
+ * pane grid — is that `files[0]` IS the entry (its module is the program root).
+ * Every producer of a file set has to establish that, whether the set came from
+ * localStorage, a share link, or a fetched example, so the reordering lives here
+ * with the type it reorders.
+ */
+export const entryFirst = (files: ProjectFile[], entry: string): ProjectFile[] => [
+  ...files.filter((file) => file.path === entry),
+  ...files.filter((file) => file.path !== entry),
+];
+
 // --- editor → player ---------------------------------------------------------
 
 /**

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -60,12 +60,12 @@ import { FilePane } from "./components/FilePane.js";
 import type { FileListState } from "./components/FilePane.js";
 import { decodeShare } from "./share-link.js";
 import type { ShareProject, ShareRole } from "./share-link.js";
-import { shareHref, copyLink, unservedAssets, assetWarning } from "./share.js";
+import { createShareController } from "./share.js";
 import { initMultiplayerPanes, MAX_CLIENTS } from "./mp-panes.js";
 import type { MultiplayerPanes, PaneProgram } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
 import { StatusBar } from "./components/StatusBar.js";
-import { asPlayerMessage, fileName } from "./protocol.js";
+import { asPlayerMessage, entryFirst, fileName } from "./protocol.js";
 import type { ProjectFile } from "./protocol.js";
 import { EXAMPLES, exampleEntryPath } from "./examples.js";
 
@@ -535,20 +535,10 @@ const bootPanes = () => {
   mp?.setSrc(frame.src, server);
 };
 
-// The assets advisory: the project's relative `Asset.*` locators that this site
-// does not serve — the only thing a link genuinely drops (share.ts explains
-// why the site-served ones are fine). Fire-and-forget on both ends of a link.
-const warnAboutAssets = (files: ProjectFile[]) => {
-  void unservedAssets(files).then((missing) => {
-    if (missing.length === 0) return;
-    const text = assetWarning(missing);
-    banner.set({ text });
-    statusBar.appendOutput("warn", text);
-  });
-};
-
 // The project the fragment carried, kept so Reset can reload it (there is no
-// served copy to re-fetch) and so the picker can name it.
+// served copy to re-fetch) and so the picker can name it. It outlives an example
+// switch, exactly as the inline snippet used to: its picker row stays, so
+// selecting that row again has to still find it.
 let shared: { project: ShareProject; label: string } | null = null;
 
 // Load a project that arrived IN the URL. The fragment is the storage, so this
@@ -566,16 +556,24 @@ const loadShared = (project_: ShareProject, label: string) => {
   const entry = project_.files.some((file) => file.path === wanted)
     ? wanted
     : project_.files[0].path;
-  const files = [
-    ...project_.files.filter((file) => file.path === entry),
-    ...project_.files.filter((file) => file.path !== entry),
-  ];
+  // COPIES: these become the live buffers, which every keystroke mutates in
+  // place (projectFiles) — handing over the retained objects would quietly turn
+  // Reset into "reload my edits".
+  const files = entryFirst(project_.files, entry).map((file) => ({ ...file }));
   boot = {
     module: client?.module,
     prefix: client?.prefix,
     server: entries?.server ? bootRole(entries.server) : undefined,
-    cursor: project_.options?.cursor,
-    mouseCapture: project_.options?.mouseCapture,
+    // The page's own `?cursor=` / `?mouseCapture=` seam still applies to a
+    // URL-carried project that declares nothing (that is how the docs' `#src=`
+    // snippets have always taken a pointer policy).
+    cursor: project_.options?.cursor ?? pageCursorPolicy ?? undefined,
+    mouseCapture:
+      project_.options?.cursor || pageCursorPolicy
+        ? undefined
+        : (project_.options?.mouseCapture ?? pageMouseCapture) === false
+          ? false
+          : undefined,
   };
   // Reflect the loaded link in the picker so it (and Reset) don't lie about
   // what's running.
@@ -595,7 +593,10 @@ const loadShared = (project_: ShareProject, label: string) => {
   // A shared multiplayer project keeps the CLIENTS control: its server role is
   // as much a reason to show it as an example's `multiplayer` flag.
   if (boot.server) clients.set({ count: mp!.count(), visible: true });
-  warnAboutAssets(files);
+  // Every LOAD re-runs the advisory (`sharing` is initialized before any load
+  // happens — see the boot block at the bottom), so the strip always describes
+  // the project that is open, however it arrived.
+  sharing.checkAssets();
 };
 
 const loadExample = async (id: string) => {
@@ -650,6 +651,7 @@ const loadExample = async (id: string) => {
       !cursorPolicy && (example?.mouseCapture ?? pageMouseCapture) === false ? false : undefined,
   };
   bootPanes();
+  sharing.checkAssets();
 };
 
 const selectExample = (value: string) => {
@@ -669,7 +671,6 @@ const selectExample = (value: string) => {
   url.hash = hash.toString();
   window.history.replaceState(null, "", url);
   updateClientsStore();
-  banner.set({ text: "" }); // the outgoing project's advisory, not this one's
   loadExample(value);
 };
 
@@ -713,38 +714,21 @@ const shareProject = (): ShareProject => {
   return carried;
 };
 
-let shareFlash = 0;
-const flashShare = (state: ShareState) => {
-  share.set(state);
-  window.clearTimeout(shareFlash);
-  shareFlash = window.setTimeout(() => share.set(SHARE_IDLE), 2600);
-};
-
-const shareLink = async () => {
-  let url: string;
-  try {
-    url = await shareHref(shareProject(), window.location.href);
-  } catch (error) {
-    // Too large, or a project the codec refuses (a name collision after
-    // flattening). The Output panel keeps the reason after the button calms.
-    const message = error instanceof Error ? error.message : String(error);
-    statusBar.appendOutput("error", message);
-    flashShare({ label: "✖ can't share", tone: "error", detail: message });
-    return;
-  }
-  window.history.replaceState(null, "", url);
-  const copied = await copyLink(url);
-  flashShare(
-    copied
-      ? { label: "✓ copied", tone: "ok", detail: url }
-      : {
-          label: "⧉ copy the URL",
-          tone: "error",
-          detail: "the clipboard refused — the link is in the address bar",
-        }
-  );
-  warnAboutAssets(projectFiles());
-};
+const sharing = createShareController({
+  share,
+  banner,
+  project: shareProject,
+  files: () => projectFiles(),
+  onOutput: (level, message) => statusBar.appendOutput(level, message),
+  // `?example=` is dropped from a share URL: the fragment carries the project,
+  // and a query still naming the sample it came from would only mislabel the
+  // link (and lose, on the next reload, to the fragment anyway).
+  href: () => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("example");
+    return url.toString();
+  },
+});
 
 // Mount the islands into the static shell's containers. Both keep their
 // element ids and class names, so styles.css and every e2e selector match the
@@ -759,7 +743,7 @@ createRoot(document.querySelector(".sandbox-controls")!).render(
     onSelect={selectExample}
     onReset={resetExample}
     onClients={selectClients}
-    onShare={shareLink}
+    onShare={sharing.shareLink}
   />
 );
 // The one thing a link can't promise (share.ts): a strip above the editor, so

--- a/site/src/sandbox.tsx
+++ b/site/src/sandbox.tsx
@@ -52,8 +52,15 @@ import type { RuntimeTargetState } from "./runtime-target-core.js";
 import { createStore } from "./store.js";
 import { SandboxControls } from "./components/SandboxControls.js";
 import type { PickerState, ClientsState } from "./components/SandboxControls.js";
+import { SHARE_IDLE } from "./components/ShareButton.js";
+import type { ShareState } from "./components/ShareButton.js";
+import { ShareBanner } from "./components/ShareBanner.js";
+import type { BannerState } from "./components/ShareBanner.js";
 import { FilePane } from "./components/FilePane.js";
 import type { FileListState } from "./components/FilePane.js";
+import { decodeShare } from "./share-link.js";
+import type { ShareProject, ShareRole } from "./share-link.js";
+import { shareHref, copyLink, unservedAssets, assetWarning } from "./share.js";
 import { initMultiplayerPanes, MAX_CLIENTS } from "./mp-panes.js";
 import type { MultiplayerPanes, PaneProgram } from "./mp-panes.js";
 import type { PillState } from "./components/StatusPill.js";
@@ -92,10 +99,17 @@ interface LangSeam {
 
 const frame = document.getElementById("player") as HTMLIFrameElement;
 
-// An inline program from the URL fragment (the docs' "try it" buttons):
-// #src=<base64url> becomes the editor buffer and a ONE-FILE project pushed to a
-// fresh player, so it starts with a fresh init — no served file involved.
-const inlineSrc = new URLSearchParams(window.location.hash.slice(1)).get("src");
+// A project carried IN the URL, decoded by the one codec (share-link.ts):
+//   #code=… — a Share link: the whole project (files, entry, roles, pointer
+//     options), so an edited example — or a multiplayer one, server role and all
+//     — reopens exactly as it was shared;
+//   #src=…  — the docs' "try it" buttons: a single uncompressed program.
+// Either becomes the editor's file set and a project pushed to a fresh player,
+// so it starts with a fresh init — no served file involved. A fragment BEATS
+// `?example=`: it is the more specific request, and it is the only copy of that
+// project that exists.
+const hashParams = new URLSearchParams(window.location.hash.slice(1));
+const fragmentKind = hashParams.has("code") ? "code" : hashParams.has("src") ? "src" : null;
 const pageParams = new URLSearchParams(window.location.search);
 const requested = pageParams.get("example");
 // Inline programs have no manifest, so `?mouseCapture=false` /
@@ -112,6 +126,9 @@ const picker = createStore<PickerState>({
   selected: initialExample,
 });
 const pill = createStore<PillState>({ state: "busy", text: "◌ loading…", detail: "" });
+// The Share button's own label (it confirms itself) and the assets advisory.
+const share = createStore<ShareState>(SHARE_IDLE);
+const banner = createStore<BannerState>({ text: "" });
 
 // Multiplayer pane-grid prototype (mp-panes.ts): #clients=2|3 turns the
 // preview column into a chrono bar + N client panes. A HASH param, not a
@@ -427,17 +444,6 @@ const openFile = (path: string) => {
   refreshLiveValues(view);
 };
 
-const fromBase64Url = (b64u: string) =>
-  new TextDecoder().decode(
-    Uint8Array.from(atob(b64u.replace(/-/g, "+").replace(/_/g, "/")), (c) => c.charCodeAt(0))
-  );
-
-let inlineB64: string | null = null;
-
-// An inline (#src=) program is a one-file project; `main.fun` is module `Main`,
-// which is what the old `?src=` data: URL boot derived for it.
-const INLINE_ENTRY = "main.fun";
-
 // The player iframe's boot params, common to every load:
 //   project=inline — the PAGE owns every source and delivers it by postMessage
 //     (project-bridge.ts); the player fetches no `.fun` at all;
@@ -462,34 +468,134 @@ const playerParams = (
 // is ignored — a slow earlier response must not overwrite a newer selection.
 let loadToken = 0;
 
-const loadInline = (b64u: string) => {
-  let source: string;
-  try {
-    source = fromBase64Url(b64u);
-  } catch {
-    setStatus("error", "✖ error", "the #src= fragment is not valid base64");
-    return false;
+// The picker row a URL-carried project occupies. The value is `__inline` from
+// the days when `#src=` was the only such fragment — it is an internal id (the
+// site e2e filters the picker by it), so the LABEL is what says which kind of
+// link is loaded.
+const SHARED_OPTION = "__inline";
+
+/**
+ * How the loaded project BOOTS: the role the editable pane plays, the server
+ * role (if the project declares one), and the pointer policy. Set by every
+ * loader; read by `bootPanes` to mount the panes and by `shareProject` to put
+ * the same shape in a link — so a shared multiplayer sample reopens as a
+ * multiplayer sample rather than as a lone client.
+ */
+// Every field is explicitly `| undefined`: a loader builds the whole record at
+// once from optional sources (an example's fields, a decoded config), so under
+// exactOptionalPropertyTypes "absent" and "undefined" have to be the same
+// thing here.
+interface Boot {
+  module?: string | undefined;
+  prefix?: string | undefined;
+  /** The server pane's entry FILE (a path in `project`) and its role. */
+  server?: { file: string; module?: string | undefined; prefix?: string | undefined } | undefined;
+  cursor?: "visible" | undefined;
+  mouseCapture?: false | undefined;
+}
+let boot: Boot = {};
+
+/** A share role in `Boot`'s shape: the bare-string form names only a file. */
+const bootRole = (role: ShareRole): { file: string; module?: string; prefix?: string } =>
+  typeof role === "string" ? { file: role } : role;
+
+// Mount the panes for the loaded project's declared roles: a FRESH iframe per
+// pane (fresh model — `init` runs), each booted BY the project push rather than
+// by fetching a served build.
+const bootPanes = () => {
+  const params = playerParams(boot.cursor ?? null, boot.mouseCapture ?? null);
+  // A same-file-entries sample plays its declared role: in the preferred form
+  // the role's inline module (e.g. orbs' Client.init/Client.tick/…)…
+  if (boot.module) params.set("module", boot.module);
+  // …or the transitional prefixed contract (clientInit/clientTick/…); the
+  // player takes one of the two.
+  if (boot.prefix) params.set("prefix", boot.prefix);
+  frame.src = `player.html?${params}`;
+  bridge.setProject(project);
+  // A project with a SERVER role also boots a server pane: the SAME file set
+  // re-entered at the server file. The pushed project is entry-first, so the
+  // pane grid hoists that file to the front — the two roles differ only in
+  // their entry and (for a same-file project) their module.
+  let server: PaneProgram | null = null;
+  if (boot.server) {
+    // Derived from the client's params, so every project setting (cursor,
+    // mouseCapture) reaches the server pane too — only the entry and the ROLE
+    // differ.
+    const serverParams = new URLSearchParams(params);
+    // The client's ROLE must not leak into the server pane — neither form, so
+    // both are dropped before the server's own is applied. A same-file sample
+    // (orbs) has both roles in the one entry and differs only here; absent a
+    // declared role, the server file's plain top-level contract is the role.
+    serverParams.delete("module");
+    serverParams.delete("prefix");
+    if (boot.server.module) serverParams.set("module", boot.server.module);
+    if (boot.server.prefix) serverParams.set("prefix", boot.server.prefix);
+    server = { src: `player.html?${serverParams}`, entry: boot.server.file };
   }
-  inlineB64 = b64u;
-  // Reflect the inline program in the picker so it (and Reset) don't lie
-  // about what's loaded.
+  mp?.setSrc(frame.src, server);
+};
+
+// The assets advisory: the project's relative `Asset.*` locators that this site
+// does not serve — the only thing a link genuinely drops (share.ts explains
+// why the site-served ones are fine). Fire-and-forget on both ends of a link.
+const warnAboutAssets = (files: ProjectFile[]) => {
+  void unservedAssets(files).then((missing) => {
+    if (missing.length === 0) return;
+    const text = assetWarning(missing);
+    banner.set({ text });
+    statusBar.appendOutput("warn", text);
+  });
+};
+
+// The project the fragment carried, kept so Reset can reload it (there is no
+// served copy to re-fetch) and so the picker can name it.
+let shared: { project: ShareProject; label: string } | null = null;
+
+// Load a project that arrived IN the URL. The fragment is the storage, so this
+// is a complete load: its file set becomes the editor's, and its declared roles
+// boot the panes.
+const loadShared = (project_: ShareProject, label: string) => {
+  shared = { project: project_, label };
+  const entries = project_.config?.entries;
+  const client = entries?.client ? bootRole(entries.client) : null;
+  // The editable pane's entry: the client role's file, the declared entry, or
+  // the codec's default. A decoded project always contains the roles' files and
+  // its declared entry, but a roles-only project need not have a `game.fun` —
+  // fall back to its first file rather than to a name that isn't there.
+  const wanted = client?.file ?? project_.entry ?? "game.fun";
+  const entry = project_.files.some((file) => file.path === wanted)
+    ? wanted
+    : project_.files[0].path;
+  const files = [
+    ...project_.files.filter((file) => file.path === entry),
+    ...project_.files.filter((file) => file.path !== entry),
+  ];
+  boot = {
+    module: client?.module,
+    prefix: client?.prefix,
+    server: entries?.server ? bootRole(entries.server) : undefined,
+    cursor: project_.options?.cursor,
+    mouseCapture: project_.options?.mouseCapture,
+  };
+  // Reflect the loaded link in the picker so it (and Reset) don't lie about
+  // what's running.
   const options = picker.getSnapshot().options;
   picker.set({
-    options: options.some((option) => option.value === "__inline")
-      ? options
-      : [...options, { value: "__inline", label: "docs snippet" }],
-    selected: "__inline",
+    options: options.some((option) => option.value === SHARED_OPTION)
+      ? options.map((option) =>
+          option.value === SHARED_OPTION ? { value: SHARED_OPTION, label } : option
+        )
+      : [...options, { value: SHARED_OPTION, label }],
+    selected: SHARED_OPTION,
   });
   loadToken += 1; // supersede any in-flight example fetch
-  setDoc([{ path: INLINE_ENTRY, source }]);
+  setDoc(files);
   setStatus("busy", "◌ loading…");
-  // A fresh iframe, booted BY the initial project push, so the inline program
-  // runs its OWN `init` (a hot-swap push would preserve the previous program's
-  // model). `main.fun` keeps the module the old `?src=` data: URL derived.
-  frame.src = `player.html?${playerParams()}`;
-  bridge.setProject(project);
-  mp?.setSrc(frame.src);
-  return true;
+  bootPanes();
+  // A shared multiplayer project keeps the CLIENTS control: its server role is
+  // as much a reason to show it as an example's `multiplayer` flag.
+  if (boot.server) clients.set({ count: mp!.count(), visible: true });
+  warnAboutAssets(files);
 };
 
 const loadExample = async (id: string) => {
@@ -529,65 +635,115 @@ const loadExample = async (id: string) => {
     assets
   );
   setStatus("busy", "◌ loading…");
+  shared = null;
   const cursorPolicy = example?.cursor ?? pageCursorPolicy;
-  const mouseCapture = cursorPolicy
-    ? null
-    : example?.mouseCapture ?? pageMouseCapture;
-  const params = playerParams(cursorPolicy, mouseCapture);
-  // A same-file-entries sample plays its declared role: in the preferred form
-  // the role's inline module (e.g. orbs' Client.init/Client.tick/…)…
-  if (example?.module) params.set("module", example.module);
-  // …or the transitional prefixed contract (clientInit/clientTick/…); the
-  // player takes one of the two.
-  if (example?.prefix) params.set("prefix", example.prefix);
-  frame.src = `player.html?${params}`;
-  bridge.setProject(project);
-  // A sample with a SERVER role (examples.ts `server`) also boots a server
-  // pane: the SAME file set re-entered at the server file. The pushed project
-  // is entry-first, so the pane grid hoists that file to the front — the two
-  // roles differ only in their entry and (for a same-file sample) their module.
-  const serverFile = example?.server?.file;
-  let server: PaneProgram | null = null;
-  if (serverFile) {
-    // Derived from the client's params, so every project setting the sample
-    // declares (cursor, mouseCapture) reaches the server pane too — only the
-    // entry and the ROLE differ.
-    const serverParams = new URLSearchParams(params);
-    // The client's ROLE must not leak into the server pane — neither form, so
-    // both are dropped before the server's own is applied. A same-file sample
-    // (orbs) has both roles in the one entry and differs only here; absent a
-    // declared role, the server file's plain top-level contract is the role.
-    serverParams.delete("module");
-    serverParams.delete("prefix");
-    if (example?.server?.module) serverParams.set("module", example.server.module);
-    if (example?.server?.prefix) serverParams.set("prefix", example.server.prefix);
-    server = { src: `player.html?${serverParams}`, entry: serverFile };
-  }
-  mp?.setSrc(frame.src, server);
+  boot = {
+    module: example?.module,
+    prefix: example?.prefix,
+    // examples.ts `server` — the sample's declared server role, whose file the
+    // fetched list above already contains.
+    server: example?.server,
+    cursor: cursorPolicy ?? undefined,
+    // A visible cursor already implies no capture, so only the capture-only
+    // samples carry the flag.
+    mouseCapture:
+      !cursorPolicy && (example?.mouseCapture ?? pageMouseCapture) === false ? false : undefined,
+  };
+  bootPanes();
 };
 
 const selectExample = (value: string) => {
   picker.set({ ...picker.getSnapshot(), selected: value });
-  if (value === "__inline") {
-    // The `__inline` option only exists once loadInline has stored its source.
-    loadInline(inlineB64!);
+  if (value === SHARED_OPTION) {
+    // That option only exists once a fragment has been decoded into `shared`.
+    loadShared(shared!.project, shared!.label);
     return;
   }
   const url = new URL(window.location.href);
   url.searchParams.set("example", value);
-  // Drop a stale inline program from the hash, but keep #clients=N alive.
+  // Drop the URL-carried project from the hash — both forms, since either would
+  // outrank `?example=` on the next reload — but keep #clients=N alive.
   const hash = new URLSearchParams(window.location.hash.slice(1));
   hash.delete("src");
+  hash.delete("code");
   url.hash = hash.toString();
   window.history.replaceState(null, "", url);
   updateClientsStore();
+  banner.set({ text: "" }); // the outgoing project's advisory, not this one's
   loadExample(value);
 };
 
 const resetExample = () => {
   const selected = picker.getSnapshot().selected;
-  if (selected === "__inline") loadInline(inlineB64!);
+  if (selected === SHARED_OPTION) loadShared(shared!.project, shared!.label);
   else loadExample(selected);
+};
+
+// Share: encode the LIVE project — every file with its edits, the entry, the
+// roles (so a shared multiplayer sample reopens with its server pane) and the
+// pointer options — into this page's own URL, then copy that URL. The fragment
+// goes in with replaceState (no navigation, and #clients=N survives), which is
+// also what makes the address bar a real fallback when the clipboard says no.
+const shareProject = (): ShareProject => {
+  // Flattened to bare module files: the codec's module space has no
+  // directories, and the runtime names a module by its file STEM — so
+  // `examples/netpong/server.fun` and `server.fun` are the same module `Server`.
+  const files = projectFiles().map((file) => ({
+    path: fileName(file.path),
+    source: file.source,
+  }));
+  const role = (
+    file: string,
+    of: { module?: string | undefined; prefix?: string | undefined }
+  ): ShareRole =>
+    of.module ? { file, module: of.module } : of.prefix ? { file, prefix: of.prefix } : file;
+  const carried: ShareProject = { files, entry: files[0].path };
+  if (boot.server) {
+    carried.config = {
+      entries: {
+        client: role(files[0].path, boot),
+        server: role(fileName(boot.server.file), boot.server),
+      },
+    };
+  } else if (boot.module || boot.prefix) {
+    carried.config = { entries: { client: role(files[0].path, boot) } };
+  }
+  if (boot.cursor) carried.options = { cursor: boot.cursor };
+  else if (boot.mouseCapture === false) carried.options = { mouseCapture: false };
+  return carried;
+};
+
+let shareFlash = 0;
+const flashShare = (state: ShareState) => {
+  share.set(state);
+  window.clearTimeout(shareFlash);
+  shareFlash = window.setTimeout(() => share.set(SHARE_IDLE), 2600);
+};
+
+const shareLink = async () => {
+  let url: string;
+  try {
+    url = await shareHref(shareProject(), window.location.href);
+  } catch (error) {
+    // Too large, or a project the codec refuses (a name collision after
+    // flattening). The Output panel keeps the reason after the button calms.
+    const message = error instanceof Error ? error.message : String(error);
+    statusBar.appendOutput("error", message);
+    flashShare({ label: "✖ can't share", tone: "error", detail: message });
+    return;
+  }
+  window.history.replaceState(null, "", url);
+  const copied = await copyLink(url);
+  flashShare(
+    copied
+      ? { label: "✓ copied", tone: "ok", detail: url }
+      : {
+          label: "⧉ copy the URL",
+          tone: "error",
+          detail: "the clipboard refused — the link is in the address bar",
+        }
+  );
+  warnAboutAssets(projectFiles());
 };
 
 // Mount the islands into the static shell's containers. Both keep their
@@ -598,11 +754,18 @@ createRoot(document.querySelector(".sandbox-controls")!).render(
     picker={picker}
     pill={pill}
     clients={clients}
+    share={share}
     runtimeTarget={runtimeTarget}
     onSelect={selectExample}
     onReset={resetExample}
     onClients={selectClients}
+    onShare={shareLink}
   />
+);
+// The one thing a link can't promise (share.ts): a strip above the editor, so
+// it is read where the sources it is about are.
+createRoot(document.querySelector(".share-banner-host")!).render(
+  <ShareBanner store={banner} onDismiss={() => banner.set({ text: "" })} />
 );
 // Rows only: `onNew`/`onDelete` are the IDE's, and an example's file set is
 // the sample's rather than the reader's. The host element carries the
@@ -616,7 +779,23 @@ createRoot(statusBarHost).render(
   <StatusBar store={statusBar} editorKeybindings={editorKeybindings} />
 );
 
-if (!(inlineSrc && loadInline(inlineSrc))) loadExample(initialExample);
+// A fragment wins over `?example=`, but only if it decodes: a mangled link (a
+// chat client that broke the URL) says why and falls back to an example rather
+// than leaving the page empty.
+if (fragmentKind) {
+  void decodeShare(window.location.hash).then((carried) => {
+    if (carried) {
+      loadShared(carried, fragmentKind === "code" ? "shared link" : "docs snippet");
+      return;
+    }
+    const message = `the #${fragmentKind}= fragment is not a valid project — loading an example instead`;
+    statusBar.appendOutput("error", message);
+    setStatus("error", "✖ error", message);
+    loadExample(initialExample);
+  });
+} else {
+  loadExample(initialExample);
+}
 
 // Test seam for the headless e2e (e2e/site-sandbox.mjs): set the buffer and
 // observe results without synthesizing keyboard events.

--- a/site/src/share-link.test.ts
+++ b/site/src/share-link.test.ts
@@ -12,12 +12,16 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { encodeShare, decodeShare, assetLocators } from "./share-link.ts";
+import { encodeShare, decodeShare, assetLocators, MAX_SHARE_CHARS } from "./share-link.ts";
 import type { ShareProject } from "./share-link.ts";
 
 const EXAMPLES = new URL("../../examples", import.meta.url).pathname;
-/** A share link must stay pasteable; the biggest example sets the bar. */
-const MAX_ENCODED_CHARS = 24_000;
+/**
+ * A share link must stay pasteable; the biggest example sets the bar. Imported
+ * rather than restated, so the cap this asserts against is the one the Share
+ * button actually enforces.
+ */
+const MAX_ENCODED_CHARS = MAX_SHARE_CHARS;
 
 const roundTrip = async (project: ShareProject) => {
   const hash = await encodeShare(project);
@@ -118,7 +122,7 @@ test("round-trips every example project, and each stays pasteable", async (t) =>
 
 // --- the locators a link cannot carry ----------------------------------------
 
-test("finds the relative Asset locators, and only those", async () => {
+test("finds the relative file locators, and only those", () => {
   const files = [
     {
       path: "game.fun",
@@ -128,8 +132,11 @@ let cdn = Asset.model("https://cdn.example/x.glb")
 let proto = Asset.texture("//cdn.example/y.png")
 let spaced = Asset.texture(
   "grid.png")
-// Not asset coercion: a texture FILE and a clip NAME keep their strings.
-let tex = Texture.file("nope.png")
+// Not asset coercion, but still files read off the site — they don't travel
+// either, so they count.
+let tex = Texture.file("wall.png")
+let sky = Skybox.files("px.png", "nx.png")
+// A clip NAME is not a file.
 let clip = Anim.clip("walk", tts)
 `,
     },
@@ -139,8 +146,11 @@ let clip = Anim.clip("walk", tts)
   assert.deepEqual(assetLocators(files), [
     "grid.png",
     "hit.ogg",
+    "nx.png",
+    "px.png",
     "sfx/shot.ogg",
     "ship.glb",
+    "wall.png",
   ]);
 });
 

--- a/site/src/share-link.test.ts
+++ b/site/src/share-link.test.ts
@@ -12,7 +12,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { encodeShare, decodeShare } from "./share-link.ts";
+import { encodeShare, decodeShare, assetLocators } from "./share-link.ts";
 import type { ShareProject } from "./share-link.ts";
 
 const EXAMPLES = new URL("../../examples", import.meta.url).pathname;
@@ -114,6 +114,38 @@ test("round-trips every example project, and each stays pasteable", async (t) =>
       `${name} encodes to ${encoded} chars, over the ${MAX_ENCODED_CHARS} cap`
     );
   }
+});
+
+// --- the locators a link cannot carry ----------------------------------------
+
+test("finds the relative Asset locators, and only those", async () => {
+  const files = [
+    {
+      path: "game.fun",
+      source: `let ship = Asset.model("ship.glb")
+let shot = Asset.sound("sfx/shot.ogg")
+let cdn = Asset.model("https://cdn.example/x.glb")
+let proto = Asset.texture("//cdn.example/y.png")
+let spaced = Asset.texture(
+  "grid.png")
+// Not asset coercion: a texture FILE and a clip NAME keep their strings.
+let tex = Texture.file("nope.png")
+let clip = Anim.clip("walk", tts)
+`,
+    },
+    // The same locator twice is one asset; a sibling's locators count too.
+    { path: "lib.fun", source: `let again = Asset.model("ship.glb")\nlet hit = Asset.sound("hit.ogg")\n` },
+  ];
+  assert.deepEqual(assetLocators(files), [
+    "grid.png",
+    "hit.ogg",
+    "sfx/shot.ogg",
+    "ship.glb",
+  ]);
+});
+
+test("a project with no local assets has nothing to warn about", () => {
+  assert.deepEqual(assetLocators([{ path: "game.fun", source: "let init = 0\n" }]), []);
 });
 
 // --- the legacy docs fragment ------------------------------------------------

--- a/site/src/share-link.ts
+++ b/site/src/share-link.ts
@@ -33,6 +33,52 @@ export const MODULE_FILE = /^[A-Za-z][A-Za-z0-9_]*\.fun$/;
 /** The default entry, omitted from the payload to keep short links short. */
 const DEFAULT_ENTRY = "game.fun";
 
+/**
+ * The longest `#code=` payload we will hand out, in characters. Chat clients,
+ * issue trackers and mail clients all mangle links well before a browser's own
+ * URL limit, and every example in the repo encodes far under this (this file's
+ * test pins that, against this constant). A project over the cap gets pointed at
+ * the zip download instead — `shareHref` (share.ts) is what enforces it.
+ *
+ * Lives here, beside MODULE_FILE, for the same reason: what a LINK can carry is
+ * one rule, and the pages, the encoder and the test all have to agree on it.
+ */
+export const MAX_SHARE_CHARS = 24_000;
+
+// A call that names a file, with its argument list: the `Asset` module's members
+// (`model`/`texture`/`sound` — the branded locators), plus the two string-taking
+// consumers that are NOT asset coercion but still read files off the site
+// (`Texture.file`, `Skybox.files`). Only literals are findable from text — a
+// locator computed at runtime is nobody's to check — which is the same set
+// `functor build` verifies on disk.
+const FILE_CALL = /\b(?:Asset\.[A-Za-z][A-Za-z0-9_]*|Texture\.file|Skybox\.files)\s*\(([^)]*)\)/g;
+const STRING_LITERAL = /"([^"\n\\]*)"/g;
+
+/**
+ * The RELATIVE file locators a project names, de-duplicated and sorted — the
+ * candidates for "this won't travel with the link". URL and scheme-relative
+ * locators are skipped: they carry themselves.
+ *
+ * A link carries `.fun` sources and nothing else, so whether a relative locator
+ * survives depends on the SITE the link opens on; `share.ts` is what checks that
+ * (and explains the cases). This half is pure text, so it is unit-tested.
+ */
+export const assetLocators = (files: ProjectFile[]): string[] => {
+  const found = new Set<string>();
+  for (const file of files) {
+    for (const [, args] of file.source.matchAll(FILE_CALL)) {
+      for (const [, locator] of args.matchAll(STRING_LITERAL)) {
+        // An empty locator is the game's own bug, not the link's.
+        if (locator === "" || /^[a-z][a-z0-9+.-]*:/i.test(locator) || locator.startsWith("//")) {
+          continue;
+        }
+        found.add(locator);
+      }
+    }
+  }
+  return [...found].sort();
+};
+
 // Caps. Generous next to the real projects (the largest example encodes to a
 // few KB) but far below what a browser will hand back from a URL, so a hostile
 // fragment is rejected before it costs anything.
@@ -92,7 +138,9 @@ export const toBase64Url = (bytes: Uint8Array): string => {
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 };
 
-const BASE64URL = /^[A-Za-z0-9_-]*$/;
+// Padding is optional: nothing here emits it, but a link rewriter that re-pads
+// a fragment must not turn a working link into "not a valid project".
+const BASE64URL = /^[A-Za-z0-9_-]*={0,2}$/;
 
 const fromBase64Url = (code: string): Uint8Array<ArrayBuffer> | null => {
   if (!BASE64URL.test(code)) return null; // atob is lenient about whitespace; we are not
@@ -295,39 +343,6 @@ const validEnvelope = (parsed: unknown): ShareProject | null => {
     if (Object.keys(options).length > 0) project.options = options;
   }
   return project;
-};
-
-// --- what a link cannot carry ------------------------------------------------
-
-// An `Asset.*("…")` locator, as the checker sees one: a literal string argument
-// to any member of the `Asset` module (`model`/`texture`/`sound`). Only literals
-// are findable from text — a locator computed at runtime is nobody's to check —
-// and that is exactly the set `functor build` verifies on disk, so the two
-// agree on what "an asset this project names" means.
-const ASSET_LOCATOR = /\bAsset\.[A-Za-z][A-Za-z0-9_]*\s*\(\s*"([^"\n\\]*)"/g;
-
-/**
- * The RELATIVE `Asset.*` locators a project names, de-duplicated and sorted.
- *
- * A link carries `.fun` sources and nothing else, so a URL locator (a CDN
- * asset) needs no help — it is skipped. A relative one resolves against
- * whatever site the link opens on, which is a promise this codec cannot keep
- * for the caller; `site/src/share.ts` is what checks whether the site actually
- * serves each of these.
- */
-export const assetLocators = (files: ProjectFile[]): string[] => {
-  const found = new Set<string>();
-  for (const file of files) {
-    for (const [, locator] of file.source.matchAll(ASSET_LOCATOR)) {
-      // A scheme-relative `//host/x.glb` is a URL too, and an empty locator is
-      // the game's own bug, not the link's.
-      if (locator === "" || /^[a-z][a-z0-9+.-]*:/i.test(locator) || locator.startsWith("//")) {
-        continue;
-      }
-      found.add(locator);
-    }
-  }
-  return [...found].sort();
 };
 
 /**

--- a/site/src/share-link.ts
+++ b/site/src/share-link.ts
@@ -77,7 +77,12 @@ export interface ShareProject {
 
 // --- base64url ---------------------------------------------------------------
 
-const toBase64Url = (bytes: Uint8Array): string => {
+/**
+ * base64url — the URL-safe alphabet, unpadded. Exported because the docs page
+ * emits the legacy `#src=` fragment with it (docs.ts), and two hand-rolled
+ * copies of an encoding are two chances to disagree about `+`, `/` and `=`.
+ */
+export const toBase64Url = (bytes: Uint8Array): string => {
   // Chunked: `String.fromCharCode(...bytes)` blows the argument limit somewhere
   // north of ~100KB, which real projects reach.
   let binary = "";
@@ -290,6 +295,39 @@ const validEnvelope = (parsed: unknown): ShareProject | null => {
     if (Object.keys(options).length > 0) project.options = options;
   }
   return project;
+};
+
+// --- what a link cannot carry ------------------------------------------------
+
+// An `Asset.*("…")` locator, as the checker sees one: a literal string argument
+// to any member of the `Asset` module (`model`/`texture`/`sound`). Only literals
+// are findable from text — a locator computed at runtime is nobody's to check —
+// and that is exactly the set `functor build` verifies on disk, so the two
+// agree on what "an asset this project names" means.
+const ASSET_LOCATOR = /\bAsset\.[A-Za-z][A-Za-z0-9_]*\s*\(\s*"([^"\n\\]*)"/g;
+
+/**
+ * The RELATIVE `Asset.*` locators a project names, de-duplicated and sorted.
+ *
+ * A link carries `.fun` sources and nothing else, so a URL locator (a CDN
+ * asset) needs no help — it is skipped. A relative one resolves against
+ * whatever site the link opens on, which is a promise this codec cannot keep
+ * for the caller; `site/src/share.ts` is what checks whether the site actually
+ * serves each of these.
+ */
+export const assetLocators = (files: ProjectFile[]): string[] => {
+  const found = new Set<string>();
+  for (const file of files) {
+    for (const [, locator] of file.source.matchAll(ASSET_LOCATOR)) {
+      // A scheme-relative `//host/x.glb` is a URL too, and an empty locator is
+      // the game's own bug, not the link's.
+      if (locator === "" || /^[a-z][a-z0-9+.-]*:/i.test(locator) || locator.startsWith("//")) {
+        continue;
+      }
+      found.add(locator);
+    }
+  }
+  return [...found].sort();
 };
 
 /**

--- a/site/src/share.ts
+++ b/site/src/share.ts
@@ -1,0 +1,105 @@
+// Sharing, minus the codec: the size guard, the URL bookkeeping, the clipboard,
+// and the one honest warning about what a link cannot carry. The sandbox and the
+// IDE both drive this, so the two Share buttons behave identically.
+//
+// WHAT TRAVELS. A `#code=` link carries `.fun` SOURCES and nothing else, so what
+// happens to an `Asset.*` locator on the other side depends on the locator, not
+// on the link:
+//
+//   • a URL locator (a CDN asset) always resolves — there is nothing to carry;
+//   • a RELATIVE locator resolves against the SITE ROOT, because the runtime in
+//     a `player.html?project=inline` iframe fetches it from there (see the
+//     header note in sandbox.tsx). Every asset the built site ships sits at that
+//     root — `grid-neon.png`, `ship.glb`, `heightmap.png` — so a shared example
+//     keeps its assets whether or not its sources were edited;
+//   • a relative locator naming a file the site does NOT serve is the one case
+//     that breaks: a path someone typed into the IDE, or an example asset
+//     renamed in the editor. The bytes exist nowhere the link can reach.
+//
+// So the warning is NOT "this project has local assets" — that would cry wolf on
+// nearly every example, which shares perfectly. It is "this locator does not
+// resolve here", probed against the site itself, which makes it identically true
+// on both ends of the link (same site, same answer).
+import { encodeShare, assetLocators } from "./share-link.js";
+import type { ShareProject } from "./share-link.js";
+import type { ProjectFile } from "./protocol.js";
+
+/**
+ * The longest `#code=` payload we will hand out, in characters. Chat clients,
+ * issue trackers and mail clients all mangle links well before a browser's own
+ * URL limit, and every example in the repo encodes far under this (the codec's
+ * own test pins that). A project over the cap gets the zip download instead.
+ */
+export const MAX_SHARE_CHARS = 24_000;
+
+/**
+ * The share URL for `project`: `href` with a `#code=` fragment, every OTHER
+ * hash param preserved (the sandbox's `#clients=N` rides along). A stale
+ * `#src=` is dropped — it would be dead weight next to a fragment that wins
+ * over it anyway.
+ *
+ * Throws when the project cannot ride in a URL (too large, or not encodable);
+ * the message is meant to be shown as-is.
+ */
+export async function shareHref(project: ShareProject, href: string): Promise<string> {
+  const code = (await encodeShare(project)).slice("#code=".length);
+  if (code.length > MAX_SHARE_CHARS) {
+    throw new Error(
+      `this project encodes to ${Math.ceil(code.length / 1000)}k — over the ` +
+        `${MAX_SHARE_CHARS / 1000}k a link can carry. Download it as a .zip and share that.`
+    );
+  }
+  const url = new URL(href);
+  const params = new URLSearchParams(url.hash.slice(1));
+  params.delete("src");
+  params.set("code", code);
+  url.hash = params.toString();
+  return url.toString();
+}
+
+/**
+ * Put `url` on the clipboard, reporting whether it landed. A denied or absent
+ * clipboard is not an error worth failing the share over: the fragment is
+ * already in the address bar by then, which is the fallback the caller offers.
+ */
+export const copyLink = async (url: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * The project's relative `Asset.*` locators that this site does not serve —
+ * the assets a link genuinely cannot deliver (see the header note).
+ *
+ * A probe that fails to complete (offline, blocked) is NOT counted: an
+ * unverifiable locator is unknown, and a warning nobody can act on is worse
+ * than none. Mirrors how `functor build` treats an unverifiable URL asset.
+ */
+export async function unservedAssets(files: ProjectFile[]): Promise<string[]> {
+  const missing: string[] = [];
+  await Promise.all(
+    assetLocators(files).map(async (locator) => {
+      try {
+        const response = await fetch(locator, { method: "HEAD" });
+        if (!response.ok) missing.push(locator);
+      } catch {
+        /* unverifiable — say nothing */
+      }
+    })
+  );
+  return missing.sort();
+}
+
+/** The banner line for `missing` (never empty — callers check first). */
+export const assetWarning = (missing: string[]): string => {
+  const named = missing.slice(0, 3).join(", ");
+  const rest = missing.length > 3 ? `, +${missing.length - 3} more` : "";
+  return (
+    `${missing.length} local asset${missing.length === 1 ? "" : "s"} won't travel with ` +
+    `this link (${named}${rest}) — host ${missing.length === 1 ? "it" : "them"} on a URL instead.`
+  );
+};

--- a/site/src/share.ts
+++ b/site/src/share.ts
@@ -1,10 +1,11 @@
 // Sharing, minus the codec: the size guard, the URL bookkeeping, the clipboard,
-// and the one honest warning about what a link cannot carry. The sandbox and the
-// IDE both drive this, so the two Share buttons behave identically.
+// the one honest warning about what a link cannot carry — and the little
+// controller that drives all of it, so the sandbox and the IDE share one Share
+// button behaviour instead of two copies of it.
 //
 // WHAT TRAVELS. A `#code=` link carries `.fun` SOURCES and nothing else, so what
-// happens to an `Asset.*` locator on the other side depends on the locator, not
-// on the link:
+// happens to a file locator on the other side depends on the locator, not on the
+// link:
 //
 //   • a URL locator (a CDN asset) always resolves — there is nothing to carry;
 //   • a RELATIVE locator resolves against the SITE ROOT, because the runtime in
@@ -19,18 +20,15 @@
 // So the warning is NOT "this project has local assets" — that would cry wolf on
 // nearly every example, which shares perfectly. It is "this locator does not
 // resolve here", probed against the site itself, which makes it identically true
-// on both ends of the link (same site, same answer).
-import { encodeShare, assetLocators } from "./share-link.js";
+// on both ends of the link (same site, same answer) and identical for a project
+// that was loaded rather than shared.
+import { encodeShare, assetLocators, MAX_SHARE_CHARS } from "./share-link.js";
 import type { ShareProject } from "./share-link.js";
 import type { ProjectFile } from "./protocol.js";
-
-/**
- * The longest `#code=` payload we will hand out, in characters. Chat clients,
- * issue trackers and mail clients all mangle links well before a browser's own
- * URL limit, and every example in the repo encodes far under this (the codec's
- * own test pins that). A project over the cap gets the zip download instead.
- */
-export const MAX_SHARE_CHARS = 24_000;
+import type { Store } from "./store.js";
+import { SHARE_IDLE } from "./components/ShareButton.js";
+import type { ShareState } from "./components/ShareButton.js";
+import type { BannerState } from "./components/ShareBanner.js";
 
 /**
  * The share URL for `project`: `href` with a `#code=` fragment, every OTHER
@@ -71,27 +69,35 @@ export const copyLink = async (url: string): Promise<boolean> => {
   }
 };
 
+// --- the locators a link cannot carry ----------------------------------------
+
+/** How many distinct locators a page will probe. See `unservedAssets`. */
+const MAX_PROBES = 32;
+
 /**
- * The project's relative `Asset.*` locators that this site does not serve —
- * the assets a link genuinely cannot deliver (see the header note).
+ * The project's relative locators that this site does not serve — the assets a
+ * link genuinely cannot deliver (see the header note).
  *
  * A probe that fails to complete (offline, blocked) is NOT counted: an
  * unverifiable locator is unknown, and a warning nobody can act on is worse
  * than none. Mirrors how `functor build` treats an unverifiable URL asset.
+ *
+ * At most `MAX_PROBES` locators are checked, and they are checked one at a
+ * time. The project may have come out of a hostile fragment, and "open this
+ * link" must never become "make this browser fire a thousand requests at
+ * whoever is listening".
  */
 export async function unservedAssets(files: ProjectFile[]): Promise<string[]> {
   const missing: string[] = [];
-  await Promise.all(
-    assetLocators(files).map(async (locator) => {
-      try {
-        const response = await fetch(locator, { method: "HEAD" });
-        if (!response.ok) missing.push(locator);
-      } catch {
-        /* unverifiable — say nothing */
-      }
-    })
-  );
-  return missing.sort();
+  for (const locator of assetLocators(files).slice(0, MAX_PROBES)) {
+    try {
+      const response = await fetch(locator, { method: "HEAD" });
+      if (!response.ok) missing.push(locator);
+    } catch {
+      /* unverifiable — say nothing */
+    }
+  }
+  return missing;
 }
 
 /** The banner line for `missing` (never empty — callers check first). */
@@ -102,4 +108,99 @@ export const assetWarning = (missing: string[]): string => {
     `${missing.length} local asset${missing.length === 1 ? "" : "s"} won't travel with ` +
     `this link (${named}${rest}) — host ${missing.length === 1 ? "it" : "them"} on a URL instead.`
   );
+};
+
+// --- the control both pages mount --------------------------------------------
+
+/** How long the button holds its confirmation before calming down. */
+const FLASH_MS = 2600;
+
+export interface ShareController {
+  /** Encode the project into the page's URL, copy it, and report. */
+  shareLink: () => Promise<void>;
+  /**
+   * Re-run the assets advisory for the project as it now stands — call it on
+   * every LOAD, so the strip describes what is open rather than what used to be.
+   */
+  checkAssets: () => void;
+}
+
+export interface ShareControllerOptions {
+  /** The button's label/tone store. */
+  share: Store<ShareState>;
+  /** The advisory strip's store. */
+  banner: Store<BannerState>;
+  /** The project to encode, built fresh at click time. */
+  project: () => ShareProject;
+  /** The sources to scan for locators (the same project, as plain files). */
+  files: () => ProjectFile[];
+  /** Where a message that outlives the flash goes (the Output panel). */
+  onOutput: (level: "warn" | "error", message: string) => void;
+  /** The page URL the fragment is written into. */
+  href: () => string;
+}
+
+/**
+ * The Share workflow, owned once: the button's little label state machine, the
+ * encode/copy/replaceState sequence, and the assets probe with its generation
+ * guard. Each page supplies only what its project IS.
+ */
+export const createShareController = ({
+  share,
+  banner,
+  project,
+  files,
+  onOutput,
+  href,
+}: ShareControllerOptions): ShareController => {
+  let flash = 0;
+  const flashShare = (state: ShareState) => {
+    share.set(state);
+    window.clearTimeout(flash);
+    flash = window.setTimeout(() => share.set(SHARE_IDLE), FLASH_MS);
+  };
+
+  // A generation counter, not a cancellation: a probe that started under the
+  // previous project must not paint its verdict over this one.
+  let probe = 0;
+  const checkAssets = () => {
+    const token = ++probe;
+    banner.set({ text: "" }); // the outgoing project's advisory is not this one's
+    void unservedAssets(files()).then((missing) => {
+      if (token !== probe || missing.length === 0) return;
+      const text = assetWarning(missing);
+      banner.set({ text });
+      onOutput("warn", text);
+    });
+  };
+
+  const shareLink = async () => {
+    let url: string;
+    try {
+      url = await shareHref(project(), href());
+    } catch (error) {
+      // Too large, or a project the codec refuses. The Output panel keeps the
+      // reason after the button calms down.
+      const message = error instanceof Error ? error.message : String(error);
+      onOutput("error", message);
+      flashShare({ label: "✖ can't share", tone: "error", detail: message });
+      return;
+    }
+    // No navigation, and the other hash params survive — which is also what
+    // makes the address bar a real fallback when the clipboard says no.
+    window.history.replaceState(null, "", url);
+    const copied = await copyLink(url);
+    flashShare(
+      copied
+        ? { label: "✓ copied", tone: "ok", detail: url }
+        : {
+            label: "⧉ copy the URL",
+            tone: "error",
+            detail: "the clipboard refused — the link is in the address bar",
+          }
+    );
+    checkAssets();
+  };
+
+  return { shareLink, checkAssets };
 };

--- a/site/styles.css
+++ b/site/styles.css
@@ -906,6 +906,7 @@ a:hover {
 #example-picker,
 #client-count,
 #reset,
+#share,
 #download,
 #restart {
   font-family: var(--font-mono);
@@ -938,15 +939,80 @@ a:hover {
 }
 
 #reset,
+#share,
 #download,
 #restart {
   cursor: pointer;
 }
 
 #reset:hover,
+#share:hover,
 #download:hover,
 #restart:hover {
   border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+/* Share confirms itself: the button that was clicked reports what happened,
+   for a beat, in the pill's own state colours — no toast, nothing new to
+   look for. `min-width` holds the row still while the label changes. */
+#share {
+  min-width: 8.5ch;
+  text-align: center;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+#share[data-tone="ok"],
+#share[data-tone="ok"]:hover {
+  color: var(--green);
+  border-color: rgba(111, 220, 146, 0.5);
+}
+
+#share[data-tone="error"],
+#share[data-tone="error"]:hover {
+  color: var(--red);
+  border-color: rgba(242, 99, 127, 0.5);
+}
+
+/* The share advisory: one line above the editor, in the warning amber the
+   Problems rows already use. A strip, not a dialog — the project is loaded and
+   running behind it. */
+.share-banner {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--line);
+  border-left: 2px solid var(--amber);
+  background: rgba(238, 200, 119, 0.07);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.share-banner-icon {
+  color: var(--amber);
+}
+
+.share-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.share-banner-close {
+  appearance: none;
+  border: 0;
+  background: none;
+  padding: 0 2px;
+  cursor: pointer;
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.share-banner-close:hover {
   color: var(--cyan);
 }
 


### PR DESCRIPTION
Both editor pages get a **Share** button. It encodes the project *as it stands* — every
file with its live edits, the entry, the role config, the pointer policy — into a `#code=`
fragment on the page's own URL (the codec from #703), writes it with `replaceState`
(so `#clients=N` survives), and copies the URL. Opening such a link loads that project
exactly like an example: the file sidebar for a multi-file project, the **server pane** for
one that declares roles.

<img src="https://gist.githubusercontent.com/tommy-xr/fc96850e7269b6ee97e7d44ee8e063a3/raw/1d2879454ae28b062ceb76af8b8a6731bb7c9486/share-flow.gif" width="900" alt="Edit an example, click share, open the copied link in a fresh page — the edit is there and the scene is live" />

Edit an example → **⧉ share** (the button confirms itself: **✓ copied**) → the link opens in a
fresh page with the edit intact, the scene live, and the picker reading *shared link*.

## The chrome

Sandbox header, before / after (desktop 1440, then mobile 420 side by side):

<img src="https://gist.githubusercontent.com/tommy-xr/fc96850e7269b6ee97e7d44ee8e063a3/raw/1d2879454ae28b062ceb76af8b8a6731bb7c9486/header-desktop-beforeafter.png" width="900" alt="Sandbox header before (no share) above, after (with share) below" />

<img src="https://gist.githubusercontent.com/tommy-xr/fc96850e7269b6ee97e7d44ee8e063a3/raw/1d2879454ae28b062ceb76af8b8a6731bb7c9486/header-mobile-beforeafter.png" width="620" alt="Mobile header before and after — the row wraps the same way, share joins the second line" />

No new chrome was invented: the button is the existing `#reset`/`#download` control, and it
is *its own* confirmation (**✓ copied** in the pill's green for 2.6s, then back) rather than a
toast. Only the assets advisory adds a surface: a one-line amber strip above the editor,
dismissible, in the same colour the Problems rows use.

## UX semantics chosen

**Sandbox.** A fragment outranks `?example=` — it is the more specific request and the only
copy of that project in existence. `#code=` and the legacy `#src=` both decode through
`decodeShare`, and a mangled fragment says so and falls back to an example rather than
leaving the page blank. The loaded link takes the picker row the docs snippet used to
(labelled *shared link*), so **Reset** reloads the link's project — from a snapshot, not from
the live buffers. Share drops `?example=` from the minted URL: the fragment *is* the project.

**IDE.** A `#code=` link outranks the stored project, but never silently and never
destructively:

| state | behaviour |
| --- | --- |
| no stored project (first visit / the starter) | the shared project just opens |
| a stored project | **prompt**; Cancel keeps it and drops `code` from the URL so a reload doesn't ask again |
| either way | the shared project is **not** written to localStorage until the reader changes something — the first edit adopts it |
| a link the IDE can't represent (entry ≠ `game.fun`, or declared roles) | **refused before prompting**, pointing at the sandbox — such a link can never cost the reader their project |

An IDE link carries no `options`: the IDE reads its pointer policy from the query
(`?cursor=` / `?mouseCapture=`), which the share URL preserves, so declaring it twice would
only let the two disagree.

**Guards.** Over ~24k encoded chars the button refuses and points at the zip download
(`MAX_SHARE_CHARS`, the same constant the codec's test asserts every example against).

## The asset banner — which cases actually break

A link carries `.fun` sources and nothing else, so what happens to a file locator depends on
the locator, not on the link:

- a **URL** locator (CDN asset) always resolves — nothing to carry;
- a **relative** locator resolves against the **site root**, because a
  `player.html?project=inline` runtime fetches it there. Every asset the built site ships
  (`grid-neon.png`, `ship.glb`, `heightmap.png`) is at that root — so a shared example keeps
  its assets **whether or not its sources were edited**, and `Assets.*` manifest constants are
  fine for the same reason;
- a **relative locator the site does not serve** is the one case that breaks: a path typed into
  the IDE, or an example asset renamed in the editor. The bytes exist nowhere the link can
  reach.

So the banner is *not* "this project has local assets" — that would cry wolf on nearly every
example, which shares perfectly. It is "this locator does not resolve **here**", probed with
`HEAD` against the site itself, which makes it identically true on both ends of the link and
for a project that was merely loaded. It scans `Asset.*` plus `Texture.file`/`Skybox.files`
(also site-read files), skips URL locators, probes at most 32 locators one at a time (a
fragment is attacker-controlled), and counts a probe that cannot complete (offline) as
*unknown* rather than missing — the same rule `functor build` applies to an unverifiable URL
asset.

## Also folded in (deferred from #703)

- the sandbox's private base64url decoder and its `main.fun` inline entry are gone — the
  legacy `#src=` path now goes through `decodeShare`;
- `docs.ts` uses the codec's exported `toBase64Url` instead of its own copy;
- padded base64url in a legacy link decodes again (a link rewriter re-adding `=` used to
  break it).

## Verification

| command | result |
| --- | --- |
| `npm run check:site` | pass |
| `npm run site:build` | pass |
| `npm run test:share-link` | 14/14 |
| `npm run test:share` *(new)* | 33/33 |
| `npm run test:site` | ALL CHECKS PASSED |
| `npm run test:sandbox-mp` | ALL CHECKS PASSED |
| `npm run test:sandbox-files` | pass |
| `npm run test:ide` | PASS |
| `npm run test:ide-page` | PASS |

**New committed e2e** (`e2e/share-page.mjs`, `npm run test:share`): edit an example → Share →
open the produced URL in a fresh page (edit present, game live, Reset restores the link's
project); netpong shared with an edited `server.fun` (all four files, edit in the right file,
**server pane mounted**, `● 1+1 running`); `#code=` outranking `?example=`; the IDE
round-trip with the prompt (Cancel / Accept / not-persisted-until-edit / refusal); and the
assets advisory on both ends plus the served-assets non-warning.

## Review dispositions (`/xreview`: Claude + Codex + a de-dup pass)

Fixed:

- **[AGREED] stale picker row** — switching examples cleared the shared project behind its
  own *shared link* option, so re-selecting it threw. The project now outlives an example
  switch, as the inline snippet did.
- **Reset reloaded the edits, not the link** (Claude, High) — the retained snapshot aliased
  the live buffers, which every keystroke mutates. Now loaded as copies; covered by a new
  e2e check.
- **[AGREED] the assets probe had no generation guard and never cleared** — a slow probe
  could paint over a newer project. One controller now clears then publishes under a token,
  and runs on *every* load (which also removes the "same project warns depending on how you
  arrived" inconsistency both reviewers flagged).
- **[AGREED] the IDE's entry guard was too weak** — it checked only that a `game.fun`
  existed. It now requires the declared entry to *be* `game.fun` and refuses declared roles,
  before prompting.
- **page `?cursor=`/`?mouseCapture=` fallback** (Claude, Medium) — a URL-carried project
  declaring nothing silently lost the page seam the `#src=` path has always honoured.
- **`Texture.file` / `Skybox.files` skipped** (Codex, Medium) — they read files off the site
  too; now scanned.
- **unbounded HEAD probes from a hostile fragment** (Codex, Medium) — capped at 32 and
  serialized.
- **[AGREED + de-dup `merge`] `shareLink`/`flashShare`/`warnAboutAssets` duplicated per page**
  — one `createShareController` in `share.ts`; each page supplies only what its project *is*.
- **de-dup `reuse`: the 24k cap was stated twice** — `MAX_SHARE_CHARS` is exported and the
  codec test asserts against it.
- **de-dup `extract`: three copies of the entry-hoist** — `entryFirst` in `protocol.ts`.
- **`?example=` left on a share URL** (Claude, Low) — dropped.
- **padded base64url rejected** (Claude, Low) — accepted.

Not taken, with reasons:

- *"the asset advisory is scope creep; ship it separately"* (both, Simplicity) — the advisory
  is part of the requested scope for this change, and the reviewers' concrete objections
  (inconsistent firing, no clearing, unbounded probes, missed consumers) are all fixed above.
  It stays, at one component + one strip.
- *"move `assetLocators` out of the codec module"* (Claude, Low) — it now sits beside
  `MODULE_FILE` and `MAX_SHARE_CHARS`, which is that module's existing role: the rules of a
  link that the pages, the encoder and the test must all agree on. It is also what keeps the
  scanner unit-testable under a plain `node --test` (a module with runtime `.js` imports is
  not loadable there).
- *"extract a shared hash-param writer"* / *"extract the e2e boot preamble"* (de-dup, Low) —
  the three hash sites differ in intent, and the e2e preamble is the repo's existing
  convention across five site suites; extracting it is its own refactor.

De-dup coverage (verbatim): *all four strategies ran — S1-names (38 queries, 8102 candidates,
min-score 0.3), S2-clones (301 jscpd pairs, 6 touching changed files; 4 of those pre-existing
seam/lint code, verified by reading), S3-index (4044-entry index grepped for clipboard, hash
params, base64url, asset-locator scanning, banner/toast chrome, localStorage, boot/role
params), S4-read over the full diff (15 files, +1160/-89). None unavailable.*

## Deferred

- Cross-surface links: a sandbox link (flat `netpong.fun` entry, roles) cannot open in the
  IDE — it is refused with a pointer to the sandbox rather than renamed. Letting the IDE hold
  a project whose entry isn't `game.fun` is its own change.
- `npm run test:share` is not wired into a CI workflow (neither is `test:sandbox-files`; same
  gap, same fix, out of scope here).
